### PR TITLE
Release TokenTimer Core v0.5.2 - dashboard 8080 and Helm CNPG cluster flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-18
+
+### Fixed
+
+- **Dashboard nginx on port 8080** in compose-built images and Helm (`containerPort: 8080`, Service still exposes port 80). Fixes `bind() to 0.0.0.0:80 failed (13: Permission denied)` when Kubernetes drops all capabilities (`securityContext.capabilities.drop: [ALL]`).
+
+### Changed
+
+- **CloudNativePG Cluster template** exposes optional CNPG spec fields with sane defaults (`maxSyncReplicas: 2`, `minSyncReplicas: 1`, 10Gi storage, 512Mi-1Gi resources). Power users can pass any other `Cluster` spec field via `postgresql.cloudnative.parameters` or `postgresql.cloudnative.extraSpec`.
+- **Version metadata bumped to 0.5.2** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
 ## [0.5.1] - 2026-05-18
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -60,7 +60,9 @@ RUN chmod +x /docker-entrypoint.sh
 # Switch to non-root user
 USER tokentimer
 
-# Expose port
-EXPOSE 80
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/ >/dev/null || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -386,9 +386,9 @@ services:
     depends_on:
       - api
     ports:
-      - "${DASHBOARD_PORT:-5173}:80"
+      - "${DASHBOARD_PORT:-5173}:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/deploy/compose/nginx.conf
+++ b/deploy/compose/nginx.conf
@@ -1,5 +1,5 @@
 worker_processes auto;
-error_log /var/log/nginx/error.log warn;
+error_log /dev/stderr warn;
 pid /var/cache/nginx/nginx.pid;
 
 events {
@@ -30,7 +30,7 @@ http {
     gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
 
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
         root /usr/share/nginx/html;
         index index.html;

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -99,8 +99,16 @@ The value is cached on .Values so both the CNPG Cluster secret and the app
 secret receive the same password within a single render pass.
 On upgrades, the existing secret is read via `lookup` to avoid regenerating.
 */}}
+{{- define "tokentimer.pgSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-pg-secret" (include "tokentimer.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "tokentimer.cnpgPassword" -}}
-{{- $secretName := printf "%s-pg-secret" (include "tokentimer.fullname" .) -}}
+{{- $secretName := include "tokentimer.pgSecretName" . -}}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- if and $existingSecret $existingSecret.data (index $existingSecret.data "password") -}}
   {{- index $existingSecret.data "password" | b64dec -}}

--- a/deploy/helm/templates/dashboard-deployment.yaml
+++ b/deploy/helm/templates/dashboard-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.dashboard.containerPort }}
               protocol: TCP
           {{- with .Values.dashboard.livenessProbe }}
           livenessProbe:

--- a/deploy/helm/templates/networkpolicy.yaml
+++ b/deploy/helm/templates/networkpolicy.yaml
@@ -145,7 +145,7 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace }}
       ports:
         - protocol: TCP
-          port: 80
+          port: {{ .Values.dashboard.containerPort }}
     {{- end }}
     {{- if .Values.networkPolicy.monitoringNamespace }}
     - from:
@@ -154,7 +154,7 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespace }}
       ports:
         - protocol: TCP
-          port: 80
+          port: {{ .Values.dashboard.containerPort }}
     {{- end }}
   egress:
     # DNS (nginx resolver)

--- a/deploy/helm/templates/postgresql-cluster.yaml
+++ b/deploy/helm/templates/postgresql-cluster.yaml
@@ -1,61 +1,193 @@
 {{- if .Values.postgresql.cloudnative.enabled }}
+{{- $cnpg := .Values.postgresql.cloudnative -}}
+{{- $pgConfig := default dict $cnpg.postgresql -}}
+{{- $bootstrap := default dict $cnpg.bootstrap -}}
+{{- $mon := default dict $cnpg.monitoring -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: {{ include "tokentimer.fullname" . }}-pg
   labels:
     {{- include "tokentimer.labels" . | nindent 4 }}
+    {{- with $cnpg.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $cnpg.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  instances: {{ .Values.postgresql.cloudnative.instances }}
-  imageName: {{ .Values.postgresql.cloudnative.imageName }}
-  primaryUpdateStrategy: {{ .Values.postgresql.cloudnative.primaryUpdateStrategy }}
+  instances: {{ $cnpg.instances }}
+  imageName: {{ $cnpg.imageName | quote }}
+  primaryUpdateStrategy: {{ $cnpg.primaryUpdateStrategy }}
+  maxSyncReplicas: {{ $cnpg.maxSyncReplicas }}
+  minSyncReplicas: {{ $cnpg.minSyncReplicas }}
+
+  {{- if hasKey $cnpg "enableSuperuserAccess" }}
+  enableSuperuserAccess: {{ $cnpg.enableSuperuserAccess }}
+  {{- end }}
+  {{- if hasKey $cnpg "enablePdb" }}
+  enablePDB: {{ $cnpg.enablePdb }}
+  {{- end }}
+  {{- if hasKey $cnpg "logLevel" }}
+  logLevel: {{ $cnpg.logLevel }}
+  {{- end }}
+  {{- if hasKey $cnpg "primaryUpdateMethod" }}
+  primaryUpdateMethod: {{ $cnpg.primaryUpdateMethod }}
+  {{- end }}
+  {{- if hasKey $cnpg "failoverDelay" }}
+  failoverDelay: {{ $cnpg.failoverDelay }}
+  {{- end }}
+  {{- if hasKey $cnpg "switchoverDelay" }}
+  switchoverDelay: {{ $cnpg.switchoverDelay }}
+  {{- end }}
+  {{- if hasKey $cnpg "startDelay" }}
+  startDelay: {{ $cnpg.startDelay }}
+  {{- end }}
+  {{- if hasKey $cnpg "stopDelay" }}
+  stopDelay: {{ $cnpg.stopDelay }}
+  {{- end }}
+  {{- if hasKey $cnpg "smartShutdownTimeout" }}
+  smartShutdownTimeout: {{ $cnpg.smartShutdownTimeout }}
+  {{- end }}
+  {{- if hasKey $cnpg "postgresUID" }}
+  postgresUID: {{ $cnpg.postgresUID }}
+  {{- end }}
+  {{- if hasKey $cnpg "postgresGID" }}
+  postgresGID: {{ $cnpg.postgresGID }}
+  {{- end }}
+  {{- if hasKey $cnpg "priorityClassName" }}
+  priorityClassName: {{ $cnpg.priorityClassName | quote }}
+  {{- end }}
+  {{- if hasKey $cnpg "imagePullPolicy" }}
+  imagePullPolicy: {{ $cnpg.imagePullPolicy }}
+  {{- end }}
+  {{- if hasKey $cnpg "livenessProbeTimeout" }}
+  livenessProbeTimeout: {{ $cnpg.livenessProbeTimeout }}
+  {{- end }}
 
   bootstrap:
     initdb:
       database: {{ .Values.postgresql.auth.database }}
       owner: {{ .Values.postgresql.auth.username }}
-      {{- if .Values.postgresql.auth.existingSecret }}
-      secret:
-        name: {{ .Values.postgresql.auth.existingSecret }}
-      {{- else }}
-      secret:
-        name: {{ include "tokentimer.fullname" . }}-pg-secret
+      {{- with $bootstrap.encoding }}
+      encoding: {{ . }}
       {{- end }}
-
-  storage:
-    size: {{ .Values.postgresql.cloudnative.storage.size }}
-    {{- if .Values.postgresql.cloudnative.storage.storageClass }}
-    storageClass: {{ .Values.postgresql.cloudnative.storage.storageClass | quote }}
+      {{- with $bootstrap.localeCType }}
+      localeCType: {{ . }}
+      {{- end }}
+      {{- with $bootstrap.localeCollate }}
+      localeCollate: {{ . }}
+      {{- end }}
+      secret:
+        name: {{ include "tokentimer.pgSecretName" . }}
+    {{- with $bootstrap.recovery }}
+    recovery:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $bootstrap.pgBaseBackup }}
+    pg_basebackup:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 
-  {{- with .Values.postgresql.cloudnative.walStorage }}
+  storage:
+    size: {{ $cnpg.storage.size }}
+    {{- if $cnpg.storage.storageClass }}
+    storageClass: {{ $cnpg.storage.storageClass | quote }}
+    {{- end }}
+    {{- if hasKey $cnpg.storage "resizeInUseVolumes" }}
+    resizeInUseVolumes: {{ $cnpg.storage.resizeInUseVolumes }}
+    {{- end }}
+    {{- with $cnpg.storage.pvcTemplate }}
+    pvcTemplate:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+  {{- with $cnpg.walStorage }}
   walStorage:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+  superuserSecret:
+    name: {{ default (include "tokentimer.pgSecretName" .) $cnpg.superuserSecret }}
+
   postgresql:
+    {{- if $cnpg.parameters }}
     parameters:
-      max_connections: {{ .Values.postgresql.cloudnative.maxConnections | quote }}
-      shared_buffers: {{ .Values.postgresql.cloudnative.sharedBuffers | quote }}
-      work_mem: {{ .Values.postgresql.cloudnative.workMem | quote }}
-      maintenance_work_mem: {{ .Values.postgresql.cloudnative.maintenanceWorkMem | quote }}
-      {{- with .Values.postgresql.cloudnative.extraParameters }}
+      {{- toYaml $cnpg.parameters | nindent 6 }}
+    {{- else }}
+    parameters:
+      max_connections: {{ $cnpg.maxConnections | quote }}
+      shared_buffers: {{ $cnpg.sharedBuffers | quote }}
+      work_mem: {{ $cnpg.workMem | quote }}
+      maintenance_work_mem: {{ $cnpg.maintenanceWorkMem | quote }}
+      {{- with $cnpg.extraParameters }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-    {{- with .Values.postgresql.cloudnative.pgHba }}
+    {{- end }}
+    {{- with $cnpg.pgHba }}
     pg_hba:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with $pgConfig.syncReplicaElectionConstraint }}
+    syncReplicaElectionConstraint:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if hasKey $pgConfig "promotionTimeout" }}
+    promotionTimeout: {{ $pgConfig.promotionTimeout }}
+    {{- end }}
+    {{- with $pgConfig.synchronous }}
+    synchronous:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $pgConfig.pgIdent }}
+    pg_ident:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $pgConfig.ldap }}
+    ldap:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if hasKey $pgConfig "enableAlterSystem" }}
+    enableAlterSystem: {{ $pgConfig.enableAlterSystem }}
+    {{- end }}
+    {{- with $pgConfig.extensions }}
+    extensions:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $pgConfig.sharedPreloadLibraries }}
+    shared_preload_libraries:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 
-  {{- if .Values.postgresql.cloudnative.enableSuperuserAccess }}
-  enableSuperuserAccess: true
+  {{- with $cnpg.replicationSlots }}
+  replicationSlots:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.postgresql.cloudnative.backup.enabled }}
+  {{- with $cnpg.probes }}
+  probes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- if or $mon.podMonitorEnabled (not (empty $mon.spec)) }}
+  monitoring:
+    {{- if $mon.podMonitorEnabled }}
+    enablePodMonitor: true
+    {{- end }}
+    {{- with $mon.spec }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if $cnpg.backup.enabled }}
   backup:
+    {{- if $cnpg.backup.spec }}
+    {{- toYaml $cnpg.backup.spec | nindent 4 }}
+    {{- else }}
     barmanObjectStore:
-      destinationPath: {{ .Values.postgresql.cloudnative.backup.destinationPath }}
-      {{- with .Values.postgresql.cloudnative.backup.s3 }}
+      destinationPath: {{ $cnpg.backup.destinationPath }}
+      {{- with $cnpg.backup.s3 }}
       {{- if .credentialsSecret }}
       s3Credentials:
         accessKeyId:
@@ -74,27 +206,91 @@ spec:
       wal:
         compression: gzip
         maxParallel: 8
-    retentionPolicy: {{ .Values.postgresql.cloudnative.backup.retentionPolicy }}
+    retentionPolicy: {{ $cnpg.backup.retentionPolicy }}
+    {{- end }}
+    {{- with $cnpg.backup.volumeSnapshot }}
+    volumeSnapshot:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
 
-  {{- if .Values.postgresql.cloudnative.monitoring.podMonitorEnabled }}
-  monitoring:
-    enablePodMonitor: true
-  {{- end }}
-
-  {{- with .Values.postgresql.cloudnative.resources }}
+  {{- with $cnpg.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
-  {{- with .Values.postgresql.cloudnative.affinity }}
+  {{- with $cnpg.affinity }}
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
-  {{- with .Values.postgresql.cloudnative.tolerations }}
-  tolerations:
+  {{- with $cnpg.topologySpreadConstraints }}
+  topologySpreadConstraints:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.plugins }}
+  plugins:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.certificates }}
+  certificates:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.externalClusters }}
+  externalClusters:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.managed }}
+  managed:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.inheritedMetadata }}
+  inheritedMetadata:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.ephemeralVolumeSource }}
+  ephemeralVolumeSource:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.ephemeralVolumesSizeLimit }}
+  ephemeralVolumesSizeLimit:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.replica }}
+  replica:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.env }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.envFrom }}
+  envFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.tablespaces }}
+  tablespaces:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with $cnpg.extraSpec }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 
 {{- if not .Values.postgresql.auth.existingSecret }}
@@ -102,7 +298,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "tokentimer.fullname" . }}-pg-secret
+  name: {{ include "tokentimer.pgSecretName" . }}
   labels:
     {{- include "tokentimer.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.5.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,9 +105,12 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.5.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
+
+  # Pod listener (unprivileged). Service port stays 80 -> targetPort http.
+  containerPort: 8080
 
   service:
     type: ClusterIP
@@ -149,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.5.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -283,23 +286,19 @@ ingress:
 # -- PostgreSQL ----------------------------------------------------------------
 postgresql:
   cloudnative:
-    # Create a CloudNativePG Cluster CR in the release namespace.
+    # CloudNativePG Cluster (operator required). More fields: deploy/helm/templates/postgresql-cluster.yaml
     enabled: true
     instances: 3
     imageName: "ghcr.io/cloudnative-pg/postgresql:17"
-    primaryUpdateStrategy: unsupervised  # unsupervised or supervised
+    primaryUpdateStrategy: unsupervised
     enableSuperuserAccess: false
+    maxSyncReplicas: 2
+    minSyncReplicas: 1
 
     storage:
       size: 10Gi
-      storageClass: "" # uses default storage class
+      storageClass: ""
 
-    # Separate WAL storage (optional, improves I/O performance)
-    walStorage: {}
-      # size: 2Gi
-      # storageClass: ""
-
-    # PostgreSQL parameters
     maxConnections: "200"
     sharedBuffers: "256MB"
     workMem: "8MB"
@@ -307,25 +306,23 @@ postgresql:
     extraParameters:
       ssl_min_protocol_version: "TLSv1.3"
       ssl_ciphers: "HIGH:!aNULL:!MD5"
-      # pg_stat_statements.max: "10000"
-      # pg_stat_statements.track: all
+    parameters: {}   # non-empty replaces maxConnections/shared_buffers/...
+    extraSpec: {}    # other Cluster spec keys (no duplicates)
 
-    # pg_hba rules -- enforce SSL connections and reject plaintext
     pgHba:
       - hostssl all all 0.0.0.0/0 md5
       - hostnossl all all 0.0.0.0/0 reject
 
-    # Barman backup (optional)
+    monitoring:
+      podMonitorEnabled: false
+
     backup:
       enabled: false
-      destinationPath: ""   # s3://bucket/path
+      destinationPath: ""
       retentionPolicy: "30d"
       s3:
         credentialsSecret: ""
         region: ""
-
-    monitoring:
-      podMonitorEnabled: false
 
     resources:
       requests:
@@ -334,12 +331,6 @@ postgresql:
       limits:
         cpu: "1"
         memory: 1Gi
-
-    # CNPG affinity (not standard K8s affinity -- see CNPG docs)
-    affinity: {}
-      # enablePodAntiAffinity: true
-      # topologyKey: topology.kubernetes.io/zone
-    tolerations: []
 
   # Credentials for CloudNativePG bootstrap and the app secret.
   # Auto-generated if password is empty and no existingSecret is set.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.5.1
+  version: 0.5.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary

This release fixes dashboard startup when Kubernetes runs the pod with a strict security context (non-root nginx could not bind to port 80). Compose-built images and the Helm chart now use port **8080** inside the container; the Service can keep port **80** externally. The Helm chart also expands the CloudNativePG `Cluster` template so operators can pass optional CNPG spec fields and use `extraSpec` for anything else, while keeping sensible defaults (sync replicas 2/1, 10Gi storage, modest resources).

## Changes

### Dashboard / images
- Nginx listens on **8080** in `deploy/compose/nginx.conf`; dashboard Dockerfile exposes and health-checks **8080**.
- Docker Compose maps host `5173` (or `DASHBOARD_PORT`) to container **8080**.

### Helm
- `dashboard.containerPort: 8080`; deployment and NetworkPolicy align with pod port **8080**; Service still **80** → `targetPort: http`.
- CloudNativePG `Cluster` template: optional CNPG fields + `postgresql.cloudnative.extraSpec`; helpers for bootstrap/superuser secret naming; trimmed default `values.yaml` with escape hatches.

### Docs / metadata
- `CHANGELOG.md` **[0.5.2]**; version **0.5.2** on packages, contracts, OpenAPI, and chart `version` / `appVersion`.

## Test plan
- [ ] CI green on this PR