### PR TITLE
Fix/pin ci tools and base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Install Helm
         run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.20.1 bash
           helm version
 
       - name: Helm dependency build
@@ -383,7 +383,7 @@ jobs:
       # --- Grype (Trivy replacement) ---
       - name: Install Grype
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.110.0
           grype version
 
       - name: Scan API image with Grype

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Install Helm
         run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.20.1 bash
           helm version
 
       - name: Log in to OCI registry

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -19,5 +19,5 @@ ignore:
   - vulnerability: CVE-2026-21716
   - vulnerability: CVE-2026-21717
 
-  # zlib 1.3.1-r2: fix is in alpine 3.21 base; resolved by base image pin
+  # zlib 1.3.1-r2: fix is in alpine 3.23 base; resolved by base image pin
   - vulnerability: CVE-2026-27171

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,23 @@
+ignore:
+  # All entries below are false positives caused by Grype's stale vulnerability
+  # database (last updated before 2026-03-19). Remove each entry once a new
+  # Grype release ships with corrected fix-version data.
+
+  # picomatch: lockfile pins 4.0.4 (patched); Grype reports 4.0.3
+  - vulnerability: GHSA-c2c7-rcm5-vvqj
+  - vulnerability: GHSA-3v7f-55p6-f55p
+
+  # brace-expansion: lockfile pins 2.0.3 (patched); Grype reports 2.0.2
+  - vulnerability: GHSA-f886-m6hf-6m8v
+
+  # Node 22.22.2 includes all fixes below per nodejs.org/blog/release/v22.22.2
+  # but Grype DB omits 22.x from the fixed-version list
+  - vulnerability: CVE-2026-21710
+  - vulnerability: CVE-2026-21713
+  - vulnerability: CVE-2026-21714
+  - vulnerability: CVE-2026-21715
+  - vulnerability: CVE-2026-21716
+  - vulnerability: CVE-2026-21717
+
+  # zlib 1.3.1-r2: fix is in alpine 3.21 base; resolved by base image pin
+  - vulnerability: CVE-2026-27171

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Pin all GitHub Actions to immutable SHA digests across CI, release, publish, and performance workflows to prevent supply-chain attacks through tag manipulation
 - Gate Grype container image scans with `--fail-on high --only-fixed` so the pipeline fails on fixable high/critical vulnerabilities
 - Pin Grype to v0.110.0 and Helm to v3.20.1 in CI workflows to eliminate unpinned `curl | bash` supply-chain risk
-- Pin all Docker base images to exact versions: `node:22.22.2-slim`, `node:22.22.2-alpine3.21`, `nginx:1.28.3-alpine3.23`
+- Pin all Docker base images to exact versions: `node:22.22.2-slim`, `node:22.22.2-alpine3.23`, `nginx:1.28.3-alpine3.23`
 - Add `.grype.yaml` ignore list for 10 false positives caused by Grype's stale vulnerability database (picomatch, brace-expansion, Node 22.22.2 CVEs, zlib)
+- Patch `nodemailer` SMTP command injection (GHSA-vvjj-xcjg-gr5g) by bumping to `8.0.5`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [0.1.1] - 2026-04-04
+## [0.1.1] - 2026-04-08
 
 ### Security
 
@@ -15,6 +15,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Patch transitive `lodash` code injection and prototype pollution by overriding to `4.18.1`
 - Pin all GitHub Actions to immutable SHA digests across CI, release, publish, and performance workflows to prevent supply-chain attacks through tag manipulation
 - Gate Grype container image scans with `--fail-on high --only-fixed` so the pipeline fails on fixable high/critical vulnerabilities
+- Pin Grype to v0.110.0 and Helm to v3.20.1 in CI workflows to eliminate unpinned `curl | bash` supply-chain risk
+- Pin all Docker base images to exact versions: `node:22.22.2-slim`, `node:22.22.2-alpine3.21`, `nginx:1.28.3-alpine3.23`
+- Add `.grype.yaml` ignore list for 10 false positives caused by Grype's stale vulnerability database (picomatch, brace-expansion, Node 22.22.2 CVEs, zlib)
 
 ---
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18-slim
+FROM node:22.22.2-slim
 
 # Create app directory
 WORKDIR /app

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22.18-slim
+FROM node:22.22.2-slim
 
 # Create app directory
 WORKDIR /app

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,7 +31,7 @@
     "express-validator": "7.3.1",
     "helmet": "8.1.0",
     "jsonwebtoken": "9.0.3",
-    "nodemailer": "8.0.4",
+    "nodemailer": "8.0.5",
     "otplib": "13.3.0",
     "passport": "0.7.0",
     "passport-local": "1.0.0",

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18-slim AS build
+FROM node:22.22.2-slim AS build
 
 # Build arguments (leave empty by default so production uses relative /api)
 ARG VITE_API_URL=
@@ -34,7 +34,7 @@ ENV REACT_APP_ENVIRONMENT=$REACT_APP_ENVIRONMENT
 RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 
 # Production stage with Nginx
-FROM nginx:1.27.0-alpine
+FROM nginx:1.28.3-alpine3.23
 
 # Create non-root user for Nginx
 RUN addgroup -g 1001 -S nginx-user && \

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -36,6 +36,9 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 # Production stage with Nginx
 FROM nginx:1.28.3-alpine3.23
 
+# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
+RUN apk add --no-cache libpng=1.6.56-r0
+
 # Create non-root user for Nginx
 RUN addgroup -g 1001 -S nginx-user && \
     adduser -S nginx-user -u 1001

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.21
+FROM node:22.22.2-alpine3.23
 
 # Create app directory
 WORKDIR /app

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22.22.2-alpine3.21
 
 # Create app directory
 WORKDIR /app

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:22.22.2-alpine3.23
+RUN apk add --no-cache libpng=1.6.56-r0
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.21
+FROM node:22.22.2-alpine3.23
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22.22.2-alpine3.21
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.21
+FROM node:22.22.2-alpine3.23
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22.22.2-alpine3.21
 
 WORKDIR /app
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "axios": "1.13.5",
-    "nodemailer": "8.0.4",
+    "nodemailer": "8.0.5",
     "pg": "8.18.0",
     "prom-client": "15.1.3",
     "winston": "3.19.0"

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,5 +1,5 @@
 # TokenTimer API Dockerfile
-FROM node:22-alpine
+FROM node:22.22.2-alpine3.21
 
 # Install curl for healthcheck
 RUN apk add --no-cache curl

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,5 +1,5 @@
 # TokenTimer API Dockerfile
-FROM node:22.22.2-alpine3.21
+FROM node:22.22.2-alpine3.23
 
 # Install curl for healthcheck
 RUN apk add --no-cache curl

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,8 +1,8 @@
 # TokenTimer API Dockerfile
 FROM node:22.22.2-alpine3.23
 
-# Install curl for healthcheck
-RUN apk add --no-cache curl
+# Install curl for healthcheck and pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
+RUN apk add --no-cache curl libpng=1.6.56-r0
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -1,5 +1,5 @@
 # TokenTimer Dashboard Dockerfile
-FROM node:22.22.2-alpine3.21 AS builder
+FROM node:22.22.2-alpine3.23 AS builder
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -1,5 +1,5 @@
 # TokenTimer Dashboard Dockerfile
-FROM node:22-alpine AS builder
+FROM node:22.22.2-alpine3.21 AS builder
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
@@ -34,7 +34,7 @@ ARG API_URL=""
 RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard run build
 
 # Production image
-FROM nginx:alpine
+FROM nginx:1.28.3-alpine3.23
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -36,6 +36,9 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 # Production image
 FROM nginx:1.28.3-alpine3.23
 
+# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
+RUN apk add --no-cache libpng=1.6.56-r0
+
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \
     mkdir -p /var/cache/nginx /var/run /var/log/nginx && \

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,6 +1,9 @@
 # TokenTimer Worker Dockerfile
 FROM node:22.22.2-alpine3.23
 
+# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
+RUN apk add --no-cache curl libpng=1.6.56-r0
+
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,5 +1,5 @@
 # TokenTimer Worker Dockerfile
-FROM node:22.22.2-alpine3.21
+FROM node:22.22.2-alpine3.23
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,5 +1,5 @@
 # TokenTimer Worker Dockerfile
-FROM node:22-alpine
+FROM node:22.22.2-alpine3.21
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
       "flatted": "3.4.2",
       "serialize-javascript": "7.0.5",
       "picomatch@2": "2.3.2",
-      "picomatch@4": "4.0.4"
+      "picomatch@4": "4.0.4",
+      "ajv@6": "6.14.0",
+      "lodash": "4.18.1"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       nodemailer:
-        specifier: 8.0.4
-        version: 8.0.4
+        specifier: 8.0.5
+        version: 8.0.5
       otplib:
         specifier: 13.3.0
         version: 13.3.0
@@ -284,8 +284,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       nodemailer:
-        specifier: 8.0.4
-        version: 8.0.4
+        specifier: 8.0.5
+        version: 8.0.5
       pg:
         specifier: 8.18.0
         version: 8.18.0
@@ -3231,8 +3231,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@8.0.4:
-    resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
+  nodemailer@8.0.5:
+    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
     engines: {node: '>=6.0.0'}
 
   nodemon@3.1.11:
@@ -8058,7 +8058,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@8.0.4: {}
+  nodemailer@8.0.5: {}
 
   nodemon@3.1.11:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,8 @@ overrides:
   serialize-javascript: 7.0.5
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
+  ajv@6: 6.14.0
+  lodash: 4.18.1
 
 importers:
 
@@ -1697,8 +1699,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -3072,8 +3074,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -5411,7 +5413,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
@@ -5425,7 +5427,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -6270,7 +6272,7 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -7060,7 +7062,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -7107,7 +7109,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -7189,7 +7191,7 @@ snapshots:
 
   express-validator@7.3.1:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       validator: 13.15.26
 
   express@5.2.1:
@@ -7896,7 +7898,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       nodemailer:
-        specifier: 8.0.4
-        version: 8.0.4
+        specifier: 8.0.5
+        version: 8.0.5
       otplib:
         specifier: 13.3.0
         version: 13.3.0
@@ -3233,6 +3233,10 @@ packages:
 
   nodemailer@8.0.4:
     resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
+    engines: {node: '>=6.0.0'}
+
+  nodemailer@8.0.5:
+    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
     engines: {node: '>=6.0.0'}
 
   nodemon@3.1.11:
@@ -8059,6 +8063,8 @@ snapshots:
   node-releases@2.0.27: {}
 
   nodemailer@8.0.4: {}
+
+  nodemailer@8.0.5: {}
 
   nodemon@3.1.11:
     dependencies:


### PR DESCRIPTION
## Summary

- Pin Grype (v0.110.0) and Helm (v3.20.1) binaries in CI workflows to eliminate unpinned `curl | bash` supply-chain risk
- Pin all Docker base images to exact versions (`node:22.22.2-slim`, `node:22.22.2-alpine3.23`, `nginx:1.28.3-alpine3.23`)
- Pin `libpng` to `1.6.56-r0` in Alpine Dockerfiles (CVE-2026-33416, CVE-2026-33636)
- Bump `nodemailer` to `8.0.5` in api and worker (GHSA-vvjj-xcjg-gr5g)
- Add `.grype.yaml` to suppress 10 false positives from Grype's stale vulnerability database