### PR TITLE
chore(release): prepare TokenTimer Core 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-30
+
+### Fixed
+
+- Fixed account deletion for users that already had audit events, so right-to-be-forgotten cleanup no longer fails on those audit references.
+
+### Changed
+
+- Refined README wording to explicitly mention public subdomain discovery, SSL certificate imports, and HTTPS endpoint checks.
+- Updated release metadata from **0.3.0** to **0.3.1** across package and contract version files.
+- Updated licensing metadata to use the registered company name **Tokentimer Sàrl, Switzerland**.
+
 ## [0.3.0] - 2026-04-27
 
 ### Added
@@ -230,6 +242,7 @@ tokentimer-cloud SaaS codebase into a standalone, variant-agnostic repository.
 
 ---
 
+[0.3.1]: https://github.com/tokentimerch/tokentimer-core/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/tokentimerch/tokentimer-core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/tokentimerch/tokentimer-core/compare/v0.1.2...v0.1.3

--- a/LICENSE
+++ b/LICENSE
@@ -7,11 +7,9 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Franz ALLIOD, on behalf of
-                      TokenTimer Sàrl (in formation), Switzerland
+Licensor:             Tokentimer Sàrl, Switzerland
 Licensed Work:        TokenTimer Core
-                      The Licensed Work is (c) 2026 Franz ALLIOD,
-                      on behalf of TokenTimer Sàrl (in formation),
+                      The Licensed Work is (c) 2026 Tokentimer Sàrl,
                       Switzerland
 
 Additional Use Grant: You may use the Licensed Work for any purpose,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ TokenTimer is a security-first expiration manager that aggregates expiring asset
 
 - **Unified expiration visibility:** Track certificates, tokens, secrets, licenses, subscriptions, and other expiring assets across providers and environments in one place.
 - **Flexible multi-channel alerting:** Notify teams through email, Slack, Microsoft Teams, Discord, PagerDuty, WhatsApp, and webhooks, with configurable delivery and escalation options.
-- **Native integrations, auto-sync, and automated discovery:** Connect TokenTimer to providers like HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Azure AD, GCP Secret Manager, GitHub, and GitLab to automatically import and keep expiration metadata up to date, while also monitoring HTTPS endpoints for SSL expiry and health.
+- **Native integrations, auto-sync, and automated discovery:** Connect TokenTimer to providers like HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, Azure AD, GCP Secret Manager, GitHub, and GitLab to automatically import and keep expiration metadata up to date, discover public subdomains for SSL certificate imports, and monitor HTTPS endpoints for SSL expiry and health.
 - **Built for teams and audits:** Organize assets with workspaces, control access with RBAC, and keep an audit trail of important actions and alert activity.
 - **Security-first by design:** TokenTimer stores expiration metadata, ownership, and status information without storing secret values or private keys.
 
@@ -122,4 +122,4 @@ Each release converts to [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.html) fo
 
 For commercial licensing or questions, contact [support@tokentimer.ch](mailto:support@tokentimer.ch).
 
-"TokenTimer" is a trademark of Franz ALLIOD, on behalf of TokenTimer Sàrl (in formation), Switzerland.
+"TokenTimer" is a trademark of Tokentimer Sàrl, Switzerland.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/account.js
+++ b/apps/api/routes/account.js
@@ -156,15 +156,7 @@ router.delete(
         userId,
       ]);
 
-      // Anonymize audit trail references for this user (preserve workspace audit history)
-      try {
-        await client.query(
-          "UPDATE audit_events SET subject_user_id = NULL WHERE subject_user_id = $1",
-          [userId],
-        );
-      } catch (_err) {
-        logger.warn("Audit write failed", { error: _err.message });
-      }
+      // Anonymize audit trail actor references for this user.
       try {
         await client.query(
           "UPDATE audit_events SET actor_user_id = NULL WHERE actor_user_id = $1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/pages/DocsTokens.jsx
+++ b/apps/dashboard/src/pages/DocsTokens.jsx
@@ -461,7 +461,9 @@ export default function DocsTokens() {
                   Import tokens directly from secret management platforms
                   (Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret
                   Manager), source control systems (GitLab, GitHub), or from
-                  files (CSV, XLSX, JSON, YAML).
+                  files (CSV, XLSX, JSON, YAML). You can also use Domain Checker
+                  to discover subdomains and import live SSL certificates as
+                  tokens.
                 </Text>
 
                 <Box

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "namespaces": [
     {
       "name": "queue",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.3.0
+  version: 0.3.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
- Bump TokenTimer Core release metadata to 0.3.1 across package and contract files.
- Update the README positioning to mention public subdomain discovery, SSL certificate imports, and HTTPS endpoint health checks.
- Document the account deletion fix for users with audit events and the registered Tokentimer Sàrl licensing metadata.

## Tests
https://github.com/tokentimerch/tokentimer-core/actions/runs/25172136068