### PR TITLE
Dependency hardening, Grype v0.111.0, Alpine image refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
       # --- Grype (Trivy replacement) ---
       - name: Install Grype
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.110.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.111.0
           grype version
 
       - name: Scan API image with Grype

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+## [0.1.2] - 2026-04-14
+
+### Security
+
+- Bump direct **axios** dependencies to **1.15.0** and add a root **pnpm** override so **follow-redirects** resolves to **1.16.0** (regenerated lockfile).
+- Bump Grype in CI to [v0.111.0](https://github.com/anchore/grype/releases/tag/v0.111.0) (same pinned `install.sh` pattern as before).
+- On Alpine-based production and dev Docker stages, run `apk update && apk upgrade --no-cache` so `libcrypto3`, `libssl3`, and `musl` pick up fixes from the current Alpine 3.23 package index (keeps Grype `--fail-on high --only-fixed` passing when base image layers lag mirrors).
+
+### Changed
+
+- Remove explicit **libpng** `apk` installs from Alpine-based Dockerfiles; rely on official **nginx** and **node** Alpine images instead of brittle version pins.
+
 ## [0.1.1] - 2026-04-08
 
 ### Security
@@ -133,5 +147,6 @@ tokentimer-cloud SaaS codebase into a standalone, variant-agnostic repository.
 
 ---
 
+[0.1.2]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/tokentimerch/tokentimer-core/releases/tag/v0.1.0

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-iam": "3.990.0",
     "@aws-sdk/client-secrets-manager": "3.990.0",
     "@aws-sdk/client-sts": "3.990.0",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "bcryptjs": "3.0.3",
     "connect-pg-simple": "10.0.0",
     "cookie-parser": "1.4.7",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -36,6 +36,9 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 # Production stage with Nginx
 FROM nginx:1.28.3-alpine3.23
 
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
+
 # Create non-root user for Nginx
 RUN addgroup -g 1001 -S nginx-user && \
     adduser -S nginx-user -u 1001

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -36,9 +36,6 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 # Production stage with Nginx
 FROM nginx:1.28.3-alpine3.23
 
-# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
-RUN apk add --no-cache libpng=1.6.56-r0
-
 # Create non-root user for Nginx
 RUN addgroup -g 1001 -S nginx-user && \
     adduser -S nginx-user -u 1001

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:22.22.2-alpine3.23
 
+RUN apk update && apk upgrade --no-cache
+
 # Create app directory
 WORKDIR /app
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "2.10.9",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "framer-motion": "11.18.2",
     "js-yaml": "4.1.1",
     "lucide-react": "0.553.0",

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:22.22.2-alpine3.23
-RUN apk add --no-cache libpng=1.6.56-r0
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22.22.2-alpine3.23
 
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
+
 WORKDIR /app
 
 # Create non-root user

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:22.22.2-alpine3.23
 
+RUN apk update && apk upgrade --no-cache
+
 WORKDIR /app
 
 # Create non-root user

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "nodemailer": "8.0.5",
     "pg": "8.18.0",
     "prom-client": "15.1.3",

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,8 +1,8 @@
 # TokenTimer API Dockerfile
 FROM node:22.22.2-alpine3.23
 
-# Install curl for healthcheck and pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
-RUN apk add --no-cache curl libpng=1.6.56-r0
+# Install curl for healthcheck
+RUN apk add --no-cache curl
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,6 +1,9 @@
 # TokenTimer API Dockerfile
 FROM node:22.22.2-alpine3.23
 
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
+
 # Install curl for healthcheck
 RUN apk add --no-cache curl
 

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -36,9 +36,6 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 # Production image
 FROM nginx:1.28.3-alpine3.23
 
-# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
-RUN apk add --no-cache libpng=1.6.56-r0
-
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \
     mkdir -p /var/cache/nginx /var/run /var/log/nginx && \

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -1,6 +1,9 @@
 # TokenTimer Dashboard Dockerfile
 FROM node:22.22.2-alpine3.23 AS builder
 
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
+
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
@@ -35,6 +38,9 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 
 # Production image
 FROM nginx:1.28.3-alpine3.23
+
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,6 +1,9 @@
 # TokenTimer Worker Dockerfile
 FROM node:22.22.2-alpine3.23
 
+# Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
+RUN apk update && apk upgrade --no-cache
+
 # Install curl for optional probes / tooling
 RUN apk add --no-cache curl
 

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,8 +1,8 @@
 # TokenTimer Worker Dockerfile
 FROM node:22.22.2-alpine3.23
 
-# Pin libpng to patched version (CVE-2026-33416, CVE-2026-33636)
-RUN apk add --no-cache curl libpng=1.6.56-r0
+# Install curl for optional probes / tooling
+RUN apk add --no-cache curl
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
       "ajv@6": "6.14.0",
-      "lodash": "4.18.1"
+      "lodash": "4.18.1",
+      "follow-redirects": "1.16.0"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/config",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shared configuration for TokenTimer",
   "main": "src/index.js",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   picomatch@4: 4.0.4
   ajv@6: 6.14.0
   lodash: 4.18.1
+  follow-redirects: 1.16.0
 
 importers:
 
@@ -69,8 +70,8 @@ importers:
         specifier: 3.990.0
         version: 3.990.0
       axios:
-        specifier: 1.13.5
-        version: 1.13.5
+        specifier: 1.15.0
+        version: 1.15.0
       bcryptjs:
         specifier: 3.0.3
         version: 3.0.3
@@ -169,8 +170,8 @@ importers:
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       axios:
-        specifier: 1.13.5
-        version: 1.13.5
+        specifier: 1.15.0
+        version: 1.15.0
       framer-motion:
         specifier: 11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -281,8 +282,8 @@ importers:
   apps/worker:
     dependencies:
       axios:
-        specifier: 1.13.5
-        version: 1.13.5
+        specifier: 1.15.0
+        version: 1.15.0
       nodemailer:
         specifier: 8.0.5
         version: 8.0.5
@@ -1813,8 +1814,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2510,8 +2511,8 @@ packages:
     resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3503,8 +3504,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
@@ -6402,11 +6404,11 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.13.5:
+  axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -7321,7 +7323,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -8322,7 +8324,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pstree.remy@1.1.8: {}
 


### PR DESCRIPTION
## Summary

Ships **v0.1.2** with dependency and container-hardening updates documented in `CHANGELOG.md`.

### Highlights

- **axios 1.15.0** and **pnpm** override for **follow-redirects 1.16.0** (lockfile updated on branch).
- **Grype** in CI bumped to **[v0.111.0](https://github.com/anchore/grype/releases/tag/v0.111.0)**.
- **Alpine** production and dev stages: `apk update && apk upgrade --no-cache` so base packages (e.g. openssl, musl) match current **Alpine 3.23** indexes and Grype `--fail-on high --only-fixed` stays green.
- **Docker:** removed redundant **libpng** `apk` installs; rely on official **node** / **nginx** Alpine bases.

### Versioning

- Monorepo and app package `version` fields set to **0.1.2** for this release.

### Checklist

- [ ] CI / merge checks green
- [ ] After merge, tag **`v0.1.2`** and run release workflow if applicable