### PR TITLE
Release TokenTimer Core v0.4.0 with Auto-Sync Hardening, UX improvements and Bulk Token Assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -69,7 +69,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -97,7 +97,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -139,7 +139,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -182,7 +182,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -217,7 +217,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -383,7 +383,7 @@ jobs:
       # --- Grype (Trivy replacement) ---
       - name: Install Grype
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.111.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.112.0
           grype version
 
       - name: Scan API image with Grype

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.0"
+          version: "10.33.4"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -21,3 +21,8 @@ ignore:
 
   # zlib 1.3.1-r2: fix is in alpine 3.23 base; resolved by base image pin
   - vulnerability: CVE-2026-27171
+
+  # ip-address 10.1.0 (GHSA-v2v4-37r5-5v8g, Medium): bundled inside express-rate-limit
+  # in the API image and inside npm's internal node_modules in the worker image.
+  # Severity is Medium — non-blocking under --fail-on high. Track for next dep refresh.
+  # - vulnerability: GHSA-v2v4-37r5-5v8g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
+### Added
+
+- **Bulk token section assignment via a single API call.** New `PUT /api/tokens/bulk` endpoint accepts up to 500 token IDs and a `section` value, applies the update in one SQL statement, and returns per-token success/failure detail. The dashboard's multi-select section workflow now uses this endpoint instead of N individual requests, and the new endpoint is fully documented in OpenAPI.
+- **`EndpointSslMonitorModal` extracted to its own component file.** The endpoint monitor and SSL certificate modal is now a standalone `apps/dashboard/src/components/EndpointSslMonitorModal.jsx`, making the file smaller and the component independently testable.
+- **Domain utilities extracted.** `domainStatusColor`, `domainSslBadge`, `domainFormatUrl`, and `domainValueToUrl` are now in `apps/dashboard/src/utils/domains.jsx`, shared across components without duplication.
+- **Auto-sync Prometheus metrics.** Three new metrics pushed to Pushgateway after every worker run: `auto_sync_runs_total{provider,status}` (counter), `auto_sync_items_imported_total{provider}` (counter), and `auto_sync_last_run_timestamp{provider,status}` (gauge). Two ready-to-use PrometheusRule alert definitions (`AutoSyncProviderFailures`, `AutoSyncNotRunning`) added to `deploy/helm/examples/values-full-test.yaml`.
+- **Server-side credential validation for auto-sync configs.** The `POST` and `PUT /api/v1/workspaces/:id/auto-sync` endpoints now validate that required credential fields (e.g. `token` for GitHub/GitLab, `accessKeyId`+`secretAccessKey` for AWS) are present and non-empty before encrypting and storing. Returns HTTP 400 with a descriptive error instead of silently storing unusable credentials.
+
+### Fixed
+
+- **Auto-sync rework and credential decryption fix.** Reworked the auto-sync worker to delegate token import to the existing `POST /api/v1/integrations/import` endpoint (the same one the dashboard uses) for all providers, so deduplication, sanitization, and audit logging are identical to a manual import. Fixed a credential decryption bug where the worker used a SHA-256-derived key while the API encrypts with `scryptSync`; the legacy SHA-256 path is kept as a fallback for older records.
+- **Auto-sync `API_URL` hardcoded in Docker Compose and Kubernetes CronJob.** The worker service in `docker-compose.yml` previously derived `API_URL` from the user-facing `.env` variable, which defaults to `http://localhost:4000`. Since `localhost` inside a container resolves to the container itself, every scan request failed with a network error. `API_URL` is now hardcoded to `http://api:4000` in the Compose service definition. The Helm CronJob template applies the same fix by injecting `http://<release>-api:<port>` directly, overriding whatever `config.apiUrl` is in the ConfigMap.
+- **Kubernetes NetworkPolicy updated for auto-sync.** The worker egress policy was missing a rule for port 4000 to the API pod, and the API ingress policy did not allow traffic from the `auto-sync` component. With NetworkPolicy enabled, every HTTP call from the auto-sync CronJob was silently dropped. Both policies are now updated.
+- **Auto-sync credential reading fixed in the import modal.** All integration form components (`ImportGitHubForm`, `ImportGitLabForm`, `ImportAWSForm`, `ImportAzureForm`, `ImportGCPForm`, `ImportVaultForm`) now expose a `getCredentials()` method via `useImperativeHandle`. The parent `ImportTokensModal` reads live form state through these refs instead of stale parent-scope state variables that were never updated, which caused every auto-sync save to silently store an empty token.
+- **Auto-sync worker pre-flight credential validation.** The worker now checks required credential fields immediately after decryption and throws a descriptive error (`token (empty)` vs `token (absent)`) before attempting any HTTP call, replacing a confusing HTTP 400 from the downstream scan endpoint.
+
+### Changed
+
+- **System color mode enabled by default.** The dashboard now follows the OS light/dark preference (`useSystemColorMode: true`, `initialColorMode: "system"`). Previously the dashboard was always light.
+- **Modal animations disabled for `ImportTokensModal`.** Added `motionPreset="none"` to remove the open/close animation, which was causing visual jank on slower machines.
+- **Backdrop blur removed from Chakra dialog containers.** Removed `backdropFilter: blur(10px)` from both light and dark dialog theme overrides to avoid a GPU compositing layer on every modal open.
+- **`CreateTokenNotesField` memoized with `flushSync`.** The notes textarea in the create/duplicate token forms is now a memoized component; `flushSync` ensures uncommitted note input is flushed to state before form submission.
+- **Bulk section assignment error messages surfaced.** The dashboard now shows the API-returned error string on failure instead of a generic "Failed to assign section" toast.
+- Updated pnpm from **10.33.0** to **10.33.4** across `package.json`, all three Dockerfiles, and CI.
+- Updated release metadata from **0.3.2** to **0.4.0** across all package and contract version files.
+
+### Security
+
+- Upgraded `axios` from **1.15.0** to **1.16.0** in all three packages (`api`, `dashboard`, `worker`) — fixes multiple prototype-pollution and SSRF advisories (GHSA-pmwg-cvhr-8vh7, GHSA-q8qp-cvcw-x6jj, GHSA-pf86-5x62-jrwf, GHSA-6chq-wfr3-2hj9, and others).
+- Upgraded `express-rate-limit` from **8.3.1** to **8.5.1** in `api`.
+- Upgraded `@aws-sdk/client-acm/iam/secrets-manager/sts` from **3.990.0** to **3.1045.0** in `api`.
+- Added `fast-xml-builder@1.2.0` and upgraded `fast-xml-parser` override from **5.7.2** to **5.7.3** to resolve GHSA-5wm8-gmm8-39j9 in the AWS SDK transitive chain.
+- Upgraded Grype from **v0.111.0** to **v0.112.0** in CI.
+- Updated the Go builder stage in `Dockerfile.api` from `golang:1.26.2-alpine3.23` to `golang:1.26.3-alpine3.23` to resolve stdlib CVEs in the subfinder binary.
+
 ## [0.3.2] - 2026-05-04
 
 ### Changed

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -29,7 +29,7 @@ COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Copy package files
 COPY package.json ./

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",
@@ -14,11 +14,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@aws-sdk/client-acm": "3.990.0",
-    "@aws-sdk/client-iam": "3.990.0",
-    "@aws-sdk/client-secrets-manager": "3.990.0",
-    "@aws-sdk/client-sts": "3.990.0",
-    "axios": "1.15.0",
+    "@aws-sdk/client-acm": "3.1045.0",
+    "@aws-sdk/client-iam": "3.1045.0",
+    "@aws-sdk/client-secrets-manager": "3.1045.0",
+    "@aws-sdk/client-sts": "3.1045.0",
+    "axios": "1.16.0",
     "bcryptjs": "3.0.3",
     "connect-pg-simple": "10.0.0",
     "cookie-parser": "1.4.7",
@@ -26,7 +26,7 @@
     "csrf-csrf": "3.2.2",
     "dotenv": "16.6.1",
     "express": "5.2.1",
-    "express-rate-limit": "8.3.1",
+    "express-rate-limit": "8.5.1",
     "express-session": "1.19.0",
     "express-slow-down": "3.0.1",
     "express-validator": "7.3.1",

--- a/apps/api/routes/admin.js
+++ b/apps/api/routes/admin.js
@@ -161,6 +161,27 @@ function computeNextSyncAt(frequency, scheduleTime, scheduleTz) {
   return candidate;
 }
 
+const REQUIRED_CRED_FIELDS = {
+  github: ["token"],
+  gitlab: ["token"],
+  aws: ["accessKeyId", "secretAccessKey"],
+  azure: ["token"],
+  "azure-ad": ["token"],
+  gcp: ["projectId", "accessToken"],
+  vault: ["address", "token"],
+};
+
+function validateAutoSyncCredentials(provider, credentials) {
+  if (!credentials || typeof credentials !== "object") return null;
+  const required = REQUIRED_CRED_FIELDS[provider] || [];
+  const empty = required.filter((f) => !credentials[f]);
+  if (empty.length === 0) return null;
+  const detail = empty.map((f) =>
+    f in credentials ? `${f} (empty)` : `${f} (absent)`,
+  );
+  return `Missing required credential fields for ${provider}: ${detail.join(", ")}`;
+}
+
 // List auto-sync configs for a workspace
 router.get(
   "/api/v1/workspaces/:id/auto-sync",
@@ -207,6 +228,10 @@ router.post(
         return res
           .status(400)
           .json({ error: "provider and credentials are required" });
+      }
+      const credError = validateAutoSyncCredentials(provider, credentials);
+      if (credError) {
+        return res.status(400).json({ error: credError });
       }
       // Check provider is allowed
       const allowed = CORE_AUTO_SYNC_PROVIDERS;
@@ -302,6 +327,20 @@ router.put(
       let idx = 1;
 
       if (credentials !== undefined) {
+        const existing = await pool.query(
+          `SELECT provider FROM auto_sync_configs WHERE id = $1 AND workspace_id = $2`,
+          [req.params.configId, req.workspace.id],
+        );
+        if (existing.rows.length === 0) {
+          return res.status(404).json({ error: "Auto-sync config not found" });
+        }
+        const credError = validateAutoSyncCredentials(
+          existing.rows[0].provider,
+          credentials,
+        );
+        if (credError) {
+          return res.status(400).json({ error: credError });
+        }
         const credJson =
           typeof credentials === "string"
             ? credentials

--- a/apps/api/routes/tokens.js
+++ b/apps/api/routes/tokens.js
@@ -613,6 +613,178 @@ router.post(
   },
 );
 
+// Bulk update tokens (supports section assignment).
+// MUST be registered before PUT /api/tokens/:id so Express does not treat the
+// literal "bulk" as an integer :id parameter.
+// Mirrors the shape and authorization of DELETE /api/tokens/bulk.
+router.put(
+  "/api/tokens/bulk",
+  getTestApiLimiter(),
+  requireAuth,
+  requireNotViewer,
+  async (req, res) => {
+    const { ids, section } = req.body;
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res
+        .status(400)
+        .json({ error: "No token IDs provided", code: "VALIDATION_ERROR" });
+    }
+
+    if (ids.length > 500) {
+      return res.status(400).json({
+        error: "Cannot update more than 500 tokens at once",
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    if (section === undefined) {
+      return res.status(400).json({ error: "No fields to update", code: "VALIDATION_ERROR" });
+    }
+
+    // Normalize section using the same rules as PUT /api/tokens/:id
+    let normalizedSection;
+    try {
+      if (section === null) {
+        normalizedSection = null;
+      } else {
+        const parts = Array.isArray(section)
+          ? section
+          : String(section).split(",");
+        if (Array.isArray(section) && section.length > 50) {
+          throw new Error("Too many labels (max 50)");
+        }
+        if (typeof section === "string" && section.length > 255) {
+          throw new Error("Section text must be less than 255 characters");
+        }
+        const flat = parts
+          .flatMap((p) => (typeof p === "string" ? p.split(",") : [p]))
+          .map((s) => (typeof s === "string" ? s.trim() : s))
+          .filter(Boolean);
+        for (const s of flat) {
+          if (typeof s !== "string") {
+            throw new Error("Labels must be strings");
+          }
+          if (s.length > 120) {
+            throw new Error("Each label must be less than 120 characters");
+          }
+          if (/[<>]/.test(s)) {
+            throw new Error("Labels cannot contain HTML tags");
+          }
+        }
+        normalizedSection = flat.length > 0 ? [...new Set(flat)] : null;
+      }
+    } catch (e) {
+      return res.status(400).json({ error: e.message, code: "VALIDATION_ERROR" });
+    }
+
+    try {
+      const userId = req.user.id;
+
+      // 1. Fetch all requested tokens to check ownership/workspace permissions in one go
+      const tokensRes = await pool.query(
+        "SELECT id, name, workspace_id, user_id FROM tokens WHERE id = ANY($1::int[])",
+        [ids],
+      );
+      const existingTokens = tokensRes.rows;
+      const existingIds = new Set(existingTokens.map((t) => t.id));
+
+      const results = {
+        success: [],
+        failed: [],
+      };
+
+      for (const id of ids) {
+        if (!existingIds.has(parseInt(id))) {
+          results.failed.push({ id, reason: "Not found" });
+        }
+      }
+
+      // 2. Filter tokens by role (core never checks is_frozen)
+      const authorizedTokens = [];
+      const workspaceIds = [
+        ...new Set(
+          existingTokens
+            .filter((t) => t.workspace_id)
+            .map((t) => t.workspace_id),
+        ),
+      ];
+
+      const rolesMap = new Map();
+      if (workspaceIds.length > 0) {
+        const rolesRes = await pool.query(
+          "SELECT workspace_id, role FROM workspace_memberships WHERE user_id = $1 AND workspace_id = ANY($2::uuid[])",
+          [userId, workspaceIds],
+        );
+        rolesRes.rows.forEach((r) => rolesMap.set(r.workspace_id, r.role));
+      }
+
+      for (const token of existingTokens) {
+        let canUpdate = false;
+        if (token.workspace_id) {
+          const role = rolesMap.get(token.workspace_id);
+          canUpdate = role === "admin" || role === "workspace_manager";
+        } else {
+          canUpdate = token.user_id === userId;
+        }
+
+        if (canUpdate) {
+          authorizedTokens.push(token);
+        } else {
+          results.failed.push({ id: token.id, reason: "Forbidden" });
+        }
+      }
+
+      const authorizedIds = authorizedTokens.map((t) => t.id);
+
+      if (authorizedIds.length > 0) {
+        // 3. Single SQL UPDATE for all authorized tokens
+        await pool.query(
+          "UPDATE tokens SET section = $1::text[], updated_at = NOW() WHERE id = ANY($2::int[])",
+          [normalizedSection, authorizedIds],
+        );
+
+        // 4. Audit per token to keep parity with PUT /api/tokens/:id
+        for (const token of authorizedTokens) {
+          results.success.push(token.id);
+          try {
+            await writeAudit({
+              actorUserId: userId,
+              subjectUserId: userId,
+              action: "TOKEN_UPDATED",
+              targetType: "token",
+              targetId: token.id,
+              channel: null,
+              workspaceId: token.workspace_id || null,
+              metadata: {
+                fields: ["section"],
+                bulk: true,
+                name: token.name,
+              },
+            });
+          } catch (_) {
+            /* ignore audit errors */
+          }
+        }
+      }
+
+      res.json({
+        message: `Processed ${ids.length} tokens`,
+        successCount: results.success.length,
+        failedCount: results.failed.length,
+        results,
+      });
+    } catch (error) {
+      logger.error("Error in bulk token update:", {
+        error: error.message,
+        stack: error.stack,
+        userId: req.user?.id,
+      });
+      res.status(500).json({ error: "Failed to process bulk update" });
+    }
+  },
+);
+
 // Update token
 router.put(
   "/api/tokens/:id",

--- a/apps/api/services/rbac.js
+++ b/apps/api/services/rbac.js
@@ -104,7 +104,11 @@ async function loadWorkspace(req, res, next) {
     if (wsRes.rowCount === 0)
       return res.status(404).json({ error: "Workspace not found" });
     req.workspace = wsRes.rows[0];
-    if (req.user && req.user.id) {
+    if (req.isWorkerCall) {
+      // Internal worker calls are pre-authenticated with WORKER_API_KEY / SESSION_SECRET.
+      // Grant admin access so they can reach any workspace endpoint without a membership row.
+      req.authz = { ...(req.authz || {}), workspaceRole: "admin" };
+    } else if (req.user && req.user.id) {
       let role = await getUserWorkspaceRole(req.user.id, workspaceIdString);
       // Treat workspace owner as implicit admin even if no membership row exists
       if (

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -10,7 +10,7 @@ RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Copy package files
 COPY package.json ./

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "2.10.9",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "framer-motion": "11.18.2",
     "js-yaml": "4.1.1",
     "lucide-react": "0.553.0",

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -1,8 +1,9 @@
-import { logger } from './utils/logger.js';
+﻿import { logger } from './utils/logger.js';
 import { getExpiryStatus, getColorFromString } from './styles/colors.js';
 
 import {
   useEffect,
+  useLayoutEffect,
   useState,
   useCallback,
   useRef,
@@ -11,6 +12,7 @@ import {
   useMemo,
   memo,
 } from 'react';
+import { flushSync } from 'react-dom';
 import {
   ChakraProvider,
   ColorModeScript,
@@ -21,8 +23,8 @@ import {
   FormLabel,
   FormErrorMessage,
   Input,
+  Textarea,
   Select,
-  Switch,
   Button,
   Flex,
   Text,
@@ -35,9 +37,6 @@ import {
   Td,
   Badge,
   VStack,
-  Stack,
-  NumberInput,
-  NumberInputField,
   useColorMode,
   useColorModeValue,
   Tooltip,
@@ -50,7 +49,6 @@ import {
   ModalBody,
   ModalCloseButton,
   useDisclosure,
-  Divider,
   HStack,
   Alert,
   AlertIcon,
@@ -79,14 +77,10 @@ import {
   FiTrash2,
   FiPlus,
   FiX,
-  FiChevronDown,
-  FiChevronUp,
   FiChevronRight,
   FiGlobe,
-  FiRefreshCw,
   FiExternalLink,
   FiActivity,
-  FiAlertTriangle,
 } from 'react-icons/fi';
 
 import { theme } from './styles/theme';
@@ -100,28 +94,18 @@ import { AccessibleSpinner } from './components/Accessibility';
 import TruncatedText from './components/TruncatedText';
 import ImportTokensModal from './components/ImportTokensModal.jsx';
 import TokenDetailModal from './components/TokenDetailModal.jsx';
-import {
-  SortableTh,
-  domainStatusColor,
-  domainSslBadge,
-  domainFormatUrl,
-} from './components/DashboardHelpers.jsx';
+import { SortableTh } from './components/DashboardHelpers.jsx';
+import EndpointSslMonitorModal from './components/EndpointSslMonitorModal.jsx';
+import { domainValueToUrl } from './utils/domains.jsx';
 
 import apiClient, {
   authAPI,
   tokenAPI,
   formatDate,
   workspaceAPI,
-  API_ENDPOINTS,
   showSuccessMessage,
 } from './utils/apiClient';
 
-function domainValueToUrl(value) {
-  const raw = String(value || '').trim();
-  if (!raw) return null;
-  if (/^https?:\/\//i.test(raw)) return raw;
-  return `https://${raw}`;
-}
 import {
   formatExpirationDate,
   isNeverExpires,
@@ -146,7 +130,7 @@ const Usage = lazy(() => import('./pages/Usage'));
 const Audit = lazy(() => import('./pages/Audit'));
 const Workspaces = lazy(() => import('./pages/Workspaces.jsx'));
 const SystemSettings = lazy(() => import('./pages/SystemSettings.jsx'));
-import { WorkspaceProvider, useWorkspace } from './utils/WorkspaceContext.jsx';
+import { WorkspaceProvider } from './utils/WorkspaceContext.jsx';
 
 // VerifyEmailWrapper component to handle session-based redirects
 function VerifyEmailWrapper({ session }) {
@@ -567,6 +551,7 @@ function App() {
   // Location entries array for dynamic location fields
   const [locationEntries, setLocationEntries] = useState(['']);
   const locationSyncRef = useRef(false);
+  const createTokenNotesFlushRef = useRef(() => {});
 
   // Sync locationEntries when formData.location changes externally (e.g., from import)
   useEffect(() => {
@@ -1411,6 +1396,9 @@ function App() {
    */
   const handleTokenAdd = async e => {
     e.preventDefault();
+    flushSync(() => {
+      createTokenNotesFlushRef.current();
+    });
 
     if (!validateForm()) {
       return;
@@ -1575,6 +1563,9 @@ function App() {
     try {
       setIsSubmitting(true);
       onDuplicateModalClose();
+      flushSync(() => {
+        createTokenNotesFlushRef.current();
+      });
 
       // Prepare token data again (same as in handleTokenAdd)
       let domainsArray = null;
@@ -2465,6 +2456,9 @@ function App() {
                                 removeLocationEntry={removeLocationEntry}
                                 updateLocationEntry={updateLocationEntry}
                                 defaultContactGroupId={defaultContactGroupId}
+                                createTokenNotesFlushRef={
+                                  createTokenNotesFlushRef
+                                }
                               />
                             )
                           ) : (
@@ -2821,6 +2815,7 @@ function DashboardWrapper({
   removeLocationEntry,
   updateLocationEntry,
   defaultContactGroupId = '',
+  createTokenNotesFlushRef,
 }) {
   const [searchParams] = useSearchParams();
   const [currentView, setCurrentView] = useState('dashboard');
@@ -2960,6 +2955,7 @@ function DashboardWrapper({
               removeLocationEntry={removeLocationEntry}
               updateLocationEntry={updateLocationEntry}
               defaultContactGroupId={defaultContactGroupId}
+              createTokenNotesFlushRef={createTokenNotesFlushRef}
             />
           ) : currentView === 'account' ? (
             <Account session={session} onAccountDeleted={onAccountDeleted} />
@@ -3090,6 +3086,58 @@ function DashboardWrapper({
  * Note: SortableTh and domain helper functions have been extracted to ./components/DashboardHelpers.jsx
  */
 
+const CreateTokenNotesField = memo(function CreateTokenNotesField({
+  parentNotes,
+  onCommitNotes,
+  submitFlushRef,
+  inputBg,
+  inputBorder,
+  placeholderColor,
+}) {
+  const [local, setLocal] = useState(() => parentNotes ?? '');
+  const taRef = useRef(null);
+
+  useEffect(() => {
+    setLocal(parentNotes ?? '');
+  }, [parentNotes]);
+
+  useLayoutEffect(() => {
+    const el = taRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [local]);
+
+  useEffect(() => {
+    submitFlushRef.current = () => {
+      onCommitNotes(taRef.current?.value ?? '');
+    };
+    return () => {
+      submitFlushRef.current = () => {};
+    };
+  }, [local, onCommitNotes, submitFlushRef]);
+
+  return (
+    <Textarea
+      ref={taRef}
+      id='notes'
+      name='notes'
+      value={local}
+      onChange={e => setLocal(e.target.value)}
+      onBlur={e => onCommitNotes(e.target.value)}
+      bg={inputBg}
+      borderColor={inputBorder}
+      placeholder='Additional information'
+      _placeholder={{ color: placeholderColor }}
+      maxLength={10000}
+      rows={2}
+      resize='none'
+      overflow='hidden'
+      minH='40px'
+    />
+  );
+});
+
 function DashboardView({
   _session,
   tokens,
@@ -3137,6 +3185,7 @@ function DashboardView({
   removeLocationEntry,
   updateLocationEntry,
   defaultContactGroupId = '',
+  createTokenNotesFlushRef,
 }) {
   const { colorMode } = useColorMode();
   const isLight = colorMode === 'light';
@@ -3147,7 +3196,6 @@ function DashboardView({
   const _popoverBg = useColorModeValue('gray.100', 'gray.800');
   const _popoverBorder = useColorModeValue('gray.400', 'gray.600');
   const helpTextColor = useColorModeValue('gray.600', 'gray.400');
-  const domainBorderColor = useColorModeValue('gray.200', 'gray.700');
 
   // Use reusable dashboard color hooks
   const {
@@ -3163,6 +3211,172 @@ function DashboardView({
     mobileCardBg,
     secondaryTextColor,
   } = useDashboardColors();
+
+  const commitCreateNotes = useCallback(
+    v => {
+      onInputChange({ target: { name: 'notes', value: v } });
+    },
+    [onInputChange]
+  );
+
+  const contactTagBg = useColorModeValue('blue.100', 'blue.800');
+  const contactTagColor = useColorModeValue('blue.800', 'blue.200');
+
+  const contactInputRef = useRef(null);
+  const [contactTags, setContactTags] = useState([]);
+  const [contactInputValue, setContactInputValue] = useState('');
+  const contactsFromTagsRef = useRef(false);
+
+  useEffect(() => {
+    if (contactsFromTagsRef.current) {
+      contactsFromTagsRef.current = false;
+      return;
+    }
+    if (!formData.contacts) {
+      setContactTags([]);
+      setContactInputValue('');
+    } else {
+      const tags = formData.contacts
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean);
+      setContactTags(tags);
+    }
+  }, [formData.contacts]);
+
+  const workspaceContactLabels = useMemo(() => {
+    const set = new Set();
+    for (const c of Array.isArray(workspaceContacts)
+      ? workspaceContacts
+      : []) {
+      const name = [c.first_name, c.last_name]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+      const phone = (c.phone_e164 || '').trim();
+      const parts = [name, phone].filter(Boolean);
+      const label = parts.join(' - ');
+      if (label) set.add(label);
+    }
+    return set;
+  }, [workspaceContacts]);
+
+  const selectedContactLabels = useMemo(
+    () => new Set(contactTags),
+    [contactTags]
+  );
+
+  const removeContactTag = index => {
+    const newTags = contactTags.filter((_, i) => i !== index);
+    setContactTags(newTags);
+    contactsFromTagsRef.current = true;
+    onInputChange({ target: { name: 'contacts', value: newTags.join(', ') } });
+  };
+
+  const commitContactTag = trimmed => {
+    if (!trimmed) return;
+    if (contactTags.includes(trimmed)) return;
+    const newTags = [...contactTags, trimmed];
+    const newValue = newTags.join(', ');
+    if (newValue.length > 500) return;
+    setContactTags(newTags);
+    setContactInputValue('');
+    contactsFromTagsRef.current = true;
+    onInputChange({ target: { name: 'contacts', value: newValue } });
+  };
+
+  const handleContactInputChange = e => {
+    const v = e.target.value;
+    const trimmed = v.trim();
+    setContactInputValue(v);
+    if (
+      workspaceContactLabels.has(trimmed) &&
+      !selectedContactLabels.has(trimmed)
+    ) {
+      commitContactTag(trimmed);
+    }
+  };
+
+  const handleContactKeyDown = e => {
+    if (e.key === 'Enter' && contactInputValue.trim()) {
+      e.preventDefault();
+      commitContactTag(contactInputValue.trim());
+    } else if (
+      e.key === 'Backspace' &&
+      !contactInputValue &&
+      contactTags.length > 0
+    ) {
+      removeContactTag(contactTags.length - 1);
+    }
+  };
+
+  const renderContactTagInput = placeholder => (
+    <Box
+      border='1px solid'
+      borderColor={inputBorder}
+      borderRadius='md'
+      bg={inputBg}
+      px={2}
+      py='6px'
+      minH='40px'
+      cursor='text'
+      onClick={() => contactInputRef.current?.focus()}
+    >
+      <Flex wrap='wrap' gap={1} alignItems='center'>
+        {contactTags.map((tag, i) => (
+          <Flex
+            key={i}
+            align='center'
+            bg={contactTagBg}
+            color={contactTagColor}
+            borderRadius='md'
+            px={2}
+            py='2px'
+            fontSize='sm'
+            gap={1}
+          >
+            <Text fontSize='sm' lineHeight='short'>
+              {tag}
+            </Text>
+            <Box
+              as='button'
+              type='button'
+              onClick={e => {
+                e.stopPropagation();
+                removeContactTag(i);
+              }}
+              lineHeight={1}
+              cursor='pointer'
+              opacity={0.7}
+              _hover={{ opacity: 1 }}
+              fontSize='xs'
+              fontWeight='bold'
+            >
+              ×
+            </Box>
+          </Flex>
+        ))}
+        <Input
+          ref={contactInputRef}
+          type='text'
+          value={contactInputValue}
+          onChange={handleContactInputChange}
+          onKeyDown={handleContactKeyDown}
+          list='workspace-contacts-suggestions'
+          placeholder={contactTags.length === 0 ? placeholder : ''}
+          _placeholder={{ color: placeholderColor }}
+          border='none'
+          bg='transparent'
+          p={0}
+          h='28px'
+          flex={1}
+          minW='120px'
+          fontSize='sm'
+          _focus={{ boxShadow: 'none', outline: 'none' }}
+        />
+      </Flex>
+    </Box>
+  );
 
   // Per-panel search terms keyed by category value
   const [panelQueries, setPanelQueries] = useState(() => {
@@ -3209,719 +3423,6 @@ function DashboardView({
     onOpen: onDomainModalOpen,
     onClose: onDomainModalClose,
   } = useDisclosure();
-  const [domainUrl, setDomainUrl] = useState('');
-  const [domainHealthCheck, setDomainHealthCheck] = useState(true);
-  const [domainInterval, setDomainInterval] = useState('hourly');
-  const [domainAlertAfter, setDomainAlertAfter] = useState(2);
-  const [domainContactGroupId, setDomainContactGroupId] = useState(
-    defaultContactGroupId || ''
-  );
-  const [addingDomain, setAddingDomain] = useState(false);
-  const [domains, setDomains] = useState([]);
-  const [domainsLoading, setDomainsLoading] = useState(false);
-  const [checkingDomain, setCheckingDomain] = useState(null);
-  const [domainListSort, setDomainListSort] = useState({
-    key: 'az',
-    direction: 'asc',
-  });
-  const [domainCheckerInput, setDomainCheckerInput] = useState('');
-  const [domainCheckerResults, setDomainCheckerResults] = useState([]);
-  const [domainCheckerSelected, setDomainCheckerSelected] = useState([]);
-  const [domainCheckerLoading, setDomainCheckerLoading] = useState(false);
-  const [domainCheckerImporting, setDomainCheckerImporting] = useState(false);
-  const [domainCheckerPartial, setDomainCheckerPartial] = useState(false);
-  const [domainCheckerTruncated, setDomainCheckerTruncated] = useState(false);
-  const [domainCheckerCapCount, setDomainCheckerCapCount] = useState(500);
-  const [domainCheckerToolErrors, setDomainCheckerToolErrors] = useState([]);
-  const [domainCheckerCreateMonitors, setDomainCheckerCreateMonitors] =
-    useState(false);
-  const [domainCheckerMonitorHealthCheck, setDomainCheckerMonitorHealthCheck] =
-    useState(false);
-  const [domainCheckerMonitorInterval, setDomainCheckerMonitorInterval] =
-    useState('hourly');
-  const [domainCheckerMonitorAlertAfter, setDomainCheckerMonitorAlertAfter] =
-    useState(2);
-  const [
-    domainCheckerMonitorContactGroupId,
-    setDomainCheckerMonitorContactGroupId,
-  ] = useState(defaultContactGroupId || '');
-  const [domainCheckerImportSection, setDomainCheckerImportSection] =
-    useState('');
-  const [domainEndpointTokenSection, setDomainEndpointTokenSection] =
-    useState('');
-  const domainCheckerImportInFlightRef = useRef(false);
-  const [domainCheckerPage, setDomainCheckerPage] = useState(0);
-  const [domainCheckerSubfinderAll, setDomainCheckerSubfinderAll] =
-    useState(false);
-  const [domainCheckerImportReport, setDomainCheckerImportReport] =
-    useState(null);
-  const [domainCheckerImportReportOpen, setDomainCheckerImportReportOpen] =
-    useState(false);
-  const DOMAIN_CHECKER_PAGE_SIZE = 50;
-  const DOMAIN_CHECKER_LOOKUP_TIMEOUT_MS = 300_000;
-  const DOMAIN_CHECKER_IMPORT_CHUNK_SIZE = 25;
-  const DOMAIN_CHECKER_IMPORT_CHUNK_TIMEOUT_MS = 300_000;
-
-  const handleDomainModalClose = () => {
-    setDomainCheckerImportReport(null);
-    setDomainCheckerImportReportOpen(false);
-    onDomainModalClose();
-  };
-
-  const normalizeDomainCheckerStringArray = value => {
-    if (Array.isArray(value)) {
-      return value.map(item => String(item || '').trim()).filter(Boolean);
-    }
-    if (typeof value === 'string') {
-      return value
-        .split(',')
-        .map(item => item.trim())
-        .filter(Boolean);
-    }
-    return [];
-  };
-
-  const normalizeDomainCheckerItems = value => {
-    const rawItems = Array.isArray(value) ? value : [];
-    const seen = new Set();
-    return rawItems
-      .map((item, index) => {
-        const record = item && typeof item === 'object' ? item : { name: item };
-        const domains = normalizeDomainCheckerStringArray(
-          record.domains || record.domain || record.hostname || record.name
-        );
-        const name = String(
-          record.name ||
-            record.hostname ||
-            record.commonName ||
-            domains[0] ||
-            ''
-        ).trim();
-        if (!name) return null;
-        const id = String(record.id || `disc-${name}-${index}`);
-        const key = id || name;
-        if (seen.has(key)) return null;
-        seen.add(key);
-        return {
-          ...record,
-          id,
-          name,
-          domains: domains.length ? domains : [name],
-          sources: normalizeDomainCheckerStringArray(
-            record.sources || record.source
-          ),
-          checked: record.checked !== false,
-        };
-      })
-      .filter(Boolean);
-  };
-
-  const normalizeDomainCheckerToolErrors = value =>
-    (Array.isArray(value) ? value : [])
-      .map(error => {
-        if (typeof error === 'string') return { tool: error };
-        if (!error || typeof error !== 'object') return null;
-        return {
-          tool: String(error.tool || error.code || '').trim(),
-          message: String(error.message || '').trim(),
-        };
-      })
-      .filter(error => error && (error.tool || error.message));
-
-  const { workspaceId: ctxWorkspaceId } = useWorkspace();
-
-  // Load domains when modal opens, with up to 3 retries for transient errors (503, 502, etc.)
-  const loadDomains = useCallback(async () => {
-    if (!ctxWorkspaceId) return;
-    setDomainsLoading(true);
-    const maxAttempts = 3;
-    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-      try {
-        const res = await apiClient.get(
-          `/api/v1/workspaces/${ctxWorkspaceId}/domains`
-        );
-        setDomains(res.data?.items || []);
-        setDomainsLoading(false);
-        return;
-      } catch (e) {
-        const status = e?.response?.status;
-        const isTransient = !status || status >= 500 || status === 429;
-        if (attempt < maxAttempts - 1 && isTransient) {
-          await new Promise(r => setTimeout(r, 1500 * (attempt + 1)));
-          continue;
-        }
-        logger.error('Failed to load endpoint monitors', e);
-      }
-    }
-    setDomainsLoading(false);
-  }, [ctxWorkspaceId]);
-
-  const visibleDomains = useMemo(() => {
-    const healthOf = item => String(item?.last_health_status || 'pending');
-    const intervalOrder = {
-      '1min': 0,
-      '5min': 1,
-      '15min': 2,
-      hourly: 3,
-      daily: 4,
-    };
-    const healthOrder = {
-      healthy: 0,
-      warning: 1,
-      error: 2,
-      pending: 3,
-    };
-    const expirationTs = item => {
-      const raw = item?.ssl_valid_to || item?.ssl_expires_at || null;
-      if (!raw) return Number.POSITIVE_INFINITY;
-      const ts = new Date(raw).getTime();
-      return Number.isFinite(ts) ? ts : Number.POSITIVE_INFINITY;
-    };
-
-    const copy = [...domains];
-
-    copy.sort((a, b) => {
-      let result;
-      switch (domainListSort.key) {
-        case 'expiration':
-          result =
-            expirationTs(a) - expirationTs(b) ||
-            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
-          break;
-        case 'interval':
-          result =
-            (intervalOrder[String(a?.check_interval || '')] ?? 999) -
-              (intervalOrder[String(b?.check_interval || '')] ?? 999) ||
-            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
-          break;
-        case 'health':
-          result =
-            (healthOrder[healthOf(a)] ?? 999) -
-              (healthOrder[healthOf(b)] ?? 999) ||
-            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
-          break;
-        case 'az':
-        default:
-          result = domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
-          break;
-      }
-      return domainListSort.direction === 'desc' ? -result : result;
-    });
-
-    return copy;
-  }, [domains, domainListSort]);
-
-  const handleDomainListSort = key => {
-    setDomainListSort(current => ({
-      key,
-      direction:
-        current.key === key && current.direction === 'asc' ? 'desc' : 'asc',
-    }));
-  };
-
-  const renderDomainSortArrow = key => (
-    <Text fontSize='xs' opacity={domainListSort.key === key ? 1 : 0.3}>
-      {domainListSort.key === key && domainListSort.direction === 'desc'
-        ? '↓'
-        : '↑'}
-    </Text>
-  );
-
-  useEffect(() => {
-    if (isDomainModalOpen && ctxWorkspaceId) loadDomains();
-  }, [isDomainModalOpen, ctxWorkspaceId, loadDomains]);
-
-  const handleAddDomain = async () => {
-    if (!domainUrl.trim() || !ctxWorkspaceId) return;
-    setAddingDomain(true);
-    try {
-      const endpointBody = {
-        url: domainUrl.trim(),
-        health_check_enabled: domainHealthCheck,
-        check_interval: domainInterval,
-        alert_after_failures: domainAlertAfter,
-        contact_group_id: domainContactGroupId || null,
-      };
-      if (domainEndpointTokenSection.trim()) {
-        endpointBody.section = domainEndpointTokenSection.trim();
-      }
-      await apiClient.post(
-        `/api/v1/workspaces/${ctxWorkspaceId}/domains`,
-        endpointBody
-      );
-      showSuccessMessage('Endpoint added! SSL certificate tracked.');
-      setDomainUrl('');
-      setDomainHealthCheck(true);
-      setDomainInterval('hourly');
-      setDomainAlertAfter(2);
-      setDomainContactGroupId(defaultContactGroupId || '');
-      setDomainEndpointTokenSection('');
-      loadDomains();
-      try {
-        window.dispatchEvent(new CustomEvent('tt:tokens-imported'));
-        window.dispatchEvent(
-          new CustomEvent('tt:tokens-updated', { detail: { t: Date.now() } })
-        );
-      } catch (_) {}
-      try {
-        await Promise.all(
-          TOKEN_CATEGORIES.map(cat =>
-            fetchTokensForCategoryReset(cat.value, {
-              workspaceId: ctxWorkspaceId,
-            })
-          )
-        );
-      } catch (err) {
-        logger.error('Token list refresh after endpoint add failed', err);
-      }
-      try {
-        const section =
-          (panelQueries && panelQueries.__section) ||
-          new URLSearchParams(window.location.search).get('section') ||
-          '__all__';
-        await fetchGlobalFacets?.({ workspaceId: ctxWorkspaceId, section });
-      } catch (_) {}
-    } catch (e) {
-      const msg = e?.response?.data?.error || 'Failed to add endpoint';
-      logger.error('Endpoint add failed:', msg);
-      toast.error(msg);
-    } finally {
-      setAddingDomain(false);
-    }
-  };
-
-  const handleDeleteDomain = async domainId => {
-    try {
-      await apiClient.delete(
-        `/api/v1/workspaces/${ctxWorkspaceId}/domains/${domainId}`
-      );
-      showSuccessMessage('Endpoint monitor deleted');
-      loadDomains();
-      window.dispatchEvent(new CustomEvent('tt:tokens-updated'));
-    } catch (e) {
-      toast.error(
-        e?.response?.data?.error || 'Failed to delete endpoint monitor'
-      );
-    }
-  };
-
-  const handleCheckDomain = async (domainId, event) => {
-    event?.preventDefault?.();
-    event?.currentTarget?.blur?.();
-    const modalBody = document.querySelector(
-      '[data-endpoint-ssl-modal-body="true"]'
-    );
-    const previousScrollTop = modalBody?.scrollTop;
-    try {
-      setCheckingDomain(domainId);
-      const res = await apiClient.post(
-        `/api/v1/workspaces/${ctxWorkspaceId}/domains/${domainId}/check`
-      );
-      const { data } = res;
-      if (data.status === 'healthy') {
-        showSuccessMessage(`Healthy (${data.responseMs}ms)`);
-      } else {
-        toast.error(
-          `${data.status}: ${data.error || 'Unknown error'} (${data.responseMs}ms)`
-        );
-      }
-      await loadDomains();
-      if (modalBody && typeof previousScrollTop === 'number') {
-        window.requestAnimationFrame(() => {
-          modalBody.scrollTop = previousScrollTop;
-        });
-      }
-    } catch (e) {
-      toast.error(e?.response?.data?.error || 'Health check failed');
-    } finally {
-      setCheckingDomain(null);
-    }
-  };
-
-  const handleDomainCheckerLookup = async () => {
-    if (!domainCheckerInput.trim() || !ctxWorkspaceId) return;
-    setDomainCheckerLoading(true);
-    setDomainCheckerTruncated(false);
-    setDomainCheckerImportReport(null);
-    setDomainCheckerImportReportOpen(false);
-    const lookupUrl = `/api/v1/workspaces/${ctxWorkspaceId}/domain-checker/lookup`;
-    const lookupBody = {
-      domain: domainCheckerInput.trim(),
-      subfinder_all: domainCheckerSubfinderAll,
-    };
-    const lookupReqOpts = { timeout: DOMAIN_CHECKER_LOOKUP_TIMEOUT_MS };
-    const lookupMaxAttempts = 3;
-    const lookupRetriable = e => {
-      if (e?.code === 'ERR_CANCELED' || e?.name === 'CanceledError')
-        return false;
-      const status = e?.response?.status;
-      if (status == null) {
-        const c = e?.code;
-        return (
-          c === 'ECONNABORTED' ||
-          c === 'ERR_NETWORK' ||
-          c === 'ETIMEDOUT' ||
-          c === 'ECONNRESET' ||
-          (!e?.response && c !== 'ERR_BAD_REQUEST')
-        );
-      }
-      return status >= 500 && status < 600;
-    };
-    try {
-      let res;
-      for (let attempt = 0; attempt < lookupMaxAttempts; attempt += 1) {
-        try {
-          res = await apiClient.post(lookupUrl, lookupBody, lookupReqOpts);
-          break;
-        } catch (e) {
-          const last = attempt === lookupMaxAttempts - 1;
-          if (last || !lookupRetriable(e)) throw e;
-          toast('Discovery is slow or the connection dropped. Retrying…', {
-            icon: '⏳',
-          });
-          await new Promise(r => setTimeout(r, 2000 * (attempt + 1)));
-        }
-      }
-      const items = normalizeDomainCheckerItems(res.data?.items);
-      const cap = Number(res.data?.meta?.maxResults);
-      const capN = Number.isFinite(cap) && cap > 0 ? cap : 500;
-      setDomainCheckerCapCount(capN);
-      setDomainCheckerTruncated(Boolean(res.data?.meta?.truncated));
-      setDomainCheckerResults(items);
-      setDomainCheckerPartial(Boolean(res.data?.partial));
-      setDomainCheckerToolErrors(
-        normalizeDomainCheckerToolErrors(res.data?.toolErrors)
-      );
-      if (items.length === 0) {
-        toast.error('No subdomains found for this domain.');
-      } else {
-        showSuccessMessage(
-          `Found ${items.length} subdomain${items.length === 1 ? '' : 's'}.`
-        );
-      }
-    } catch (e) {
-      setDomainCheckerTruncated(false);
-      const code = e?.response?.data?.code;
-      const retryAfter = e?.response?.data?.retry_after_seconds;
-      const base =
-        code === 'DOMAIN_CHECKER_RATE_LIMITED' && Number.isFinite(retryAfter)
-          ? `Rate limited. Try again in about ${retryAfter}s.`
-          : e?.response?.data?.error;
-      toast.error(
-        base ||
-          'Domain checker lookup failed. Discovery tools may be slow or unavailable.'
-      );
-    } finally {
-      setDomainCheckerLoading(false);
-    }
-  };
-
-  const toggleDomainCheckerResult = id => {
-    setDomainCheckerSelected(prev =>
-      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
-    );
-  };
-
-  const domainCheckerVisibleResults = useMemo(() => {
-    return Array.isArray(domainCheckerResults)
-      ? domainCheckerResults.filter(Boolean)
-      : [];
-  }, [domainCheckerResults]);
-
-  const domainCheckerPageItems = useMemo(
-    () =>
-      domainCheckerVisibleResults.slice(
-        domainCheckerPage * DOMAIN_CHECKER_PAGE_SIZE,
-        (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE
-      ),
-    [domainCheckerPage, domainCheckerVisibleResults]
-  );
-
-  const domainCheckerSelectedSet = useMemo(
-    () => new Set(domainCheckerSelected),
-    [domainCheckerSelected]
-  );
-
-  const domainCheckerSelectAllVisibleState = useMemo(() => {
-    const ids = domainCheckerVisibleResults.map(c => c?.id).filter(Boolean);
-    if (ids.length === 0) return { checked: false, indeterminate: false };
-    let n = 0;
-    for (const id of ids) {
-      if (domainCheckerSelectedSet.has(id)) n += 1;
-    }
-    return {
-      checked: n === ids.length,
-      indeterminate: n > 0 && n < ids.length,
-    };
-  }, [domainCheckerVisibleResults, domainCheckerSelectedSet]);
-
-  const toggleDomainCheckerSelectAllVisible = useCallback(() => {
-    const ids = domainCheckerVisibleResults.map(c => c?.id).filter(Boolean);
-    if (ids.length === 0) return;
-    const allOn = ids.every(id => domainCheckerSelectedSet.has(id));
-    if (allOn) {
-      const drop = new Set(ids);
-      setDomainCheckerSelected(prev => prev.filter(id => !drop.has(id)));
-    } else {
-      setDomainCheckerSelected(prev => Array.from(new Set([...prev, ...ids])));
-    }
-  }, [domainCheckerVisibleResults, domainCheckerSelectedSet]);
-
-  const prevDomainCheckerResultsRef = useRef(null);
-  useEffect(() => {
-    const isNewLookup =
-      domainCheckerResults !== prevDomainCheckerResultsRef.current;
-    prevDomainCheckerResultsRef.current = domainCheckerResults;
-    if (isNewLookup) {
-      setDomainCheckerSelected(
-        domainCheckerVisibleResults
-          .filter(c => c?.checked && c?.id)
-          .map(c => c.id)
-      );
-    } else {
-      const visibleIds = new Set(
-        domainCheckerVisibleResults.map(c => c.id).filter(Boolean)
-      );
-      setDomainCheckerSelected(prev => prev.filter(id => visibleIds.has(id)));
-    }
-    setDomainCheckerPage(0);
-  }, [domainCheckerVisibleResults, domainCheckerResults]);
-
-  const handleDomainCheckerImport = async () => {
-    if (!ctxWorkspaceId || domainCheckerSelectedSet.size === 0) return;
-    if (domainCheckerImportInFlightRef.current) return;
-    domainCheckerImportInFlightRef.current = true;
-    const selected = domainCheckerVisibleResults.filter(item =>
-      domainCheckerSelectedSet.has(item.id)
-    );
-    setDomainCheckerImporting(true);
-    setDomainCheckerImportReport(null);
-    setDomainCheckerImportReportOpen(false);
-    try {
-      const peelDomainCheckerSelectionAfterImport = (
-        importedList,
-        skippedList
-      ) => {
-        const drop = new Set();
-        for (const row of importedList || []) {
-          const cid = row && (row.certificateId || row.certificate_id);
-          if (cid) drop.add(String(cid));
-        }
-        for (const row of skippedList || []) {
-          if (row && row.reason === 'duplicate' && row.id)
-            drop.add(String(row.id));
-        }
-        if (drop.size === 0) return;
-        setDomainCheckerSelected(prev =>
-          prev.filter(id => !drop.has(String(id)))
-        );
-      };
-
-      const payloadBase = {
-        domain: domainCheckerInput.trim(),
-        monitorOptions: {
-          enabled: domainCheckerCreateMonitors,
-          health_check_enabled: domainCheckerMonitorHealthCheck,
-          check_interval: domainCheckerMonitorInterval,
-          alert_after_failures: domainCheckerMonitorAlertAfter,
-          contact_group_id: domainCheckerMonitorContactGroupId || null,
-        },
-      };
-      if (domainCheckerImportSection.trim()) {
-        payloadBase.tokenOptions = {
-          section: domainCheckerImportSection.trim(),
-        };
-      }
-
-      const mergedImported = [];
-      const mergedSkipped = [];
-      let monitorsCreated = 0;
-      let monitorsExisting = 0;
-      let chunkError = null;
-      let hadNoResponseChunk = false;
-
-      for (
-        let i = 0;
-        i < selected.length;
-        i += DOMAIN_CHECKER_IMPORT_CHUNK_SIZE
-      ) {
-        const chunk = selected.slice(i, i + DOMAIN_CHECKER_IMPORT_CHUNK_SIZE);
-        try {
-          const res = await apiClient.post(
-            `/api/v1/workspaces/${ctxWorkspaceId}/domain-checker/import`,
-            { ...payloadBase, certificates: chunk },
-            { timeout: DOMAIN_CHECKER_IMPORT_CHUNK_TIMEOUT_MS }
-          );
-          mergedImported.push(
-            ...(Array.isArray(res.data?.imported)
-              ? res.data.imported
-              : []
-            ).filter(Boolean)
-          );
-          mergedSkipped.push(
-            ...(Array.isArray(res.data?.skipped)
-              ? res.data.skipped
-              : []
-            ).filter(Boolean)
-          );
-          monitorsCreated += res.data?.monitors?.created || 0;
-          monitorsExisting += res.data?.monitors?.existing || 0;
-        } catch (e) {
-          if (!e?.response) {
-            // Continue with remaining chunks; backend may still commit this interrupted chunk.
-            hadNoResponseChunk = true;
-            chunkError = e;
-            continue;
-          }
-          chunkError = e;
-          break;
-        }
-      }
-
-      const refreshAfterDomainCheckerImport = async () => {
-        try {
-          window.dispatchEvent(new CustomEvent('tt:tokens-imported'));
-          window.dispatchEvent(
-            new CustomEvent('tt:tokens-updated', { detail: { t: Date.now() } })
-          );
-        } catch (_) {}
-        try {
-          await Promise.all(
-            TOKEN_CATEGORIES.map(cat =>
-              fetchTokensForCategoryReset(cat.value, {
-                workspaceId: ctxWorkspaceId,
-              })
-            )
-          );
-        } catch (err) {
-          logger.error(
-            'Token list refresh after domain checker import failed',
-            err
-          );
-        }
-        try {
-          const section =
-            (panelQueries && panelQueries.__section) ||
-            new URLSearchParams(window.location.search).get('section') ||
-            '__all__';
-          await fetchGlobalFacets?.({ workspaceId: ctxWorkspaceId, section });
-        } catch (_) {}
-        try {
-          await loadDomains();
-        } catch (_) {}
-      };
-
-      const applyImportReport = (imported, skippedList, options = {}) => {
-        const safeSkipped = skippedList.filter(Boolean);
-        const dnsUnreachableDetails = new Set([
-          'live_certificate_dns_unresolved',
-          'live_certificate_dns_temporary',
-        ]);
-        const unreachable = safeSkipped.filter(
-          s =>
-            s.reason === 'invalid_certificate' &&
-            dnsUnreachableDetails.has(s.detail)
-        ).length;
-        const errorLike = safeSkipped.length - unreachable;
-        const logLines = safeSkipped.map(s => {
-          const label =
-            (typeof s.subject === 'string' && s.subject.trim()) ||
-            (Array.isArray(s.domains) && s.domains[0]) ||
-            (typeof s.name === 'string' && s.name) ||
-            s.id ||
-            'host';
-          const reason = s.reason || 'unknown';
-          const detail = s.detail ? ` — ${s.detail}` : '';
-          return `${label}: ${reason}${detail}`;
-        });
-        setDomainCheckerImportReport({
-          unreachable,
-          errorLike,
-          imported,
-          importedLowerBound: Boolean(options.importedLowerBound),
-          logLines,
-        });
-        setDomainCheckerImportReportOpen(false);
-      };
-
-      if (chunkError && !hadNoResponseChunk) {
-        await refreshAfterDomainCheckerImport();
-        if (mergedImported.length || mergedSkipped.length) {
-          peelDomainCheckerSelectionAfterImport(mergedImported, mergedSkipped);
-          applyImportReport(mergedImported.length, mergedSkipped, {
-            importedLowerBound: false,
-          });
-          toast.error(
-            chunkError?.response?.data?.error || 'Failed to import certificates'
-          );
-        } else {
-          setDomainCheckerImportReport(null);
-          toast.error(
-            chunkError?.response?.data?.error || 'Failed to import certificates'
-          );
-        }
-      } else {
-        const importedList = mergedImported;
-        const skippedList = mergedSkipped;
-        const imported = importedList.length;
-
-        let summary = `Imported ${imported} SSL token${imported === 1 ? '' : 's'}`;
-        if (monitorsCreated || monitorsExisting) {
-          const monitorParts = [];
-          if (monitorsCreated)
-            monitorParts.push(
-              `${monitorsCreated} new monitor${monitorsCreated === 1 ? '' : 's'}`
-            );
-          if (monitorsExisting)
-            monitorParts.push(`${monitorsExisting} already existed`);
-          summary += ` (${monitorParts.join(', ')})`;
-        }
-        summary += '.';
-        peelDomainCheckerSelectionAfterImport(importedList, skippedList);
-        showSuccessMessage(summary);
-
-        applyImportReport(imported, skippedList, {
-          importedLowerBound: hadNoResponseChunk,
-        });
-        if (!hadNoResponseChunk) {
-          setDomainCheckerResults([]);
-          setDomainCheckerSelected([]);
-          setDomainCheckerPage(0);
-          setDomainCheckerPartial(false);
-          setDomainCheckerTruncated(false);
-          setDomainCheckerToolErrors([]);
-          setDomainCheckerInput('');
-          setDomainListSort({ key: 'az', direction: 'asc' });
-          await refreshAfterDomainCheckerImport();
-          window.requestAnimationFrame(() => {
-            const modalBody = document.querySelector(
-              '[data-endpoint-ssl-modal-body="true"]'
-            );
-            modalBody?.scrollTo({ top: 0, behavior: 'smooth' });
-          });
-        } else {
-          await refreshAfterDomainCheckerImport();
-        }
-        if (hadNoResponseChunk) {
-          toast.error(
-            `One or more import batches lost the response before completion. At least ${imported} token(s) are confirmed from completed batches; additional tokens may have been imported in interrupted batches. Refresh the list to verify the final total.`
-          );
-        }
-      }
-    } catch (e) {
-      setDomainCheckerImportReport(null);
-      const noResponse = !e?.response;
-      toast.error(
-        noResponse
-          ? 'Connection closed before the response finished. Some tokens may already be imported; refresh the list before retrying.'
-          : e?.response?.data?.error || 'Failed to import certificates'
-      );
-    } finally {
-      domainCheckerImportInFlightRef.current = false;
-      setDomainCheckerImporting(false);
-    }
-  };
-
   // Form collapse state - collapsed by default for cleaner UI
   const [isFormExpanded, setIsFormExpanded] = useState(false);
 
@@ -3995,22 +3496,24 @@ function DashboardView({
     }
 
     try {
-      const updates = await Promise.allSettled(
-        tokenIds.map(id =>
-          apiClient.put(API_ENDPOINTS.UPDATE_TOKEN(id), { section: [draft] })
-        )
-      );
-      const successIds = [];
-      let failedCount = 0;
-      updates.forEach((result, index) => {
-        if (result.status === 'fulfilled') successIds.push(tokenIds[index]);
-        else failedCount += 1;
+      const res = await apiClient.put('/api/tokens/bulk', {
+        ids: tokenIds,
+        section: [draft],
       });
+      const data = res.data || {};
+      const successIds = Array.isArray(data.results?.success)
+        ? data.results.success
+        : [];
+      const failedCount =
+        typeof data.failedCount === 'number'
+          ? data.failedCount
+          : Math.max(tokenIds.length - successIds.length, 0);
 
       if (successIds.length > 0) {
-        safeSetTokens(prev =>
+        const successSet = new Set(successIds.map(id => String(id)));
+        _setTokens(prev =>
           prev.map(token =>
-            successIds.includes(token.id)
+            successSet.has(String(token.id))
               ? { ...token, section: [draft] }
               : token
           )
@@ -4029,7 +3532,9 @@ function DashboardView({
       }
     } catch (error) {
       logger.error('Bulk section assignment failed', error);
-      toast.error('Failed to assign section');
+      toast.error(
+        error?.response?.data?.error || 'Failed to assign section'
+      );
     }
   };
 
@@ -4681,19 +4186,7 @@ function DashboardView({
                       <FormLabel htmlFor='contacts'>
                         Contacts (Key custodian)
                       </FormLabel>
-                      <Input
-                        type='text'
-                        id='contacts'
-                        name='contacts'
-                        value={formData.contacts}
-                        onChange={onInputChange}
-                        bg={inputBg}
-                        borderColor={inputBorder}
-                        placeholder='Who manages this certificate?'
-                        _placeholder={{ color: placeholderColor }}
-                        maxLength={200}
-                        list='workspace-contacts-suggestions'
-                      />
+                      {renderContactTagInput('Who manages this certificate?')}
                     </FormControl>
                   </SimpleGrid>
                 )}
@@ -4840,19 +4333,7 @@ function DashboardView({
                       <FormLabel htmlFor='contacts'>
                         Contacts (Key custodian)
                       </FormLabel>
-                      <Input
-                        type='text'
-                        id='contacts'
-                        name='contacts'
-                        value={formData.contacts}
-                        onChange={onInputChange}
-                        bg={inputBg}
-                        borderColor={inputBorder}
-                        placeholder='Who manages this key/secret?'
-                        _placeholder={{ color: placeholderColor }}
-                        maxLength={200}
-                        list='workspace-contacts-suggestions'
-                      />
+                      {renderContactTagInput('Who manages this key/secret?')}
                     </FormControl>
                   </SimpleGrid>
                 )}
@@ -4947,19 +4428,7 @@ function DashboardView({
 
                     <FormControl>
                       <FormLabel htmlFor='contacts'>Contacts</FormLabel>
-                      <Input
-                        type='text'
-                        id='contacts'
-                        name='contacts'
-                        value={formData.contacts}
-                        onChange={onInputChange}
-                        bg={inputBg}
-                        borderColor={inputBorder}
-                        placeholder='Who owns this renewal?'
-                        _placeholder={{ color: placeholderColor }}
-                        maxLength={200}
-                        list='workspace-contacts-suggestions'
-                      />
+                      {renderContactTagInput('Who owns this renewal?')}
                     </FormControl>
                   </SimpleGrid>
                 )}
@@ -5040,19 +4509,7 @@ function DashboardView({
 
                     <FormControl>
                       <FormLabel htmlFor='contacts'>Contacts</FormLabel>
-                      <Input
-                        type='text'
-                        id='contacts'
-                        name='contacts'
-                        value={formData.contacts}
-                        onChange={onInputChange}
-                        bg={inputBg}
-                        borderColor={inputBorder}
-                        placeholder='Who manages this item?'
-                        _placeholder={{ color: placeholderColor }}
-                        maxLength={200}
-                        list='workspace-contacts-suggestions'
-                      />
+                      {renderContactTagInput('Who manages this item?')}
                     </FormControl>
                   </SimpleGrid>
                 )}
@@ -5062,32 +4519,33 @@ function DashboardView({
                   {(Array.isArray(workspaceContacts)
                     ? workspaceContacts
                     : []
-                  ).map(c => {
-                    const name = [c.first_name, c.last_name]
-                      .filter(Boolean)
-                      .join(' ')
-                      .trim();
-                    const phone = (c.phone_e164 || '').trim();
-                    const parts = [name, phone].filter(Boolean);
-                    const label = parts.join(' - ');
-                    return <option key={c.id} value={label} />;
-                  })}
+                  )
+                    .map(c => {
+                      const name = [c.first_name, c.last_name]
+                        .filter(Boolean)
+                        .join(' ')
+                        .trim();
+                      const phone = (c.phone_e164 || '').trim();
+                      const parts = [name, phone].filter(Boolean);
+                      const label = parts.join(' - ');
+                      return { c, label };
+                    })
+                    .filter(({ label }) => label && !selectedContactLabels.has(label))
+                    .map(({ c, label }) => (
+                      <option key={c.id} value={label} />
+                    ))}
                 </datalist>
 
                 {/* Notes field for all categories */}
                 <FormControl mt={6}>
                   <FormLabel htmlFor='notes'>Notes</FormLabel>
-                  <Input
-                    type='text'
-                    id='notes'
-                    name='notes'
-                    value={formData.notes}
-                    onChange={onInputChange}
-                    bg={inputBg}
-                    borderColor={inputBorder}
-                    placeholder='Additional information'
-                    _placeholder={{ color: placeholderColor }}
-                    maxLength={500}
+                  <CreateTokenNotesField
+                    parentNotes={formData.notes}
+                    onCommitNotes={commitCreateNotes}
+                    submitFlushRef={createTokenNotesFlushRef}
+                    inputBg={inputBg}
+                    inputBorder={inputBorder}
+                    placeholderColor={placeholderColor}
                   />
                 </FormControl>
 
@@ -6285,866 +5743,16 @@ function DashboardView({
 
       {/* Global load more removed in favor of per-category controls */}
 
-      {/* Endpoint & SSL monitoring modal: single-URL health checks + Domain Checker SSL discovery */}
-      <Modal
+      <EndpointSslMonitorModal
         isOpen={isDomainModalOpen}
-        onClose={handleDomainModalClose}
-        size='xl'
-      >
-        <ModalOverlay />
-        <ModalContent maxW='1100px'>
-          <ModalHeader>Endpoint & SSL monitoring</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody data-endpoint-ssl-modal-body='true'>
-            <VStack spacing={5} align='stretch'>
-              <Text fontSize='sm' color={helpTextColor}>
-                Monitor SSL certificates and endpoint health for your URLs.
-                Tokens are auto-created for each SSL certificate detected.
-              </Text>
-
-              {domainCheckerImportReport && (
-                <Box
-                  p={3}
-                  borderRadius='md'
-                  borderWidth='1px'
-                  borderColor={domainBorderColor}
-                  fontSize='sm'
-                >
-                  <HStack justify='space-between' align='start' spacing={3}>
-                    <Box>
-                      <Text fontWeight='semibold'>Last import summary</Text>
-                      <Text color={helpTextColor}>
-                        {domainCheckerImportReport.importedLowerBound
-                          ? 'At least '
-                          : ''}
-                        {domainCheckerImportReport.imported} SSL token
-                        {domainCheckerImportReport.imported === 1
-                          ? ''
-                          : 's'}{' '}
-                        {domainCheckerImportReport.importedLowerBound
-                          ? 'confirmed in completed responses'
-                          : 'created'}
-                        , {domainCheckerImportReport.errorLike} skipped,{' '}
-                        {domainCheckerImportReport.unreachable} unreachable.
-                      </Text>
-                    </Box>
-                    <Button
-                      size='xs'
-                      variant='ghost'
-                      onClick={() => {
-                        setDomainCheckerImportReport(null);
-                        setDomainCheckerImportReportOpen(false);
-                      }}
-                    >
-                      Dismiss
-                    </Button>
-                  </HStack>
-                  {domainCheckerImportReport.logLines.length > 0 && (
-                    <>
-                      <Button
-                        variant='link'
-                        size='xs'
-                        mt={1}
-                        rightIcon={
-                          domainCheckerImportReportOpen ? (
-                            <FiChevronUp />
-                          ) : (
-                            <FiChevronDown />
-                          )
-                        }
-                        onClick={() =>
-                          setDomainCheckerImportReportOpen(o => !o)
-                        }
-                      >
-                        {domainCheckerImportReportOpen
-                          ? 'Show less'
-                          : 'Show more'}
-                      </Button>
-                      <Collapse
-                        in={domainCheckerImportReportOpen}
-                        animateOpacity
-                      >
-                        <Box
-                          as='pre'
-                          mt={2}
-                          p={2}
-                          borderRadius='md'
-                          bg='blackAlpha.50'
-                          _dark={{ bg: 'whiteAlpha.100' }}
-                          fontSize='xs'
-                          whiteSpace='pre-wrap'
-                          wordBreak='break-word'
-                          maxH='220px'
-                          overflowY='auto'
-                        >
-                          {domainCheckerImportReport.logLines.join('\n')}
-                        </Box>
-                      </Collapse>
-                    </>
-                  )}
-                </Box>
-              )}
-
-              {/* Existing domains list */}
-              {domainsLoading ? (
-                <Text fontSize='sm' color={helpTextColor}>
-                  Loading endpoints...
-                </Text>
-              ) : domains.length === 0 ? (
-                <Alert status='info' borderRadius='md' size='sm'>
-                  <AlertIcon />
-                  <AlertDescription fontSize='sm'>
-                    No endpoints monitored yet. Add one below to start tracking
-                    SSL certificates and endpoint health.
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <>
-                  {visibleDomains.length === 0 ? (
-                    <Alert status='info' borderRadius='md' size='sm'>
-                      <AlertIcon />
-                      <AlertDescription fontSize='sm'>
-                        No endpoints match your current filters.
-                      </AlertDescription>
-                    </Alert>
-                  ) : (
-                    <>
-                      {/* Mobile: Card list */}
-                      <Box display={{ base: 'block', md: 'none' }}>
-                        <VStack align='stretch' spacing={3}>
-                          {visibleDomains.map(d => (
-                            <Box
-                              key={d.id}
-                              p={4}
-                              bg={mobileCardBg}
-                              border='1px solid'
-                              borderColor={domainBorderColor}
-                              borderRadius='md'
-                            >
-                              <HStack
-                                justify='space-between'
-                                align='start'
-                                mb={2}
-                              >
-                                <Box flex='1' minW='0'>
-                                  <HStack spacing={1}>
-                                    <Text
-                                      fontWeight='semibold'
-                                      fontSize='sm'
-                                      wordBreak='break-all'
-                                    >
-                                      {domainFormatUrl(d.url)}
-                                    </Text>
-                                    <IconButton
-                                      as='a'
-                                      href={d.url}
-                                      target='_blank'
-                                      rel='noopener'
-                                      size='xs'
-                                      variant='ghost'
-                                      icon={<FiExternalLink />}
-                                      aria-label='Open'
-                                    />
-                                  </HStack>
-                                  {d.ssl_issuer && (
-                                    <Text fontSize='xs' color={helpTextColor}>
-                                      Issuer: {d.ssl_issuer}
-                                    </Text>
-                                  )}
-                                </Box>
-                                <HStack spacing={1}>
-                                  <IconButton
-                                    size='xs'
-                                    icon={<FiRefreshCw />}
-                                    aria-label='Check now'
-                                    onClick={event =>
-                                      handleCheckDomain(d.id, event)
-                                    }
-                                    isLoading={checkingDomain === d.id}
-                                  />
-                                  <IconButton
-                                    size='xs'
-                                    icon={<FiTrash2 />}
-                                    aria-label='Delete'
-                                    colorScheme='red'
-                                    variant='ghost'
-                                    onClick={() => handleDeleteDomain(d.id)}
-                                  />
-                                </HStack>
-                              </HStack>
-                              <HStack spacing={2} flexWrap='wrap' mb={2}>
-                                {domainSslBadge(d)}
-                                {d.last_health_status ? (
-                                  <Badge
-                                    colorScheme={domainStatusColor(
-                                      d.last_health_status
-                                    )}
-                                  >
-                                    {d.last_health_status}
-                                  </Badge>
-                                ) : (
-                                  <Badge colorScheme='gray'>Pending</Badge>
-                                )}
-                                <Badge variant='outline'>
-                                  {d.check_interval}
-                                </Badge>
-                                <Badge variant='outline' colorScheme='orange'>
-                                  {d.alert_after_failures || 2}x
-                                </Badge>
-                              </HStack>
-                              <HStack
-                                spacing={4}
-                                fontSize='xs'
-                                color={helpTextColor}
-                              >
-                                {d.last_health_response_ms != null && (
-                                  <Text>{d.last_health_response_ms}ms</Text>
-                                )}
-                                {d.last_health_check_at && (
-                                  <Text>
-                                    {new Date(
-                                      d.last_health_check_at
-                                    ).toLocaleString()}
-                                  </Text>
-                                )}
-                              </HStack>
-                            </Box>
-                          ))}
-                        </VStack>
-                      </Box>
-
-                      {/* Desktop: Table */}
-                      <Box
-                        display={{ base: 'none', md: 'block' }}
-                        borderRadius='md'
-                        border='1px solid'
-                        borderColor={domainBorderColor}
-                        overflow='auto'
-                      >
-                        <Table size='sm' variant='simple' tableLayout='fixed'>
-                          <Thead>
-                            <Tr>
-                              <Th
-                                w='28%'
-                                cursor='pointer'
-                                userSelect='none'
-                                onClick={() => handleDomainListSort('az')}
-                              >
-                                <HStack spacing={1} justify='space-between'>
-                                  <Text>Endpoint</Text>
-                                  {renderDomainSortArrow('az')}
-                                </HStack>
-                              </Th>
-                              <Th
-                                whiteSpace='nowrap'
-                                cursor='pointer'
-                                userSelect='none'
-                                onClick={() =>
-                                  handleDomainListSort('expiration')
-                                }
-                              >
-                                <HStack spacing={1} justify='space-between'>
-                                  <Text>SSL</Text>
-                                  {renderDomainSortArrow('expiration')}
-                                </HStack>
-                              </Th>
-                              <Th
-                                whiteSpace='nowrap'
-                                cursor='pointer'
-                                userSelect='none'
-                                onClick={() => handleDomainListSort('health')}
-                              >
-                                <HStack spacing={1} justify='space-between'>
-                                  <Text>Health</Text>
-                                  {renderDomainSortArrow('health')}
-                                </HStack>
-                              </Th>
-                              <Th whiteSpace='nowrap'>Response</Th>
-                              <Th whiteSpace='nowrap'>Last Check</Th>
-                              <Th
-                                whiteSpace='nowrap'
-                                cursor='pointer'
-                                userSelect='none'
-                                onClick={() => handleDomainListSort('interval')}
-                              >
-                                <HStack spacing={1} justify='space-between'>
-                                  <Text>Interval</Text>
-                                  {renderDomainSortArrow('interval')}
-                                </HStack>
-                              </Th>
-                              <Th whiteSpace='nowrap'>Alert after</Th>
-                              <Th
-                                textAlign='right'
-                                whiteSpace='nowrap'
-                                width='92px'
-                              ></Th>
-                            </Tr>
-                          </Thead>
-                          <Tbody>
-                            {visibleDomains.map(d => (
-                              <Tr key={d.id}>
-                                <Td maxW='0'>
-                                  <HStack spacing={1} minW='0'>
-                                    <Text
-                                      fontWeight='medium'
-                                      fontSize='sm'
-                                      whiteSpace='normal'
-                                      wordBreak='break-all'
-                                      overflowWrap='anywhere'
-                                      flex='1'
-                                      minW='0'
-                                    >
-                                      {domainFormatUrl(d.url)}
-                                    </Text>
-                                    <Tooltip label='Open in browser'>
-                                      <IconButton
-                                        as='a'
-                                        href={d.url}
-                                        target='_blank'
-                                        rel='noopener'
-                                        size='xs'
-                                        variant='ghost'
-                                        icon={<FiExternalLink />}
-                                        aria-label='Open'
-                                      />
-                                    </Tooltip>
-                                  </HStack>
-                                  {d.ssl_issuer && (
-                                    <Text fontSize='2xs' color={helpTextColor}>
-                                      Issuer: {d.ssl_issuer}
-                                    </Text>
-                                  )}
-                                </Td>
-                                <Td whiteSpace='nowrap'>{domainSslBadge(d)}</Td>
-                                <Td whiteSpace='nowrap'>
-                                  {d.last_health_status ? (
-                                    <Tooltip
-                                      label={
-                                        d.last_health_error ||
-                                        `HTTP ${d.last_health_status_code}`
-                                      }
-                                    >
-                                      <Badge
-                                        colorScheme={domainStatusColor(
-                                          d.last_health_status
-                                        )}
-                                      >
-                                        {d.last_health_status}
-                                      </Badge>
-                                    </Tooltip>
-                                  ) : (
-                                    <Badge colorScheme='gray'>Pending</Badge>
-                                  )}
-                                </Td>
-                                <Td fontSize='xs' whiteSpace='nowrap'>
-                                  {d.last_health_response_ms != null
-                                    ? `${d.last_health_response_ms}ms`
-                                    : '-'}
-                                </Td>
-                                <Td fontSize='xs' whiteSpace='nowrap'>
-                                  {d.last_health_check_at
-                                    ? new Date(
-                                        d.last_health_check_at
-                                      ).toLocaleString()
-                                    : '-'}
-                                </Td>
-                                <Td whiteSpace='nowrap'>
-                                  <Badge variant='outline'>
-                                    {d.check_interval}
-                                  </Badge>
-                                </Td>
-                                <Td>
-                                  <Tooltip
-                                    label={`Alert sent after ${d.alert_after_failures || 2} consecutive failures`}
-                                  >
-                                    <Badge
-                                      variant='outline'
-                                      colorScheme='orange'
-                                    >
-                                      {d.alert_after_failures || 2}x
-                                    </Badge>
-                                  </Tooltip>
-                                </Td>
-                                <Td textAlign='right'>
-                                  <HStack spacing={1} justify='flex-end'>
-                                    <Tooltip label='Run health check now'>
-                                      <IconButton
-                                        size='xs'
-                                        icon={<FiRefreshCw />}
-                                        aria-label='Check now'
-                                        onClick={event =>
-                                          handleCheckDomain(d.id, event)
-                                        }
-                                        isLoading={checkingDomain === d.id}
-                                      />
-                                    </Tooltip>
-                                    <Tooltip label='Delete endpoint monitor'>
-                                      <IconButton
-                                        size='xs'
-                                        icon={<FiTrash2 />}
-                                        aria-label='Delete'
-                                        colorScheme='red'
-                                        variant='ghost'
-                                        onClick={() => handleDeleteDomain(d.id)}
-                                      />
-                                    </Tooltip>
-                                  </HStack>
-                                </Td>
-                              </Tr>
-                            ))}
-                          </Tbody>
-                        </Table>
-                      </Box>
-                    </>
-                  )}
-                </>
-              )}
-
-              <Divider />
-              <Box>
-                <HStack justify='space-between' align='start' mb={2}>
-                  <Box>
-                    <Text fontWeight='semibold' fontSize='sm'>
-                      Domain checker
-                    </Text>
-                    <Text fontSize='xs' color={helpTextColor}>
-                      Discovery is best-effort and uses subfinder&apos;s default
-                      passive discovery behavior. Results come from public
-                      passive sources; TokenTimer does not scan private DNS or
-                      internal network records. Then import selected hosts as
-                      SSL tokens and endpoint monitors.
-                    </Text>
-                  </Box>
-                  <Badge colorScheme='purple'>Subdomain discovery</Badge>
-                </HStack>
-                <HStack spacing={3} align='flex-end' flexWrap='wrap'>
-                  <FormControl flex={2} minW='220px'>
-                    <FormLabel fontSize='sm'>Root domain</FormLabel>
-                    <Input
-                      size='sm'
-                      value={domainCheckerInput}
-                      onChange={e => setDomainCheckerInput(e.target.value)}
-                      placeholder='example.com'
-                    />
-                  </FormControl>
-                  <HStack align='center' spacing={1} pb={1}>
-                    <Checkbox
-                      size='sm'
-                      colorScheme='blue'
-                      isChecked={domainCheckerSubfinderAll}
-                      onChange={e =>
-                        setDomainCheckerSubfinderAll(e.target.checked)
-                      }
-                    >
-                      Use all sources
-                    </Checkbox>
-                    <Tooltip
-                      hasArrow
-                      fontSize='xs'
-                      maxW='280px'
-                      label='subfinder -all uses every passive source and is slower than the default. Passive indexes can list stale or abandoned subdomains; SSL import may then touch hosts that no longer match your live certificates.'
-                    >
-                      <IconButton
-                        aria-label='About subfinder all sources'
-                        icon={<FiAlertTriangle />}
-                        size='xs'
-                        variant='ghost'
-                        colorScheme='orange'
-                      />
-                    </Tooltip>
-                  </HStack>
-                  <Button
-                    size='sm'
-                    colorScheme='purple'
-                    isLoading={domainCheckerLoading}
-                    loadingText='Discovering...'
-                    onClick={handleDomainCheckerLookup}
-                    isDisabled={!domainCheckerInput.trim()}
-                  >
-                    Discover subdomains
-                  </Button>
-                </HStack>
-                <Alert status='info' borderRadius='md' mt={3} py={2}>
-                  <AlertIcon />
-                  <AlertDescription fontSize='xs'>
-                    Discovery can take up to about 5 minutes on large domains.
-                    Leave this tab open while a scan runs.
-                  </AlertDescription>
-                </Alert>
-                {domainCheckerPartial && (
-                  <Alert status='warning' borderRadius='md' mt={3}>
-                    <AlertIcon />
-                    <AlertDescription fontSize='sm'>
-                      Some discovery sources were unavailable. Showing partial
-                      results
-                      {domainCheckerToolErrors.length
-                        ? ` (${domainCheckerToolErrors
-                            .map(error => error?.tool || error?.message)
-                            .filter(Boolean)
-                            .join(', ')})`
-                        : ''}
-                      .
-                    </AlertDescription>
-                  </Alert>
-                )}
-                {domainCheckerTruncated && (
-                  <Alert status='info' borderRadius='md' mt={3} py={2}>
-                    <AlertIcon />
-                    <AlertDescription fontSize='xs'>
-                      This list is capped at {domainCheckerCapCount} hostnames
-                      per discovery run. Names beyond that cap are not stored or
-                      shown, so import is limited to this table. The server
-                      limit is configurable (DOMAIN_CHECKER_MAX_RESULTS).
-                    </AlertDescription>
-                  </Alert>
-                )}
-                {domainCheckerResults.length > 0 && (
-                  <Box
-                    mt={3}
-                    border='1px solid'
-                    borderColor={domainBorderColor}
-                    borderRadius='md'
-                    overflow='auto'
-                  >
-                    <Table size='sm'>
-                      <Thead>
-                        <Tr>
-                          <Th>
-                            <Checkbox
-                              aria-label='Select all discovered hosts (all pages)'
-                              isChecked={
-                                domainCheckerSelectAllVisibleState.checked
-                              }
-                              isIndeterminate={
-                                domainCheckerSelectAllVisibleState.indeterminate
-                              }
-                              onChange={toggleDomainCheckerSelectAllVisible}
-                            />
-                          </Th>
-                          <Th>Hostname</Th>
-                          <Th>Domains</Th>
-                        </Tr>
-                      </Thead>
-                      <Tbody>
-                        {domainCheckerPageItems.map(cert => {
-                          const domains = Array.isArray(cert.domains)
-                            ? cert.domains
-                            : [];
-                          return (
-                            <Tr key={cert.id}>
-                              <Td>
-                                <Checkbox
-                                  isChecked={domainCheckerSelectedSet.has(
-                                    cert.id
-                                  )}
-                                  onChange={() =>
-                                    toggleDomainCheckerResult(cert.id)
-                                  }
-                                />
-                              </Td>
-                              <Td>
-                                <Text fontSize='sm' fontWeight='medium'>
-                                  {cert.name}
-                                </Text>
-                              </Td>
-                              <Td fontSize='xs'>
-                                {domains.slice(0, 6).join(', ')}
-                                {domains.length > 6
-                                  ? ` +${domains.length - 6} more`
-                                  : ''}
-                              </Td>
-                            </Tr>
-                          );
-                        })}
-                      </Tbody>
-                    </Table>
-                  </Box>
-                )}
-                {domainCheckerResults.length > 0 && (
-                  <HStack mt={3} spacing={2} align='center' flexWrap='wrap'>
-                    <Button
-                      size='xs'
-                      variant='outline'
-                      isDisabled={domainCheckerPage === 0}
-                      onClick={() => setDomainCheckerPage(p => p - 1)}
-                    >
-                      ← Prev
-                    </Button>
-                    <Text fontSize='xs' color={helpTextColor}>
-                      {domainCheckerPage * DOMAIN_CHECKER_PAGE_SIZE + 1}–
-                      {Math.min(
-                        (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE,
-                        domainCheckerVisibleResults.length
-                      )}{' '}
-                      of {domainCheckerVisibleResults.length}
-                      {domainCheckerResults.length !==
-                      domainCheckerVisibleResults.length
-                        ? ` (${domainCheckerResults.length} total)`
-                        : ''}
-                    </Text>
-                    <Button
-                      size='xs'
-                      variant='outline'
-                      isDisabled={
-                        (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE >=
-                        domainCheckerVisibleResults.length
-                      }
-                      onClick={() => setDomainCheckerPage(p => p + 1)}
-                    >
-                      Next →
-                    </Button>
-                  </HStack>
-                )}
-                {domainCheckerResults.length > 0 && (
-                  <Stack mt={3} spacing={3}>
-                    <Alert status='info' borderRadius='md' py={2}>
-                      <AlertIcon />
-                      <AlertDescription fontSize='xs'>
-                        Import runs in batches (up to about 5 minutes per batch
-                        on slow hosts). After each run, hosts that finished
-                        importing are removed from your selection so you can
-                        click Import again for the rest without re-scanning.
-                      </AlertDescription>
-                    </Alert>
-                    <FormControl maxW='480px'>
-                      <FormLabel fontSize='sm'>
-                        Section for imported SSL tokens
-                      </FormLabel>
-                      <Input
-                        size='sm'
-                        value={domainCheckerImportSection}
-                        onChange={e =>
-                          setDomainCheckerImportSection(e.target.value)
-                        }
-                        placeholder='Comma-separated labels (optional)'
-                      />
-                    </FormControl>
-                    <FormControl
-                      display='flex'
-                      alignItems='center'
-                      minW='200px'
-                      maxW='360px'
-                    >
-                      <FormLabel mb={0} fontSize='sm'>
-                        Also create endpoint monitors
-                      </FormLabel>
-                      <Switch
-                        size='sm'
-                        isChecked={domainCheckerCreateMonitors}
-                        onChange={e =>
-                          setDomainCheckerCreateMonitors(e.target.checked)
-                        }
-                      />
-                    </FormControl>
-                    {domainCheckerCreateMonitors && (
-                      <HStack spacing={3} align='flex-end' flexWrap='wrap'>
-                        <FormControl minW='140px' maxW='220px'>
-                          <FormLabel fontSize='sm'>Interval</FormLabel>
-                          <Select
-                            size='sm'
-                            value={domainCheckerMonitorInterval}
-                            onChange={e =>
-                              setDomainCheckerMonitorInterval(e.target.value)
-                            }
-                          >
-                            <option value='1min'>Every 1 min</option>
-                            <option value='5min'>Every 5 min</option>
-                            <option value='30min'>Every 30 min</option>
-                            <option value='hourly'>Hourly</option>
-                            <option value='daily'>Daily</option>
-                          </Select>
-                        </FormControl>
-                        <FormControl
-                          display='flex'
-                          alignItems='center'
-                          minW='120px'
-                          pb={1}
-                        >
-                          <FormLabel mb={0} fontSize='sm'>
-                            Health Check
-                          </FormLabel>
-                          <Switch
-                            size='sm'
-                            isChecked={domainCheckerMonitorHealthCheck}
-                            onChange={e =>
-                              setDomainCheckerMonitorHealthCheck(
-                                e.target.checked
-                              )
-                            }
-                          />
-                        </FormControl>
-                        {domainCheckerMonitorHealthCheck && (
-                          <FormControl minW='130px' maxW='220px'>
-                            <FormLabel fontSize='sm'>
-                              Alert after failures
-                            </FormLabel>
-                            <NumberInput
-                              size='sm'
-                              min={1}
-                              max={10}
-                              value={domainCheckerMonitorAlertAfter}
-                              onChange={(_, valueAsNumber) =>
-                                setDomainCheckerMonitorAlertAfter(
-                                  Number.isFinite(valueAsNumber)
-                                    ? valueAsNumber
-                                    : 2
-                                )
-                              }
-                            >
-                              <NumberInputField />
-                            </NumberInput>
-                          </FormControl>
-                        )}
-                        <FormControl minW='220px' maxW='280px'>
-                          <FormLabel fontSize='sm'>Contact group</FormLabel>
-                          <Select
-                            size='sm'
-                            value={domainCheckerMonitorContactGroupId}
-                            onChange={e =>
-                              setDomainCheckerMonitorContactGroupId(
-                                e.target.value
-                              )
-                            }
-                          >
-                            <option value=''>Default workspace group</option>
-                            {contactGroups.map(g => (
-                              <option key={g.id} value={g.id}>
-                                {g.name}
-                              </option>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </HStack>
-                    )}
-                    <HStack justify='flex-end' align='center' flexWrap='wrap'>
-                      <Button
-                        size='sm'
-                        colorScheme='purple'
-                        isLoading={domainCheckerImporting}
-                        isDisabled={
-                          domainCheckerSelectedSet.size === 0 ||
-                          domainCheckerImporting
-                        }
-                        onClick={handleDomainCheckerImport}
-                      >
-                        Import selected ({domainCheckerSelectedSet.size})
-                      </Button>
-                    </HStack>
-                  </Stack>
-                )}
-              </Box>
-
-              {/* Add new endpoint form */}
-              <Divider />
-              <Text fontWeight='semibold' fontSize='sm'>
-                Add new endpoint
-              </Text>
-              <HStack spacing={3} align='flex-end' flexWrap='wrap'>
-                <FormControl flex={2} minW='200px'>
-                  <FormLabel fontSize='sm'>URL</FormLabel>
-                  <Input
-                    size='sm'
-                    value={domainUrl}
-                    onChange={e => setDomainUrl(e.target.value)}
-                    placeholder='https://example.com'
-                  />
-                </FormControl>
-                <FormControl flex={1} minW='160px' maxW='260px'>
-                  <FormLabel fontSize='sm'>SSL token section</FormLabel>
-                  <Input
-                    size='sm'
-                    value={domainEndpointTokenSection}
-                    onChange={e =>
-                      setDomainEndpointTokenSection(e.target.value)
-                    }
-                    placeholder='Optional, comma-separated'
-                  />
-                </FormControl>
-                <FormControl flex={1} minW='120px'>
-                  <FormLabel fontSize='sm'>Interval</FormLabel>
-                  <Select
-                    size='sm'
-                    value={domainInterval}
-                    onChange={e => setDomainInterval(e.target.value)}
-                  >
-                    <option value='1min'>Every 1 min</option>
-                    <option value='5min'>Every 5 min</option>
-                    <option value='30min'>Every 30 min</option>
-                    <option value='hourly'>Hourly</option>
-                    <option value='daily'>Daily</option>
-                  </Select>
-                </FormControl>
-                <FormControl
-                  display='flex'
-                  alignItems='center'
-                  minW='120px'
-                  pb={1}
-                >
-                  <FormLabel mb={0} fontSize='sm'>
-                    Health Check
-                  </FormLabel>
-                  <Switch
-                    size='sm'
-                    isChecked={domainHealthCheck}
-                    onChange={e => setDomainHealthCheck(e.target.checked)}
-                  />
-                </FormControl>
-                {domainHealthCheck && (
-                  <FormControl minW='130px' flex={1}>
-                    <FormLabel fontSize='sm'>Alert after failures</FormLabel>
-                    <Select
-                      size='sm'
-                      value={domainAlertAfter}
-                      onChange={e =>
-                        setDomainAlertAfter(Number(e.target.value))
-                      }
-                    >
-                      <option value={1}>1 failure</option>
-                      <option value={2}>2 failures</option>
-                      <option value={3}>3 failures</option>
-                      <option value={5}>5 failures</option>
-                      <option value={10}>10 failures</option>
-                    </Select>
-                  </FormControl>
-                )}
-                {Array.isArray(contactGroups) && contactGroups.length > 0 && (
-                  <FormControl minW='150px' flex={1}>
-                    <FormLabel fontSize='sm'>Contact group</FormLabel>
-                    <Select
-                      size='sm'
-                      value={domainContactGroupId}
-                      onChange={e => setDomainContactGroupId(e.target.value)}
-                    >
-                      <option value=''>Workspace default</option>
-                      {contactGroups.map(g => (
-                        <option key={g.id} value={g.id}>
-                          {g.name}
-                          {String(g.id) === String(defaultContactGroupId)
-                            ? ' (default)'
-                            : ''}
-                        </option>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
-                <Button
-                  size='sm'
-                  colorScheme='blue'
-                  leftIcon={<FiPlus />}
-                  isLoading={addingDomain}
-                  onClick={handleAddDomain}
-                  isDisabled={!domainUrl.trim()}
-                >
-                  Add
-                </Button>
-              </HStack>
-            </VStack>
-          </ModalBody>
-          <ModalFooter>
-            <Button onClick={handleDomainModalClose}>Close</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+        onClose={onDomainModalClose}
+        contactGroups={contactGroups}
+        defaultContactGroupId={defaultContactGroupId}
+        panelQueries={panelQueries}
+        TOKEN_CATEGORIES={TOKEN_CATEGORIES}
+        fetchGlobalFacets={fetchGlobalFacets}
+        fetchTokensForCategoryReset={fetchTokensForCategoryReset}
+      />
     </Box>
   );
 }

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -3246,13 +3246,8 @@ function DashboardView({
 
   const workspaceContactLabels = useMemo(() => {
     const set = new Set();
-    for (const c of Array.isArray(workspaceContacts)
-      ? workspaceContacts
-      : []) {
-      const name = [c.first_name, c.last_name]
-        .filter(Boolean)
-        .join(' ')
-        .trim();
+    for (const c of Array.isArray(workspaceContacts) ? workspaceContacts : []) {
+      const name = [c.first_name, c.last_name].filter(Boolean).join(' ').trim();
       const phone = (c.phone_e164 || '').trim();
       const parts = [name, phone].filter(Boolean);
       const label = parts.join(' - ');
@@ -3532,9 +3527,7 @@ function DashboardView({
       }
     } catch (error) {
       logger.error('Bulk section assignment failed', error);
-      toast.error(
-        error?.response?.data?.error || 'Failed to assign section'
-      );
+      toast.error(error?.response?.data?.error || 'Failed to assign section');
     }
   };
 
@@ -4516,10 +4509,7 @@ function DashboardView({
 
                 {/* Datalist for workspace contacts suggestions (creation form) */}
                 <datalist id='workspace-contacts-suggestions'>
-                  {(Array.isArray(workspaceContacts)
-                    ? workspaceContacts
-                    : []
-                  )
+                  {(Array.isArray(workspaceContacts) ? workspaceContacts : [])
                     .map(c => {
                       const name = [c.first_name, c.last_name]
                         .filter(Boolean)
@@ -4530,7 +4520,9 @@ function DashboardView({
                       const label = parts.join(' - ');
                       return { c, label };
                     })
-                    .filter(({ label }) => label && !selectedContactLabels.has(label))
+                    .filter(
+                      ({ label }) => label && !selectedContactLabels.has(label)
+                    )
                     .map(({ c, label }) => (
                       <option key={c.id} value={label} />
                     ))}

--- a/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
+++ b/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
@@ -95,11 +95,7 @@ function normalizeDomainCheckerItems(value) {
         record.domains || record.domain || record.hostname || record.name
       );
       const name = String(
-        record.name ||
-          record.hostname ||
-          record.commonName ||
-          domains[0] ||
-          ''
+        record.name || record.hostname || record.commonName || domains[0] || ''
       ).trim();
       if (!name) return null;
       const id = String(record.id || `disc-${name}-${index}`);
@@ -142,10 +138,7 @@ const DomainCheckerRow = memo(function DomainCheckerRow({
   return (
     <Tr>
       <Td>
-        <Checkbox
-          isChecked={isSelected}
-          onChange={() => onToggle(cert.id)}
-        />
+        <Checkbox isChecked={isSelected} onChange={() => onToggle(cert.id)} />
       </Td>
       <Td>
         <Text fontSize='sm' fontWeight='medium'>
@@ -563,9 +556,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
   );
 
   const domainCheckerSelectAllVisibleState = useMemo(() => {
-    const ids = domainCheckerVisibleResults
-      .map(c => c?.id)
-      .filter(Boolean);
+    const ids = domainCheckerVisibleResults.map(c => c?.id).filter(Boolean);
     if (ids.length === 0) return { checked: false, indeterminate: false };
     let n = 0;
     for (const id of ids) {
@@ -578,9 +569,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
   }, [domainCheckerVisibleResults, selectedIds]);
 
   const toggleDomainCheckerSelectAllVisible = useCallback(() => {
-    const ids = domainCheckerVisibleResults
-      .map(c => c?.id)
-      .filter(Boolean);
+    const ids = domainCheckerVisibleResults.map(c => c?.id).filter(Boolean);
     if (ids.length === 0) return;
     setSelectedIds(prev => {
       const allOn = ids.every(id => prev.has(id));
@@ -874,8 +863,8 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
         <ModalBody data-endpoint-ssl-modal-body='true'>
           <VStack spacing={5} align='stretch'>
             <Text fontSize='sm' color={helpTextColor}>
-              Monitor SSL certificates and endpoint health for your URLs.
-              Tokens are auto-created for each SSL certificate detected.
+              Monitor SSL certificates and endpoint health for your URLs. Tokens
+              are auto-created for each SSL certificate detected.
             </Text>
 
             {domainCheckerImportReport && (
@@ -926,18 +915,13 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                           <FiChevronDown />
                         )
                       }
-                      onClick={() =>
-                        setDomainCheckerImportReportOpen(o => !o)
-                      }
+                      onClick={() => setDomainCheckerImportReportOpen(o => !o)}
                     >
                       {domainCheckerImportReportOpen
                         ? 'Show less'
                         : 'Show more'}
                     </Button>
-                    <Collapse
-                      in={domainCheckerImportReportOpen}
-                      animateOpacity
-                    >
+                    <Collapse in={domainCheckerImportReportOpen} animateOpacity>
                       <Box
                         as='pre'
                         mt={2}
@@ -1256,9 +1240,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                                         aria-label='Delete'
                                         colorScheme='red'
                                         variant='ghost'
-                                        onClick={() =>
-                                          handleDeleteDomain(d.id)
-                                        }
+                                        onClick={() => handleDeleteDomain(d.id)}
                                       />
                                     </Tooltip>
                                   </HStack>
@@ -1284,8 +1266,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                         </Button>
                         <Text fontSize='sm' color={helpTextColor}>
                           Showing{' '}
-                          {endpointMonitorsPage *
-                            ENDPOINT_MONITORS_PAGE_SIZE +
+                          {endpointMonitorsPage * ENDPOINT_MONITORS_PAGE_SIZE +
                             1}
                           –
                           {Math.min(
@@ -1303,9 +1284,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                               ENDPOINT_MONITORS_PAGE_SIZE >=
                             visibleDomains.length
                           }
-                          onClick={() =>
-                            setEndpointMonitorsPage(p => p + 1)
-                          }
+                          onClick={() => setEndpointMonitorsPage(p => p + 1)}
                         >
                           Next
                         </Button>
@@ -1405,8 +1384,8 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                 <Alert status='info' borderRadius='md' mt={3} py={2}>
                   <AlertIcon />
                   <AlertDescription fontSize='xs'>
-                    This list is capped at {domainCheckerCapCount} hostnames
-                    per discovery run. Names beyond that cap are not stored or
+                    This list is capped at {domainCheckerCapCount} hostnames per
+                    discovery run. Names beyond that cap are not stored or
                     shown, so import is limited to this table. Team workspaces
                     can discover more hostnames than Pro workspaces.
                   </AlertDescription>
@@ -1492,10 +1471,10 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                   <Alert status='info' borderRadius='md' py={2}>
                     <AlertIcon />
                     <AlertDescription fontSize='xs'>
-                      Import runs in batches (up to about 5 minutes per batch
-                      on slow hosts). After each run, hosts that finished
-                      importing are removed from your selection so you can
-                      click Import again for the rest without re-scanning.
+                      Import runs in batches (up to about 5 minutes per batch on
+                      slow hosts). After each run, hosts that finished importing
+                      are removed from your selection so you can click Import
+                      again for the rest without re-scanning.
                     </AlertDescription>
                   </Alert>
                   <FormControl maxW='480px'>
@@ -1559,9 +1538,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                           size='sm'
                           isChecked={domainCheckerMonitorHealthCheck}
                           onChange={e =>
-                            setDomainCheckerMonitorHealthCheck(
-                              e.target.checked
-                            )
+                            setDomainCheckerMonitorHealthCheck(e.target.checked)
                           }
                         />
                       </FormControl>
@@ -1644,9 +1621,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                 <Input
                   size='sm'
                   value={domainEndpointTokenSection}
-                  onChange={e =>
-                    setDomainEndpointTokenSection(e.target.value)
-                  }
+                  onChange={e => setDomainEndpointTokenSection(e.target.value)}
                   placeholder='Optional, comma-separated'
                 />
               </FormControl>
@@ -1685,9 +1660,7 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                   <Select
                     size='sm'
                     value={domainAlertAfter}
-                    onChange={e =>
-                      setDomainAlertAfter(Number(e.target.value))
-                    }
+                    onChange={e => setDomainAlertAfter(Number(e.target.value))}
                   >
                     <option value={1}>1 failure</option>
                     <option value={2}>2 failures</option>

--- a/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
+++ b/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
@@ -1,0 +1,1741 @@
+import {
+  memo,
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  Collapse,
+  Divider,
+  FormControl,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  NumberInput,
+  NumberInputField,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tooltip,
+  Tr,
+  VStack,
+  useBreakpointValue,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import {
+  FiAlertTriangle,
+  FiChevronDown,
+  FiChevronUp,
+  FiExternalLink,
+  FiPlus,
+  FiRefreshCw,
+  FiTrash2,
+} from 'react-icons/fi';
+import toast from 'react-hot-toast';
+import apiClient, { showSuccessMessage } from '../utils/apiClient';
+import { logger } from '../utils/logger.js';
+import { useWorkspace } from '../utils/WorkspaceContext.jsx';
+import {
+  domainFormatUrl,
+  domainSslBadge,
+  domainStatusColor,
+} from '../utils/domains.jsx';
+
+const DOMAIN_CHECKER_PAGE_SIZE = 50;
+const ENDPOINT_MONITORS_PAGE_SIZE = 40;
+const DOMAIN_CHECKER_LOOKUP_TIMEOUT_MS = 300_000;
+const DOMAIN_CHECKER_IMPORT_CHUNK_SIZE = 25;
+const DOMAIN_CHECKER_IMPORT_CHUNK_TIMEOUT_MS = 300_000;
+
+function normalizeDomainCheckerStringArray(value) {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item || '').trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeDomainCheckerItems(value) {
+  const rawItems = Array.isArray(value) ? value : [];
+  const seen = new Set();
+  return rawItems
+    .map((item, index) => {
+      const record = item && typeof item === 'object' ? item : { name: item };
+      const domains = normalizeDomainCheckerStringArray(
+        record.domains || record.domain || record.hostname || record.name
+      );
+      const name = String(
+        record.name ||
+          record.hostname ||
+          record.commonName ||
+          domains[0] ||
+          ''
+      ).trim();
+      if (!name) return null;
+      const id = String(record.id || `disc-${name}-${index}`);
+      const key = id || name;
+      if (seen.has(key)) return null;
+      seen.add(key);
+      return {
+        ...record,
+        id,
+        name,
+        domains: domains.length ? domains : [name],
+        sources: normalizeDomainCheckerStringArray(
+          record.sources || record.source
+        ),
+        checked: record.checked !== false,
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeDomainCheckerToolErrors(value) {
+  return (Array.isArray(value) ? value : [])
+    .map(error => {
+      if (typeof error === 'string') return { tool: error };
+      if (!error || typeof error !== 'object') return null;
+      return {
+        tool: String(error.tool || error.code || '').trim(),
+        message: String(error.message || '').trim(),
+      };
+    })
+    .filter(error => error && (error.tool || error.message));
+}
+
+const DomainCheckerRow = memo(function DomainCheckerRow({
+  cert,
+  isSelected,
+  onToggle,
+}) {
+  const domains = Array.isArray(cert.domains) ? cert.domains : [];
+  return (
+    <Tr>
+      <Td>
+        <Checkbox
+          isChecked={isSelected}
+          onChange={() => onToggle(cert.id)}
+        />
+      </Td>
+      <Td>
+        <Text fontSize='sm' fontWeight='medium'>
+          {cert.name}
+        </Text>
+      </Td>
+      <Td fontSize='xs'>
+        {domains.slice(0, 6).join(', ')}
+        {domains.length > 6 ? ` +${domains.length - 6} more` : ''}
+      </Td>
+    </Tr>
+  );
+});
+
+const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
+  isOpen,
+  onClose,
+  contactGroups,
+  defaultContactGroupId = '',
+  panelQueries,
+  TOKEN_CATEGORIES,
+  fetchGlobalFacets,
+  fetchTokensForCategoryReset,
+}) {
+  const helpTextColor = useColorModeValue('gray.600', 'gray.400');
+  const domainBorderColor = useColorModeValue('gray.200', 'gray.700');
+  const mobileCardBg = useColorModeValue('gray.50', 'gray.700');
+
+  const { workspaceId: ctxWorkspaceId } = useWorkspace();
+
+  // Endpoint form state
+  const [domainUrl, setDomainUrl] = useState('');
+  const [domainHealthCheck, setDomainHealthCheck] = useState(true);
+  const [domainInterval, setDomainInterval] = useState('hourly');
+  const [domainAlertAfter, setDomainAlertAfter] = useState(2);
+  const [domainContactGroupId, setDomainContactGroupId] = useState(
+    defaultContactGroupId || ''
+  );
+  const [addingDomain, setAddingDomain] = useState(false);
+  const [domains, setDomains] = useState([]);
+  const [domainsLoading, setDomainsLoading] = useState(false);
+  const [checkingDomain, setCheckingDomain] = useState(null);
+  const [domainListSort, setDomainListSort] = useState({
+    key: 'az',
+    direction: 'asc',
+  });
+  const [endpointMonitorsPage, setEndpointMonitorsPage] = useState(0);
+  const [domainEndpointTokenSection, setDomainEndpointTokenSection] =
+    useState('');
+
+  // Domain checker state
+  const [domainCheckerInput, setDomainCheckerInput] = useState('');
+  const [domainCheckerResults, setDomainCheckerResults] = useState([]);
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [domainCheckerLoading, setDomainCheckerLoading] = useState(false);
+  const [domainCheckerImporting, setDomainCheckerImporting] = useState(false);
+  const [domainCheckerPartial, setDomainCheckerPartial] = useState(false);
+  const [domainCheckerTruncated, setDomainCheckerTruncated] = useState(false);
+  const [domainCheckerCapCount, setDomainCheckerCapCount] = useState(500);
+  const [domainCheckerToolErrors, setDomainCheckerToolErrors] = useState([]);
+  const [domainCheckerCreateMonitors, setDomainCheckerCreateMonitors] =
+    useState(false);
+  const [domainCheckerMonitorHealthCheck, setDomainCheckerMonitorHealthCheck] =
+    useState(false);
+  const [domainCheckerMonitorInterval, setDomainCheckerMonitorInterval] =
+    useState('hourly');
+  const [domainCheckerMonitorAlertAfter, setDomainCheckerMonitorAlertAfter] =
+    useState(2);
+  const [
+    domainCheckerMonitorContactGroupId,
+    setDomainCheckerMonitorContactGroupId,
+  ] = useState(defaultContactGroupId || '');
+  const [domainCheckerImportSection, setDomainCheckerImportSection] =
+    useState('');
+  const domainCheckerImportInFlightRef = useRef(false);
+  const [domainCheckerPage, setDomainCheckerPage] = useState(0);
+  const [domainCheckerSubfinderAll, setDomainCheckerSubfinderAll] =
+    useState(false);
+  const [domainCheckerImportReport, setDomainCheckerImportReport] =
+    useState(null);
+  const [domainCheckerImportReportOpen, setDomainCheckerImportReportOpen] =
+    useState(false);
+
+  const handleDomainModalClose = () => {
+    setDomainCheckerImportReport(null);
+    setDomainCheckerImportReportOpen(false);
+    onClose();
+  };
+
+  const loadDomains = useCallback(async () => {
+    if (!ctxWorkspaceId) return;
+    setDomainsLoading(true);
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        const res = await apiClient.get(
+          `/api/v1/workspaces/${ctxWorkspaceId}/domains`
+        );
+        setDomains(res.data?.items || []);
+        setDomainsLoading(false);
+        return;
+      } catch (e) {
+        const status = e?.response?.status;
+        const isTransient = !status || status >= 500 || status === 429;
+        if (attempt < maxAttempts - 1 && isTransient) {
+          await new Promise(r => setTimeout(r, 1500 * (attempt + 1)));
+          continue;
+        }
+        logger.error('Failed to load endpoint monitors', e);
+      }
+    }
+    setDomainsLoading(false);
+  }, [ctxWorkspaceId]);
+
+  const visibleDomains = useMemo(() => {
+    const healthOf = item => String(item?.last_health_status || 'pending');
+    const intervalOrder = {
+      '1min': 0,
+      '5min': 1,
+      '15min': 2,
+      hourly: 3,
+      daily: 4,
+    };
+    const healthOrder = {
+      healthy: 0,
+      warning: 1,
+      error: 2,
+      pending: 3,
+    };
+    const expirationTs = item => {
+      const raw = item?.ssl_valid_to || item?.ssl_expires_at || null;
+      if (!raw) return Number.POSITIVE_INFINITY;
+      const ts = new Date(raw).getTime();
+      return Number.isFinite(ts) ? ts : Number.POSITIVE_INFINITY;
+    };
+
+    const copy = [...domains];
+
+    copy.sort((a, b) => {
+      let result;
+      switch (domainListSort.key) {
+        case 'expiration':
+          result =
+            expirationTs(a) - expirationTs(b) ||
+            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
+          break;
+        case 'interval':
+          result =
+            (intervalOrder[String(a?.check_interval || '')] ?? 999) -
+              (intervalOrder[String(b?.check_interval || '')] ?? 999) ||
+            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
+          break;
+        case 'health':
+          result =
+            (healthOrder[healthOf(a)] ?? 999) -
+              (healthOrder[healthOf(b)] ?? 999) ||
+            domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
+          break;
+        case 'az':
+        default:
+          result = domainFormatUrl(a.url).localeCompare(domainFormatUrl(b.url));
+          break;
+      }
+      return domainListSort.direction === 'desc' ? -result : result;
+    });
+
+    return copy;
+  }, [domains, domainListSort]);
+
+  useEffect(() => {
+    setEndpointMonitorsPage(0);
+  }, [domains, domainListSort.key, domainListSort.direction]);
+
+  const paginatedVisibleDomains = useMemo(() => {
+    const start = endpointMonitorsPage * ENDPOINT_MONITORS_PAGE_SIZE;
+    return visibleDomains.slice(start, start + ENDPOINT_MONITORS_PAGE_SIZE);
+  }, [visibleDomains, endpointMonitorsPage]);
+
+  const isMdUpForEndpointList = useBreakpointValue(
+    { base: false, md: true },
+    { fallback: 'md' }
+  );
+
+  const handleDomainListSort = key => {
+    setDomainListSort(current => ({
+      key,
+      direction:
+        current.key === key && current.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  };
+
+  const renderDomainSortArrow = key => (
+    <Text fontSize='xs' opacity={domainListSort.key === key ? 1 : 0.3}>
+      {domainListSort.key === key && domainListSort.direction === 'desc'
+        ? '↓'
+        : '↑'}
+    </Text>
+  );
+
+  useEffect(() => {
+    if (isOpen && ctxWorkspaceId) loadDomains();
+  }, [isOpen, ctxWorkspaceId, loadDomains]);
+
+  const handleAddDomain = async () => {
+    if (!domainUrl.trim() || !ctxWorkspaceId) return;
+    setAddingDomain(true);
+    try {
+      const endpointBody = {
+        url: domainUrl.trim(),
+        health_check_enabled: domainHealthCheck,
+        check_interval: domainInterval,
+        alert_after_failures: domainAlertAfter,
+        contact_group_id: domainContactGroupId || null,
+      };
+      if (domainEndpointTokenSection.trim()) {
+        endpointBody.section = domainEndpointTokenSection.trim();
+      }
+      await apiClient.post(
+        `/api/v1/workspaces/${ctxWorkspaceId}/domains`,
+        endpointBody
+      );
+      showSuccessMessage('Endpoint added! SSL certificate tracked.');
+      setDomainUrl('');
+      setDomainHealthCheck(true);
+      setDomainInterval('hourly');
+      setDomainAlertAfter(2);
+      setDomainContactGroupId(defaultContactGroupId || '');
+      setDomainEndpointTokenSection('');
+      loadDomains();
+      try {
+        window.dispatchEvent(new CustomEvent('tt:tokens-imported'));
+        window.dispatchEvent(
+          new CustomEvent('tt:tokens-updated', { detail: { t: Date.now() } })
+        );
+      } catch (_) {}
+      try {
+        await Promise.all(
+          TOKEN_CATEGORIES.map(cat =>
+            fetchTokensForCategoryReset(cat.value, {
+              workspaceId: ctxWorkspaceId,
+            })
+          )
+        );
+      } catch (err) {
+        logger.error('Token list refresh after endpoint add failed', err);
+      }
+      try {
+        const section =
+          (panelQueries && panelQueries.__section) ||
+          new URLSearchParams(window.location.search).get('section') ||
+          '__all__';
+        await fetchGlobalFacets?.({ workspaceId: ctxWorkspaceId, section });
+      } catch (_) {}
+    } catch (e) {
+      const msg = e?.response?.data?.error || 'Failed to add endpoint';
+      logger.error('Endpoint add failed:', msg);
+      toast.error(msg);
+    } finally {
+      setAddingDomain(false);
+    }
+  };
+
+  const handleDeleteDomain = async domainId => {
+    try {
+      await apiClient.delete(
+        `/api/v1/workspaces/${ctxWorkspaceId}/domains/${domainId}`
+      );
+      showSuccessMessage('Endpoint monitor deleted');
+      loadDomains();
+      window.dispatchEvent(new CustomEvent('tt:tokens-updated'));
+    } catch (e) {
+      toast.error(
+        e?.response?.data?.error || 'Failed to delete endpoint monitor'
+      );
+    }
+  };
+
+  const handleCheckDomain = async (domainId, event) => {
+    event?.preventDefault?.();
+    event?.currentTarget?.blur?.();
+    const modalBody = document.querySelector(
+      '[data-endpoint-ssl-modal-body="true"]'
+    );
+    const previousScrollTop = modalBody?.scrollTop;
+    try {
+      setCheckingDomain(domainId);
+      const res = await apiClient.post(
+        `/api/v1/workspaces/${ctxWorkspaceId}/domains/${domainId}/check`
+      );
+      const data = res.data;
+      if (data.status === 'healthy') {
+        showSuccessMessage(`Healthy (${data.responseMs}ms)`);
+      } else {
+        toast.error(
+          `${data.status}: ${data.error || 'Unknown error'} (${data.responseMs}ms)`
+        );
+      }
+      await loadDomains();
+      if (modalBody && typeof previousScrollTop === 'number') {
+        window.requestAnimationFrame(() => {
+          modalBody.scrollTop = previousScrollTop;
+        });
+      }
+    } catch (e) {
+      toast.error(e?.response?.data?.error || 'Health check failed');
+    } finally {
+      setCheckingDomain(null);
+    }
+  };
+
+  const handleDomainCheckerLookup = async () => {
+    if (!domainCheckerInput.trim() || !ctxWorkspaceId) return;
+    setDomainCheckerLoading(true);
+    setDomainCheckerTruncated(false);
+    setDomainCheckerImportReport(null);
+    setDomainCheckerImportReportOpen(false);
+    const lookupUrl = `/api/v1/workspaces/${ctxWorkspaceId}/domain-checker/lookup`;
+    const lookupBody = {
+      domain: domainCheckerInput.trim(),
+      subfinder_all: domainCheckerSubfinderAll,
+    };
+    const lookupReqOpts = { timeout: DOMAIN_CHECKER_LOOKUP_TIMEOUT_MS };
+    const lookupMaxAttempts = 3;
+    const lookupRetriable = e => {
+      if (e?.code === 'ERR_CANCELED' || e?.name === 'CanceledError')
+        return false;
+      const status = e?.response?.status;
+      if (status == null) {
+        const c = e?.code;
+        return (
+          c === 'ECONNABORTED' ||
+          c === 'ERR_NETWORK' ||
+          c === 'ETIMEDOUT' ||
+          c === 'ECONNRESET' ||
+          (!e?.response && c !== 'ERR_BAD_REQUEST')
+        );
+      }
+      return status >= 500 && status < 600;
+    };
+    try {
+      let res;
+      for (let attempt = 0; attempt < lookupMaxAttempts; attempt += 1) {
+        try {
+          res = await apiClient.post(lookupUrl, lookupBody, lookupReqOpts);
+          break;
+        } catch (e) {
+          const last = attempt === lookupMaxAttempts - 1;
+          if (last || !lookupRetriable(e)) throw e;
+          toast('Discovery is slow or the connection dropped. Retrying…', {
+            icon: '⏳',
+          });
+          await new Promise(r => setTimeout(r, 2000 * (attempt + 1)));
+        }
+      }
+      const items = normalizeDomainCheckerItems(res.data?.items);
+      const cap = Number(res.data?.meta?.maxResults);
+      const capN = Number.isFinite(cap) && cap > 0 ? cap : 500;
+      startTransition(() => {
+        setDomainCheckerCapCount(capN);
+        setDomainCheckerTruncated(Boolean(res.data?.meta?.truncated));
+        setDomainCheckerResults(items);
+        setDomainCheckerPartial(Boolean(res.data?.partial));
+        setDomainCheckerToolErrors(
+          normalizeDomainCheckerToolErrors(res.data?.toolErrors)
+        );
+      });
+      items.length === 0
+        ? toast.error('No subdomains found for this domain.')
+        : showSuccessMessage(
+            `Found ${items.length} subdomain${items.length === 1 ? '' : 's'}.`
+          );
+    } catch (e) {
+      setDomainCheckerTruncated(false);
+      const code = e?.response?.data?.code;
+      const retryAfter = e?.response?.data?.retry_after_seconds;
+      const base =
+        code === 'DOMAIN_CHECKER_RATE_LIMITED' && Number.isFinite(retryAfter)
+          ? `Rate limited. Try again in about ${retryAfter}s.`
+          : e?.response?.data?.error;
+      toast.error(
+        base ||
+          'Domain checker lookup failed. Discovery tools may be slow or unavailable.'
+      );
+    } finally {
+      setDomainCheckerLoading(false);
+    }
+  };
+
+  const toggleDomainCheckerResult = useCallback(id => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const domainCheckerVisibleResults = useMemo(() => {
+    return Array.isArray(domainCheckerResults)
+      ? domainCheckerResults.filter(Boolean)
+      : [];
+  }, [domainCheckerResults]);
+
+  const deferredDomainCheckerVisibleForTable = useDeferredValue(
+    domainCheckerVisibleResults
+  );
+
+  const domainCheckerPageItems = useMemo(
+    () =>
+      deferredDomainCheckerVisibleForTable.slice(
+        domainCheckerPage * DOMAIN_CHECKER_PAGE_SIZE,
+        (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE
+      ),
+    [domainCheckerPage, deferredDomainCheckerVisibleForTable]
+  );
+
+  const domainCheckerSelectAllVisibleState = useMemo(() => {
+    const ids = domainCheckerVisibleResults
+      .map(c => c?.id)
+      .filter(Boolean);
+    if (ids.length === 0) return { checked: false, indeterminate: false };
+    let n = 0;
+    for (const id of ids) {
+      if (selectedIds.has(id)) n += 1;
+    }
+    return {
+      checked: n === ids.length,
+      indeterminate: n > 0 && n < ids.length,
+    };
+  }, [domainCheckerVisibleResults, selectedIds]);
+
+  const toggleDomainCheckerSelectAllVisible = useCallback(() => {
+    const ids = domainCheckerVisibleResults
+      .map(c => c?.id)
+      .filter(Boolean);
+    if (ids.length === 0) return;
+    setSelectedIds(prev => {
+      const allOn = ids.every(id => prev.has(id));
+      const next = new Set(prev);
+      if (allOn) {
+        for (const id of ids) next.delete(id);
+      } else {
+        for (const id of ids) next.add(id);
+      }
+      return next;
+    });
+  }, [domainCheckerVisibleResults]);
+
+  const prevDomainCheckerResultsRef = useRef(null);
+  useEffect(() => {
+    const isNewLookup =
+      domainCheckerResults !== prevDomainCheckerResultsRef.current;
+    prevDomainCheckerResultsRef.current = domainCheckerResults;
+    startTransition(() => {
+      if (isNewLookup) {
+        setSelectedIds(
+          new Set(
+            domainCheckerVisibleResults
+              .filter(c => c?.checked && c?.id)
+              .map(c => c.id)
+          )
+        );
+      } else {
+        setSelectedIds(prev => {
+          const visibleIds = new Set(
+            domainCheckerVisibleResults.map(c => c.id).filter(Boolean)
+          );
+          const next = new Set();
+          for (const id of prev) if (visibleIds.has(id)) next.add(id);
+          return next;
+        });
+      }
+      setDomainCheckerPage(0);
+    });
+  }, [domainCheckerVisibleResults, domainCheckerResults]);
+
+  const handleDomainCheckerImport = async () => {
+    if (!ctxWorkspaceId || selectedIds.size === 0) return;
+    if (domainCheckerImportInFlightRef.current) return;
+    domainCheckerImportInFlightRef.current = true;
+    const selected = domainCheckerVisibleResults.filter(item =>
+      selectedIds.has(item.id)
+    );
+    setDomainCheckerImporting(true);
+    setDomainCheckerImportReport(null);
+    setDomainCheckerImportReportOpen(false);
+    try {
+      const peelDomainCheckerSelectionAfterImport = (
+        importedList,
+        skippedList
+      ) => {
+        const drop = new Set();
+        for (const row of importedList || []) {
+          const cid = row && (row.certificateId || row.certificate_id);
+          if (cid) drop.add(String(cid));
+        }
+        for (const row of skippedList || []) {
+          if (row && row.reason === 'duplicate' && row.id)
+            drop.add(String(row.id));
+        }
+        if (drop.size === 0) return;
+        setSelectedIds(prev => {
+          const next = new Set();
+          for (const id of prev) {
+            if (!drop.has(String(id))) next.add(id);
+          }
+          return next;
+        });
+      };
+
+      const payloadBase = {
+        domain: domainCheckerInput.trim(),
+        monitorOptions: {
+          enabled: domainCheckerCreateMonitors,
+          health_check_enabled: domainCheckerMonitorHealthCheck,
+          check_interval: domainCheckerMonitorInterval,
+          alert_after_failures: domainCheckerMonitorAlertAfter,
+          contact_group_id: domainCheckerMonitorContactGroupId || null,
+        },
+      };
+      if (domainCheckerImportSection.trim()) {
+        payloadBase.tokenOptions = {
+          section: domainCheckerImportSection.trim(),
+        };
+      }
+
+      const mergedImported = [];
+      const mergedSkipped = [];
+      let monitorsCreated = 0;
+      let monitorsExisting = 0;
+      let chunkError = null;
+      let hadNoResponseChunk = false;
+
+      for (
+        let i = 0;
+        i < selected.length;
+        i += DOMAIN_CHECKER_IMPORT_CHUNK_SIZE
+      ) {
+        const chunk = selected.slice(i, i + DOMAIN_CHECKER_IMPORT_CHUNK_SIZE);
+        try {
+          const res = await apiClient.post(
+            `/api/v1/workspaces/${ctxWorkspaceId}/domain-checker/import`,
+            { ...payloadBase, certificates: chunk },
+            { timeout: DOMAIN_CHECKER_IMPORT_CHUNK_TIMEOUT_MS }
+          );
+          mergedImported.push(
+            ...(Array.isArray(res.data?.imported)
+              ? res.data.imported
+              : []
+            ).filter(Boolean)
+          );
+          mergedSkipped.push(
+            ...(Array.isArray(res.data?.skipped)
+              ? res.data.skipped
+              : []
+            ).filter(Boolean)
+          );
+          monitorsCreated += res.data?.monitors?.created || 0;
+          monitorsExisting += res.data?.monitors?.existing || 0;
+        } catch (e) {
+          if (!e?.response) {
+            hadNoResponseChunk = true;
+            chunkError = e;
+            continue;
+          }
+          chunkError = e;
+          break;
+        }
+      }
+
+      const refreshAfterDomainCheckerImport = async () => {
+        try {
+          window.dispatchEvent(new CustomEvent('tt:tokens-imported'));
+          window.dispatchEvent(
+            new CustomEvent('tt:tokens-updated', { detail: { t: Date.now() } })
+          );
+        } catch (_) {}
+        try {
+          await Promise.all(
+            TOKEN_CATEGORIES.map(cat =>
+              fetchTokensForCategoryReset(cat.value, {
+                workspaceId: ctxWorkspaceId,
+              })
+            )
+          );
+        } catch (err) {
+          logger.error(
+            'Token list refresh after domain checker import failed',
+            err
+          );
+        }
+        try {
+          const section =
+            (panelQueries && panelQueries.__section) ||
+            new URLSearchParams(window.location.search).get('section') ||
+            '__all__';
+          await fetchGlobalFacets?.({ workspaceId: ctxWorkspaceId, section });
+        } catch (_) {}
+        try {
+          await loadDomains();
+        } catch (_) {}
+      };
+
+      const applyImportReport = (imported, skippedList, options = {}) => {
+        const safeSkipped = skippedList.filter(Boolean);
+        const dnsUnreachableDetails = new Set([
+          'live_certificate_dns_unresolved',
+          'live_certificate_dns_temporary',
+        ]);
+        const unreachable = safeSkipped.filter(
+          s =>
+            s.reason === 'invalid_certificate' &&
+            dnsUnreachableDetails.has(s.detail)
+        ).length;
+        const errorLike = safeSkipped.length - unreachable;
+        const logLines = safeSkipped.map(s => {
+          const label =
+            (typeof s.subject === 'string' && s.subject.trim()) ||
+            (Array.isArray(s.domains) && s.domains[0]) ||
+            (typeof s.name === 'string' && s.name) ||
+            s.id ||
+            'host';
+          const reason = s.reason || 'unknown';
+          const detail = s.detail ? ` — ${s.detail}` : '';
+          return `${label}: ${reason}${detail}`;
+        });
+        setDomainCheckerImportReport({
+          unreachable,
+          errorLike,
+          imported,
+          importedLowerBound: Boolean(options.importedLowerBound),
+          logLines,
+        });
+        setDomainCheckerImportReportOpen(false);
+      };
+
+      if (chunkError && !hadNoResponseChunk) {
+        await refreshAfterDomainCheckerImport();
+        if (mergedImported.length || mergedSkipped.length) {
+          peelDomainCheckerSelectionAfterImport(mergedImported, mergedSkipped);
+          applyImportReport(mergedImported.length, mergedSkipped, {
+            importedLowerBound: false,
+          });
+          toast.error(
+            chunkError?.response?.data?.error || 'Failed to import SSL tokens'
+          );
+        } else {
+          setDomainCheckerImportReport(null);
+          toast.error(
+            chunkError?.response?.data?.error || 'Failed to import SSL tokens'
+          );
+        }
+      } else {
+        const importedList = mergedImported;
+        const skippedList = mergedSkipped;
+        const imported = importedList.length;
+
+        let summary = `Imported ${imported} SSL token${imported === 1 ? '' : 's'}`;
+        if (monitorsCreated || monitorsExisting) {
+          const monitorParts = [];
+          if (monitorsCreated)
+            monitorParts.push(
+              `${monitorsCreated} new monitor${monitorsCreated === 1 ? '' : 's'}`
+            );
+          if (monitorsExisting)
+            monitorParts.push(`${monitorsExisting} already existed`);
+          summary += ` (${monitorParts.join(', ')})`;
+        }
+        summary += '.';
+        peelDomainCheckerSelectionAfterImport(importedList, skippedList);
+        showSuccessMessage(summary);
+
+        applyImportReport(imported, skippedList, {
+          importedLowerBound: hadNoResponseChunk,
+        });
+        if (!hadNoResponseChunk) {
+          setDomainCheckerResults([]);
+          setSelectedIds(new Set());
+          setDomainCheckerPage(0);
+          setDomainCheckerPartial(false);
+          setDomainCheckerTruncated(false);
+          setDomainCheckerToolErrors([]);
+          setDomainCheckerInput('');
+          setDomainListSort({ key: 'az', direction: 'asc' });
+          await refreshAfterDomainCheckerImport();
+          window.requestAnimationFrame(() => {
+            const modalBody = document.querySelector(
+              '[data-endpoint-ssl-modal-body="true"]'
+            );
+            modalBody?.scrollTo({ top: 0, behavior: 'smooth' });
+          });
+        } else {
+          await refreshAfterDomainCheckerImport();
+        }
+        if (hadNoResponseChunk) {
+          toast.error(
+            `One or more import batches lost the response before completion. At least ${imported} token(s) are confirmed from completed batches; additional tokens may have been imported in interrupted batches. Refresh the list to verify the final total.`
+          );
+        }
+      }
+    } catch (e) {
+      setDomainCheckerImportReport(null);
+      const noResponse = !e?.response;
+      toast.error(
+        noResponse
+          ? 'Connection closed before the response finished. Some tokens may already be imported; refresh the list before retrying.'
+          : e?.response?.data?.error || 'Failed to import SSL tokens'
+      );
+    } finally {
+      domainCheckerImportInFlightRef.current = false;
+      setDomainCheckerImporting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleDomainModalClose}
+      size='xl'
+      motionPreset='none'
+    >
+      <ModalOverlay />
+      <ModalContent maxW='1100px'>
+        <ModalHeader>Endpoint & SSL monitoring</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody data-endpoint-ssl-modal-body='true'>
+          <VStack spacing={5} align='stretch'>
+            <Text fontSize='sm' color={helpTextColor}>
+              Monitor SSL certificates and endpoint health for your URLs.
+              Tokens are auto-created for each SSL certificate detected.
+            </Text>
+
+            {domainCheckerImportReport && (
+              <Box
+                p={3}
+                borderRadius='md'
+                borderWidth='1px'
+                borderColor={domainBorderColor}
+                fontSize='sm'
+              >
+                <HStack justify='space-between' align='start' spacing={3}>
+                  <Box>
+                    <Text fontWeight='semibold'>Last import summary</Text>
+                    <Text color={helpTextColor}>
+                      {domainCheckerImportReport.importedLowerBound
+                        ? 'At least '
+                        : ''}
+                      {domainCheckerImportReport.imported} SSL token
+                      {domainCheckerImportReport.imported === 1 ? '' : 's'}{' '}
+                      {domainCheckerImportReport.importedLowerBound
+                        ? 'confirmed in completed responses'
+                        : 'created'}
+                      , {domainCheckerImportReport.errorLike} skipped,{' '}
+                      {domainCheckerImportReport.unreachable} unreachable.
+                    </Text>
+                  </Box>
+                  <Button
+                    size='xs'
+                    variant='ghost'
+                    onClick={() => {
+                      setDomainCheckerImportReport(null);
+                      setDomainCheckerImportReportOpen(false);
+                    }}
+                  >
+                    Dismiss
+                  </Button>
+                </HStack>
+                {domainCheckerImportReport.logLines.length > 0 && (
+                  <>
+                    <Button
+                      variant='link'
+                      size='xs'
+                      mt={1}
+                      rightIcon={
+                        domainCheckerImportReportOpen ? (
+                          <FiChevronUp />
+                        ) : (
+                          <FiChevronDown />
+                        )
+                      }
+                      onClick={() =>
+                        setDomainCheckerImportReportOpen(o => !o)
+                      }
+                    >
+                      {domainCheckerImportReportOpen
+                        ? 'Show less'
+                        : 'Show more'}
+                    </Button>
+                    <Collapse
+                      in={domainCheckerImportReportOpen}
+                      animateOpacity
+                    >
+                      <Box
+                        as='pre'
+                        mt={2}
+                        p={2}
+                        borderRadius='md'
+                        bg='blackAlpha.50'
+                        _dark={{ bg: 'whiteAlpha.100' }}
+                        fontSize='xs'
+                        whiteSpace='pre-wrap'
+                        wordBreak='break-word'
+                        maxH='220px'
+                        overflowY='auto'
+                      >
+                        {domainCheckerImportReport.logLines.join('\n')}
+                      </Box>
+                    </Collapse>
+                  </>
+                )}
+              </Box>
+            )}
+
+            {domainsLoading ? (
+              <Text fontSize='sm' color={helpTextColor}>
+                Loading endpoints...
+              </Text>
+            ) : domains.length === 0 ? (
+              <Alert status='info' borderRadius='md' size='sm'>
+                <AlertIcon />
+                <AlertDescription fontSize='sm'>
+                  No endpoints monitored yet. Add one below to start tracking
+                  SSL certificates and endpoint health.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <>
+                {visibleDomains.length === 0 ? (
+                  <Alert status='info' borderRadius='md' size='sm'>
+                    <AlertIcon />
+                    <AlertDescription fontSize='sm'>
+                      No endpoints match your current filters.
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <>
+                    {!isMdUpForEndpointList ? (
+                      <Box>
+                        <VStack align='stretch' spacing={3}>
+                          {paginatedVisibleDomains.map(d => (
+                            <Box
+                              key={d.id}
+                              p={4}
+                              bg={mobileCardBg}
+                              border='1px solid'
+                              borderColor={domainBorderColor}
+                              borderRadius='md'
+                            >
+                              <HStack
+                                justify='space-between'
+                                align='start'
+                                mb={2}
+                              >
+                                <Box flex='1' minW='0'>
+                                  <HStack spacing={1}>
+                                    <Text
+                                      fontWeight='semibold'
+                                      fontSize='sm'
+                                      wordBreak='break-all'
+                                    >
+                                      {domainFormatUrl(d.url)}
+                                    </Text>
+                                    <IconButton
+                                      as='a'
+                                      href={d.url}
+                                      target='_blank'
+                                      rel='noopener'
+                                      size='xs'
+                                      variant='ghost'
+                                      icon={<FiExternalLink />}
+                                      aria-label='Open'
+                                    />
+                                  </HStack>
+                                  {d.ssl_issuer && (
+                                    <Text fontSize='xs' color={helpTextColor}>
+                                      Issuer: {d.ssl_issuer}
+                                    </Text>
+                                  )}
+                                </Box>
+                                <HStack spacing={1}>
+                                  <IconButton
+                                    size='xs'
+                                    icon={<FiRefreshCw />}
+                                    aria-label='Check now'
+                                    onClick={event =>
+                                      handleCheckDomain(d.id, event)
+                                    }
+                                    isLoading={checkingDomain === d.id}
+                                  />
+                                  <IconButton
+                                    size='xs'
+                                    icon={<FiTrash2 />}
+                                    aria-label='Delete'
+                                    colorScheme='red'
+                                    variant='ghost'
+                                    onClick={() => handleDeleteDomain(d.id)}
+                                  />
+                                </HStack>
+                              </HStack>
+                              <HStack spacing={2} flexWrap='wrap' mb={2}>
+                                {domainSslBadge(d)}
+                                {d.last_health_status ? (
+                                  <Badge
+                                    colorScheme={domainStatusColor(
+                                      d.last_health_status
+                                    )}
+                                  >
+                                    {d.last_health_status}
+                                  </Badge>
+                                ) : (
+                                  <Badge colorScheme='gray'>Pending</Badge>
+                                )}
+                                <Badge variant='outline'>
+                                  {d.check_interval}
+                                </Badge>
+                                <Badge variant='outline' colorScheme='orange'>
+                                  {d.alert_after_failures || 2}x
+                                </Badge>
+                              </HStack>
+                              <HStack
+                                spacing={4}
+                                fontSize='xs'
+                                color={helpTextColor}
+                              >
+                                {d.last_health_response_ms != null && (
+                                  <Text>{d.last_health_response_ms}ms</Text>
+                                )}
+                                {d.last_health_check_at && (
+                                  <Text>
+                                    {new Date(
+                                      d.last_health_check_at
+                                    ).toLocaleString()}
+                                  </Text>
+                                )}
+                              </HStack>
+                            </Box>
+                          ))}
+                        </VStack>
+                      </Box>
+                    ) : (
+                      <Box
+                        borderRadius='md'
+                        border='1px solid'
+                        borderColor={domainBorderColor}
+                        overflow='auto'
+                      >
+                        <Table size='sm' variant='simple' tableLayout='fixed'>
+                          <Thead>
+                            <Tr>
+                              <Th
+                                w='28%'
+                                cursor='pointer'
+                                userSelect='none'
+                                onClick={() => handleDomainListSort('az')}
+                              >
+                                <HStack spacing={1} justify='space-between'>
+                                  <Text>Endpoint</Text>
+                                  {renderDomainSortArrow('az')}
+                                </HStack>
+                              </Th>
+                              <Th
+                                whiteSpace='nowrap'
+                                cursor='pointer'
+                                userSelect='none'
+                                onClick={() =>
+                                  handleDomainListSort('expiration')
+                                }
+                              >
+                                <HStack spacing={1} justify='space-between'>
+                                  <Text>SSL</Text>
+                                  {renderDomainSortArrow('expiration')}
+                                </HStack>
+                              </Th>
+                              <Th
+                                whiteSpace='nowrap'
+                                cursor='pointer'
+                                userSelect='none'
+                                onClick={() => handleDomainListSort('health')}
+                              >
+                                <HStack spacing={1} justify='space-between'>
+                                  <Text>Health</Text>
+                                  {renderDomainSortArrow('health')}
+                                </HStack>
+                              </Th>
+                              <Th whiteSpace='nowrap'>Response</Th>
+                              <Th whiteSpace='nowrap'>Last Check</Th>
+                              <Th
+                                whiteSpace='nowrap'
+                                cursor='pointer'
+                                userSelect='none'
+                                onClick={() => handleDomainListSort('interval')}
+                              >
+                                <HStack spacing={1} justify='space-between'>
+                                  <Text>Interval</Text>
+                                  {renderDomainSortArrow('interval')}
+                                </HStack>
+                              </Th>
+                              <Th whiteSpace='nowrap'>Alert after</Th>
+                              <Th
+                                textAlign='right'
+                                whiteSpace='nowrap'
+                                width='92px'
+                              ></Th>
+                            </Tr>
+                          </Thead>
+                          <Tbody>
+                            {paginatedVisibleDomains.map(d => (
+                              <Tr key={d.id}>
+                                <Td maxW='0'>
+                                  <HStack spacing={1} minW='0'>
+                                    <Text
+                                      fontWeight='medium'
+                                      fontSize='sm'
+                                      whiteSpace='normal'
+                                      wordBreak='break-all'
+                                      overflowWrap='anywhere'
+                                      flex='1'
+                                      minW='0'
+                                    >
+                                      {domainFormatUrl(d.url)}
+                                    </Text>
+                                    <Tooltip label='Open in browser'>
+                                      <IconButton
+                                        as='a'
+                                        href={d.url}
+                                        target='_blank'
+                                        rel='noopener'
+                                        size='xs'
+                                        variant='ghost'
+                                        icon={<FiExternalLink />}
+                                        aria-label='Open'
+                                      />
+                                    </Tooltip>
+                                  </HStack>
+                                  {d.ssl_issuer && (
+                                    <Text fontSize='2xs' color={helpTextColor}>
+                                      Issuer: {d.ssl_issuer}
+                                    </Text>
+                                  )}
+                                </Td>
+                                <Td whiteSpace='nowrap'>{domainSslBadge(d)}</Td>
+                                <Td whiteSpace='nowrap'>
+                                  {d.last_health_status ? (
+                                    <Tooltip
+                                      label={
+                                        d.last_health_error ||
+                                        `HTTP ${d.last_health_status_code}`
+                                      }
+                                    >
+                                      <Badge
+                                        colorScheme={domainStatusColor(
+                                          d.last_health_status
+                                        )}
+                                      >
+                                        {d.last_health_status}
+                                      </Badge>
+                                    </Tooltip>
+                                  ) : (
+                                    <Badge colorScheme='gray'>Pending</Badge>
+                                  )}
+                                </Td>
+                                <Td fontSize='xs' whiteSpace='nowrap'>
+                                  {d.last_health_response_ms != null
+                                    ? `${d.last_health_response_ms}ms`
+                                    : '-'}
+                                </Td>
+                                <Td fontSize='xs' whiteSpace='nowrap'>
+                                  {d.last_health_check_at
+                                    ? new Date(
+                                        d.last_health_check_at
+                                      ).toLocaleString()
+                                    : '-'}
+                                </Td>
+                                <Td whiteSpace='nowrap'>
+                                  <Badge variant='outline'>
+                                    {d.check_interval}
+                                  </Badge>
+                                </Td>
+                                <Td>
+                                  <Tooltip
+                                    label={`Alert sent after ${d.alert_after_failures || 2} consecutive failures`}
+                                  >
+                                    <Badge
+                                      variant='outline'
+                                      colorScheme='orange'
+                                    >
+                                      {d.alert_after_failures || 2}x
+                                    </Badge>
+                                  </Tooltip>
+                                </Td>
+                                <Td textAlign='right'>
+                                  <HStack spacing={1} justify='flex-end'>
+                                    <Tooltip label='Run health check now'>
+                                      <IconButton
+                                        size='xs'
+                                        icon={<FiRefreshCw />}
+                                        aria-label='Check now'
+                                        onClick={event =>
+                                          handleCheckDomain(d.id, event)
+                                        }
+                                        isLoading={checkingDomain === d.id}
+                                      />
+                                    </Tooltip>
+                                    <Tooltip label='Delete endpoint monitor'>
+                                      <IconButton
+                                        size='xs'
+                                        icon={<FiTrash2 />}
+                                        aria-label='Delete'
+                                        colorScheme='red'
+                                        variant='ghost'
+                                        onClick={() =>
+                                          handleDeleteDomain(d.id)
+                                        }
+                                      />
+                                    </Tooltip>
+                                  </HStack>
+                                </Td>
+                              </Tr>
+                            ))}
+                          </Tbody>
+                        </Table>
+                      </Box>
+                    )}
+
+                    {visibleDomains.length > ENDPOINT_MONITORS_PAGE_SIZE && (
+                      <HStack justify='center' spacing={3} pt={2}>
+                        <Button
+                          size='sm'
+                          variant='outline'
+                          isDisabled={endpointMonitorsPage <= 0}
+                          onClick={() =>
+                            setEndpointMonitorsPage(p => Math.max(0, p - 1))
+                          }
+                        >
+                          Previous
+                        </Button>
+                        <Text fontSize='sm' color={helpTextColor}>
+                          Showing{' '}
+                          {endpointMonitorsPage *
+                            ENDPOINT_MONITORS_PAGE_SIZE +
+                            1}
+                          –
+                          {Math.min(
+                            (endpointMonitorsPage + 1) *
+                              ENDPOINT_MONITORS_PAGE_SIZE,
+                            visibleDomains.length
+                          )}{' '}
+                          of {visibleDomains.length}
+                        </Text>
+                        <Button
+                          size='sm'
+                          variant='outline'
+                          isDisabled={
+                            (endpointMonitorsPage + 1) *
+                              ENDPOINT_MONITORS_PAGE_SIZE >=
+                            visibleDomains.length
+                          }
+                          onClick={() =>
+                            setEndpointMonitorsPage(p => p + 1)
+                          }
+                        >
+                          Next
+                        </Button>
+                      </HStack>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+
+            <Divider />
+            <Box>
+              <HStack justify='space-between' align='start' mb={2}>
+                <Box>
+                  <Text fontWeight='semibold' fontSize='sm'>
+                    Domain checker
+                  </Text>
+                  <Text fontSize='xs' color={helpTextColor}>
+                    Discovery is best-effort and limited to publicly available
+                    subdomains seen by passive sources. Then import selected
+                    hosts as SSL tokens and endpoint monitors.
+                  </Text>
+                </Box>
+                <Badge colorScheme='purple'>Pro/Team</Badge>
+              </HStack>
+              <HStack spacing={3} align='flex-end' flexWrap='wrap'>
+                <FormControl flex={2} minW='220px'>
+                  <FormLabel fontSize='sm'>Root domain</FormLabel>
+                  <Input
+                    size='sm'
+                    value={domainCheckerInput}
+                    onChange={e => setDomainCheckerInput(e.target.value)}
+                    placeholder='example.com'
+                  />
+                </FormControl>
+                <HStack align='center' spacing={1} pb={1}>
+                  <Checkbox
+                    size='sm'
+                    colorScheme='blue'
+                    isChecked={domainCheckerSubfinderAll}
+                    onChange={e =>
+                      setDomainCheckerSubfinderAll(e.target.checked)
+                    }
+                  >
+                    Use all sources
+                  </Checkbox>
+                  <Tooltip
+                    hasArrow
+                    fontSize='xs'
+                    maxW='280px'
+                    label='subfinder -all uses every passive source and is slower than the default. Passive indexes can list stale or abandoned subdomains; SSL import may then touch hosts that no longer match your live certificates.'
+                  >
+                    <IconButton
+                      aria-label='About subfinder all sources'
+                      icon={<FiAlertTriangle />}
+                      size='xs'
+                      variant='ghost'
+                      colorScheme='orange'
+                    />
+                  </Tooltip>
+                </HStack>
+                <Button
+                  size='sm'
+                  colorScheme='purple'
+                  isLoading={domainCheckerLoading}
+                  loadingText='Discovering...'
+                  onClick={handleDomainCheckerLookup}
+                  isDisabled={!domainCheckerInput.trim()}
+                >
+                  Discover subdomains
+                </Button>
+              </HStack>
+              <Alert status='info' borderRadius='md' mt={3} py={2}>
+                <AlertIcon />
+                <AlertDescription fontSize='xs'>
+                  Discovery can take up to about 5 minutes on large domains.
+                  Leave this tab open while a scan runs.
+                </AlertDescription>
+              </Alert>
+              {domainCheckerPartial && (
+                <Alert status='warning' borderRadius='md' mt={3}>
+                  <AlertIcon />
+                  <AlertDescription fontSize='sm'>
+                    Some discovery sources were unavailable. Showing partial
+                    results
+                    {domainCheckerToolErrors.length
+                      ? ` (${domainCheckerToolErrors
+                          .map(e => e?.tool || e?.message)
+                          .filter(Boolean)
+                          .join(', ')})`
+                      : ''}
+                    .
+                  </AlertDescription>
+                </Alert>
+              )}
+              {domainCheckerTruncated && (
+                <Alert status='info' borderRadius='md' mt={3} py={2}>
+                  <AlertIcon />
+                  <AlertDescription fontSize='xs'>
+                    This list is capped at {domainCheckerCapCount} hostnames
+                    per discovery run. Names beyond that cap are not stored or
+                    shown, so import is limited to this table. Team workspaces
+                    can discover more hostnames than Pro workspaces.
+                  </AlertDescription>
+                </Alert>
+              )}
+              {domainCheckerResults.length > 0 && (
+                <Box
+                  mt={3}
+                  border='1px solid'
+                  borderColor={domainBorderColor}
+                  borderRadius='md'
+                  overflow='auto'
+                >
+                  <Table size='sm'>
+                    <Thead>
+                      <Tr>
+                        <Th>
+                          <Checkbox
+                            aria-label='Select all discovered hosts (all pages)'
+                            isChecked={
+                              domainCheckerSelectAllVisibleState.checked
+                            }
+                            isIndeterminate={
+                              domainCheckerSelectAllVisibleState.indeterminate
+                            }
+                            onChange={toggleDomainCheckerSelectAllVisible}
+                          />
+                        </Th>
+                        <Th>Hostname</Th>
+                        <Th>Domains</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {domainCheckerPageItems.map(cert => (
+                        <DomainCheckerRow
+                          key={cert.id}
+                          cert={cert}
+                          isSelected={selectedIds.has(cert.id)}
+                          onToggle={toggleDomainCheckerResult}
+                        />
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+              )}
+              {domainCheckerResults.length > 0 && (
+                <HStack mt={3} spacing={2} align='center' flexWrap='wrap'>
+                  <Button
+                    size='xs'
+                    variant='outline'
+                    isDisabled={domainCheckerPage === 0}
+                    onClick={() => setDomainCheckerPage(p => p - 1)}
+                  >
+                    ← Prev
+                  </Button>
+                  <Text fontSize='xs' color={helpTextColor}>
+                    {domainCheckerPage * DOMAIN_CHECKER_PAGE_SIZE + 1}–
+                    {Math.min(
+                      (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE,
+                      domainCheckerVisibleResults.length
+                    )}{' '}
+                    of {domainCheckerVisibleResults.length}
+                    {domainCheckerResults.length !==
+                    domainCheckerVisibleResults.length
+                      ? ` (${domainCheckerResults.length} total)`
+                      : ''}
+                  </Text>
+                  <Button
+                    size='xs'
+                    variant='outline'
+                    isDisabled={
+                      (domainCheckerPage + 1) * DOMAIN_CHECKER_PAGE_SIZE >=
+                      domainCheckerVisibleResults.length
+                    }
+                    onClick={() => setDomainCheckerPage(p => p + 1)}
+                  >
+                    Next →
+                  </Button>
+                </HStack>
+              )}
+              {domainCheckerResults.length > 0 && (
+                <Stack mt={3} spacing={3}>
+                  <Alert status='info' borderRadius='md' py={2}>
+                    <AlertIcon />
+                    <AlertDescription fontSize='xs'>
+                      Import runs in batches (up to about 5 minutes per batch
+                      on slow hosts). After each run, hosts that finished
+                      importing are removed from your selection so you can
+                      click Import again for the rest without re-scanning.
+                    </AlertDescription>
+                  </Alert>
+                  <FormControl maxW='480px'>
+                    <FormLabel fontSize='sm'>
+                      Section for imported SSL tokens
+                    </FormLabel>
+                    <Input
+                      size='sm'
+                      value={domainCheckerImportSection}
+                      onChange={e =>
+                        setDomainCheckerImportSection(e.target.value)
+                      }
+                      placeholder='Comma-separated labels (optional)'
+                    />
+                  </FormControl>
+                  <FormControl
+                    display='flex'
+                    alignItems='center'
+                    minW='200px'
+                    maxW='360px'
+                  >
+                    <FormLabel mb={0} fontSize='sm'>
+                      Also create endpoint monitors
+                    </FormLabel>
+                    <Switch
+                      size='sm'
+                      isChecked={domainCheckerCreateMonitors}
+                      onChange={e =>
+                        setDomainCheckerCreateMonitors(e.target.checked)
+                      }
+                    />
+                  </FormControl>
+                  {domainCheckerCreateMonitors && (
+                    <HStack spacing={3} align='flex-end' flexWrap='wrap'>
+                      <FormControl minW='140px' maxW='220px'>
+                        <FormLabel fontSize='sm'>Interval</FormLabel>
+                        <Select
+                          size='sm'
+                          value={domainCheckerMonitorInterval}
+                          onChange={e =>
+                            setDomainCheckerMonitorInterval(e.target.value)
+                          }
+                        >
+                          <option value='1min'>Every 1 min</option>
+                          <option value='5min'>Every 5 min</option>
+                          <option value='30min'>Every 30 min</option>
+                          <option value='hourly'>Hourly</option>
+                          <option value='daily'>Daily</option>
+                        </Select>
+                      </FormControl>
+                      <FormControl
+                        display='flex'
+                        alignItems='center'
+                        minW='120px'
+                        pb={1}
+                      >
+                        <FormLabel mb={0} fontSize='sm'>
+                          Health Check
+                        </FormLabel>
+                        <Switch
+                          size='sm'
+                          isChecked={domainCheckerMonitorHealthCheck}
+                          onChange={e =>
+                            setDomainCheckerMonitorHealthCheck(
+                              e.target.checked
+                            )
+                          }
+                        />
+                      </FormControl>
+                      {domainCheckerMonitorHealthCheck && (
+                        <FormControl minW='130px' maxW='220px'>
+                          <FormLabel fontSize='sm'>
+                            Alert after failures
+                          </FormLabel>
+                          <NumberInput
+                            size='sm'
+                            min={1}
+                            max={10}
+                            value={domainCheckerMonitorAlertAfter}
+                            onChange={(_, valueAsNumber) =>
+                              setDomainCheckerMonitorAlertAfter(
+                                Number.isFinite(valueAsNumber)
+                                  ? valueAsNumber
+                                  : 2
+                              )
+                            }
+                          >
+                            <NumberInputField />
+                          </NumberInput>
+                        </FormControl>
+                      )}
+                      <FormControl minW='220px' maxW='280px'>
+                        <FormLabel fontSize='sm'>Contact group</FormLabel>
+                        <Select
+                          size='sm'
+                          value={domainCheckerMonitorContactGroupId}
+                          onChange={e =>
+                            setDomainCheckerMonitorContactGroupId(
+                              e.target.value
+                            )
+                          }
+                        >
+                          <option value=''>Default workspace group</option>
+                          {contactGroups.map(g => (
+                            <option key={g.id} value={g.id}>
+                              {g.name}
+                            </option>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </HStack>
+                  )}
+                  <HStack justify='flex-end' align='center' flexWrap='wrap'>
+                    <Button
+                      size='sm'
+                      colorScheme='purple'
+                      isLoading={domainCheckerImporting}
+                      isDisabled={
+                        selectedIds.size === 0 || domainCheckerImporting
+                      }
+                      onClick={handleDomainCheckerImport}
+                    >
+                      Import selected ({selectedIds.size})
+                    </Button>
+                  </HStack>
+                </Stack>
+              )}
+            </Box>
+
+            <Divider />
+            <Text fontWeight='semibold' fontSize='sm'>
+              Add new endpoint
+            </Text>
+            <HStack spacing={3} align='flex-end' flexWrap='wrap'>
+              <FormControl flex={2} minW='200px'>
+                <FormLabel fontSize='sm'>URL</FormLabel>
+                <Input
+                  size='sm'
+                  value={domainUrl}
+                  onChange={e => setDomainUrl(e.target.value)}
+                  placeholder='https://example.com'
+                />
+              </FormControl>
+              <FormControl flex={1} minW='160px' maxW='260px'>
+                <FormLabel fontSize='sm'>SSL token section</FormLabel>
+                <Input
+                  size='sm'
+                  value={domainEndpointTokenSection}
+                  onChange={e =>
+                    setDomainEndpointTokenSection(e.target.value)
+                  }
+                  placeholder='Optional, comma-separated'
+                />
+              </FormControl>
+              <FormControl flex={1} minW='120px'>
+                <FormLabel fontSize='sm'>Interval</FormLabel>
+                <Select
+                  size='sm'
+                  value={domainInterval}
+                  onChange={e => setDomainInterval(e.target.value)}
+                >
+                  <option value='1min'>Every 1 min</option>
+                  <option value='5min'>Every 5 min</option>
+                  <option value='30min'>Every 30 min</option>
+                  <option value='hourly'>Hourly</option>
+                  <option value='daily'>Daily</option>
+                </Select>
+              </FormControl>
+              <FormControl
+                display='flex'
+                alignItems='center'
+                minW='120px'
+                pb={1}
+              >
+                <FormLabel mb={0} fontSize='sm'>
+                  Health Check
+                </FormLabel>
+                <Switch
+                  size='sm'
+                  isChecked={domainHealthCheck}
+                  onChange={e => setDomainHealthCheck(e.target.checked)}
+                />
+              </FormControl>
+              {domainHealthCheck && (
+                <FormControl minW='130px' flex={1}>
+                  <FormLabel fontSize='sm'>Alert after failures</FormLabel>
+                  <Select
+                    size='sm'
+                    value={domainAlertAfter}
+                    onChange={e =>
+                      setDomainAlertAfter(Number(e.target.value))
+                    }
+                  >
+                    <option value={1}>1 failure</option>
+                    <option value={2}>2 failures</option>
+                    <option value={3}>3 failures</option>
+                    <option value={5}>5 failures</option>
+                    <option value={10}>10 failures</option>
+                  </Select>
+                </FormControl>
+              )}
+              {Array.isArray(contactGroups) && contactGroups.length > 0 && (
+                <FormControl minW='150px' flex={1}>
+                  <FormLabel fontSize='sm'>Contact group</FormLabel>
+                  <Select
+                    size='sm'
+                    value={domainContactGroupId}
+                    onChange={e => setDomainContactGroupId(e.target.value)}
+                  >
+                    <option value=''>Workspace default</option>
+                    {contactGroups.map(g => (
+                      <option key={g.id} value={g.id}>
+                        {g.name}
+                        {String(g.id) === String(defaultContactGroupId)
+                          ? ' (default)'
+                          : ''}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+              <Button
+                size='sm'
+                colorScheme='blue'
+                leftIcon={<FiPlus />}
+                isLoading={addingDomain}
+                onClick={handleAddDomain}
+                isDisabled={!domainUrl.trim()}
+              >
+                Add
+              </Button>
+            </HStack>
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={handleDomainModalClose}>Close</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+});
+
+export default EndpointSslMonitorModal;

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -1046,12 +1046,13 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
     let credentials = {};
     let scanParams = {};
     switch (source) {
-      case 'github':
-        credentials = {
+      case 'github': {
+        const formCreds = githubFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? {
           baseUrl: githubBaseUrl || 'https://api.github.com',
           token: githubToken,
         };
-        scanParams = {
+        scanParams = formCreds?.scanParams ?? {
           baseUrl: githubBaseUrl || 'https://api.github.com',
           include: {
             tokens: githubIncludeTokens,
@@ -1061,12 +1062,14 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
           },
         };
         break;
-      case 'gitlab':
-        credentials = {
+      }
+      case 'gitlab': {
+        const formCreds = gitlabFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? {
           baseUrl: gitlabBaseUrl || 'https://gitlab.com',
           token: gitlabToken,
         };
-        scanParams = {
+        scanParams = formCreds?.scanParams ?? {
           baseUrl: gitlabBaseUrl || 'https://gitlab.com',
           include: { tokens: true, keys: true },
           filters: {
@@ -1081,33 +1084,40 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
           },
         };
         break;
-      case 'vault':
-        credentials = { address: vaultAddress, token: vaultToken };
-        scanParams = {
+      }
+      case 'vault': {
+        const formCreds = vaultFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? { address: vaultAddress, token: vaultToken };
+        scanParams = formCreds?.scanParams ?? {
           address: vaultAddress,
           include: { kv: includeKV, pki: includePKI },
           pathPrefix: pathPrefix || '',
           maxItemsPerMount: maxItemsPerMount || 1000,
         };
         break;
-      case 'aws':
-        credentials = {
+      }
+      case 'aws': {
+        const formCreds = awsFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? {
           accessKeyId: awsAccessKeyId,
           secretAccessKey: awsSecretAccessKey,
           region: awsRegion || 'us-east-1',
         };
-        scanParams = {
+        scanParams = formCreds?.scanParams ?? {
           region: awsRegion || 'us-east-1',
           include: { secrets: true, iam: true, certificates: true },
         };
         break;
-      case 'azure':
-        credentials = { vaultUrl: azureVaultUrl, token: azureToken };
-        scanParams = {
+      }
+      case 'azure': {
+        const formCreds = azureFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? { vaultUrl: azureVaultUrl, token: azureToken };
+        scanParams = formCreds?.scanParams ?? {
           vaultUrl: azureVaultUrl,
           include: { secrets: true, certificates: true, keys: true },
         };
         break;
+      }
       case 'azure-ad':
         credentials = { token: azureADToken };
         scanParams = {
@@ -1117,10 +1127,15 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
           },
         };
         break;
-      case 'gcp':
-        credentials = { projectId: gcpProjectId, accessToken: gcpAccessToken };
-        scanParams = { projectId: gcpProjectId, include: { secrets: true } };
+      case 'gcp': {
+        const formCreds = gcpFormRef.current?.getCredentials();
+        credentials = formCreds?.credentials ?? { projectId: gcpProjectId, accessToken: gcpAccessToken };
+        scanParams = formCreds?.scanParams ?? {
+          projectId: gcpProjectId,
+          include: { secrets: true },
+        };
         break;
+      }
     }
     return { credentials, scanParams };
   };
@@ -1740,7 +1755,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onCloseInternal} size='4xl'>
+      <Modal isOpen={isOpen} onClose={onCloseInternal} size='4xl' motionPreset='none'>
         <ModalOverlay />
         <ModalContent bg={cardBg} border='1px solid' borderColor={borderColor}>
           <ModalHeader>

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -1087,7 +1087,10 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
       }
       case 'vault': {
         const formCreds = vaultFormRef.current?.getCredentials();
-        credentials = formCreds?.credentials ?? { address: vaultAddress, token: vaultToken };
+        credentials = formCreds?.credentials ?? {
+          address: vaultAddress,
+          token: vaultToken,
+        };
         scanParams = formCreds?.scanParams ?? {
           address: vaultAddress,
           include: { kv: includeKV, pki: includePKI },
@@ -1111,7 +1114,10 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
       }
       case 'azure': {
         const formCreds = azureFormRef.current?.getCredentials();
-        credentials = formCreds?.credentials ?? { vaultUrl: azureVaultUrl, token: azureToken };
+        credentials = formCreds?.credentials ?? {
+          vaultUrl: azureVaultUrl,
+          token: azureToken,
+        };
         scanParams = formCreds?.scanParams ?? {
           vaultUrl: azureVaultUrl,
           include: { secrets: true, certificates: true, keys: true },
@@ -1129,7 +1135,10 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
         break;
       case 'gcp': {
         const formCreds = gcpFormRef.current?.getCredentials();
-        credentials = formCreds?.credentials ?? { projectId: gcpProjectId, accessToken: gcpAccessToken };
+        credentials = formCreds?.credentials ?? {
+          projectId: gcpProjectId,
+          accessToken: gcpAccessToken,
+        };
         scanParams = formCreds?.scanParams ?? {
           projectId: gcpProjectId,
           include: { secrets: true },
@@ -1755,7 +1764,12 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onCloseInternal} size='4xl' motionPreset='none'>
+      <Modal
+        isOpen={isOpen}
+        onClose={onCloseInternal}
+        size='4xl'
+        motionPreset='none'
+      >
         <ModalOverlay />
         <ModalContent bg={cardBg} border='1px solid' borderColor={borderColor}>
           <ModalHeader>

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -344,6 +344,17 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importAwsSelected,
     getSelectedCount: () => selectedRowsAws.size,
+    getCredentials: () => ({
+      credentials: {
+        accessKeyId: awsAccessKeyId,
+        secretAccessKey: awsSecretAccessKey,
+        region: awsRegion || 'us-east-1',
+      },
+      scanParams: {
+        region: awsRegion || 'us-east-1',
+        include: { secrets: true, iam: true, certificates: true },
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/components/imports/ImportAzureForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAzureForm.jsx
@@ -190,6 +190,13 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importAzureSelected,
     getSelectedCount: () => selectedRowsAzure.size,
+    getCredentials: () => ({
+      credentials: { vaultUrl: azureVaultUrl, token: azureToken },
+      scanParams: {
+        vaultUrl: azureVaultUrl,
+        include: { secrets: true, certificates: true, keys: true },
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/components/imports/ImportGCPForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGCPForm.jsx
@@ -186,6 +186,13 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importGcpSelected,
     getSelectedCount: () => selectedRowsGcp.size,
+    getCredentials: () => ({
+      credentials: { projectId: gcpProjectId, accessToken: gcpAccessToken },
+      scanParams: {
+        projectId: gcpProjectId,
+        include: { secrets: true },
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -226,6 +226,21 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importGithubSelected,
     getSelectedCount: () => selectedRowsGithub.size,
+    getCredentials: () => ({
+      credentials: {
+        baseUrl: githubBaseUrl || 'https://api.github.com',
+        token: githubToken,
+      },
+      scanParams: {
+        baseUrl: githubBaseUrl || 'https://api.github.com',
+        include: {
+          tokens: githubIncludeTokens,
+          sshKeys: githubIncludeSSHKeys,
+          deployKeys: githubIncludeDeployKeys,
+          secrets: githubIncludeSecrets,
+        },
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -231,6 +231,27 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importGitlabSelected,
     getSelectedCount: () => selectedRowsGitlab.size,
+    getCredentials: () => ({
+      credentials: {
+        baseUrl: gitlabBaseUrl || 'https://gitlab.com',
+        token: gitlabToken,
+      },
+      scanParams: {
+        baseUrl: gitlabBaseUrl || 'https://gitlab.com',
+        include: {
+          tokens: gitlabIncludePATs,
+          keys: gitlabIncludeSSHKeys,
+        },
+        filters: {
+          excludeUserPATs: gitlabExcludeUserPATs,
+          includeProjectTokens: gitlabIncludeProjectTokens,
+          includeGroupTokens: gitlabIncludeGroupTokens,
+          includeDeployTokens: gitlabIncludeDeployTokens,
+          includeExpired: gitlabIncludeExpired,
+          includeRevoked: gitlabIncludeRevoked,
+        },
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -249,6 +249,15 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importVaultSelected,
     getSelectedCount: () => selectedRowsVault.size,
+    getCredentials: () => ({
+      credentials: { address: vaultAddress, token: vaultToken },
+      scanParams: {
+        address: vaultAddress,
+        include: { kv: includeKV, pki: includePKI },
+        pathPrefix: pathPrefix || '',
+        maxItemsPerMount,
+      },
+    }),
   }));
 
   return (

--- a/apps/dashboard/src/styles/theme.js
+++ b/apps/dashboard/src/styles/theme.js
@@ -654,8 +654,6 @@ const components = {
       dialogContainer: {
         bg: 'transparent',
         backgroundColor: 'transparent',
-        backdropFilter: 'blur(10px)',
-        WebkitBackdropFilter: 'blur(10px)',
         _light: {
           bg: 'transparent',
           backgroundColor: 'transparent',
@@ -673,8 +671,6 @@ const components = {
       dialogContainer: {
         bg: 'transparent',
         backgroundColor: 'transparent',
-        backdropFilter: 'blur(10px)',
-        WebkitBackdropFilter: 'blur(10px)',
         _light: {
           bg: 'transparent',
           backgroundColor: 'transparent',
@@ -799,8 +795,8 @@ export const theme = extendTheme({
   shadows,
   components,
   config: {
-    initialColorMode: 'light',
-    useSystemColorMode: false,
+    initialColorMode: 'system',
+    useSystemColorMode: true,
   },
   styles: {
     global: props => ({

--- a/apps/dashboard/src/utils/domains.jsx
+++ b/apps/dashboard/src/utils/domains.jsx
@@ -1,0 +1,44 @@
+import { Badge } from '@chakra-ui/react';
+
+export function domainStatusColor(status) {
+  switch (status) {
+    case 'healthy':
+      return 'green';
+    case 'unhealthy':
+      return 'orange';
+    case 'error':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}
+
+export function domainSslBadge(domain) {
+  if (!domain.ssl_valid_to)
+    return <Badge colorScheme='gray'>No SSL</Badge>;
+  const daysLeft = Math.ceil(
+    (new Date(domain.ssl_valid_to) - new Date()) / (1000 * 60 * 60 * 24)
+  );
+  if (daysLeft < 0) return <Badge colorScheme='red'>Expired</Badge>;
+  if (daysLeft < 14)
+    return <Badge colorScheme='orange'>{daysLeft}d left</Badge>;
+  if (daysLeft < 30)
+    return <Badge colorScheme='yellow'>{daysLeft}d left</Badge>;
+  return <Badge colorScheme='green'>Valid ({daysLeft}d)</Badge>;
+}
+
+export function domainFormatUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.hostname + (u.pathname !== '/' ? u.pathname : '');
+  } catch {
+    return url;
+  }
+}
+
+export function domainValueToUrl(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `https://${raw}`;
+}

--- a/apps/dashboard/src/utils/domains.jsx
+++ b/apps/dashboard/src/utils/domains.jsx
@@ -14,8 +14,7 @@ export function domainStatusColor(status) {
 }
 
 export function domainSslBadge(domain) {
-  if (!domain.ssl_valid_to)
-    return <Badge colorScheme='gray'>No SSL</Badge>;
+  if (!domain.ssl_valid_to) return <Badge colorScheme='gray'>No SSL</Badge>;
   const daysLeft = Math.ceil(
     (new Date(domain.ssl_valid_to) - new Date()) / (1000 * 60 * 60 * 24)
   );

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -10,7 +10,7 @@ RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Ensure production mode
 ENV NODE_ENV=production

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Copy workspace config, root package.json, and lockfile from repo root
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",
@@ -13,7 +13,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "nodemailer": "8.0.5",
     "pg": "8.18.0",
     "prom-client": "15.1.3",

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -8,34 +8,65 @@
 
 import { pool, withClient } from "./db.js";
 import { logger } from "./logger.js";
+import {
+  cAutoSync,
+  cAutoSyncItems,
+  gAutoSyncLastRun,
+  pushMetrics,
+} from "./metrics.js";
 import crypto from "crypto";
 import axios from "axios";
 
-// Encryption helpers (same as systemSettings.js)
+// Encryption helpers — must mirror systemSettings.js exactly
+const KDF_SALT = "tokentimer-settings-encryption";
+
+// Derive the key once per process; scryptSync is intentionally expensive.
+let _encryptionKey = null;
+let _legacyEncryptionKey = null;
+
 function getEncryptionKey() {
-  const secret = process.env.SESSION_SECRET || "";
-  return crypto.createHash("sha256").update(secret).digest();
+  if (!_encryptionKey) {
+    const secret = process.env.SESSION_SECRET || "";
+    _encryptionKey = crypto.scryptSync(secret, KDF_SALT, 32);
+  }
+  return _encryptionKey;
+}
+
+// Legacy key used before the scrypt KDF was introduced (pre-v0.1 values)
+function getLegacyEncryptionKey() {
+  if (!_legacyEncryptionKey) {
+    const secret = process.env.SESSION_SECRET || "";
+    _legacyEncryptionKey = crypto.createHash("sha256").update(secret).digest();
+  }
+  return _legacyEncryptionKey;
+}
+
+function decryptWithKey(ciphertext, key) {
+  const parts = ciphertext.split(":");
+  if (parts.length !== 3) return null;
+  const iv = Buffer.from(parts[0], "hex");
+  const tag = Buffer.from(parts[1], "hex");
+  const encrypted = parts[2];
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  let decrypted = decipher.update(encrypted, "hex", "utf8");
+  decrypted += decipher.final("utf8");
+  return decrypted;
 }
 
 function decrypt(ciphertext) {
   if (!ciphertext) return null;
   try {
-    const parts = ciphertext.split(":");
-    if (parts.length !== 3) return null;
-    const key = getEncryptionKey();
-    const iv = Buffer.from(parts[0], "hex");
-    const tag = Buffer.from(parts[1], "hex");
-    const encrypted = parts[2];
-    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
-    decipher.setAuthTag(tag);
-    let decrypted = decipher.update(encrypted, "hex", "utf8");
-    decrypted += decipher.final("utf8");
-    return decrypted;
-  } catch (e) {
-    logger.error("Failed to decrypt auto-sync credentials", {
-      error: e.message,
-    });
-    return null;
+    return decryptWithKey(ciphertext, getEncryptionKey());
+  } catch (_) {
+    try {
+      return decryptWithKey(ciphertext, getLegacyEncryptionKey());
+    } catch (e) {
+      logger.error("Failed to decrypt auto-sync credentials", {
+        error: e.message,
+      });
+      return null;
+    }
   }
 }
 
@@ -137,6 +168,12 @@ async function runAutoSync() {
   logger.info("Auto-sync worker started");
 
   await withClient(async (client) => {
+    // Wrap the SELECT FOR UPDATE and the per-config status updates in an
+    // explicit transaction so the row locks are held until each UPDATE commits.
+    // Without BEGIN/COMMIT the lock is released immediately after SELECT in
+    // autocommit mode, making SKIP LOCKED useless against concurrent workers.
+    await client.query("BEGIN");
+
     // Pick up due configs with row-level locking
     const dueResult = await client.query(
       `SELECT * FROM auto_sync_configs
@@ -147,24 +184,30 @@ async function runAutoSync() {
     );
 
     if (dueResult.rows.length === 0) {
+      await client.query("ROLLBACK");
       logger.info("No auto-sync configs due");
       return;
     }
 
     logger.info(`Processing ${dueResult.rows.length} auto-sync configs`);
 
-    for (const config of dueResult.rows) {
-      const {
-        id,
-        workspace_id,
-        provider,
-        credentials_encrypted,
-        scan_params,
-        frequency,
-        schedule_time,
-        schedule_tz,
-      } = config;
-      logger.info(`Syncing ${provider} for workspace ${workspace_id}`);
+    // Run all due configs concurrently. The HTTP calls (scan + import) are
+    // independent of each other; only the final status UPDATE needs the
+    // shared client, but since we serialise those writes and they are fast,
+    // sharing the client is safe here.
+    await Promise.allSettled(
+      dueResult.rows.map(async (config) => {
+        const {
+          id,
+          workspace_id,
+          provider,
+          credentials_encrypted,
+          scan_params,
+          frequency,
+          schedule_time,
+          schedule_tz,
+        } = config;
+        logger.info(`Syncing ${provider} for workspace ${workspace_id}`);
 
       try {
         // Decrypt credentials
@@ -173,6 +216,31 @@ async function runAutoSync() {
           throw new Error("Failed to decrypt credentials");
         }
         const creds = JSON.parse(credJson);
+
+        // Validate that required credential fields are present before hitting
+        // the scan endpoint, so missing-field errors surface with clear context
+        // rather than an opaque 400 from the downstream API.
+        const REQUIRED_CRED_FIELDS = {
+          github: ["token"],
+          gitlab: ["token"],
+          aws: ["accessKeyId", "secretAccessKey"],
+          azure: ["token"],
+          "azure-ad": ["token"],
+          gcp: ["projectId", "accessToken"],
+          vault: ["address", "token"],
+        };
+        const missing = (REQUIRED_CRED_FIELDS[provider] || []).filter(
+          (f) => !creds[f],
+        );
+        if (missing.length > 0) {
+          const detail = missing.map((f) =>
+            f in creds ? `${f} (empty)` : `${f} (absent)`,
+          );
+          throw new Error(
+            `Invalid credentials for ${provider}: ${detail.join(", ")}. ` +
+              `Re-save the auto-sync config with valid credentials.`,
+          );
+        }
 
         // Call the API's scan endpoint via HTTP
         const apiUrl = process.env.API_URL || "http://api:4000";
@@ -271,57 +339,24 @@ async function runAutoSync() {
             throw new Error(`Unknown provider: ${provider}`);
         }
 
-        // Call the scan API endpoint
+        // 1. Scan: discover items from the provider
         const scanResponse = await axios.post(scanUrl, scanBody, {
           timeout: 120000,
           headers: authHeaders,
         });
         const scanResult = scanResponse.data;
-
         const itemsCount = scanResult?.items?.length || 0;
 
-        // Import results into workspace
+        // 2. Import: delegate to the existing import endpoint so deduplication,
+        //    sanitization, type validation, and audit logging are identical to
+        //    what a user gets when importing manually from the dashboard.
         if (itemsCount > 0) {
-          const NEVER_EXPIRES_DATE = "2099-12-31";
-          for (const item of scanResult.items) {
-            try {
-              const name = String(item.name || "").trim();
-              if (!name || name.length < 3) continue;
-              let expiration = item.expiration || item.expiresAt || null;
-              if (expiration) {
-                const d = new Date(expiration);
-                if (isNaN(d.getTime())) expiration = null;
-                else expiration = d.toISOString().split("T")[0];
-              }
-              if (!expiration) expiration = NEVER_EXPIRES_DATE;
-
-              const category = (item.category || "general").toLowerCase();
-              const type = (item.type || "other").toLowerCase();
-              const section = item.source ? [item.source] : null;
-
-              // Upsert: update if exists, create if not
-              await client.query(
-                `INSERT INTO tokens (user_id, workspace_id, created_by, name, expiration, type, category, section, location, notes, imported_at)
-                 VALUES (NULL, $1, NULL, $2, $3, $4, $5, $6, $7, $8, NOW())
-                 ON CONFLICT ON CONSTRAINT tokens_pkey DO NOTHING`,
-                [
-                  workspace_id,
-                  name.substring(0, 100),
-                  expiration,
-                  type,
-                  category,
-                  section,
-                  item.location || null,
-                  `Auto-synced from ${provider}`,
-                ],
-              );
-            } catch (itemErr) {
-              logger.warn("Auto-sync: failed to import item", {
-                name: item.name,
-                error: itemErr.message,
-              });
-            }
-          }
+          const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
+          await axios.post(
+            importUrl,
+            { items: scanResult.items },
+            { timeout: 60000, headers: authHeaders },
+          );
         }
 
         // Update config: success
@@ -334,15 +369,23 @@ async function runAutoSync() {
           [itemsCount, nextSync, id],
         );
 
+        cAutoSync.inc({ provider, status: "success" });
+        cAutoSyncItems.inc({ provider }, itemsCount);
+        gAutoSyncLastRun.set({ provider, status: "success" }, Date.now() / 1000);
         logger.info(`Auto-sync ${provider} completed: ${itemsCount} items`, {
           workspace_id,
         });
       } catch (syncErr) {
         logger.error(`Auto-sync ${provider} failed`, {
           workspace_id,
-          error: syncErr.message,
+          error: syncErr?.message || String(syncErr),
+          httpStatus: syncErr?.response?.status,
+          httpBody: syncErr?.response?.data,
+          stack: syncErr?.stack,
         });
 
+        cAutoSync.inc({ provider, status: "failure" });
+        gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
         // Update config: failed
         const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
         await client.query(
@@ -350,13 +393,19 @@ async function runAutoSync() {
            SET last_sync_at = NOW(), last_sync_status = 'failed',
                last_sync_error = $1, next_sync_at = $2, updated_at = NOW()
            WHERE id = $3`,
-          [String(syncErr.message).substring(0, 1000), nextSync, id],
+          [String(syncErr?.message || syncErr).substring(0, 1000), nextSync, id],
         );
       }
-    }
+    }));
+
+    // Commit all status updates and release the FOR UPDATE locks atomically.
+    await client.query("COMMIT");
   });
 
   logger.info("Auto-sync worker finished");
+  await pushMetrics("auto-sync").catch((e) =>
+    logger.warn("Failed to push metrics", { error: e.message }),
+  );
 }
 
 // Entry point

--- a/apps/worker/src/metrics.js
+++ b/apps/worker/src/metrics.js
@@ -137,6 +137,28 @@ export const gWeeklyDigestLastRunSuccess = new client.Gauge({
   registers: [metricsRegister],
 });
 
+// Auto-sync metrics
+export const cAutoSync = new client.Counter({
+  name: "auto_sync_runs_total",
+  help: "Auto-sync runs by provider and status (success|failure)",
+  labelNames: ["provider", "status"],
+  registers: [metricsRegister],
+});
+
+export const cAutoSyncItems = new client.Counter({
+  name: "auto_sync_items_imported_total",
+  help: "Items imported (created or updated) by auto-sync, by provider",
+  labelNames: ["provider"],
+  registers: [metricsRegister],
+});
+
+export const gAutoSyncLastRun = new client.Gauge({
+  name: "auto_sync_last_run_timestamp",
+  help: "Unix timestamp of the last auto-sync attempt, by provider and status",
+  labelNames: ["provider", "status"],
+  registers: [metricsRegister],
+});
+
 // Centralized error counter for logger
 export const cLogError = new client.Counter({
   name: "app_log_errors_total",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,5 +1,5 @@
 # TokenTimer API Dockerfile
-FROM golang:1.26.2-alpine3.23 AS subfinder-builder
+FROM golang:1.26.3-alpine3.23 AS subfinder-builder
 
 RUN apk add --no-cache ca-certificates git && \
     CGO_ENABLED=0 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
@@ -16,7 +16,7 @@ COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Create non-root user (UID/GID 1000 is taken by the built-in node user)
 RUN addgroup -g 1001 -S tokentimer && adduser -u 1001 -S tokentimer -G tokentimer

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -5,7 +5,7 @@ FROM node:22.22.2-alpine3.23 AS builder
 RUN apk update && apk upgrade --no-cache
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 WORKDIR /app
 

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade --no-cache
 RUN apk add --no-cache curl
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 
 # Create non-root user (UID/GID 1000 is taken by the built-in node user)
 RUN addgroup -g 1001 -S tokentimer && adduser -u 1001 -S tokentimer -G tokentimer

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -273,7 +273,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-changeme}
       DB_NAME: ${DB_NAME:-tokentimer}
       SESSION_SECRET: ${SESSION_SECRET:?Session secret is required}
-      API_URL: ${API_URL:-http://api:4000}
+      API_URL: http://api:4000
     volumes: []
 
   # Worker Service - Endpoint (SSL) Check

--- a/deploy/helm/examples/values-full-test.yaml
+++ b/deploy/helm/examples/values-full-test.yaml
@@ -404,6 +404,40 @@ monitoring:
             annotations:
               summary: "High SMTP latency (p95)"
               description: "95th percentile SMTP latency > 2s (kind={{ $labels.kind }})"
+      # ── Auto-sync ─────────────────────────────────────────────────────────
+      - name: tokentimer.auto-sync
+        rules:
+          - alert: AutoSyncProviderFailures
+            expr: |
+              sum by (provider) (increase(auto_sync_runs_total{status="failure"}[3h]))
+              >= 3
+              unless
+              sum by (provider) (increase(auto_sync_runs_total{status="success"}[3h]))
+              > 0
+            for: 0m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Auto-sync provider {{ $labels.provider }} failing"
+              description: >-
+                Auto-sync for {{ $labels.provider }} has failed
+                {{ $value | printf "%.0f" }} times in 3 h with no successes.
+                Check credentials and network connectivity.
+              runbook_url: "https://tokentimer.ch/docs#auto-sync-troubleshooting"
+          - alert: AutoSyncNotRunning
+            expr: |
+              (time() - max by (provider) (auto_sync_last_run_timestamp{status="success"}))
+              > 90000
+            for: 0m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Auto-sync for {{ $labels.provider }} has not succeeded in > 25 h"
+              description: >-
+                The auto-sync CronJob for {{ $labels.provider }} has not completed
+                a successful run in more than 25 hours. The CronJob may be stuck,
+                misconfigured, or disabled.
+              runbook_url: "https://tokentimer.ch/docs#auto-sync-troubleshooting"
       # ── Auth / Security ───────────────────────────────────────────────────
       - name: tokentimer.security
         rules:

--- a/deploy/helm/templates/cronjob-auto-sync.yaml
+++ b/deploy/helm/templates/cronjob-auto-sync.yaml
@@ -56,13 +56,13 @@ spec:
                 {{- with .Values.worker.envFrom }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
-              {{- if .Values.worker.env }}
               env:
+                - name: API_URL
+                  value: "http://{{ include "tokentimer.fullname" . }}-api:{{ .Values.api.service.port }}"
                 {{- range $key, $value := .Values.worker.env }}
                 - name: {{ $key }}
                   value: {{ $value | quote }}
                 {{- end }}
-              {{- end }}
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp

--- a/deploy/helm/templates/networkpolicy.yaml
+++ b/deploy/helm/templates/networkpolicy.yaml
@@ -60,6 +60,14 @@ spec:
       ports:
         - protocol: TCP
           port: 4000
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "tokentimer.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: auto-sync
+      ports:
+        - protocol: TCP
+          port: 4000
   egress:
     {{- if .Values.postgresql.cloudnative.enabled }}
     - to:
@@ -212,6 +220,15 @@ spec:
           port: 465
         - protocol: TCP
           port: 587
+    # API (auto-sync scan + import endpoints)
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "tokentimer.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: api
+      ports:
+        - protocol: TCP
+          port: {{ .Values.api.service.port }}
     # HTTPS (Slack, Discord, Teams webhooks, Twilio)
     - to:
         - ipBlock:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -434,22 +434,8 @@ monitoring:
     namespace: ""
     labels: {}
     groups: []
-    #   - name: tokentimer.rules
-    #     rules:
-    #       - alert: TokenTimerZeroSends72h
-    #         expr: sum(increase(alerts_delivery_total{status="success"}[72h])) == 0
-    #         for: 1h
-    #         labels:
-    #           severity: warning
-    #         annotations:
-    #           summary: No successful sends in 72h
-    #       - alert: AppErrorsRecent
-    #         expr: sum(increase(app_log_errors_total[5m])) > 0
-    #         for: 0m
-    #         labels:
-    #           severity: warning
-    #         annotations:
-    #           summary: Application errors detected
+    # See deploy/helm/examples/values-full-test.yaml for ready-to-use rule groups
+    # covering alert delivery, auto-sync failures, application errors, and security.
 
 # -- ServiceAccount ------------------------------------------------------------
 serviceAccount:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {
@@ -53,14 +53,15 @@
     "docker:up": "docker compose -f deploy/compose/docker-compose.yml up",
     "docker:down": "docker compose -f deploy/compose/docker-compose.yml down"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=22.0.0"
   },
   "pnpm": {
     "overrides": {
       "tar": "7.5.7",
-      "fast-xml-parser": "5.7.2",
+      "fast-xml-builder": "1.2.0",
+      "fast-xml-parser": "5.7.3",
       "minimatch": "9.0.9",
       "brace-expansion": "2.0.3",
       "path-to-regexp": "8.4.0",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.3.2
+  version: 0.4.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.
@@ -990,6 +990,52 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
   /api/tokens/bulk:
+    put:
+      tags: [Tokens]
+      summary: Bulk update tokens
+      operationId: bulkUpdateTokens
+      description: Updates multiple tokens in one request (supports section assignment) and returns per-item processing details.
+      requestBody:
+        description: List of token ids and fields to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ids, section]
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: integer
+                section:
+                  nullable: true
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+      responses:
+        "200":
+          description: Bulk update result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  successCount:
+                    type: integer
+                  failedCount:
+                    type: integer
+                  results:
+                    type: object
+                    additionalProperties: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
     delete:
       tags: [Tokens]
       summary: Bulk delete tokens

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   tar: 7.5.7
-  fast-xml-parser: 5.7.2
+  fast-xml-builder: 1.2.0
+  fast-xml-parser: 5.7.3
   minimatch: 9.0.9
   brace-expansion: 2.0.3
   path-to-regexp: 8.4.0
@@ -59,20 +60,20 @@ importers:
   apps/api:
     dependencies:
       '@aws-sdk/client-acm':
-        specifier: 3.990.0
-        version: 3.990.0
+        specifier: 3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-iam':
-        specifier: 3.990.0
-        version: 3.990.0
+        specifier: 3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-secrets-manager':
-        specifier: 3.990.0
-        version: 3.990.0
+        specifier: 3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-sts':
-        specifier: 3.990.0
-        version: 3.990.0
+        specifier: 3.1045.0
+        version: 3.1045.0
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       bcryptjs:
         specifier: 3.0.3
         version: 3.0.3
@@ -95,8 +96,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       express-rate-limit:
-        specifier: 8.3.1
-        version: 8.3.1(express@5.2.1)
+        specifier: 8.5.1
+        version: 8.5.1(express@5.2.1)
       express-session:
         specifier: 1.19.0
         version: 1.19.0
@@ -171,8 +172,8 @@ importers:
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       framer-motion:
         specifier: 11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -283,8 +284,8 @@ importers:
   apps/worker:
     dependencies:
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.16.0
+        version: 1.16.0
       nodemailer:
         specifier: 8.0.5
         version: 8.0.5
@@ -346,107 +347,115 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-acm@3.990.0':
-    resolution: {integrity: sha512-hZoRIStUKndck5h7Ok232nr1NBDjL29tQ5UhghXi/UkvUCV2gLqKNtaE5KxRLsqiP2ByM3p4ilFdQ5u4ZlaYkg==}
+  '@aws-sdk/client-acm@3.1045.0':
+    resolution: {integrity: sha512-l3b5FNvcPtMH/B/WqT7F1i7TmadFOJnqL5eM1wCl9VLVnD69qqzBzIF/Vn+LIh8g1jqIXGZUz3ntPun2GcL5bQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-iam@3.990.0':
-    resolution: {integrity: sha512-Agx4+Xzclky6kOjmIbOolwHP/VfRHOCHU5ezWBwpudyg71xsIQw/xUyaXj62gz8wb06lMjqNUZdUmd7YfsR8iA==}
+  '@aws-sdk/client-iam@3.1045.0':
+    resolution: {integrity: sha512-1kCDjvkOUyZ7MxQu2ybgXxYDW+8PG+cHjVCk0IXZwYy5R2dhAeHLLlDGJB9jA/KeSh6+XcN5uMlApqJGP1zbUg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-secrets-manager@3.990.0':
-    resolution: {integrity: sha512-cf4ZLsjczU/Rh+QAxoXUbc/2OKAm8WWC3j1axE4qIO6FLziJCze94sTSCmhSMeLoSjixtIORERQeAXYnjrYVAg==}
+  '@aws-sdk/client-secrets-manager@3.1045.0':
+    resolution: {integrity: sha512-ceXmaTE/3j7bHgVzUrpL/ECjQQ+aE/x8wNbblC/SIb020OxYRMj0DscFimnI5kEjutGHQ+A68bbX2A+bZuAMEA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sso@3.990.0':
-    resolution: {integrity: sha512-xTEaPjZwOqVjGbLOP7qzwbdOWJOo1ne2mUhTZwEBBkPvNk4aXB/vcYwWwrjoSWUqtit4+GDbO75ePc/S6TUJYQ==}
+  '@aws-sdk/client-sts@3.1045.0':
+    resolution: {integrity: sha512-oDJJ7rM1osvfBdfZuhQ5DM6lHD9iuypL9m2LsEiA/lB8xuE5uPYsftNDcS0J9VRXFSvYTqC14K7Y5vMMKMg0vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-sts@3.990.0':
-    resolution: {integrity: sha512-w1MfhIKV1GmQJI2gN64gvtwSPJR55n5TIkujIoZZy3V3OlksAOWCnfUBHoyfu8x4aZn70cINfa+ixPtUHtnEew==}
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.10':
-    resolution: {integrity: sha512-4u/FbyyT3JqzfsESI70iFg6e2yp87MB5kS2qcxIA66m52VSTN1fvuvbCY1h/LKq1LvuxIrlJ1ItcyjvcKoaPLg==}
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.8':
-    resolution: {integrity: sha512-r91OOPAcHnLCSxaeu/lzZAVRCZ/CtTNuwmJkUwpwSDshUrP7bkX1OmFn2nUMWd9kN53Q4cEo8b7226G4olt2Mg==}
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.10':
-    resolution: {integrity: sha512-DTtuyXSWB+KetzLcWaSahLJCtTUe/3SXtlGp4ik9PCe9xD6swHEkG8n8/BNsQ9dsihb9nhFvuUB4DpdBGDcvVg==}
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.8':
-    resolution: {integrity: sha512-n2dMn21gvbBIEh00E8Nb+j01U/9rSqFIamWRdGm/mE5e+vHQ9g0cBNdrYFlM6AAiryKVHZmShWT9D1JAWJ3ISw==}
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.8':
-    resolution: {integrity: sha512-rMFuVids8ICge/X9DF5pRdGMIvkVhDV9IQFQ8aTYk6iF0rl9jOUa1C3kjepxiXUlpgJQT++sLZkT9n0TMLHhQw==}
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.9':
-    resolution: {integrity: sha512-LfJfO0ClRAq2WsSnA9JuUsNyIicD2eyputxSlSL0EiMrtxOxELLRG6ZVYDf/a1HCepaYPXeakH4y8D5OLCauag==}
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.8':
-    resolution: {integrity: sha512-6cg26ffFltxM51OOS8NH7oE41EccaYiNlbd5VgUYwhiGCySLfHoGuGrLm2rMB4zhy+IO5nWIIG0HiodX8zdvHA==}
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.8':
-    resolution: {integrity: sha512-35kqmFOVU1n26SNv+U37sM8b2TzG8LyqAcd6iM9gprqxyHEh/8IM3gzN4Jzufs3qM6IrH8e43ryZWYdvfVzzKQ==}
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.8':
-    resolution: {integrity: sha512-CZhN1bOc1J3ubQPqbmr5b4KaMJBgdDvYsmEIZuX++wFlzmZsKj1bwkaiTEb5U2V7kXuzLlpF5HJSOM9eY/6nGA==}
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.3':
-    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.3':
-    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.3':
-    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.10':
-    resolution: {integrity: sha512-bBEL8CAqPQkI91ZM5a9xnFAzedpzH6NYCOtNyLarRAzTUTFN2DKqaC60ugBa7pnU1jSi4mA7WAXBsrod7nJltg==}
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.990.0':
-    resolution: {integrity: sha512-3NA0s66vsy8g7hPh36ZsUgO4SiMyrhwcYvuuNK1PezO52vX3hXDW4pQrC6OQLGKGJV0o6tbEyQtXb/mPs8zg8w==}
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.3':
-    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.990.0':
-    resolution: {integrity: sha512-L3BtUb2v9XmYgQdfGBzbBtKMXaP5fV973y3Qdxeevs6oUTVXFmi/mV1+LnScA/1wVPJC9/hlK+1o5vbt7cG7EQ==}
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.1':
-    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.990.0':
-    resolution: {integrity: sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==}
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.4':
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.3':
-    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
 
-  '@aws-sdk/util-user-agent-node@3.972.8':
-    resolution: {integrity: sha512-XJZuT0LWsFCW1C8dEpPAXSa7h6Pb3krr2y//1X0Zidpcl0vmgY5nL/X0JuBZlntpBzaN3+U4hvKjuijyiiR8zw==}
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -454,8 +463,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.4':
-    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -1309,180 +1318,176 @@ packages:
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
-  '@smithy/abort-controller@4.2.8':
-    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.6':
-    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.0':
-    resolution: {integrity: sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==}
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.8':
-    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.3.9':
-    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@4.2.8':
-    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.8':
-    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.2.0':
-    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.8':
-    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.14':
-    resolution: {integrity: sha512-FUFNE5KVeaY6U/GL0nzAAHkaCHzXLZcY1EhtQnsAqhD8Du13oPKtMB9/0WK4/LK6a/T5OZ24wPoSShff5iI6Ag==}
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.31':
-    resolution: {integrity: sha512-RXBzLpMkIrxBPe4C8OmEOHvS8aH9RUuCOH++Acb5jZDEblxDjyg6un72X9IcbrGTJoiUwmI7hLypNfuDACypbg==}
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.9':
-    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-stack@4.2.8':
-    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.8':
-    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.4.10':
-    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@4.2.8':
-    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@5.3.8':
-    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@4.2.8':
-    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@4.2.8':
-    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@4.2.8':
-    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.3':
-    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.3.8':
-    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.11.3':
-    resolution: {integrity: sha512-Q7kY5sDau8OoE6Y9zJoRGgje8P4/UY0WzH8R2ok0PDh+iJ+ZnEKowhjEqYafVcubkbYxQVaqwm3iufktzhprGg==}
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.12.0':
-    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/url-parser@4.2.8':
-    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-base64@4.3.0':
-    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-body-length-browser@4.2.0':
-    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-body-length-node@4.2.1':
-    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@4.2.0':
-    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-config-provider@4.2.0':
-    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.30':
-    resolution: {integrity: sha512-cMni0uVU27zxOiU8TuC8pQLC1pYeZ/xEMxvchSK/ILwleRd1ugobOcIRr5vXtcRqKd4aBLWlpeBoDPJJ91LQng==}
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.33':
-    resolution: {integrity: sha512-LEb2aq5F4oZUSzWBG7S53d4UytZSkOEJPXcBq/xbG2/TmK9EW5naUZ8lKu1BEyWMzdHIzEVN16M3k8oxDq+DJA==}
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-endpoints@3.2.8':
-    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-hex-encoding@4.2.0':
-    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.8':
-    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.8':
-    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.12':
-    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-uri-escape@4.2.0':
-    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-utf8@4.2.0':
-    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-waiter@4.2.8':
-    resolution: {integrity: sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==}
+  '@smithy/util-waiter@4.3.0':
+    resolution: {integrity: sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/uuid@1.1.0':
-    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
   '@so-ric/colorspace@1.1.6':
@@ -1818,8 +1823,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2401,8 +2406,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.1:
-    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+  express-rate-limit@8.5.1:
+    resolution: {integrity: sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2444,11 +2449,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.20.1:
@@ -2770,8 +2775,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -4363,6 +4368,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
@@ -4467,7 +4476,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -4475,7 +4484,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4484,481 +4493,474 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-acm@3.990.0':
+  '@aws-sdk/client-acm@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-node': 3.972.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      '@smithy/util-waiter': 4.2.8
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-iam@3.990.0':
+  '@aws-sdk/client-iam@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-node': 3.972.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      '@smithy/util-waiter': 4.2.8
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-secrets-manager@3.990.0':
+  '@aws-sdk/client-secrets-manager@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-node': 3.972.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso@3.990.0':
+  '@aws-sdk/client-sts@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.990.0':
+  '@aws-sdk/core@3.974.8':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-node': 3.972.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.10':
+  '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/xml-builder': 3.972.4
-      '@smithy/core': 3.23.0
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.8':
-    dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.10':
-    dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/types': 3.973.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.12
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.8':
-    dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/credential-provider-env': 3.972.8
-      '@aws-sdk/credential-provider-http': 3.972.10
-      '@aws-sdk/credential-provider-login': 3.972.8
-      '@aws-sdk/credential-provider-process': 3.972.8
-      '@aws-sdk/credential-provider-sso': 3.972.8
-      '@aws-sdk/credential-provider-web-identity': 3.972.8
-      '@aws-sdk/nested-clients': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.8':
+  '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/nested-clients': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.9':
+  '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.8
-      '@aws-sdk/credential-provider-http': 3.972.10
-      '@aws-sdk/credential-provider-ini': 3.972.8
-      '@aws-sdk/credential-provider-process': 3.972.8
-      '@aws-sdk/credential-provider-sso': 3.972.8
-      '@aws-sdk/credential-provider-web-identity': 3.972.8
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.8':
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.8':
-    dependencies:
-      '@aws-sdk/client-sso': 3.990.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/token-providers': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.8':
+  '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/nested-clients': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/middleware-host-header@3.972.3':
-    dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.3':
+  '@aws-sdk/middleware-logger@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.3':
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.8
       '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.10':
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
     dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@smithy/core': 3.23.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.990.0':
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.6':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.990.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.8
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.3':
+  '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.990.0':
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
-      '@aws-sdk/core': 3.973.10
-      '@aws-sdk/nested-clients': 3.990.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.1':
+  '@aws-sdk/types@3.973.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.990.0':
+  '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.4':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.3':
+  '@aws-sdk/util-user-agent-browser@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.972.8':
+  '@aws-sdk/util-user-agent-node@3.973.24':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.10
-      '@aws-sdk/types': 3.973.1
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.4':
+  '@aws-sdk/xml-builder@3.972.22':
     dependencies:
-      '@smithy/types': 4.12.0
-      fast-xml-parser: 5.7.2
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -5727,196 +5729,192 @@ snapshots:
 
   '@scure/base@2.0.0': {}
 
-  '@smithy/abort-controller@4.2.8':
+  '@smithy/config-resolver@4.4.17':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.6':
+  '@smithy/core@3.23.17':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-config-provider': 4.2.0
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/core@3.23.0':
+  '@smithy/credential-provider-imds@4.2.14':
     dependencies:
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-stream': 4.5.12
-      '@smithy/util-utf8': 4.2.0
-      '@smithy/uuid': 1.1.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.8':
+  '@smithy/fetch-http-handler@5.3.17':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.9':
+  '@smithy/hash-node@4.2.14':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/querystring-builder': 4.2.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/hash-node@4.2.8':
+  '@smithy/invalid-dependency@4.2.14':
     dependencies:
-      '@smithy/types': 4.12.0
-      '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.8':
-    dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@4.2.0':
+  '@smithy/is-array-buffer@4.2.2':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.8':
+  '@smithy/middleware-content-length@4.2.14':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.14':
+  '@smithy/middleware-endpoint@4.4.32':
     dependencies:
-      '@smithy/core': 3.23.0
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-middleware': 4.2.8
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.31':
+  '@smithy/middleware-retry@4.5.7':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/service-error-classification': 4.2.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/uuid': 1.1.0
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.9':
+  '@smithy/middleware-serde@4.2.20':
     dependencies:
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/middleware-stack@4.2.8':
+  '@smithy/middleware-stack@4.2.14':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-config-provider@4.3.8':
+  '@smithy/node-config-provider@4.3.14':
     dependencies:
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.4.10':
+  '@smithy/node-http-handler@4.6.1':
     dependencies:
-      '@smithy/abort-controller': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/querystring-builder': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.8':
+  '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/protocol-http@5.3.8':
+  '@smithy/protocol-http@5.3.14':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/querystring-builder@4.2.8':
+  '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.12.0
-      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.8':
+  '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/service-error-classification@4.2.8':
+  '@smithy/service-error-classification@4.3.1':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
 
-  '@smithy/shared-ini-file-loader@4.4.3':
+  '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.3.8':
+  '@smithy/signature-v4@5.3.14':
     dependencies:
-      '@smithy/is-array-buffer': 4.2.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-uri-escape': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.11.3':
+  '@smithy/smithy-client@4.12.13':
     dependencies:
-      '@smithy/core': 3.23.0
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.12
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
-  '@smithy/types@4.12.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.8':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.0':
+  '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-body-length-node@4.2.1':
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
     dependencies:
       tslib: 2.8.1
 
@@ -5925,65 +5923,65 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.0':
+  '@smithy/util-buffer-from@4.2.2':
     dependencies:
-      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/is-array-buffer': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-config-provider@4.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.30':
-    dependencies:
-      '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.33':
-    dependencies:
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.2.8':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.0':
+  '@smithy/util-config-provider@4.2.2':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.8':
+  '@smithy/util-defaults-mode-browser@4.3.49':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.2.8':
+  '@smithy/util-defaults-mode-node@4.2.54':
     dependencies:
-      '@smithy/service-error-classification': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.12':
+  '@smithy/util-endpoints@3.4.2':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/util-uri-escape@4.2.0':
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
     dependencies:
       tslib: 2.8.1
 
@@ -5992,18 +5990,17 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-utf8@4.2.0':
+  '@smithy/util-utf8@4.2.2':
     dependencies:
-      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-buffer-from': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-waiter@4.2.8':
+  '@smithy/util-waiter@4.3.0':
     dependencies:
-      '@smithy/abort-controller': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/uuid@1.1.0':
+  '@smithy/uuid@1.1.2':
     dependencies:
       tslib: 2.8.1
 
@@ -6410,7 +6407,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -7174,10 +7171,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.1(express@5.2.1):
+  express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express-session@1.19.0:
     dependencies:
@@ -7195,7 +7192,7 @@ snapshots:
   express-slow-down@3.0.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
+      express-rate-limit: 8.5.1(express@5.2.1)
 
   express-validator@7.3.1:
     dependencies:
@@ -7253,14 +7250,15 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.5:
+  fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
 
-  fast-xml-parser@5.7.2:
+  fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.5
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -7594,7 +7592,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9320,6 +9318,8 @@ snapshots:
   ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xml@1.0.1: {}
 

--- a/tests/integration/auto-sync-import.test.js
+++ b/tests/integration/auto-sync-import.test.js
@@ -1,0 +1,404 @@
+/**
+ * Auto-Sync Import Integration Tests
+ *
+ * Verifies that the auto-sync worker imports tokens using the same
+ * deduplication semantics as the manual import endpoint:
+ *   - Token.findByNameLocationAndWorkspace (name + location, exact case)
+ *   - UPDATE when (name, location, workspace) already exists
+ *   - INSERT when not found
+ *   - No dedup when location is absent (always insert, same as manual import)
+ *
+ * Also covers worker-level behaviors:
+ *   - KDF mismatch: credentials encrypted with the legacy SHA-256 key still decrypt
+ *   - Disabled / future-scheduled configs are skipped
+ *   - Scan failure records last_sync_status = "failed" with a non-empty error
+ *   - next_sync_at is always advanced after a run (success or failure)
+ */
+
+const crypto = require("crypto");
+const { TestUtils, request, expect } = require("./setup");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+const WORKER_SECRET = "auto-sync-import-test-secret";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Encrypt credentials the same way the API does (scrypt KDF) */
+function encryptScrypt(plaintext, secret) {
+  const KDF_SALT = "tokentimer-settings-encryption";
+  const key = crypto.scryptSync(secret, KDF_SALT, 32);
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let enc = cipher.update(plaintext, "utf8", "hex");
+  enc += cipher.final("hex");
+  return `${iv.toString("hex")}:${cipher.getAuthTag().toString("hex")}:${enc}`;
+}
+
+/** Encrypt credentials with the legacy SHA-256 key (pre-v0.1 tokens in DB) */
+function encryptLegacy(plaintext, secret) {
+  const key = crypto.createHash("sha256").update(secret).digest();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let enc = cipher.update(plaintext, "utf8", "hex");
+  enc += cipher.final("hex");
+  return `${iv.toString("hex")}:${cipher.getAuthTag().toString("hex")}:${enc}`;
+}
+
+async function runWorker() {
+  return TestUtils.runNode(
+    "node",
+    ["--experimental-vm-modules", "src/auto-sync-worker.js"],
+    "apps/worker",
+    {
+      SESSION_SECRET: WORKER_SECRET,
+      API_URL: BASE,
+      NODE_ENV: "test",
+    },
+    { allowExitCodes: [0, 1] },
+  );
+}
+
+async function insertConfig(workspaceId, userId, overrides = {}) {
+  const creds = encryptScrypt(
+    JSON.stringify({ token: "fake-token", baseUrl: "https://api.github.com" }),
+    WORKER_SECRET,
+  );
+  const res = await TestUtils.execQuery(
+    `INSERT INTO auto_sync_configs
+       (workspace_id, provider, credentials_encrypted, frequency,
+        schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     RETURNING id`,
+    [
+      workspaceId,
+      overrides.provider ?? "github",
+      overrides.credentials ?? creds,
+      overrides.frequency ?? "daily",
+      overrides.schedule_time ?? "09:00",
+      overrides.schedule_tz ?? "UTC",
+      overrides.enabled ?? true,
+      overrides.next_sync_at ?? new Date(Date.now() - 60000),
+      userId,
+    ],
+  );
+  return res.rows[0].id;
+}
+
+async function tokenCount(workspaceId) {
+  const r = await TestUtils.execQuery(
+    "SELECT COUNT(*)::int AS n FROM tokens WHERE workspace_id = $1",
+    [workspaceId],
+  );
+  return r.rows[0].n;
+}
+
+async function getTokens(workspaceId) {
+  const r = await TestUtils.execQuery(
+    "SELECT * FROM tokens WHERE workspace_id = $1 ORDER BY id",
+    [workspaceId],
+  );
+  return r.rows;
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1: deduplication with location (mirrors manual import)
+// ---------------------------------------------------------------------------
+describe("Auto-sync import deduplication — with location", function () {
+  this.timeout(90000);
+
+  let testUser, workspaceId, configId;
+
+  before(async () => {
+    testUser = await TestUtils.createVerifiedTestUser();
+    const ws = await TestUtils.execQuery(
+      "SELECT id FROM workspaces WHERE created_by = $1 LIMIT 1",
+      [testUser.id],
+    );
+    workspaceId = ws.rows[0].id;
+    configId = await insertConfig(workspaceId, testUser.id);
+  });
+
+  after(async () => {
+    await TestUtils.execQuery(
+      "DELETE FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM tokens WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    await TestUtils.cleanupTestUser(testUser.email);
+  });
+
+  // The worker calls the scan endpoint (which is mocked to return items via the
+  // API's test-mode stub). Since no real GitHub token is provided, the scan will
+  // fail at the API level. We insert a token manually then verify that a second
+  // manual-import call does NOT create a duplicate — this validates that the
+  // import endpoint itself deduplicates correctly, which is what auto-sync now
+  // delegates to.
+
+  it("POST /api/v1/integrations/import - creates token on first import", async () => {
+    // Authenticate as the test user
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", session.cookie)
+      .send({
+        items: [
+          {
+            name: "my-github-pat",
+            type: "api_key",
+            category: "key_secret",
+            location: "user/my-github-pat",
+            expiration: "2027-01-01",
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.created).to.be.an("array").with.length(1);
+    expect(res.body.updated).to.be.an("array").with.length(0);
+    expect(await tokenCount(workspaceId)).to.equal(1);
+  });
+
+  it("POST /api/v1/integrations/import - updates (not duplicates) on re-import with same name+location", async () => {
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+
+    const newExpiry = "2028-06-30";
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", session.cookie)
+      .send({
+        items: [
+          {
+            name: "my-github-pat",
+            type: "api_key",
+            category: "key_secret",
+            location: "user/my-github-pat",
+            expiration: newExpiry,
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.created).to.be.an("array").with.length(0);
+    expect(res.body.updated).to.be.an("array").with.length(1);
+
+    // Token count must stay at 1 — no duplicate inserted
+    expect(await tokenCount(workspaceId)).to.equal(1);
+
+    // Expiration must have been refreshed
+    const tokens = await getTokens(workspaceId);
+    expect(tokens[0].expiration).to.include(newExpiry.replace(/-/g, "-"));
+  });
+
+  it("POST /api/v1/integrations/import - same name but different location creates a new token", async () => {
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", session.cookie)
+      .send({
+        items: [
+          {
+            name: "my-github-pat",
+            type: "api_key",
+            category: "key_secret",
+            location: "org/different-repo",
+            expiration: "2027-01-01",
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.created).to.be.an("array").with.length(1);
+    expect(await tokenCount(workspaceId)).to.equal(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2: deduplication without location (no-dedup path, same as manual)
+// ---------------------------------------------------------------------------
+describe("Auto-sync import deduplication — without location", function () {
+  this.timeout(90000);
+
+  let testUser, workspaceId;
+
+  before(async () => {
+    testUser = await TestUtils.createVerifiedTestUser();
+    const ws = await TestUtils.execQuery(
+      "SELECT id FROM workspaces WHERE created_by = $1 LIMIT 1",
+      [testUser.id],
+    );
+    workspaceId = ws.rows[0].id;
+  });
+
+  after(async () => {
+    await TestUtils.execQuery(
+      "DELETE FROM tokens WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    await TestUtils.cleanupTestUser(testUser.email);
+  });
+
+  it("POST /api/v1/integrations/import - inserts a new token when location is absent", async () => {
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+
+    await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", session.cookie)
+      .send({ items: [{ name: "no-location-key", type: "api_key", category: "key_secret" }] })
+      .expect(200);
+
+    expect(await tokenCount(workspaceId)).to.equal(1);
+  });
+
+  it("POST /api/v1/integrations/import - second call without location creates a second row (no dedup)", async () => {
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+
+    // This matches manual import behavior: without a location, two items with
+    // the same name are treated as distinct entries.
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", session.cookie)
+      .send({ items: [{ name: "no-location-key", type: "api_key", category: "key_secret" }] })
+      .expect(200);
+
+    expect(res.body.created).to.be.an("array").with.length(1);
+    expect(await tokenCount(workspaceId)).to.equal(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3: worker-level behaviours
+// ---------------------------------------------------------------------------
+describe("Auto-sync worker behaviours", function () {
+  this.timeout(120000);
+
+  let testUser, workspaceId;
+
+  before(async () => {
+    testUser = await TestUtils.createVerifiedTestUser();
+    const ws = await TestUtils.execQuery(
+      "SELECT id FROM workspaces WHERE created_by = $1 LIMIT 1",
+      [testUser.id],
+    );
+    workspaceId = ws.rows[0].id;
+  });
+
+  afterEach(async () => {
+    await TestUtils.execQuery(
+      "DELETE FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM tokens WHERE workspace_id = $1",
+      [workspaceId],
+    );
+  });
+
+  after(async () => {
+    await TestUtils.cleanupTestUser(testUser.email);
+  });
+
+  it("skips disabled configs (no last_sync_at set)", async () => {
+    await insertConfig(workspaceId, testUser.id, { enabled: false });
+    await runWorker();
+
+    const r = await TestUtils.execQuery(
+      "SELECT COUNT(*)::int AS n FROM auto_sync_configs WHERE workspace_id = $1 AND last_sync_at IS NOT NULL",
+      [workspaceId],
+    );
+    expect(r.rows[0].n).to.equal(0);
+  });
+
+  it("skips configs whose next_sync_at is in the future", async () => {
+    await insertConfig(workspaceId, testUser.id, {
+      next_sync_at: new Date(Date.now() + 3600000),
+    });
+    await runWorker();
+
+    const r = await TestUtils.execQuery(
+      "SELECT COUNT(*)::int AS n FROM auto_sync_configs WHERE workspace_id = $1 AND last_sync_at IS NOT NULL",
+      [workspaceId],
+    );
+    expect(r.rows[0].n).to.equal(0);
+  });
+
+  it("records last_sync_status=failed and a non-empty error when the scan fails", async () => {
+    await insertConfig(workspaceId, testUser.id);
+    await runWorker();
+
+    const r = await TestUtils.execQuery(
+      "SELECT last_sync_status, last_sync_error FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    expect(r.rows[0].last_sync_status).to.equal("failed");
+    expect(String(r.rows[0].last_sync_error || "").length).to.be.greaterThan(0);
+  });
+
+  it("advances next_sync_at after a failed run", async () => {
+    await insertConfig(workspaceId, testUser.id);
+    const before = Date.now();
+    await runWorker();
+
+    const r = await TestUtils.execQuery(
+      "SELECT next_sync_at FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    expect(new Date(r.rows[0].next_sync_at).getTime()).to.be.greaterThan(before);
+  });
+
+  it("decrypts credentials encrypted with the legacy SHA-256 KDF (fallback path)", async () => {
+    // Pre-v0.1 credentials were encrypted with SHA-256; the worker must still
+    // handle them via the fallback path.
+    const legacyCreds = encryptLegacy(
+      JSON.stringify({ token: "legacy-token", baseUrl: "https://api.github.com" }),
+      WORKER_SECRET,
+    );
+    await insertConfig(workspaceId, testUser.id, { credentials: legacyCreds });
+    await runWorker();
+
+    // The run should have attempted a scan (not aborted at decryption).
+    // For an invalid token the scan fails — but it must fail with a
+    // scan error, not "Failed to decrypt credentials".
+    const r = await TestUtils.execQuery(
+      "SELECT last_sync_error FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    expect(String(r.rows[0].last_sync_error || "")).to.not.include(
+      "Failed to decrypt",
+    );
+  });
+
+  it("worker auth: import endpoint is reachable with SESSION_SECRET bearer token", async () => {
+    // Verify that loadWorkspace grants admin role to worker calls so the
+    // import endpoint does not return 403.
+    const session = await TestUtils.loginTestUser(testUser.email, "SecureTest123!@#");
+    const ws = await request(BASE)
+      .get(`/api/v1/workspaces?limit=1`)
+      .set("Cookie", session.cookie)
+      .expect(200);
+    const wsId = ws.body.items?.[0]?.id;
+
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${wsId}`)
+      .set("Authorization", `Bearer ${WORKER_SECRET}`)
+      .send({
+        items: [
+          {
+            name: "worker-auth-test-token",
+            type: "api_key",
+            category: "key_secret",
+            location: "test/location",
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(res.body.created).to.be.an("array").with.length(1);
+  });
+});


### PR DESCRIPTION
## Summary

This release delivers a fully hardened auto-sync feature and a new bulk token section API. Six interlocking bugs prevented auto-sync from working end-to-end in any deployment — a KDF mismatch that corrupted credential decryption, a broken SQL upsert that created duplicates, stale React state that silently stored empty tokens, a wrong `API_URL` that caused every worker HTTP call to fail with a network error, and missing Kubernetes NetworkPolicy rules that silently dropped all worker traffic. All six are fixed. Auto-sync now delegates scan results to the same import endpoint the dashboard uses, guaranteeing identical deduplication and audit logging.

## Changes

### API
- `PUT /api/tokens/bulk` — new endpoint for batch section assignment (up to 500 tokens, single SQL statement, per-token result detail), fully documented in OpenAPI
- Auto-sync `POST`/`PUT` endpoints now validate required credential fields server-side before encrypting; returns HTTP 400 with a field-level error (e.g. `token (empty)`) instead of silently storing unusable credentials
- `loadWorkspace` RBAC middleware now grants `workspaceRole: admin` to authenticated worker calls (`req.isWorkerCall`), allowing the auto-sync worker to reach the import endpoint

### Worker
- Auto-sync worker reworked to call `POST /api/v1/integrations/import` for all providers — deduplication, sanitization, type validation, and audit logging are now identical to a manual dashboard import
- Fixed credential decryption KDF mismatch: worker now uses `scryptSync` (matching `systemSettings.js`); SHA-256 kept as fallback for pre-migration records
- Fixed `API_URL` hardcoded to `http://api:4000` in `docker-compose.yml` — previously inherited from the user-facing `.env` (`localhost:4000`), making every HTTP call fail inside Docker
- Pre-flight credential validation in the worker: missing/empty required fields are caught immediately after decryption with a clear error instead of a confusing 400 from the scan endpoint
- `Promise.allSettled` + explicit `BEGIN/COMMIT` transaction for concurrent config processing and correct `FOR UPDATE SKIP LOCKED` semantics
- Three new Prometheus metrics: `auto_sync_runs_total`, `auto_sync_items_imported_total`, `auto_sync_last_run_timestamp`; pushed to Pushgateway after every run

### Dashboard
- All integration form components (`ImportGitHubForm`, `ImportGitLabForm`, `ImportAWSForm`, `ImportAzureForm`, `ImportGCPForm`, `ImportVaultForm`) expose `getCredentials()` via `useImperativeHandle`; `ImportTokensModal` now reads live credentials and scan-param state from child refs instead of stale parent-scope variables that were never updated
- `PUT /api/tokens/bulk` wired to multi-select section assignment flow
- `EndpointSslMonitorModal` extracted to standalone component
- Domain utilities (`domainStatusColor`, `domainSslBadge`, `domainFormatUrl`, `domainValueToUrl`) extracted to `utils/domains.jsx`
- System color mode enabled by default; modal animations and backdrop blur removed for smoother UX; `CreateTokenNotesField` memoized with `flushSync`

### Infra
- Kubernetes `networkpolicy.yaml`: added worker egress to API port 4000 and API ingress from `auto-sync` pods — without this, every auto-sync HTTP call was silently dropped when NetworkPolicy is enabled
- Kubernetes `cronjob-auto-sync.yaml`: `API_URL` now hardcoded to the internal service URL, overriding the shared ConfigMap value
- `deploy/helm/examples/values-full-test.yaml`: added `tokentimer.auto-sync` PrometheusRule group with `AutoSyncProviderFailures` and `AutoSyncNotRunning` alerts
- `deploy/helm/values.yaml`: simplified `prometheusRules` comments to a single pointer to the example file

### Docs / metadata
- `README.md`: security-first statement updated to acknowledge auto-sync credential storage
- `CHANGELOG.md` updated for 0.4.0
- pnpm bumped **10.33.0 → 10.33.4** across all Dockerfiles, `package.json`, and CI
- Version bumped **0.3.2 → 0.4.0** across all manifests and contracts
- Integration tests added: `tests/integration/auto-sync-import.test.js`

### Security
- `axios` **1.15.0 → 1.16.0** (GHSA-pmwg-cvhr-8vh7, GHSA-q8qp-cvcw-x6jj, GHSA-pf86-5x62-jrwf, GHSA-6chq-wfr3-2hj9)
- `express-rate-limit` **8.3.1 → 8.5.1**
- `@aws-sdk/*` **3.990.0 → 3.1045.0**
- `fast-xml-parser` override **5.7.2 → 5.7.3** + `fast-xml-builder@1.2.0` (GHSA-5wm8-gmm8-39j9)
- Grype **v0.111.0 → v0.112.0** in CI
- Go builder stage `golang:1.26.2-alpine3.23 → golang:1.26.3-alpine3.23` (stdlib CVEs)

## Test plan
- [X] CI job passes: https://github.com/tokentimerch/tokentimer-core/actions/runs/25611011030
- [X] Manual: enable GitHub auto-sync from the dashboard — first-time config saves without error, worker picks it up and completes with `completed: N items` in logs
- [X] Manual: re-open existing auto-sync config and click Enable — modal no longer returns "token (empty)"
- [X] Manual: multi-select tokens, assign section — uses bulk endpoint, succeeds in one call