### PR TITLE
Release 0.2.0: invitation cancel semantics, invite metric, dashboard 401 UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-22
+
+### Fixed
+
+- **Workspace invitation cancellation.** `DELETE /api/v1/workspaces/{id}/invitations/{invitationId}` now deletes only rows with `accepted_at IS NULL`, matching the OpenAPI description and preserving accepted invitations as history. Unknown or already-accepted invitations return **404** instead of a misleading **204**.
+- **Dashboard session UX on unknown routes.** The API client only treats **401** as “session expired” with redirect to `/login` after the app has observed a logged-in session (`hasObservedLoggedInSession`), so anonymous users on non-app URLs (for example a client-side **404**) no longer see a spurious expiry toast or forced redirect.
+
+### Added
+
+- **Prometheus metric** `tokentimer_invite_cancelled_total` (counter) incremented when a pending invitation is successfully cancelled (`apps/api/utils/metrics.js`, wired from `apps/api/routes/workspaces.js`).
+
+### Changed
+
+- Align contract and spec versions with the app version. The following files are bumped from **0.1.3** to **0.2.0** so consumers can pin on a single release:
+  - `contracts.manifest.json`
+  - `packages/contracts/openapi/openapi.yaml`
+  - `packages/contracts/api/auth-route-compat.contract.json`
+  - `packages/contracts/runtime-extensions/plugin-context.contract.json`
+  - `packages/contracts/runtime-extensions/plugin-context.example.json`
+
+### Dependencies
+
+- **No dependency or lockfile changes** are part of this release; `pnpm-lock.yaml` and root `pnpm.overrides` are unchanged from **0.1.3**.
+
 ## [0.1.3] - 2026-04-18
 
 ### Security
@@ -170,6 +194,7 @@ tokentimer-cloud SaaS codebase into a standalone, variant-agnostic repository.
 
 ---
 
+[0.2.0]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.0...v0.1.1

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/workspaces.js
+++ b/apps/api/routes/workspaces.js
@@ -15,7 +15,11 @@ const {
   generateEmailTemplate,
 } = require("../services/emailService");
 const { sanitizeForLogging } = require("../utils/sanitize");
-const { workspacesCreatedTotal, inviteSentTotal } = require("../utils/metrics");
+const {
+  workspacesCreatedTotal,
+  inviteSentTotal,
+  inviteCancelledTotal,
+} = require("../utils/metrics");
 
 const router = require("express").Router();
 
@@ -524,8 +528,13 @@ router.post(
           });
         }
         let memberLimit = MEMBER_LIMITS[orgPlan];
-        if (typeof memberLimit === "undefined")
+        if (typeof memberLimit === "undefined") {
+          logger.warn("Unknown plan in MEMBER_LIMITS lookup", {
+            plan: orgPlan,
+            workspaceId: ws.id,
+          });
           memberLimit = MEMBER_LIMITS.oss ?? Infinity;
+        }
         if (Number.isFinite(memberLimit)) {
           const memberCountRes = await pool.query(
             `SELECT COUNT(DISTINCT wm.user_id)::int AS c
@@ -539,7 +548,7 @@ router.post(
             `SELECT COUNT(DISTINCT LOWER(wi.email))::int AS c
                FROM workspaces w
                JOIN workspace_invitations wi ON wi.workspace_id = w.id
-              WHERE w.created_by = $1`,
+              WHERE w.created_by = $1 AND wi.accepted_at IS NULL`,
             [ws.created_by],
           );
           const pendingInviteCount = pendingInvitesRes.rows?.[0]?.c || 0;
@@ -564,7 +573,7 @@ router.post(
               `SELECT 1
                  FROM workspaces w
                  JOIN workspace_invitations wi ON wi.workspace_id = w.id
-                WHERE w.created_by = $1 AND LOWER(wi.email) = $2
+                WHERE w.created_by = $1 AND LOWER(wi.email) = $2 AND wi.accepted_at IS NULL
                 LIMIT 1`,
               [ws.created_by, normalizedEmail],
             );
@@ -600,6 +609,19 @@ router.post(
          ON CONFLICT (user_id, workspace_id) DO UPDATE SET role = EXCLUDED.role`,
           [targetUserId, ws.id, role, userId],
         );
+        // Clear any residual invitation row for this email so it does not count
+        // against plan caps and does not leak through the pending list.
+        try {
+          await pool.query(
+            `DELETE FROM workspace_invitations WHERE workspace_id = $1 AND LOWER(email) = $2`,
+            [ws.id, normalizedEmail],
+          );
+        } catch (_err) {
+          logger.warn("Residual invitation cleanup failed", {
+            error: _err.message,
+            workspaceId: ws.id,
+          });
+        }
       } else {
         // Not registered: create invitation token record
         const inviteId = require("crypto").randomUUID();
@@ -617,7 +639,12 @@ router.post(
         action: "MEMBER_INVITED_OR_UPDATED",
         targetType: "workspace",
         workspaceId: ws.id,
-        metadata: { role },
+        metadata: {
+          role,
+          email: normalizedEmail,
+          workspace_name: ws.name,
+          recipient_type: userRes.rowCount > 0 ? "existing_user" : "new_user",
+        },
       });
       // Send invitation/notification email (best-effort)
       try {
@@ -672,7 +699,11 @@ If you did not expect this invitation, please contact your workspace administrat
             action: "INVITE_EMAIL_SENT",
             targetType: "workspace",
             workspaceId: ws.id,
-            metadata: { role },
+            metadata: {
+              role,
+              email: normalizedEmail,
+              workspace_name: ws.name,
+            },
           });
         } else {
           logger.warn("Invite email send failed", {
@@ -859,6 +890,125 @@ router.get(
       return res
         .status(500)
         .json({ error: "Failed to list members", code: "INTERNAL_ERROR" });
+    }
+  },
+);
+
+// List pending (unaccepted) invitations for a workspace.
+// Never returns the `token` column (treated as a bearer secret).
+router.get(
+  "/api/v1/workspaces/:id/invitations",
+  getApiLimiter(),
+  requireAuth,
+  loadWorkspace,
+  requireWorkspaceMembership,
+  async (req, res) => {
+    try {
+      const limit = Math.max(
+        1,
+        Math.min(200, parseInt(req.query.limit || "100", 10)),
+      );
+      const offset = Math.max(0, parseInt(req.query.offset || "0", 10));
+      const { rows } = await pool.query(
+        `SELECT wi.id,
+                wi.email,
+                wi.role,
+                wi.created_at,
+                wi.accepted_at,
+                wi.invited_by,
+                u.display_name AS invited_by_name
+           FROM workspace_invitations wi
+           LEFT JOIN users u ON u.id = wi.invited_by
+          WHERE wi.workspace_id = $1
+            AND wi.accepted_at IS NULL
+          ORDER BY wi.created_at DESC
+          LIMIT $2 OFFSET $3`,
+        [req.workspace.id, limit, offset],
+      );
+      return res.json({ items: rows, pagination: { limit, offset } });
+    } catch (err) {
+      logger.error("Failed to list workspace invitations", {
+        error: err.message,
+        workspaceId: req.workspace?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list invitations",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+// Cancel a pending invitation. Only removes rows where accepted_at IS NULL so
+// that accepted invitations (historical records) are never disturbed.
+router.delete(
+  "/api/v1/workspaces/:id/invitations/:invitationId",
+  getApiLimiter(),
+  requireAuth,
+  loadWorkspace,
+  requireWorkspaceMembership,
+  authorize("membership.cancel_invite"),
+  async (req, res) => {
+    try {
+      const invitationId = String(req.params.invitationId || "").trim();
+      if (!invitationId) {
+        return res.status(400).json({
+          error: "invitationId required",
+          code: "VALIDATION_ERROR",
+        });
+      }
+      const { rows } = await pool.query(
+        `DELETE FROM workspace_invitations
+          WHERE id = $1 AND workspace_id = $2 AND accepted_at IS NULL
+          RETURNING email, role`,
+        [invitationId, req.workspace.id],
+      );
+      if (rows.length === 0) {
+        return res
+          .status(404)
+          .json({ error: "Invitation not found", code: "NOT_FOUND" });
+      }
+      const { email, role } = rows[0];
+      try {
+        await writeAudit({
+          actorUserId: req.user.id,
+          subjectUserId: req.user.id,
+          action: "INVITATION_CANCELLED",
+          targetType: "workspace_invitation",
+          targetId: invitationId,
+          workspaceId: req.workspace.id,
+          metadata: {
+            email,
+            role,
+            workspace_name: req.workspace.name,
+            invitation_id: invitationId,
+          },
+        });
+      } catch (auditErr) {
+        logger.warn("Failed to write INVITATION_CANCELLED audit event", {
+          error: auditErr.message,
+          workspaceId: req.workspace.id,
+          invitationId,
+        });
+      }
+      try {
+        inviteCancelledTotal.inc();
+      } catch (metricErr) {
+        logger.warn("Failed to increment inviteCancelledTotal metric", {
+          error: metricErr.message,
+        });
+      }
+      return res.status(204).send();
+    } catch (err) {
+      logger.error("Failed to cancel workspace invitation", {
+        error: err.message,
+        workspaceId: req.workspace?.id,
+        invitationId: req.params?.invitationId,
+      });
+      return res.status(500).json({
+        error: "Failed to cancel invitation",
+        code: "INTERNAL_ERROR",
+      });
     }
   },
 );

--- a/apps/api/services/rbac.js
+++ b/apps/api/services/rbac.js
@@ -33,6 +33,7 @@ const actionPolicy = {
   "membership.invite": "workspace_manager",
   "membership.change_role": "workspace_manager",
   "membership.remove": "workspace_manager",
+  "membership.cancel_invite": "workspace_manager",
   "section.create": "workspace_manager",
   "section.update": "workspace_manager",
   "section.delete": "workspace_manager",

--- a/apps/api/utils/metrics.js
+++ b/apps/api/utils/metrics.js
@@ -50,6 +50,11 @@ const inviteSentTotal = new client.Counter({
   help: "Workspace invites created",
 });
 
+const inviteCancelledTotal = new client.Counter({
+  name: "tokentimer_invite_cancelled_total",
+  help: "Workspace invites cancelled (pending rows only)",
+});
+
 module.exports = {
   httpRequestDuration,
   httpRequestsTotal,
@@ -60,4 +65,5 @@ module.exports = {
   rbacDeniedTotal,
   workspacesCreatedTotal,
   inviteSentTotal,
+  inviteCancelledTotal,
 };

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -109,6 +109,7 @@ const ALL_ACTION_TYPES = [
   'MEMBER_ROLE_CHANGED',
   'MEMBER_REMOVED',
   'INVITE_EMAIL_SENT',
+  'INVITATION_CANCELLED',
   // Contact management
   'WORKSPACE_CONTACT_CREATED',
   'WORKSPACE_CONTACT_UPDATED',
@@ -564,6 +565,11 @@ export default function Audit({
       if (md.old_role && md.new_role)
         parts.push(`Role: ${md.old_role} -> ${md.new_role}`);
       if (md.workspace_name) parts.push(`Workspace: ${md.workspace_name}`);
+      if (md.recipient_type)
+        parts.push(
+          `Recipient: ${md.recipient_type === 'existing_user' ? 'existing user' : 'new user'}`
+        );
+      if (md.invitation_id) parts.push(`Invitation ID: ${md.invitation_id}`);
       if (md.invited_by) parts.push(`Invited by: ${md.invited_by}`);
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {
@@ -738,7 +744,8 @@ export default function Audit({
       action === 'MEMBER_INVITED_OR_UPDATED' ||
       action === 'MEMBER_ROLE_CHANGED' ||
       action === 'MEMBER_REMOVED' ||
-      action === 'INVITE_EMAIL_SENT'
+      action === 'INVITE_EMAIL_SENT' ||
+      action === 'INVITATION_CANCELLED'
     ) {
       const formatted = formatMemberMetadata(ev);
       if (formatted) return formatted;

--- a/apps/dashboard/src/pages/DocsApi.jsx
+++ b/apps/dashboard/src/pages/DocsApi.jsx
@@ -989,12 +989,32 @@ curl -s -b cookies.txt -X POST <your-backend-url>/api/v1/workspaces/11111111-111
                     </strong>{' '}
                     — remove
                   </ListItem>
+                  <ListItem>
+                    <strong>
+                      GET /api/v1/workspaces/:id/invitations
+                    </strong>{' '}
+                    — list pending (unaccepted) invitations. Never returns the
+                    invitation token.
+                  </ListItem>
+                  <ListItem>
+                    <strong>
+                      DELETE /api/v1/workspaces/:id/invitations/:invitationId
+                    </strong>{' '}
+                    — cancel a pending invitation (manager+). Responds 204 on
+                    success and emits an INVITATION_CANCELLED audit event.
+                  </ListItem>
                 </List>
                 <CopyableCodeBlock
                   code={`# Invite member (manager+)
 curl -s -b cookies.txt -X POST <your-backend-url>/api/v1/workspaces/00000000-0000-0000-0000-000000000000/members \
   -H 'Content-Type: application/json' \
-  -d '{"email":"teammate@example.com","role":"viewer"}' | jq '.'`}
+  -d '{"email":"teammate@example.com","role":"viewer"}' | jq '.'
+
+# List pending invitations
+curl -s -b cookies.txt <your-backend-url>/api/v1/workspaces/00000000-0000-0000-0000-000000000000/invitations | jq '.'
+
+# Cancel a pending invitation (manager+)
+curl -s -b cookies.txt -X DELETE <your-backend-url>/api/v1/workspaces/00000000-0000-0000-0000-000000000000/invitations/<invitation-id>`}
                 />
               </Box>
 

--- a/apps/dashboard/src/pages/DocsAudit.jsx
+++ b/apps/dashboard/src/pages/DocsAudit.jsx
@@ -438,10 +438,27 @@ export default function DocsAudit() {
                   </ListItem>
                   <ListItem>
                     <strong>MEMBER_INVITED_OR_UPDATED</strong> metadata:{' '}
-                    {'{ role }'}
+                    {'{ role, email, workspace_name, recipient_type }'}. Emitted
+                    synchronously when an invitation or direct membership is
+                    created. {`recipient_type`} is {`"existing_user"`} when the
+                    email already has a TokenTimer account (membership created
+                    directly) or {`"invitation"`} when a pending invitation row
+                    was written for a new email.
                   </ListItem>
                   <ListItem>
-                    <strong>INVITE_EMAIL_SENT</strong> metadata: {'{ role }'}
+                    <strong>INVITE_EMAIL_SENT</strong> metadata:{' '}
+                    {'{ role, email, workspace_name }'}. Emitted only after the
+                    invitation email was handed off to the SMTP transport
+                    successfully. Absence of this event after
+                    MEMBER_INVITED_OR_UPDATED means the email step failed and
+                    the operator should check mail logs.
+                  </ListItem>
+                  <ListItem>
+                    <strong>INVITATION_CANCELLED</strong> metadata:{' '}
+                    {'{ email, role, workspace_name, invitation_id }'}. Emitted
+                    when a pending invitation is removed via{' '}
+                    <code>DELETE /api/v1/workspaces/:id/invitations/:invitationId</code>.
+                    Accepted invitations are never cancelled by this endpoint.
                   </ListItem>
                   <ListItem>
                     <strong>MEMBER_ROLE_CHANGED</strong> metadata: {'{ role }'}

--- a/apps/dashboard/src/pages/DocsIntro.jsx
+++ b/apps/dashboard/src/pages/DocsIntro.jsx
@@ -511,6 +511,15 @@ export default function DocsIntro() {
                     <ListItem>
                       <ChakraLink
                         as={RouterLink}
+                        to='/docs/teams#pending-invitations'
+                        color={linkColor}
+                      >
+                        Pending invitations
+                      </ChakraLink>
+                    </ListItem>
+                    <ListItem>
+                      <ChakraLink
+                        as={RouterLink}
                         to='/docs/teams#deleting'
                         color={linkColor}
                       >

--- a/apps/dashboard/src/pages/DocsTeams.jsx
+++ b/apps/dashboard/src/pages/DocsTeams.jsx
@@ -405,6 +405,45 @@ export default function DocsTeams() {
               </Box>
 
               <Box
+                id='pending-invitations'
+                bg={cardBg}
+                border='1px solid'
+                borderColor={borderColor}
+                borderRadius='md'
+                p={{ base: 4, md: 6 }}
+                w='full'
+                overflowX='hidden'
+              >
+                <Heading size='md' mb={2}>
+                  Pending invitations
+                </Heading>
+                <Text fontSize='sm' color={bodyColor} mb={2}>
+                  When you invite a teammate who does not yet have a TokenTimer
+                  account, a pending invitation row is stored until they
+                  register. Admins and workspace managers can see and cancel
+                  these rows from <em>Workspaces</em>.
+                </Text>
+                <List
+                  spacing={1}
+                  pl={4}
+                  styleType='disc'
+                  mb={2}
+                  color={bodyColor}
+                  fontSize='sm'
+                >
+                  <ListItem>
+                    Cancelling a pending invitation deletes the row and writes
+                    an <strong>INVITATION_CANCELLED</strong> audit event. It
+                    never affects invitations that have already been accepted.
+                  </ListItem>
+                  <ListItem>
+                    The invitation token is treated as a bearer secret and is
+                    never returned by the list endpoint.
+                  </ListItem>
+                </List>
+              </Box>
+
+              <Box
                 id='deleting'
                 bg={cardBg}
                 border='1px solid'

--- a/apps/dashboard/src/pages/Workspaces.jsx
+++ b/apps/dashboard/src/pages/Workspaces.jsx
@@ -48,6 +48,7 @@ export default function Workspaces({
   const [workspaces, setWorkspaces] = React.useState([]);
   const [currentWorkspace, setCurrentWorkspace] = React.useState(null);
   const [members, setMembers] = React.useState([]);
+  const [pendingInvitations, setPendingInvitations] = React.useState([]);
   const [inviteEmail, setInviteEmail] = React.useState('');
   const [inviteRole, setInviteRole] = React.useState('viewer');
   const [newWorkspaceName, setNewWorkspaceName] = React.useState('');
@@ -266,11 +267,18 @@ export default function Workspaces({
         if (selected) {
           const res = await workspaceAPI.listMembers(selected.id, 100, 0);
           if (!cancelled) setMembers(res?.items || []);
+          try {
+            const inv = await workspaceAPI.listInvitations(selected.id, 100, 0);
+            if (!cancelled) setPendingInvitations(inv?.items || []);
+          } catch (_) {
+            if (!cancelled) setPendingInvitations([]);
+          }
         }
       } catch (_) {
         if (!cancelled) {
           setWorkspaces([]);
           setMembers([]);
+          setPendingInvitations([]);
         }
       }
     })();
@@ -282,6 +290,15 @@ export default function Workspaces({
   async function reloadMembers(workspaceId) {
     const res = await workspaceAPI.listMembers(workspaceId, 100, 0);
     setMembers(res?.items || []);
+  }
+
+  async function reloadInvitations(workspaceId) {
+    try {
+      const res = await workspaceAPI.listInvitations(workspaceId, 100, 0);
+      setPendingInvitations(res?.items || []);
+    } catch (_) {
+      setPendingInvitations([]);
+    }
   }
 
   return (
@@ -368,6 +385,7 @@ export default function Workspaces({
                             0
                           );
                           setMembers(res?.items || []);
+                          await reloadInvitations(sel.id);
                           try {
                             // Keep user on the same page, only refresh context + nav
                             selectWorkspace(sel.id, { replace: true });
@@ -412,6 +430,7 @@ export default function Workspaces({
                           } catch (_) {}
                         } else {
                           setMembers([]);
+                          setPendingInvitations([]);
                         }
                         // No redirect to tokens; stay on Workspaces page
                       } catch (_) {
@@ -444,8 +463,13 @@ export default function Workspaces({
                     const ws = workspaces.find(w => w.id === id);
                     setCurrentWorkspace(ws || null);
                     setRenaming(false);
-                    if (ws) await reloadMembers(ws.id);
-                    else setMembers([]);
+                    if (ws) {
+                      await reloadMembers(ws.id);
+                      await reloadInvitations(ws.id);
+                    } else {
+                      setMembers([]);
+                      setPendingInvitations([]);
+                    }
                   }}
                 >
                   {workspaces.map(w => (
@@ -655,7 +679,6 @@ export default function Workspaces({
                 <Button
                   onClick={async () => {
                     if (!currentWorkspace || !inviteEmail) return;
-                    // Core: no restrictions on adding members to personal workspaces
                     const email = inviteEmail.trim();
                     if (!/.+@.+\..+/.test(email)) {
                       showWarning('Invalid email');
@@ -667,6 +690,7 @@ export default function Workspaces({
                     });
                     setInviteEmail('');
                     await reloadMembers(currentWorkspace.id);
+                    await reloadInvitations(currentWorkspace.id);
                   }}
                   isDisabled={!canManage}
                 >
@@ -779,6 +803,67 @@ export default function Workspaces({
                   </Tbody>
                 </Table>
               </Box>
+
+              {pendingInvitations.length > 0 && (
+                <Box mt={6}>
+                  <Text fontWeight='semibold' mb={2}>
+                    Pending invitations ({pendingInvitations.length})
+                  </Text>
+                  <Text fontSize='sm' color='gray.500' mb={3}>
+                    Invitations that have not yet been accepted. They count
+                    toward your workspace member cap when one is configured.
+                  </Text>
+                  <Box overflowX='auto'>
+                    <Table size='sm' minW='600px'>
+                      <Thead>
+                        <Tr>
+                          <Th>Email</Th>
+                          <Th>Role</Th>
+                          <Th>Sent</Th>
+                          <Th></Th>
+                        </Tr>
+                      </Thead>
+                      <Tbody>
+                        {pendingInvitations.map(inv => (
+                          <Tr key={inv.id}>
+                            <Td>{inv.email}</Td>
+                            <Td>{inv.role}</Td>
+                            <Td>
+                              {inv.created_at
+                                ? new Date(inv.created_at).toLocaleString()
+                                : ''}
+                            </Td>
+                            <Td>
+                              <Button
+                                size='sm'
+                                variant='outline'
+                                isDisabled={!canManage}
+                                onClick={async () => {
+                                  if (!currentWorkspace) return;
+                                  try {
+                                    await workspaceAPI.cancelInvitation(
+                                      currentWorkspace.id,
+                                      inv.id
+                                    );
+                                  } catch (e) {
+                                    showError(
+                                      'Failed to cancel invitation',
+                                      String(e?.message || '')
+                                    );
+                                  }
+                                  await reloadInvitations(currentWorkspace.id);
+                                }}
+                              >
+                                Cancel invite
+                              </Button>
+                            </Td>
+                          </Tr>
+                        ))}
+                      </Tbody>
+                    </Table>
+                  </Box>
+                </Box>
+              )}
             </Box>
           </VStack>
         )}
@@ -1169,8 +1254,10 @@ export default function Workspaces({
                   if (next) {
                     const res = await workspaceAPI.listMembers(next.id, 100, 0);
                     setMembers(res?.items || []);
+                    await reloadInvitations(next.id);
                   } else {
                     setMembers([]);
+                    setPendingInvitations([]);
                   }
                   try {
                     window.dispatchEvent(

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -6,6 +6,12 @@ import {
 import { logger } from './logger.js';
 import { resetIdentity } from './analytics.js';
 
+// Tracks whether the frontend has ever observed a logged-in session. A 401
+// should only trigger the "session expired" toast + redirect when the user
+// actually had a session that could expire. Without this, background 401s on
+// public pages or 404s look like forced logouts.
+let hasObservedLoggedInSession = false;
+
 // API base URL resolution:
 // - If runtime env.js defines API_URL, use it first
 // - Otherwise if VITE_API_URL is set and not pointing to localhost when we're not on localhost, use it
@@ -387,6 +393,15 @@ export const handleApiError = (error, customMessage = null) => {
           message = null;
           break;
         }
+        // If the user never had a logged-in session, there is no session to
+        // expire. Skip the toast + redirect so background 401s on unknown
+        // paths (e.g. a 404 URL hitting /api/v1/workspaces) don't masquerade
+        // as a forced logout.
+        if (!hasObservedLoggedInSession) {
+          suppressToast = true;
+          message = null;
+          break;
+        }
         message = 'Your session has expired. Please log in again.';
         // Secure redirect - don't expose authentication state details
         setTimeout(() => {
@@ -512,6 +527,9 @@ export const API_ENDPOINTS = {
   WORKSPACE_INVITE: id => `/api/v1/workspaces/${id}/members`,
   WORKSPACE_MEMBER: (id, userId) =>
     `/api/v1/workspaces/${id}/members/${userId}`,
+  WORKSPACE_INVITATIONS: id => `/api/v1/workspaces/${id}/invitations`,
+  WORKSPACE_INVITATION: (id, invitationId) =>
+    `/api/v1/workspaces/${id}/invitations/${invitationId}`,
   WORKSPACE_ALERT_SETTINGS: id => `/api/v1/workspaces/${id}/alert-settings`,
   WORKSPACE_TRANSFER_TOKENS: id => `/api/v1/workspaces/${id}/transfer-tokens`,
   // Vault integration (workspace_id required for scan)
@@ -552,6 +570,9 @@ export const authAPI = {
   login: async credentials => {
     try {
       const response = await apiClient.post(API_ENDPOINTS.LOGIN, credentials);
+      if (response?.data?.success || response?.data?.user) {
+        hasObservedLoggedInSession = true;
+      }
       return response.data;
     } catch (error) {
       throw new Error(handleApiError(error));
@@ -569,6 +590,8 @@ export const authAPI = {
       } catch (_) {}
     } catch (error) {
       handleApiError(error);
+    } finally {
+      hasObservedLoggedInSession = false;
     }
   },
 
@@ -576,6 +599,9 @@ export const authAPI = {
   getSession: async () => {
     try {
       const response = await apiClient.get(API_ENDPOINTS.GET_SESSION);
+      if (response?.data?.loggedIn) {
+        hasObservedLoggedInSession = true;
+      }
       return response.data;
     } catch (error) {
       // Don't show error for session check
@@ -592,6 +618,7 @@ export const authAPI = {
         const response = await apiClient.get(API_ENDPOINTS.GET_SESSION);
 
         if (response.data && response.data.loggedIn) {
+          hasObservedLoggedInSession = true;
           logger.info('Session verified successfully');
           return true;
         }
@@ -630,6 +657,7 @@ export const authAPI = {
         const response = await apiClient.get(API_ENDPOINTS.GET_SESSION);
 
         if (response.data && response.data.loggedIn) {
+          hasObservedLoggedInSession = true;
           logger.info('Session established successfully');
           return true;
         }
@@ -1003,6 +1031,27 @@ export const workspaceAPI = {
     try {
       await apiClient.delete(API_ENDPOINTS.WORKSPACE_MEMBER(id, userId));
       showSuccessMessage('Member removed');
+    } catch (e) {
+      throw new Error(handleApiError(e));
+    }
+  },
+  listInvitations: async (id, limit = 100, offset = 0) => {
+    try {
+      const res = await apiClient.get(
+        API_ENDPOINTS.WORKSPACE_INVITATIONS(id),
+        { params: { limit, offset } }
+      );
+      return res.data;
+    } catch (e) {
+      throw new Error(handleApiError(e));
+    }
+  },
+  cancelInvitation: async (id, invitationId) => {
+    try {
+      await apiClient.delete(
+        API_ENDPOINTS.WORKSPACE_INVITATION(id, invitationId)
+      );
+      showSuccessMessage('Invitation cancelled');
     } catch (e) {
       throw new Error(handleApiError(e));
     }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "namespaces": [
     {
       "name": "queue",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/config",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Shared configuration for TokenTimer",
   "main": "src/index.js",
   "type": "module",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.1.3
+  version: 0.2.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.
@@ -691,6 +691,96 @@ paths:
           description: Member removed
         "403":
           $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/invitations:
+    get:
+      tags: [Workspaces]
+      summary: List pending workspace invitations
+      operationId: listWorkspaceInvitations
+      description: >
+        Returns unaccepted invitations for the workspace. The invitation
+        `token` is a bearer secret and is never returned by this endpoint.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Pending invitations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        email:
+                          type: string
+                          format: email
+                        role:
+                          type: string
+                        invited_by:
+                          type: integer
+                        created_at:
+                          type: string
+                          format: date-time
+                        accepted_at:
+                          type: string
+                          format: date-time
+                          nullable: true
+                  pagination:
+                    type: object
+                    properties:
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/invitations/{invitationId}:
+    delete:
+      tags: [Workspaces]
+      summary: Cancel a pending workspace invitation
+      operationId: cancelWorkspaceInvitation
+      description: >
+        Deletes a pending invitation (accepted_at IS NULL) and emits an
+        INVITATION_CANCELLED audit event. Does not touch invitations that have
+        already been accepted.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: invitationId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Invitation cancelled
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/transfer-tokens:

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/suites/cloud-compatible.txt
+++ b/tests/integration/suites/cloud-compatible.txt
@@ -10,6 +10,8 @@ tests/integration/two-factor-disable.test.js
 # Contacts/workspace settings
 tests/integration/contact-groups-settings.test.js
 tests/integration/workspaces-lifecycle.integration.test.js
+tests/integration/workspace-invitations-list.integration.test.js
+tests/integration/workspace-invitations-cancel.integration.test.js
 
 # Alerts and queue behavior
 tests/integration/alert-stats-whatsapp-channel.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -22,6 +22,8 @@ tests/integration/contacts-crud.test.js
 tests/integration/contact-groups-settings.test.js
 tests/integration/workspaces-lifecycle.integration.test.js
 tests/integration/workspace-transfer-tokens.test.js
+tests/integration/workspace-invitations-list.integration.test.js
+tests/integration/workspace-invitations-cancel.integration.test.js
 tests/integration/contact-group-reassignment.test.js
 
 # Alert system

--- a/tests/integration/workspace-invitations-cancel.integration.test.js
+++ b/tests/integration/workspace-invitations-cancel.integration.test.js
@@ -1,0 +1,170 @@
+const { request, expect, TestUtils } = require("./setup");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+describe("Workspace pending invitation cancellation", function () {
+  this.timeout(90000);
+
+  let ownerUser;
+  let ownerSession;
+  let viewerUser;
+  let viewerSession;
+  let outsiderUser;
+  let outsiderSession;
+  let workspaceId;
+
+  async function seedInvite(email, role = "viewer") {
+    const res = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/members`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ email, role })
+      .expect(201);
+    expect(res.body.role).to.equal(role);
+    const row = await TestUtils.execQuery(
+      `SELECT id FROM workspace_invitations
+        WHERE workspace_id = $1 AND LOWER(email) = LOWER($2)
+          AND accepted_at IS NULL
+        ORDER BY created_at DESC LIMIT 1`,
+      [workspaceId, email],
+    );
+    return row.rows[0]?.id;
+  }
+
+  before(async () => {
+    ownerUser = await TestUtils.createVerifiedTestUser();
+    ownerSession = await TestUtils.loginTestUser(
+      ownerUser.email,
+      "SecureTest123!@#",
+    );
+    viewerUser = await TestUtils.createVerifiedTestUser();
+    viewerSession = await TestUtils.loginTestUser(
+      viewerUser.email,
+      "SecureTest123!@#",
+    );
+    outsiderUser = await TestUtils.createVerifiedTestUser();
+    outsiderSession = await TestUtils.loginTestUser(
+      outsiderUser.email,
+      "SecureTest123!@#",
+    );
+
+    const wsRes = await request(BASE)
+      .get("/api/v1/workspaces?limit=50&offset=0")
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+    workspaceId = wsRes?.body?.items?.[0]?.id;
+
+    await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/members`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ email: viewerUser.email, role: "viewer" })
+      .expect(201);
+  });
+
+  after(async () => {
+    await TestUtils.execQuery(
+      `DELETE FROM workspace_invitations WHERE workspace_id = $1`,
+      [workspaceId],
+    );
+    await TestUtils.cleanupTestUser(ownerUser.email, ownerSession.cookie);
+    await TestUtils.cleanupTestUser(viewerUser.email, viewerSession.cookie);
+    await TestUtils.cleanupTestUser(outsiderUser.email, outsiderSession.cookie);
+  });
+
+  it("admin cancels a pending invitation and writes audit event", async () => {
+    const email = `cancel-${Date.now()}@example.com`;
+    const invId = await seedInvite(email);
+    expect(invId, "seed returned invitation id").to.exist;
+
+    await request(BASE)
+      .delete(`/api/v1/workspaces/${workspaceId}/invitations/${invId}`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(204);
+
+    const check = await TestUtils.execQuery(
+      `SELECT 1 FROM workspace_invitations WHERE id = $1`,
+      [invId],
+    );
+    expect(check.rowCount).to.equal(0);
+
+    const audit = await TestUtils.execQuery(
+      `SELECT action, target_type, metadata
+         FROM audit_events
+        WHERE workspace_id = $1 AND action = 'INVITATION_CANCELLED'
+          AND actor_user_id = $2
+        ORDER BY occurred_at DESC
+        LIMIT 5`,
+      [workspaceId, ownerUser.id],
+    );
+    const hit = audit.rows.find(
+      (r) =>
+        r.metadata &&
+        String(r.metadata.email || "").toLowerCase() === email.toLowerCase(),
+    );
+    expect(hit, "audit event for cancelled invitation").to.exist;
+    expect(hit.target_type).to.equal("workspace_invitation");
+    expect(hit.metadata.role).to.equal("viewer");
+    expect(hit.metadata.invitation_id).to.equal(invId);
+    expect(hit.metadata.workspace_name).to.be.a("string");
+  });
+
+  it("viewer lacks membership.cancel_invite permission", async () => {
+    const email = `cancel-viewer-${Date.now()}@example.com`;
+    const invId = await seedInvite(email);
+    expect(invId).to.exist;
+
+    const res = await request(BASE)
+      .delete(`/api/v1/workspaces/${workspaceId}/invitations/${invId}`)
+      .set("Cookie", viewerSession.cookie);
+    expect([401, 403]).to.include(res.status);
+
+    const check = await TestUtils.execQuery(
+      `SELECT 1 FROM workspace_invitations WHERE id = $1`,
+      [invId],
+    );
+    expect(check.rowCount).to.equal(1);
+  });
+
+  it("outsider cannot cancel invitations in a foreign workspace (IDOR guard)", async () => {
+    const email = `cancel-outsider-${Date.now()}@example.com`;
+    const invId = await seedInvite(email);
+    expect(invId).to.exist;
+
+    const res = await request(BASE)
+      .delete(`/api/v1/workspaces/${workspaceId}/invitations/${invId}`)
+      .set("Cookie", outsiderSession.cookie);
+    expect([401, 403, 404]).to.include(res.status);
+
+    const check = await TestUtils.execQuery(
+      `SELECT 1 FROM workspace_invitations WHERE id = $1`,
+      [invId],
+    );
+    expect(check.rowCount).to.equal(1);
+  });
+
+  it("returns 404 for unknown invitation id under the same workspace", async () => {
+    const bogus = "00000000-0000-0000-0000-000000000000";
+    const res = await request(BASE)
+      .delete(`/api/v1/workspaces/${workspaceId}/invitations/${bogus}`)
+      .set("Cookie", ownerSession.cookie);
+    expect(res.status).to.equal(404);
+  });
+
+  it("does not cancel invitations that were already accepted", async () => {
+    const email = `cancel-accepted-${Date.now()}@example.com`;
+    const invId = await seedInvite(email);
+    expect(invId).to.exist;
+    await TestUtils.execQuery(
+      `UPDATE workspace_invitations SET accepted_at = NOW() WHERE id = $1`,
+      [invId],
+    );
+    const res = await request(BASE)
+      .delete(`/api/v1/workspaces/${workspaceId}/invitations/${invId}`)
+      .set("Cookie", ownerSession.cookie);
+    expect(res.status).to.equal(404);
+    const check = await TestUtils.execQuery(
+      `SELECT 1 FROM workspace_invitations WHERE id = $1`,
+      [invId],
+    );
+    expect(check.rowCount).to.equal(1);
+  });
+});

--- a/tests/integration/workspace-invitations-list.integration.test.js
+++ b/tests/integration/workspace-invitations-list.integration.test.js
@@ -1,0 +1,87 @@
+const { request, expect, TestUtils } = require("./setup");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+describe("Workspace pending invitations list", function () {
+  this.timeout(90000);
+
+  let ownerUser;
+  let ownerSession;
+  let outsiderUser;
+  let outsiderSession;
+  let workspaceId;
+  const pendingEmail = `pending-${Date.now()}@example.com`;
+
+  before(async () => {
+    ownerUser = await TestUtils.createVerifiedTestUser();
+    ownerSession = await TestUtils.loginTestUser(
+      ownerUser.email,
+      "SecureTest123!@#",
+    );
+    outsiderUser = await TestUtils.createVerifiedTestUser();
+    outsiderSession = await TestUtils.loginTestUser(
+      outsiderUser.email,
+      "SecureTest123!@#",
+    );
+
+    const wsRes = await request(BASE)
+      .get("/api/v1/workspaces?limit=50&offset=0")
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+    workspaceId = wsRes?.body?.items?.[0]?.id;
+
+    await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/members`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ email: pendingEmail, role: "viewer" })
+      .expect(201);
+  });
+
+  after(async () => {
+    await TestUtils.execQuery(
+      "DELETE FROM workspace_invitations WHERE LOWER(email) = LOWER($1)",
+      [pendingEmail],
+    );
+    await TestUtils.cleanupTestUser(ownerUser.email, ownerSession.cookie);
+    await TestUtils.cleanupTestUser(outsiderUser.email, outsiderSession.cookie);
+  });
+
+  it("returns pending invitations without leaking the token column", async () => {
+    const res = await request(BASE)
+      .get(`/api/v1/workspaces/${workspaceId}/invitations?limit=100&offset=0`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+    expect(res.body.items).to.be.an("array");
+    const found = res.body.items.find(
+      (inv) => String(inv.email).toLowerCase() === pendingEmail.toLowerCase(),
+    );
+    expect(found, "pending invitation should be listed").to.exist;
+    expect(found.role).to.equal("viewer");
+    expect(found).to.not.have.property("token");
+    expect(found.accepted_at == null).to.equal(true);
+  });
+
+  it("excludes already-accepted invitations from the list", async () => {
+    await TestUtils.execQuery(
+      `UPDATE workspace_invitations
+          SET accepted_at = NOW()
+        WHERE workspace_id = $1 AND LOWER(email) = LOWER($2)`,
+      [workspaceId, pendingEmail],
+    );
+    const res = await request(BASE)
+      .get(`/api/v1/workspaces/${workspaceId}/invitations?limit=100&offset=0`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+    const stillThere = res.body.items.find(
+      (inv) => String(inv.email).toLowerCase() === pendingEmail.toLowerCase(),
+    );
+    expect(stillThere, "accepted invitation must not appear").to.not.exist;
+  });
+
+  it("rejects non-members with 403", async () => {
+    const res = await request(BASE)
+      .get(`/api/v1/workspaces/${workspaceId}/invitations?limit=100&offset=0`)
+      .set("Cookie", outsiderSession.cookie);
+    expect([401, 403]).to.include(res.status);
+  });
+});


### PR DESCRIPTION
## Summary

Ships **tokentimer-core 0.2.0** with invitation cancellation correctness, a core-scoped invite-cancel metric, and a small dashboard auth UX fix. Contract and OpenAPI versions are aligned to **0.2.0**; **pnpm-lock.yaml** is unchanged.

## Changes

### API
- `DELETE /api/v1/workspaces/{id}/invitations/{invitationId}` only deletes rows with `accepted_at IS NULL`. Unknown or already-accepted invitations return **404** (no silent **204** on accepted rows).
- Prometheus: new counter **`tokentimer_invite_cancelled_total`** (replaces legacy `oauth_backend_invite_cancelled_total` name for this repo).

### Dashboard
- **401** handling: “session expired” toast and redirect to `/login` only after the client has observed a logged-in session (`hasObservedLoggedInSession`), so anonymous users on unknown routes (e.g. client-side 404) are not pushed to login.

### Release / contracts
- Version **0.2.0** on root, apps, `packages/contracts`, `packages/config`, `contracts.manifest.json`, OpenAPI `info.version`, and small contract JSON artifacts (same pattern as [0.1.3](https://github.com/tokentimerch/tokentimer-core/releases)).
- **CHANGELOG.md** updated for **0.2.0**.

## Testing

- [X ] `pnpm run check:contracts` / `check:contracts:integrity`
- [X ] `pnpm run lint` && `pnpm run build`
- [X ] `pnpm run test:contracts`
- [X ] Integration: `pnpm run test:core` (or your usual Docker suite)

## Notes

- **No dependency or lockfile changes** for this release.
- Anyone scraping **`oauth_backend_invite_cancelled_total`** should switch dashboards to **`tokentimer_invite_cancelled_total`** (metric rename only; behavior is the pending-only cancel path above).