### PR TITLE
Release v0.1.3: invalidate sessions on password change, reset, and 2FA toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-18
+
+### Security
+
+- **Session invalidation on password change.** `POST /api/account/change-password` now deletes every other session for the acting user from the `connect-pg-simple` `session` table and rotates the acting session id via `req.session.regenerate` + `req.login`, so other browsers and devices are logged out immediately. Mitigates OWASP **ASVS 3.3.1** and the attacker-persistence-after-password-change scenario.
+- **Session invalidation on password reset.** `POST /auth/reset-password` (token-based, unauthenticated) now deletes all sessions belonging to the reset user, so any live attacker session is revoked when the legitimate user completes a reset from an email link.
+- Revocation is transactional to the request but wrapped in a best-effort `try/catch` so a transient `session` store error cannot block the credential update itself; the audit entry (`PASSWORD_CHANGED` / `PASSWORD_RESET_COMPLETED`) is still emitted.
+
+### Added
+
+- Integration suite `tests/integration/auth-session-invalidation.integration.test.js` asserting: acting session survives, every other session row for the user is deleted, `Set-Cookie` is emitted (session rotation), old password is rejected, new password works, other users are unaffected, and reset flow wipes every session for the target account only.
+
+### Changed
+
+- Align contract and spec versions with the app version. The following files are bumped from **0.1.0** to **0.1.3** so consumers can pin on a single release:
+  - `contracts.manifest.json`
+  - `packages/contracts/openapi/openapi.yaml`
+  - `packages/contracts/api/auth-route-compat.contract.json`
+  - `packages/contracts/runtime-extensions/plugin-context.contract.json`
+  - `packages/contracts/runtime-extensions/plugin-context.example.json`
+
 ## [0.1.2] - 2026-04-14
 
 ### Security
@@ -147,6 +168,7 @@ tokentimer-cloud SaaS codebase into a standalone, variant-agnostic repository.
 
 ---
 
+[0.1.3]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/tokentimerch/tokentimer-core/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Session invalidation on password change.** `POST /api/account/change-password` now deletes every other session for the acting user from the `connect-pg-simple` `session` table and rotates the acting session id via `req.session.regenerate` + `req.login`, so other browsers and devices are logged out immediately. Mitigates OWASP **ASVS 3.3.1** and the attacker-persistence-after-password-change scenario.
 - **Session invalidation on password reset.** `POST /auth/reset-password` (token-based, unauthenticated) now deletes all sessions belonging to the reset user, so any live attacker session is revoked when the legitimate user completes a reset from an email link.
-- Revocation is transactional to the request but wrapped in a best-effort `try/catch` so a transient `session` store error cannot block the credential update itself; the audit entry (`PASSWORD_CHANGED` / `PASSWORD_RESET_COMPLETED`) is still emitted.
+- **Session invalidation on 2FA enable.** `POST /api/account/2fa/enable` now deletes every other session for the acting user and rotates the acting session id. A concurrent session that pre-dates the 2FA enrollment no longer skips the new second factor.
+- **Session invalidation on 2FA disable.** `POST /api/account/2fa/disable` (password-gated) now deletes every other session for the acting user and rotates the acting session id, so a 2FA downgrade cannot silently leave other devices authenticated.
+- Revocation is transactional to the request but wrapped in a best-effort `try/catch` so a transient `session` store error cannot block the credential or 2FA update itself; the audit entry (`PASSWORD_CHANGED`, `PASSWORD_RESET_COMPLETED`, `TWO_FACTOR_ENABLED`, `TWO_FACTOR_DISABLED`) is still emitted.
 
 ### Added
 
-- Integration suite `tests/integration/auth-session-invalidation.integration.test.js` asserting: acting session survives, every other session row for the user is deleted, `Set-Cookie` is emitted (session rotation), old password is rejected, new password works, other users are unaffected, and reset flow wipes every session for the target account only.
+- Integration suite `tests/integration/auth-session-invalidation.integration.test.js` asserting, for every covered flow: acting session survives, every other session row for the user is deleted, `Set-Cookie` is emitted (session rotation), old credentials are rejected, new credentials work, other users are unaffected, and `reset-password` wipes every session for the target account only. New describe blocks cover `POST /api/account/2fa/enable` and `POST /api/account/2fa/disable`, driving real TOTP tokens through `otplib` against the live `/api/account/2fa/setup` + `/auth/verify-2fa` endpoints.
 
 ### Changed
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -679,6 +679,23 @@ router.post(
       );
 
       delete req.session.setup2FA;
+
+      const currentSid = req.sessionID;
+      const actingUser = req.user;
+      try {
+        await pool.query(
+          `DELETE FROM session
+             WHERE sid <> $1
+               AND (sess #>> '{passport,user}') = $2`,
+          [currentSid, String(req.user.id)],
+        );
+      } catch (revokeErr) {
+        logger.error("Failed to revoke other sessions on 2FA enable", {
+          userId: req.user.id,
+          error: revokeErr.message,
+        });
+      }
+
       try {
         await writeAudit({
           actorUserId: req.user.id,
@@ -695,7 +712,30 @@ router.post(
           error: _err.message,
         });
       }
-      res.json({ message: "Two-factor authentication enabled" });
+
+      return req.session.regenerate((regenErr) => {
+        if (regenErr) {
+          logger.error("Session regenerate failed after 2FA enable", {
+            userId: actingUser.id,
+            error: regenErr.message,
+          });
+          return res
+            .status(500)
+            .json({ error: "Failed to rotate session after 2FA enable" });
+        }
+        req.login(actingUser, (loginErr) => {
+          if (loginErr) {
+            logger.error("Re-login after 2FA enable failed", {
+              userId: actingUser.id,
+              error: loginErr.message,
+            });
+            return res.status(500).json({
+              error: "Failed to re-establish session after 2FA enable",
+            });
+          }
+          return res.json({ message: "Two-factor authentication enabled" });
+        });
+      });
     } catch (error) {
       logger.error("2FA enable error:", {
         error: error.message,
@@ -728,6 +768,23 @@ router.post(
         "UPDATE users SET two_factor_enabled = FALSE, two_factor_secret = NULL, updated_at = NOW() WHERE id = $1",
         [req.user.id],
       );
+
+      const currentSid = req.sessionID;
+      const actingUser = req.user;
+      try {
+        await pool.query(
+          `DELETE FROM session
+             WHERE sid <> $1
+               AND (sess #>> '{passport,user}') = $2`,
+          [currentSid, String(req.user.id)],
+        );
+      } catch (revokeErr) {
+        logger.error("Failed to revoke other sessions on 2FA disable", {
+          userId: req.user.id,
+          error: revokeErr.message,
+        });
+      }
+
       try {
         await writeAudit({
           actorUserId: req.user.id,
@@ -744,7 +801,30 @@ router.post(
           error: _err.message,
         });
       }
-      res.json({ message: "Two-factor authentication disabled" });
+
+      return req.session.regenerate((regenErr) => {
+        if (regenErr) {
+          logger.error("Session regenerate failed after 2FA disable", {
+            userId: actingUser.id,
+            error: regenErr.message,
+          });
+          return res
+            .status(500)
+            .json({ error: "Failed to rotate session after 2FA disable" });
+        }
+        req.login(actingUser, (loginErr) => {
+          if (loginErr) {
+            logger.error("Re-login after 2FA disable failed", {
+              userId: actingUser.id,
+              error: loginErr.message,
+            });
+            return res.status(500).json({
+              error: "Failed to re-establish session after 2FA disable",
+            });
+          }
+          return res.json({ message: "Two-factor authentication disabled" });
+        });
+      });
     } catch (error) {
       logger.error("2FA disable error:", {
         error: error.message,

--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -1112,6 +1112,21 @@ router.post(
       // Update password and clear reset token
       await User.resetPassword(token, passwordHash);
 
+      // Revoke every session for this user so any attacker with a live
+      // session is kicked and only the new password lets them back in.
+      try {
+        await pool.query(
+          `DELETE FROM session
+             WHERE (sess #>> '{passport,user}') = $1`,
+          [String(user.id)],
+        );
+      } catch (revokeErr) {
+        logger.error("Failed to revoke sessions on password reset", {
+          userId: user.id,
+          error: revokeErr.message,
+        });
+      }
+
       res.json({
         message:
           "Password reset successfully! You can now log in with your new password.",
@@ -1193,6 +1208,24 @@ router.post(
         [req.user.id, newHash],
       );
 
+      // Revoke every session for this user except the one performing the change.
+      // This logs out any other browser/device so the new password is required there.
+      const currentSid = req.sessionID;
+      const actingUser = req.user;
+      try {
+        await pool.query(
+          `DELETE FROM session
+             WHERE sid <> $1
+               AND (sess #>> '{passport,user}') = $2`,
+          [currentSid, String(req.user.id)],
+        );
+      } catch (revokeErr) {
+        logger.error("Failed to revoke other sessions on password change", {
+          userId: req.user.id,
+          error: revokeErr.message,
+        });
+      }
+
       try {
         await writeAudit({
           actorUserId: req.user.id,
@@ -1210,7 +1243,30 @@ router.post(
         });
       }
 
-      res.json({ message: "Password changed successfully" });
+      // Rotate the session id for the acting session (defense in depth).
+      return req.session.regenerate((regenErr) => {
+        if (regenErr) {
+          logger.error("Session regenerate failed after password change", {
+            userId: actingUser.id,
+            error: regenErr.message,
+          });
+          return res
+            .status(500)
+            .json({ error: "Failed to rotate session after password change" });
+        }
+        req.login(actingUser, (loginErr) => {
+          if (loginErr) {
+            logger.error("Re-login after password change failed", {
+              userId: actingUser.id,
+              error: loginErr.message,
+            });
+            return res.status(500).json({
+              error: "Failed to re-establish session after password change",
+            });
+          }
+          return res.json({ message: "Password changed successfully" });
+        });
+      });
     } catch (error) {
       logger.error("Change password error:", {
         error: error.message,

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "namespaces": [
     {
       "name": "queue",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/config",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared configuration for TokenTimer",
   "main": "src/index.js",
   "type": "module",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.1.0
+  version: 0.1.3
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/auth-session-invalidation.integration.test.js
+++ b/tests/integration/auth-session-invalidation.integration.test.js
@@ -1,0 +1,227 @@
+const crypto = require("crypto");
+const { TestUtils, request, expect } = require("./setup");
+
+// These tests guard the fix for the "password change does not invalidate other
+// sessions" vulnerability. See apps/api/routes/auth.js change-password and
+// reset-password handlers.
+
+describe("Auth session invalidation on credential change", () => {
+  const countSessionsForUser = async (userId) => {
+    const res = await TestUtils.execQuery(
+      `SELECT sid
+         FROM session
+        WHERE (sess #>> '{passport,user}') = $1`,
+      [String(userId)],
+    );
+    return { count: res.rowCount, rows: res.rows };
+  };
+
+  const loginAgent = async (email, password) => {
+    const agent = await TestUtils.newAgent();
+    await agent
+      .post("/auth/login")
+      .send({ email, password })
+      .expect(200);
+    return agent;
+  };
+
+  describe("POST /api/account/change-password", () => {
+    it("keeps the acting session and destroys other sessions for the same user", async () => {
+      const email = TestUtils.generateTestEmail("pwchange-sessions");
+      const oldPassword = "OldValidPass123!@#";
+      const newPassword = "NewValidPass456!@#";
+      const user = await TestUtils.createVerifiedTestUser(email, oldPassword);
+
+      const browserA = await loginAgent(email, oldPassword);
+      const browserB = await loginAgent(email, oldPassword);
+
+      const aBefore = await browserA.get("/api/session").expect(200);
+      const bBefore = await browserB.get("/api/session").expect(200);
+      expect(aBefore.body.loggedIn).to.equal(true);
+      expect(bBefore.body.loggedIn).to.equal(true);
+
+      const before = await countSessionsForUser(user.id);
+      expect(before.count).to.be.at.least(2);
+
+      await browserA
+        .post("/api/account/change-password")
+        .send({ currentPassword: oldPassword, newPassword })
+        .expect(200);
+
+      const aAfter = await browserA.get("/api/session").expect(200);
+      expect(aAfter.body.loggedIn).to.equal(true);
+      expect(aAfter.body.user).to.have.property("email", email);
+
+      const bAfter = await browserB.get("/api/session").expect(200);
+      expect(bAfter.body.loggedIn).to.equal(false);
+
+      const after = await countSessionsForUser(user.id);
+      expect(after.count).to.equal(1);
+    });
+
+    it("rotates the session id for the acting browser after password change", async () => {
+      const email = TestUtils.generateTestEmail("pwchange-rotate");
+      const oldPassword = "OldValidPass123!@#";
+      const newPassword = "NewValidPass456!@#";
+      await TestUtils.createVerifiedTestUser(email, oldPassword);
+
+      const agent = await TestUtils.newAgent();
+      const loginRes = await agent
+        .post("/auth/login")
+        .send({ email, password: oldPassword })
+        .expect(200);
+
+      const cookiesBefore = loginRes.headers["set-cookie"] || [];
+      expect(cookiesBefore.length).to.be.at.least(1);
+
+      const changeRes = await agent
+        .post("/api/account/change-password")
+        .send({ currentPassword: oldPassword, newPassword })
+        .expect(200);
+
+      const cookiesAfter = changeRes.headers["set-cookie"] || [];
+      expect(
+        cookiesAfter.length,
+        "change-password should emit a Set-Cookie for the rotated session",
+      ).to.be.at.least(1);
+    });
+
+    it("allows login with the new password and rejects the old password", async () => {
+      const email = TestUtils.generateTestEmail("pwchange-reauth");
+      const oldPassword = "OldValidPass123!@#";
+      const newPassword = "NewValidPass456!@#";
+      await TestUtils.createVerifiedTestUser(email, oldPassword);
+
+      const agent = await TestUtils.newAgent();
+      await agent
+        .post("/auth/login")
+        .send({ email, password: oldPassword })
+        .expect(200);
+
+      await agent
+        .post("/api/account/change-password")
+        .send({ currentPassword: oldPassword, newPassword })
+        .expect(200);
+
+      await request("http://localhost:4000")
+        .post("/auth/login")
+        .send({ email, password: oldPassword })
+        .expect(401);
+
+      await request("http://localhost:4000")
+        .post("/auth/login")
+        .send({ email, password: newPassword })
+        .expect(200);
+    });
+
+    it("does not affect sessions of other unrelated users", async () => {
+      const ownerEmail = TestUtils.generateTestEmail("pwchange-owner");
+      const otherEmail = TestUtils.generateTestEmail("pwchange-other");
+      const password = "ValidPass123!@#";
+      const newPassword = "UpdatedPass456!@#";
+
+      const owner = await TestUtils.createVerifiedTestUser(ownerEmail, password);
+      const other = await TestUtils.createVerifiedTestUser(otherEmail, password);
+
+      const ownerAgent = await loginAgent(ownerEmail, password);
+      const otherAgent = await loginAgent(otherEmail, password);
+
+      await ownerAgent
+        .post("/api/account/change-password")
+        .send({ currentPassword: password, newPassword })
+        .expect(200);
+
+      const otherSessionAfter = await otherAgent.get("/api/session").expect(200);
+      expect(otherSessionAfter.body.loggedIn).to.equal(true);
+      expect(otherSessionAfter.body.user).to.have.property("email", otherEmail);
+
+      const remainingOwner = await countSessionsForUser(owner.id);
+      const remainingOther = await countSessionsForUser(other.id);
+      expect(remainingOwner.count).to.equal(1);
+      expect(remainingOther.count).to.be.at.least(1);
+    });
+  });
+
+  describe("POST /auth/reset-password", () => {
+    it("revokes every session for the user whose password was reset", async () => {
+      const email = TestUtils.generateTestEmail("pwreset-sessions");
+      const oldPassword = "OldValidPass123!@#";
+      const newPassword = "NewValidPass456!@#";
+      const user = await TestUtils.createVerifiedTestUser(email, oldPassword);
+
+      const browserA = await loginAgent(email, oldPassword);
+      const browserB = await loginAgent(email, oldPassword);
+
+      const before = await countSessionsForUser(user.id);
+      expect(before.count).to.be.at.least(2);
+
+      const resetToken = crypto.randomBytes(24).toString("hex");
+      await TestUtils.execQuery(
+        `UPDATE users
+            SET reset_token = $2,
+                reset_token_expires = NOW() + INTERVAL '5 minutes'
+          WHERE LOWER(email) = LOWER($1)`,
+        [email, resetToken],
+      );
+
+      await request("http://localhost:4000")
+        .post("/auth/reset-password")
+        .send({ token: resetToken, newPassword })
+        .expect(200);
+
+      const after = await countSessionsForUser(user.id);
+      expect(after.count).to.equal(0);
+
+      const aAfter = await browserA.get("/api/session").expect(200);
+      const bAfter = await browserB.get("/api/session").expect(200);
+      expect(aAfter.body.loggedIn).to.equal(false);
+      expect(bAfter.body.loggedIn).to.equal(false);
+
+      await request("http://localhost:4000")
+        .post("/auth/login")
+        .send({ email, password: newPassword })
+        .expect(200);
+    });
+
+    it("does not revoke sessions of other users when resetting one account", async () => {
+      const victimEmail = TestUtils.generateTestEmail("pwreset-victim");
+      const bystanderEmail = TestUtils.generateTestEmail("pwreset-bystander");
+      const password = "ValidPass123!@#";
+      const newPassword = "UpdatedPass456!@#";
+
+      await TestUtils.createVerifiedTestUser(victimEmail, password);
+      const bystander = await TestUtils.createVerifiedTestUser(
+        bystanderEmail,
+        password,
+      );
+
+      const bystanderAgent = await loginAgent(bystanderEmail, password);
+
+      const resetToken = crypto.randomBytes(24).toString("hex");
+      await TestUtils.execQuery(
+        `UPDATE users
+            SET reset_token = $2,
+                reset_token_expires = NOW() + INTERVAL '5 minutes'
+          WHERE LOWER(email) = LOWER($1)`,
+        [victimEmail, resetToken],
+      );
+
+      await request("http://localhost:4000")
+        .post("/auth/reset-password")
+        .send({ token: resetToken, newPassword })
+        .expect(200);
+
+      const bystanderStatus = await bystanderAgent
+        .get("/api/session")
+        .expect(200);
+      expect(bystanderStatus.body.loggedIn).to.equal(true);
+      expect(bystanderStatus.body.user).to.have.property(
+        "email",
+        bystanderEmail,
+      );
+
+      const remaining = await countSessionsForUser(bystander.id);
+      expect(remaining.count).to.be.at.least(1);
+    });
+  });
+});

--- a/tests/integration/auth-session-invalidation.integration.test.js
+++ b/tests/integration/auth-session-invalidation.integration.test.js
@@ -1,9 +1,33 @@
 const crypto = require("crypto");
+const _otplib = require("otplib");
 const { TestUtils, request, expect } = require("./setup");
 
-// These tests guard the fix for the "password change does not invalidate other
-// sessions" vulnerability. See apps/api/routes/auth.js change-password and
-// reset-password handlers.
+// The repo ships a custom otplib build (top-level generateSync/verify that take
+// { secret } and { token, secret }). Match the production route's usage rather
+// than assuming the public otplib API.
+const totpGenerate = (secret) => {
+  const gen =
+    _otplib.generateSync ||
+    _otplib.generate ||
+    _otplib.authenticator?.generate ||
+    _otplib.default?.authenticator?.generate;
+  if (typeof gen !== "function") {
+    throw new Error("No usable otplib generate function in test runtime");
+  }
+  const result = gen({ secret });
+  const token =
+    typeof result === "string" ? result : result?.token || result?.otp;
+  if (!token) {
+    throw new Error(
+      `otplib generate returned empty token (got ${JSON.stringify(result)})`,
+    );
+  }
+  return token;
+};
+
+// These tests guard the fix for the "credential or 2FA change does not
+// invalidate other sessions" vulnerability. Covers apps/api/routes/auth.js
+// change-password, reset-password, 2fa/enable and 2fa/disable handlers.
 
 describe("Auth session invalidation on credential change", () => {
   const countSessionsForUser = async (userId) => {
@@ -22,6 +46,21 @@ describe("Auth session invalidation on credential change", () => {
       .post("/auth/login")
       .send({ email, password })
       .expect(200);
+    return agent;
+  };
+
+  const loginAgentWith2FA = async (email, password, secret) => {
+    const agent = await TestUtils.newAgent();
+    const loginRes = await agent
+      .post("/auth/login")
+      .send({ email, password })
+      .expect(200);
+    if (loginRes.body && loginRes.body.requires2FA) {
+      await agent
+        .post("/auth/verify-2fa")
+        .send({ token: totpGenerate(secret) })
+        .expect(200);
+    }
     return agent;
   };
 
@@ -222,6 +261,120 @@ describe("Auth session invalidation on credential change", () => {
 
       const remaining = await countSessionsForUser(bystander.id);
       expect(remaining.count).to.be.at.least(1);
+    });
+  });
+
+  describe("POST /api/account/2fa/enable", () => {
+    it("keeps the acting session and destroys other sessions when enabling 2FA", async () => {
+      const email = TestUtils.generateTestEmail("2fa-enable-sessions");
+      const password = "ValidPass123!@#";
+      const user = await TestUtils.createVerifiedTestUser(email, password);
+
+      const browserA = await loginAgent(email, password);
+      const browserB = await loginAgent(email, password);
+
+      const before = await countSessionsForUser(user.id);
+      expect(before.count).to.be.at.least(2);
+
+      const setupRes = await browserA
+        .post("/api/account/2fa/setup")
+        .expect(200);
+      const secret = setupRes.body.secret;
+      expect(secret, "2FA setup should return a secret").to.be.a("string");
+
+      const token = totpGenerate(secret);
+      await browserA
+        .post("/api/account/2fa/enable")
+        .send({ token })
+        .expect(200);
+
+      const aAfter = await browserA.get("/api/session").expect(200);
+      expect(aAfter.body.loggedIn).to.equal(true);
+      expect(aAfter.body.user).to.have.property("email", email);
+
+      const bAfter = await browserB.get("/api/session").expect(200);
+      expect(bAfter.body.loggedIn).to.equal(false);
+
+      const after = await countSessionsForUser(user.id);
+      expect(after.count).to.equal(1);
+    });
+
+    it("does not affect sessions of other unrelated users", async () => {
+      const ownerEmail = TestUtils.generateTestEmail("2fa-enable-owner");
+      const otherEmail = TestUtils.generateTestEmail("2fa-enable-other");
+      const password = "ValidPass123!@#";
+
+      await TestUtils.createVerifiedTestUser(ownerEmail, password);
+      const other = await TestUtils.createVerifiedTestUser(
+        otherEmail,
+        password,
+      );
+
+      const ownerAgent = await loginAgent(ownerEmail, password);
+      const otherAgent = await loginAgent(otherEmail, password);
+
+      const setupRes = await ownerAgent
+        .post("/api/account/2fa/setup")
+        .expect(200);
+      const token = totpGenerate(setupRes.body.secret);
+      await ownerAgent
+        .post("/api/account/2fa/enable")
+        .send({ token })
+        .expect(200);
+
+      const otherSessionAfter = await otherAgent
+        .get("/api/session")
+        .expect(200);
+      expect(otherSessionAfter.body.loggedIn).to.equal(true);
+      expect(otherSessionAfter.body.user).to.have.property(
+        "email",
+        otherEmail,
+      );
+
+      const remainingOther = await countSessionsForUser(other.id);
+      expect(remainingOther.count).to.be.at.least(1);
+    });
+  });
+
+  describe("POST /api/account/2fa/disable", () => {
+    it("keeps the acting session and destroys other sessions when disabling 2FA", async () => {
+      const email = TestUtils.generateTestEmail("2fa-disable-sessions");
+      const password = "ValidPass123!@#";
+      const user = await TestUtils.createVerifiedTestUser(email, password);
+
+      const browserA = await loginAgent(email, password);
+
+      const setupRes = await browserA
+        .post("/api/account/2fa/setup")
+        .expect(200);
+      await browserA
+        .post("/api/account/2fa/enable")
+        .send({ token: totpGenerate(setupRes.body.secret) })
+        .expect(200);
+
+      const browserB = await loginAgentWith2FA(
+        email,
+        password,
+        setupRes.body.secret,
+      );
+
+      const before = await countSessionsForUser(user.id);
+      expect(before.count).to.be.at.least(2);
+
+      await browserA
+        .post("/api/account/2fa/disable")
+        .send({ currentPassword: password })
+        .expect(200);
+
+      const aAfter = await browserA.get("/api/session").expect(200);
+      expect(aAfter.body.loggedIn).to.equal(true);
+      expect(aAfter.body.user).to.have.property("email", email);
+
+      const bAfter = await browserB.get("/api/session").expect(200);
+      expect(bAfter.body.loggedIn).to.equal(false);
+
+      const after = await countSessionsForUser(user.id);
+      expect(after.count).to.equal(1);
     });
   });
 });

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -3,6 +3,7 @@
 # Auth and account
 tests/integration/auth.test.js
 tests/integration/auth-invite-reset.integration.test.js
+tests/integration/auth-session-invalidation.integration.test.js
 tests/integration/account.test.js
 tests/integration/account-settings-display.test.js
 tests/integration/two-factor-disable.test.js


### PR DESCRIPTION
## Summary

Security release. Revokes concurrent sessions when a user rotates
credentials or toggles 2FA. Closes OWASP ASVS 3.3.1 (stolen session
cookie outliving the event that was supposed to revoke it).

## Fix

Same pattern in all four handlers: delete every other session for the
user from the `connect-pg-simple` `session` table, then rotate the
acting session id via `req.session.regenerate` + `req.login`. Wrapped
in a best-effort `try/catch` so a transient session-store error never
blocks the credential update; audit events always fire.

| Endpoint | Revokes | Acting session |
|---|---|---|
| `POST /api/account/change-password` | others | rotated |
| `POST /api/account/2fa/enable` | others | rotated |
| `POST /api/account/2fa/disable` | others | rotated |

## Tests

`tests/integration/auth-session-invalidation.integration.test.js`
covers all four handlers. The 2FA specs drive real TOTP via `otplib`
against `/api/account/2fa/setup` + `/auth/verify-2fa`.

## Release hygiene

- App version `0.1.2` -> `0.1.3` in root + every workspace `package.json`.
- Contract/OpenAPI specs `0.1.0` -> `0.1.3` so consumers can pin a single number.
- `CHANGELOG.md` updated.

## Verification

- `pnpm audit`: no advisories above moderate.
- `grype --fail-on high --only-fixed` on api/dashboard/worker images
  (`deploy/compose/Dockerfile.*`): **No vulnerabilities found**.

## Test plan

- [ ] CI green on `release/v0.1.3`.
- [ ] Manual: two browsers logged in, perform each of the four
      actions from browser A, confirm B is logged out.