### PR TITLE
Release TokenTimer Core v0.5.4 with Split-Host Session Cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`runtime-labels.js`** — API log and rate-limit labels from `TT_MODE` / `.tokentimer-variant` (enterprise vs core) with optional env overrides.
 - **Dashboard `resolveApiBaseUrl.js`** — local dev rewrites configured `localhost` API URLs to the page hostname (`127.0.0.1` vs `localhost`).
 - **Tests** — Mocha unit suites for session cookies and runtime labels (in core integration suite); Vitest for `resolveApiBaseUrl`; integration logout asserts matching `sessionId` clear-cookie attributes.
-- **Startup warning** when HTTPS split-host is configured without `SESSION_COOKIE_DOMAIN`.
 
 ### Fixed
 
@@ -25,13 +24,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Logout and account deletion** — `clearCookie("sessionId")` matches express-session options (`sameSite`, `secure`, `domain`); no hard-coded `SameSite=Strict`.
 - **`API_URL` fallback in cookie/CORS logic** — missing `API_URL` falls back to `APP_URL`, aligned with `constants.js` and Helm same-origin installs.
 - **`__Host-` CSRF cookie** — disabled when `SESSION_COOKIE_DOMAIN` is set (Host-prefix cookies cannot include `Domain`).
+- **`SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE`** — honored only when both `APP_URL` and `API_URL` are local HTTP; ignored on public HTTPS even if the flag is set.
+- **Production CORS** — localhost dev origins omitted unless `ALLOW_LOCAL_DEV_CORS=true`; OPTIONS preflight uses the same CORS options as other routes.
+- **Dashboard `resolveApiBaseUrl`** — classifies local API hosts via URL hostname, not substring match (avoids query-string false positives).
 - **Integration test drift** — `auto-sync-import.test.js` expects HTTP `201` on `POST /api/v1/integrations/import` and uses the test stack `SESSION_SECRET` for worker bearer auth (was mismatched hard-coded secret).
 
 ### Changed
 
 - **API logger and rate limiter** use `getRuntimeLabels()` instead of hard-coded `tokentimer-core-api` / `oss`.
 - **Compose** — dashboard service receives `API_URL` for runtime `env.js`; **Helm** — `API_URL` defaults to `baseUrl` when `apiUrl` is omitted.
-- **`docs/CONFIGURATION.md`** — split-host cookies, Helm vs Compose vs runtime URL table, HTTP vs HTTPS behaviour.
+- **`docs/CONFIGURATION.md`** — split-host cookies, optional `SESSION_COOKIE_DOMAIN`, `ALLOW_LOCAL_DEV_CORS`, localhost override guard, Helm vs Compose vs runtime URL table.
 - **Domain checker UI** — removed outdated Pro/Team badge copy from the SSL monitor modal.
 - **Version metadata bumped to 0.5.4** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-23
+
+### Added
+
+- **`session-cookie-options.js`** — shared session/CSRF cookie and CORS origin resolution for split `APP_URL` / `API_URL` (`SameSite`, `Secure`, `SESSION_COOKIE_DOMAIN`, localhost override, logout `clearCookie` parity).
+- **`runtime-labels.js`** — API log and rate-limit labels from `TT_MODE` / `.tokentimer-variant` (enterprise vs core) with optional env overrides.
+- **Dashboard `resolveApiBaseUrl.js`** — local dev rewrites configured `localhost` API URLs to the page hostname (`127.0.0.1` vs `localhost`).
+- **Tests** — Mocha unit suites for session cookies and runtime labels (in core integration suite); Vitest for `resolveApiBaseUrl`; integration logout asserts matching `sessionId` clear-cookie attributes.
+- **Startup warning** when HTTPS split-host is configured without `SESSION_COOKIE_DOMAIN`.
+
+### Fixed
+
+- **Docker Compose login on localhost** — split HTTP ports (`5173` + `4000`, or Helm port-forward `8080` + `4000`) stay `SameSite=Lax` instead of `SameSite=None; Secure` (blocked as third-party cookies in strict browsers).
+- **Logout and account deletion** — `clearCookie("sessionId")` matches express-session options (`sameSite`, `secure`, `domain`); no hard-coded `SameSite=Strict`.
+- **`API_URL` fallback in cookie/CORS logic** — missing `API_URL` falls back to `APP_URL`, aligned with `constants.js` and Helm same-origin installs.
+- **`__Host-` CSRF cookie** — disabled when `SESSION_COOKIE_DOMAIN` is set (Host-prefix cookies cannot include `Domain`).
+- **Integration test drift** — `auto-sync-import.test.js` expects HTTP `201` on `POST /api/v1/integrations/import` and uses the test stack `SESSION_SECRET` for worker bearer auth (was mismatched hard-coded secret).
+
+### Changed
+
+- **API logger and rate limiter** use `getRuntimeLabels()` instead of hard-coded `tokentimer-core-api` / `oss`.
+- **Compose** — dashboard service receives `API_URL` for runtime `env.js`; **Helm** — `API_URL` defaults to `baseUrl` when `apiUrl` is omitted.
+- **`docs/CONFIGURATION.md`** — split-host cookies, Helm vs Compose vs runtime URL table, HTTP vs HTTPS behaviour.
+- **Domain checker UI** — removed outdated Pro/Team badge copy from the SSL monitor modal.
+- **Version metadata bumped to 0.5.4** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Security
+
+- **pnpm override `qs@6.15.2`** — addresses [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) (moderate DoS in `qs.stringify` via Express).
+
 ## [0.5.3] - 2026-05-19
 
 ### Changed

--- a/apps/api/config/constants.js
+++ b/apps/api/config/constants.js
@@ -3,7 +3,10 @@ const { logger } = require("../utils/logger");
 
 const normalizeUrl = (value) => String(value || "").replace(/\/$/, "");
 const APP_URL = normalizeUrl(process.env.APP_URL) || "http://localhost:5173";
-const API_URL = normalizeUrl(process.env.API_URL) || "http://localhost:4000";
+const API_URL =
+  normalizeUrl(process.env.API_URL) ||
+  normalizeUrl(process.env.APP_URL) ||
+  "http://localhost:4000";
 
 // Core: no usage limits. All features available.
 const TOKEN_LIMITS = parseLimits(process.env.PLAN_TOKEN_LIMITS, {

--- a/apps/api/config/runtime-labels.js
+++ b/apps/api/config/runtime-labels.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_LABELS = Object.freeze({
+  service: "tokentimer-core-api",
+  rateLabel: "oss",
+  plan: "oss",
+  limitsKey: "oss",
+});
+
+const MODE_LABELS = Object.freeze({
+  oss: DEFAULT_LABELS,
+  core: DEFAULT_LABELS,
+  enterprise: Object.freeze({
+    service: "tokentimer-enterprise-api",
+    rateLabel: "enterprise",
+    plan: "enterprise",
+    limitsKey: "enterprise",
+  }),
+  cloud: Object.freeze({
+    service: "tokentimer-cloud",
+    rateLabel: "cloud",
+    plan: "cloud",
+    limitsKey: "cloud",
+  }),
+});
+
+let cachedLabels;
+
+/**
+ * Resolve deployment mode from env or /.tokentimer-variant (written by variant images).
+ * @returns {string}
+ */
+function normalizeMode() {
+  const fromEnv = process.env.TT_MODE || process.env.TT_VARIANT;
+  if (fromEnv && String(fromEnv).trim()) {
+    return String(fromEnv).trim().toLowerCase();
+  }
+  try {
+    const variantPath = path.join(process.cwd(), ".tokentimer-variant");
+    if (!fs.existsSync(variantPath)) return "oss";
+    const text = fs.readFileSync(variantPath, "utf8");
+    for (const line of text.split(/\r?\n/)) {
+      const match = /^variant=(.+)$/.exec(line.trim());
+      if (match) return match[1].trim().toLowerCase();
+    }
+  } catch (_) {
+    /* optional file */
+  }
+  return "oss";
+}
+
+/**
+ * Logging, rate-limit log types, and default plan/limit keys for this runtime.
+ * Env overrides: LOG_SERVICE_NAME, API_RATE_LIMIT_LOG_LABEL, API_RATE_LIMIT_PLAN, API_RATE_LIMIT_LIMITS_KEY.
+ * @returns {{ service: string, rateLabel: string, plan: string, limitsKey: string }}
+ */
+function getRuntimeLabels() {
+  if (cachedLabels) return cachedLabels;
+  const preset = MODE_LABELS[normalizeMode()] || DEFAULT_LABELS;
+  cachedLabels = Object.freeze({
+    service:
+      String(process.env.LOG_SERVICE_NAME || "").trim() || preset.service,
+    rateLabel:
+      String(process.env.API_RATE_LIMIT_LOG_LABEL || "").trim() ||
+      preset.rateLabel,
+    plan: String(process.env.API_RATE_LIMIT_PLAN || "").trim() || preset.plan,
+    limitsKey:
+      String(process.env.API_RATE_LIMIT_LIMITS_KEY || "").trim() ||
+      preset.limitsKey,
+  });
+  return cachedLabels;
+}
+
+/** @param {string} mode */
+function resetRuntimeLabelsCacheForTests(mode) {
+  cachedLabels = undefined;
+  if (mode === undefined) {
+    delete process.env.TT_MODE;
+    delete process.env.TT_VARIANT;
+    return;
+  }
+  process.env.TT_MODE = mode;
+}
+
+module.exports = {
+  getRuntimeLabels,
+  normalizeMode,
+  resetRuntimeLabelsCacheForTests,
+};

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -188,23 +188,33 @@ const parseBooleanEnv = (value) => {
   return null;
 };
 const sessionCookieSecureLocalhostOverride =
-  parseBooleanEnv(process.env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE) === true;
-const configuredPublicUrls = [
-  process.env.API_URL?.trim(),
-  process.env.APP_URL?.trim(),
-  process.env.PUBLIC_BASE_URL?.trim(),
-].filter(Boolean);
-const hasLocalhostOrLoopbackUrl = configuredPublicUrls.some((url) =>
-  /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0)(:\d+)?(\/|$)/i.test(url),
-);
-const hasNonHttpsUrl = configuredPublicUrls.some((url) => /^http:\/\//i.test(url));
-const localInsecureUrlDetected = hasLocalhostOrLoopbackUrl || hasNonHttpsUrl;
+  parseBooleanEnv(process.env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE);
+// Opt-in only: set SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true for plain-HTTP /
+// localhost installs in production (e.g. port-forward). Never enable on internet-facing HTTPS.
 const allowInsecureLocalProdCookie =
-  isProductionEnvironment &&
-  sessionCookieSecureLocalhostOverride &&
-  localInsecureUrlDetected;
-const sessionCookieSecure = isProductionEnvironment && !allowInsecureLocalProdCookie;
-
+  isProductionEnvironment && sessionCookieSecureLocalhostOverride === true;
+const {
+  resolveSessionCookieOptions,
+  resolveCsrfCookieName,
+  buildCorsOrigins,
+  resolveEffectiveOrigins,
+  shouldUseCrossOriginCookies,
+} = require("./session-cookie-options.js");
+const sessionCookieOptions = resolveSessionCookieOptions(process.env);
+const csrfCookieName = resolveCsrfCookieName(
+  process.env,
+  sessionCookieOptions,
+);
+const { apiOrigin: startupApiOrigin, appOrigin: startupAppOrigin } =
+  resolveEffectiveOrigins(process.env);
+if (
+  shouldUseCrossOriginCookies(startupApiOrigin, startupAppOrigin) &&
+  !sessionCookieOptions.domain
+) {
+  logger.warn(
+    "HTTPS split-host without SESSION_COOKIE_DOMAIN: session cookies will not be shared between APP_URL and API_URL",
+  );
+}
 
 const { requireAuth, enforceEmailVerification } = require("./middleware/auth");
 
@@ -242,15 +252,10 @@ app.use(
   }),
 );
 
-// 2. CORS with strict configuration
+// 2. CORS with strict configuration (include API_URL for split-host dashboard → API)
 app.use(
   cors({
-    origin: [
-      APP_URL,
-      "http://localhost:3000",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ], // Support multiple origins
+    origin: buildCorsOrigins(process.env),
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowedHeaders: [
@@ -281,13 +286,7 @@ app.use(
     secret: process.env.SESSION_SECRET,
     resave: true, // Changed to true to ensure session is saved
     saveUninitialized: false,
-    cookie: {
-      httpOnly: true,
-      // Use 'lax' to preserve session across top-level redirects
-      sameSite: "lax",
-      secure: sessionCookieSecure,
-      maxAge: 2 * 60 * 60 * 1000, // 2 hours (reduced from 7 days for security)
-    },
+    cookie: sessionCookieOptions,
     // Security enhancements
     rolling: true, // Reset expiration on activity
     genid: () => {
@@ -572,12 +571,6 @@ app.post(
 );
 
 // CSRF Protection using Double Submit Cookie pattern (replaces deprecated csurf)
-// __Host- prefix requires Secure flag; fall back to plain name when running
-// production mode over plain HTTP (SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE).
-const csrfCookieName =
-  process.env.NODE_ENV === "production" && sessionCookieSecure
-    ? "__Host-psifi.x-csrf-token"
-    : "x-csrf-token";
 const { generateToken: generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
   getSecret: () => {
     if (!process.env.SESSION_SECRET) {
@@ -587,17 +580,16 @@ const { generateToken: generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
   },
   cookieName: csrfCookieName,
   cookieOptions: {
-    httpOnly: true,
-    secure: sessionCookieSecure,
-    sameSite: "lax",
+    ...sessionCookieOptions,
     path: "/",
   },
   getTokenFromRequest: (req) => req.headers["x-csrf-token"],
 });
 
-// CSRF token endpoint
+// CSRF token endpoint — always rotate (overwrite) so stale cookies after secret
+// rotation or cookie-name changes cannot 403 this route (csrf-csrf validateOnReuse).
 app.get("/api/csrf-token", (req, res) => {
-  const csrfToken = generateCsrfToken(req, res);
+  const csrfToken = generateCsrfToken(req, res, true, false);
   res.json({ csrfToken });
 });
 
@@ -768,12 +760,10 @@ function validateStartupConfig() {
   const hasNonHttpsUrlFromStartup = configuredUrls.some((url) => /^http:\/\//i.test(url));
 
   if (allowInsecureLocalProdCookie) {
-    logger.warn(
-      "SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true: secure session cookie is disabled for local non-TLS production troubleshooting only.",
+    logger.info(
+      "SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true: session and CSRF cookies use Secure=false (local HTTP testing only).",
     );
-  }
-
-  if (
+  } else if (
     nodeEnv === "production" &&
     !allowInsecureLocalProdCookie &&
     (hasLocalUrl || hasNonHttpsUrlFromStartup)

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -180,41 +180,19 @@ if (apiDocsEnabled) {
 const APP_URL = process.env.APP_URL || "http://localhost:5173";
 const isProductionEnvironment =
   (process.env.NODE_ENV || "").trim().toLowerCase() === "production";
-const parseBooleanEnv = (value) => {
-  if (typeof value !== "string") return null;
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  return null;
-};
-const sessionCookieSecureLocalhostOverride =
-  parseBooleanEnv(process.env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE);
-// Opt-in only: set SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true for plain-HTTP /
-// localhost installs in production (e.g. port-forward). Never enable on internet-facing HTTPS.
-const allowInsecureLocalProdCookie =
-  isProductionEnvironment && sessionCookieSecureLocalhostOverride === true;
 const {
   resolveSessionCookieOptions,
   resolveCsrfCookieName,
   buildCorsOrigins,
-  resolveEffectiveOrigins,
-  shouldUseCrossOriginCookies,
+  resolveProductionSecure,
 } = require("./session-cookie-options.js");
+const allowInsecureLocalProdCookie =
+  isProductionEnvironment && !resolveProductionSecure(process.env);
 const sessionCookieOptions = resolveSessionCookieOptions(process.env);
 const csrfCookieName = resolveCsrfCookieName(
   process.env,
   sessionCookieOptions,
 );
-const { apiOrigin: startupApiOrigin, appOrigin: startupAppOrigin } =
-  resolveEffectiveOrigins(process.env);
-if (
-  shouldUseCrossOriginCookies(startupApiOrigin, startupAppOrigin) &&
-  !sessionCookieOptions.domain
-) {
-  logger.warn(
-    "HTTPS split-host without SESSION_COOKIE_DOMAIN: session cookies will not be shared between APP_URL and API_URL",
-  );
-}
 
 const { requireAuth, enforceEmailVerification } = require("./middleware/auth");
 
@@ -253,22 +231,20 @@ app.use(
 );
 
 // 2. CORS with strict configuration (include API_URL for split-host dashboard → API)
-app.use(
-  cors({
-    origin: buildCorsOrigins(process.env),
-    credentials: true,
-    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: [
-      "Content-Type",
-      "Authorization",
-      "X-Requested-With",
-      "X-CSRF-Token",
-    ],
-    maxAge: 86400, // 24 hours
-  }),
-);
-
-app.options(/.*/, cors());
+const corsOptions = {
+  origin: buildCorsOrigins(process.env),
+  credentials: true,
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowedHeaders: [
+    "Content-Type",
+    "Authorization",
+    "X-Requested-With",
+    "X-CSRF-Token",
+  ],
+  maxAge: 86400, // 24 hours
+};
+app.use(cors(corsOptions));
+app.options(/.*/, cors(corsOptions));
 
 // 3. Request size limits
 app.use(express.json({ limit: "10mb" })); // Limit JSON payload size (10mb for large integration scans)

--- a/apps/api/middleware/rateLimit.js
+++ b/apps/api/middleware/rateLimit.js
@@ -2,8 +2,11 @@ const rateLimit = require("express-rate-limit");
 const { ipKeyGenerator } = require("express-rate-limit");
 const slowDown = require("express-slow-down");
 const { logger } = require("../utils/logger");
+const { getRuntimeLabels } = require("../config/runtime-labels");
 const { parseLimits } = require("../services/planLimits");
 const { normalizeRootDomain } = require("../services/domainChecker");
+
+const { rateLabel, plan: runtimePlan, limitsKey } = getRuntimeLabels();
 
 function intEnv(name, fallback) {
   const raw = process.env[name];
@@ -176,7 +179,9 @@ const emailVerificationLimiter = rateLimit({
   },
 });
 
-const API_LIMITS = parseLimits(process.env.PLAN_API_LIMITS, { oss: 6000 });
+const API_LIMIT_DEFAULTS = { oss: 6000, [limitsKey]: 6000 };
+const API_LIMITS = parseLimits(process.env.PLAN_API_LIMITS, API_LIMIT_DEFAULTS);
+const apiLimitMax = API_LIMITS[limitsKey] ?? API_LIMITS.oss ?? 6000;
 
 function createApiLimiter(max, label) {
   return rateLimit({
@@ -206,7 +211,7 @@ function createApiLimiter(max, label) {
         logger.warn("RATE_LIMIT_EXCEEDED", {
           type: `api_user_${label}`,
           userId: req.user.id,
-          plan: "oss",
+          plan: runtimePlan,
           ip: ipKeyGenerator(req),
           userAgent: req.get("User-Agent"),
         });
@@ -225,8 +230,9 @@ function createApiLimiter(max, label) {
   });
 }
 
-const ossLimiter = createApiLimiter(API_LIMITS.oss, "oss");
-const planAwareApiLimiter = (req, res, next) => ossLimiter(req, res, next);
+const defaultApiLimiter = createApiLimiter(apiLimitMax, rateLabel);
+const planAwareApiLimiter = (req, res, next) =>
+  defaultApiLimiter(req, res, next);
 
 const testApiLimiter = rateLimit({
   windowMs: intEnv("TEST_API_RATE_LIMIT_WINDOW_MS", 15 * 60 * 1000),

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/account.js
+++ b/apps/api/routes/account.js
@@ -2,6 +2,9 @@ const { pool } = require("../db/database");
 const { logger } = require("../utils/logger");
 const { requireAuth } = require("../middleware/auth");
 const { getApiLimiter } = require("../middleware/rateLimit");
+const {
+  resolveClearSessionCookieOptions,
+} = require("../session-cookie-options.js");
 const bcrypt = require("bcryptjs");
 
 const router = require("express").Router();
@@ -179,8 +182,10 @@ router.delete(
 
       await client.query("COMMIT");
 
-      // Clear the session cookie first
-      res.clearCookie("sessionId");
+      res.clearCookie(
+        "sessionId",
+        resolveClearSessionCookieOptions(process.env),
+      );
 
       // Logout and destroy session properly through Passport.js
       req.logout((err) => {

--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -37,32 +37,10 @@ const verifyOtp =
   _otplib.verify ||
   _otplib.authenticator?.verify ||
   _otplib.default?.authenticator?.verify;
-const isProductionEnvironment =
-  (process.env.NODE_ENV || "").trim().toLowerCase() === "production";
-const parseBooleanEnv = (value) => {
-  if (typeof value !== "string") return null;
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  return null;
-};
-const sessionCookieSecureLocalhostOverride =
-  parseBooleanEnv(process.env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE) === true;
-const configuredPublicUrls = [
-  process.env.API_URL?.trim(),
-  process.env.APP_URL?.trim(),
-  process.env.PUBLIC_BASE_URL?.trim(),
-].filter(Boolean);
-const hasLocalhostOrLoopbackUrl = configuredPublicUrls.some((url) =>
-  /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0)(:\d+)?(\/|$)/i.test(url),
-);
-const hasNonHttpsUrl = configuredPublicUrls.some((url) => /^http:\/\//i.test(url));
-const localInsecureUrlDetected = hasLocalhostOrLoopbackUrl || hasNonHttpsUrl;
-const allowInsecureLocalProdCookie =
-  isProductionEnvironment &&
-  sessionCookieSecureLocalhostOverride &&
-  localInsecureUrlDetected;
-const sessionCookieSecure = isProductionEnvironment && !allowInsecureLocalProdCookie;
+const {
+  resolveClearSessionCookieOptions,
+} = require("../session-cookie-options.js");
+const clearSessionCookieOptions = resolveClearSessionCookieOptions(process.env);
 
 const router = require("express").Router();
 
@@ -1409,14 +1387,7 @@ router.post("/api/logout", getApiLimiter(), (req, res) => {
         logger.warn("Audit write failed", { error: _err.message });
       }
 
-      // Clear the session cookie in both dev and prod settings
-      const cookieOptions = {
-        httpOnly: true,
-        sameSite: process.env.NODE_ENV === "production" ? "strict" : "lax",
-        secure: sessionCookieSecure,
-        path: "/",
-      };
-      res.clearCookie("sessionId", cookieOptions);
+      res.clearCookie("sessionId", clearSessionCookieOptions);
       res.json({ success: true });
     });
   });
@@ -1432,14 +1403,7 @@ router.post("/auth/logout", getApiLimiter(), (req, res) => {
         stack: err.stack,
       });
     }
-    // Clear the session cookie in both dev and prod settings
-    const cookieOptions = {
-      httpOnly: true,
-      sameSite: process.env.NODE_ENV === "production" ? "strict" : "lax",
-      secure: sessionCookieSecure,
-      path: "/",
-    };
-    res.clearCookie("sessionId", cookieOptions);
+    res.clearCookie("sessionId", clearSessionCookieOptions);
     res.json({ message: "logged out successfully" });
   });
 });

--- a/apps/api/session-cookie-options.js
+++ b/apps/api/session-cookie-options.js
@@ -1,0 +1,164 @@
+"use strict";
+
+function parseBooleanEnv(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return null;
+}
+
+function normalizeOrigin(value) {
+  if (!value || typeof value !== "string") return null;
+  try {
+    return new URL(value.trim()).origin;
+  } catch {
+    return null;
+  }
+}
+
+function parseOrigin(value) {
+  if (!value) return null;
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/** http://localhost / 127.0.0.1 / [::1] (any port) */
+function isLocalHttpOrigin(origin) {
+  const parsed = parseOrigin(origin);
+  if (!parsed || parsed.protocol !== "http:") return false;
+  const host = parsed.hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+}
+
+function isHttpsOrigin(origin) {
+  const parsed = parseOrigin(origin);
+  return Boolean(parsed && parsed.protocol === "https:");
+}
+
+/**
+ * SameSite=None is only valid with Secure and is blocked as third-party on many
+ * browsers. Use it only for HTTPS split-host (real subdomains). Local HTTP
+ * split ports (Compose, Helm port-forward) stay Lax (same-site across ports).
+ */
+function shouldUseCrossOriginCookies(apiOrigin, appOrigin) {
+  if (!apiOrigin || !appOrigin || apiOrigin === appOrigin) return false;
+  if (isLocalHttpOrigin(apiOrigin) && isLocalHttpOrigin(appOrigin)) return false;
+  return isHttpsOrigin(apiOrigin) && isHttpsOrigin(appOrigin);
+}
+
+function resolveProductionSecure(env) {
+  const isProductionEnvironment =
+    (env.NODE_ENV || "").trim().toLowerCase() === "production";
+  const sessionCookieSecureLocalhostOverride =
+    parseBooleanEnv(env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE) === true;
+  const allowInsecureLocalProdCookie =
+    isProductionEnvironment && sessionCookieSecureLocalhostOverride;
+  return isProductionEnvironment && !allowInsecureLocalProdCookie;
+}
+
+/**
+ * Session (and CSRF) cookie options for split APP_URL / API_URL deployments.
+ */
+function resolveEffectiveOrigins(env = process.env) {
+  const appOrigin = normalizeOrigin(env.APP_URL);
+  const apiOrigin =
+    normalizeOrigin(env.API_URL) || normalizeOrigin(env.APP_URL);
+  return { apiOrigin, appOrigin };
+}
+
+function resolveSessionCookieOptions(env = process.env) {
+  const productionSecure = resolveProductionSecure(env);
+
+  const { apiOrigin, appOrigin } = resolveEffectiveOrigins(env);
+  const useCrossOriginCookies = shouldUseCrossOriginCookies(
+    apiOrigin,
+    appOrigin,
+  );
+
+  const cookie = {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: productionSecure,
+    maxAge: 2 * 60 * 60 * 1000,
+  };
+
+  const explicitDomain = String(env.SESSION_COOKIE_DOMAIN || "").trim();
+  if (explicitDomain) {
+    cookie.domain = explicitDomain.startsWith(".")
+      ? explicitDomain
+      : `.${explicitDomain}`;
+  }
+
+  if (useCrossOriginCookies) {
+    cookie.sameSite = "none";
+    cookie.secure = true;
+  }
+
+  return cookie;
+}
+
+/** Options that must match express-session when calling res.clearCookie. */
+function resolveClearSessionCookieOptions(env = process.env) {
+  const cookie = resolveSessionCookieOptions(env);
+  const clearOptions = {
+    path: "/",
+    httpOnly: true,
+    sameSite: cookie.sameSite,
+    secure: cookie.secure,
+  };
+  if (cookie.domain) {
+    clearOptions.domain = cookie.domain;
+  }
+  return clearOptions;
+}
+
+/**
+ * __Host- prefix cookies cannot include Domain; only use when production Secure
+ * and session cookie has no Domain attribute.
+ */
+function resolveCsrfCookieName(env, sessionCookie) {
+  const isProduction =
+    (env.NODE_ENV || "").trim().toLowerCase() === "production";
+  const productionSecure = resolveProductionSecure(env);
+  if (isProduction && productionSecure && !sessionCookie.domain) {
+    return "__Host-psifi.x-csrf-token";
+  }
+  return "x-csrf-token";
+}
+
+/** Dev / port-forward origins when APP_URL or API_URL env are missing or mismatched. */
+const LOCAL_DEV_CORS_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:5173",
+  "http://localhost:4000",
+  "http://localhost:8080",
+  "http://127.0.0.1:5173",
+  "http://127.0.0.1:4000",
+  "http://127.0.0.1:8080",
+];
+
+function buildCorsOrigins(env = process.env) {
+  const { apiOrigin, appOrigin } = resolveEffectiveOrigins(env);
+  const origins = new Set([...LOCAL_DEV_CORS_ORIGINS]);
+  origins.add(appOrigin || "http://localhost:5173");
+  if (apiOrigin) {
+    origins.add(apiOrigin);
+  }
+  return [...origins];
+}
+
+module.exports = {
+  resolveSessionCookieOptions,
+  resolveClearSessionCookieOptions,
+  resolveCsrfCookieName,
+  buildCorsOrigins,
+  resolveEffectiveOrigins,
+  normalizeOrigin,
+  isLocalHttpOrigin,
+  isHttpsOrigin,
+  shouldUseCrossOriginCookies,
+};

--- a/apps/api/session-cookie-options.js
+++ b/apps/api/session-cookie-options.js
@@ -51,13 +51,20 @@ function shouldUseCrossOriginCookies(apiOrigin, appOrigin) {
 }
 
 function resolveProductionSecure(env) {
-  const isProductionEnvironment =
+  const isProduction =
     (env.NODE_ENV || "").trim().toLowerCase() === "production";
-  const sessionCookieSecureLocalhostOverride =
+  if (!isProduction) return false;
+
+  const override =
     parseBooleanEnv(env.SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE) === true;
-  const allowInsecureLocalProdCookie =
-    isProductionEnvironment && sessionCookieSecureLocalhostOverride;
-  return isProductionEnvironment && !allowInsecureLocalProdCookie;
+  if (!override) return true;
+
+  const { apiOrigin, appOrigin } = resolveEffectiveOrigins(env);
+  if (isLocalHttpOrigin(apiOrigin) && isLocalHttpOrigin(appOrigin)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -143,11 +150,20 @@ const LOCAL_DEV_CORS_ORIGINS = [
 
 function buildCorsOrigins(env = process.env) {
   const { apiOrigin, appOrigin } = resolveEffectiveOrigins(env);
-  const origins = new Set([...LOCAL_DEV_CORS_ORIGINS]);
+  const origins = new Set();
+
   origins.add(appOrigin || "http://localhost:5173");
   if (apiOrigin) {
     origins.add(apiOrigin);
   }
+
+  const isProd = (env.NODE_ENV || "").trim().toLowerCase() === "production";
+  if (!isProd || parseBooleanEnv(env.ALLOW_LOCAL_DEV_CORS) === true) {
+    for (const origin of LOCAL_DEV_CORS_ORIGINS) {
+      origins.add(origin);
+    }
+  }
+
   return [...origins];
 }
 
@@ -157,8 +173,10 @@ module.exports = {
   resolveCsrfCookieName,
   buildCorsOrigins,
   resolveEffectiveOrigins,
+  resolveProductionSecure,
   normalizeOrigin,
   isLocalHttpOrigin,
   isHttpsOrigin,
   shouldUseCrossOriginCookies,
+  LOCAL_DEV_CORS_ORIGINS,
 };

--- a/apps/api/utils/logger.js
+++ b/apps/api/utils/logger.js
@@ -1,5 +1,8 @@
 const winston = require("winston");
 const client = require("prom-client");
+const { getRuntimeLabels } = require("../config/runtime-labels");
+
+const SERVICE_NAME = getRuntimeLabels().service;
 
 // Environment detection
 const isDev =
@@ -40,7 +43,7 @@ const logger = winston.createLogger({
     winston.format.errors({ stack: true }),
     safeJsonFormat(),
   ),
-  defaultMeta: { service: "tokentimer-core-api" },
+  defaultMeta: { service: SERVICE_NAME },
   transports: [],
 });
 
@@ -103,7 +106,7 @@ try {
 const origError = logger.error.bind(logger);
 logger.error = (...args) => {
   try {
-    if (cLogError) cLogError.labels("tokentimer-core-api").inc();
+    if (cLogError) cLogError.labels(SERVICE_NAME).inc();
   } catch (_) {}
   return origError(...args);
 };

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
+++ b/apps/dashboard/src/components/EndpointSslMonitorModal.jsx
@@ -1297,19 +1297,16 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
 
             <Divider />
             <Box>
-              <HStack justify='space-between' align='start' mb={2}>
-                <Box>
-                  <Text fontWeight='semibold' fontSize='sm'>
-                    Domain checker
-                  </Text>
-                  <Text fontSize='xs' color={helpTextColor}>
-                    Discovery is best-effort and limited to publicly available
-                    subdomains seen by passive sources. Then import selected
-                    hosts as SSL tokens and endpoint monitors.
-                  </Text>
-                </Box>
-                <Badge colorScheme='purple'>Pro/Team</Badge>
-              </HStack>
+              <Box mb={2}>
+                <Text fontWeight='semibold' fontSize='sm'>
+                  Domain checker
+                </Text>
+                <Text fontSize='xs' color={helpTextColor}>
+                  Discovery is best-effort and limited to publicly available
+                  subdomains seen by passive sources. Then import selected hosts
+                  as SSL tokens and endpoint monitors.
+                </Text>
+              </Box>
               <HStack spacing={3} align='flex-end' flexWrap='wrap'>
                 <FormControl flex={2} minW='220px'>
                   <FormLabel fontSize='sm'>Root domain</FormLabel>
@@ -1385,9 +1382,8 @@ const EndpointSslMonitorModal = memo(function EndpointSslMonitorModal({
                   <AlertIcon />
                   <AlertDescription fontSize='xs'>
                     This list is capped at {domainCheckerCapCount} hostnames per
-                    discovery run. Names beyond that cap are not stored or
-                    shown, so import is limited to this table. Team workspaces
-                    can discover more hostnames than Pro workspaces.
+                    discovery run. Names beyond that cap are not stored or shown,
+                    so import is limited to this table.
                   </AlertDescription>
                 </Alert>
               )}

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -12,42 +12,9 @@ import { resetIdentity } from './analytics.js';
 // public pages or 404s look like forced logouts.
 let hasObservedLoggedInSession = false;
 
-// API base URL resolution:
-// - If runtime env.js defines API_URL, use it first
-// - Otherwise if VITE_API_URL is set and not pointing to localhost when we're not on localhost, use it
-// - If running on localhost, default to local backend
-// - Otherwise, use relative paths so ingress can route /api and /auth
-const resolveApiBaseUrl = () => {
-  const runtimeUrl =
-    typeof window !== 'undefined' && window.__ENV__
-      ? window.__ENV__.API_URL
-      : undefined;
-  const viteUrl =
-    typeof import.meta !== 'undefined' && import.meta.env
-      ? import.meta.env.VITE_API_URL
-      : undefined;
-  const isBrowser = typeof window !== 'undefined';
-  const isLocalHost =
-    isBrowser &&
-    (window.location.hostname === 'localhost' ||
-      window.location.hostname === '127.0.0.1');
+import { resolveApiBaseUrl } from './resolveApiBaseUrl.js';
 
-  const configuredUrl = runtimeUrl || viteUrl;
-
-  if (configuredUrl) {
-    const pointsToLocalhost = /(^http:\/\/localhost|127\.0\.0\.1)/i.test(
-      String(configuredUrl)
-    );
-    if (!isLocalHost && pointsToLocalhost) {
-      return '';
-    }
-    return configuredUrl;
-  }
-
-  if (isLocalHost) return 'http://localhost:4000';
-  return '';
-};
-
+export { resolveApiBaseUrl };
 export const API_BASE_URL = resolveApiBaseUrl();
 
 // Debug: Log environment variables only in development or on local/staging hosts
@@ -82,7 +49,28 @@ const apiClient = axios.create({
 // CSRF token management
 let csrfToken = null;
 
-// Deduplicate identical error toasts within a short time window
+export const resetCsrfToken = () => {
+  csrfToken = null;
+};
+
+// Function to get CSRF token
+const getCsrfToken = async (forceRefresh = false) => {
+  if (forceRefresh) {
+    csrfToken = null;
+  }
+  if (!csrfToken) {
+    try {
+      const response = await apiClient.get('/api/csrf-token', {
+        _suppressLog: true,
+      });
+      const { csrfToken: token } = response.data;
+      csrfToken = token;
+    } catch (error) {
+      logger.warn('Failed to get CSRF token:', error);
+    }
+  }
+  return csrfToken;
+};
 // Keyed by message string to avoid spamming users with repeated identical errors
 const recentlyShownErrorToasts = new Map(); // message -> timestamp
 const ERROR_TOAST_DEDUP_WINDOW_MS = 4000;
@@ -106,22 +94,6 @@ const showErrorToastOnce = message => {
   }
 
   showGlobalError(message);
-};
-
-// Function to get CSRF token
-const getCsrfToken = async () => {
-  if (!csrfToken) {
-    try {
-      const response = await axios.get(`${API_BASE_URL}/api/csrf-token`, {
-        withCredentials: true,
-      });
-      const { csrfToken: token } = response.data;
-      csrfToken = token;
-    } catch (error) {
-      logger.warn('Failed to get CSRF token:', error);
-    }
-  }
-  return csrfToken;
 };
 
 // Request interceptor for authentication and logging
@@ -231,7 +203,7 @@ apiClient.interceptors.response.use(
       csrfToken = null; // Reset token
 
       // Retry the request with new token
-      const token = await getCsrfToken();
+      const token = await getCsrfToken(true);
       if (token && error.config) {
         error.config.headers['X-CSRF-Token'] = token;
         return apiClient.request(error.config);
@@ -571,6 +543,7 @@ export const authAPI = {
       const response = await apiClient.post(API_ENDPOINTS.LOGIN, credentials);
       if (response?.data?.success || response?.data?.user) {
         hasObservedLoggedInSession = true;
+        resetCsrfToken();
       }
       return response.data;
     } catch (error) {
@@ -591,6 +564,7 @@ export const authAPI = {
       handleApiError(error);
     } finally {
       hasObservedLoggedInSession = false;
+      resetCsrfToken();
     }
   },
 

--- a/apps/dashboard/src/utils/resolveApiBaseUrl.js
+++ b/apps/dashboard/src/utils/resolveApiBaseUrl.js
@@ -1,0 +1,45 @@
+/**
+ * Resolve API base URL for browser requests (runtime env.js, Vite, local dev, ingress).
+ */
+export function resolveApiBaseUrl() {
+  const runtimeUrl =
+    typeof window !== 'undefined' && window.__ENV__
+      ? window.__ENV__.API_URL
+      : undefined;
+  const viteUrl =
+    typeof import.meta !== 'undefined' && import.meta.env
+      ? import.meta.env.VITE_API_URL
+      : undefined;
+  const isBrowser = typeof window !== 'undefined';
+  const isLocalHost =
+    isBrowser &&
+    (window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1');
+
+  const configuredUrl = runtimeUrl || viteUrl;
+
+  if (configuredUrl) {
+    const pointsToLocalhost = /(^http:\/\/localhost|127\.0\.0\.1)/i.test(
+      String(configuredUrl)
+    );
+    if (!isLocalHost && pointsToLocalhost) {
+      return '';
+    }
+    if (isLocalHost && pointsToLocalhost) {
+      try {
+        const parsed = new URL(String(configuredUrl));
+        const port =
+          parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+        return `${window.location.protocol}//${window.location.hostname}:${port}`;
+      } catch {
+        return configuredUrl;
+      }
+    }
+    return configuredUrl;
+  }
+
+  if (isLocalHost) {
+    return `${window.location.protocol}//${window.location.hostname}:4000`;
+  }
+  return '';
+}

--- a/apps/dashboard/src/utils/resolveApiBaseUrl.js
+++ b/apps/dashboard/src/utils/resolveApiBaseUrl.js
@@ -1,6 +1,17 @@
 /**
  * Resolve API base URL for browser requests (runtime env.js, Vite, local dev, ingress).
  */
+
+function pointsToLocalhostUrl(value) {
+  try {
+    const parsed = new URL(String(value));
+    const host = parsed.hostname.toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
 export function resolveApiBaseUrl() {
   const runtimeUrl =
     typeof window !== 'undefined' && window.__ENV__
@@ -19,13 +30,11 @@ export function resolveApiBaseUrl() {
   const configuredUrl = runtimeUrl || viteUrl;
 
   if (configuredUrl) {
-    const pointsToLocalhost = /(^http:\/\/localhost|127\.0\.0\.1)/i.test(
-      String(configuredUrl)
-    );
-    if (!isLocalHost && pointsToLocalhost) {
+    const pointsToLocal = pointsToLocalhostUrl(configuredUrl);
+    if (!isLocalHost && pointsToLocal) {
       return '';
     }
-    if (isLocalHost && pointsToLocalhost) {
+    if (isLocalHost && pointsToLocal) {
       try {
         const parsed = new URL(String(configuredUrl));
         const port =
@@ -43,3 +52,5 @@ export function resolveApiBaseUrl() {
   }
   return '';
 }
+
+export { pointsToLocalhostUrl };

--- a/apps/dashboard/tests/unit/resolveApiBaseUrl.test.js
+++ b/apps/dashboard/tests/unit/resolveApiBaseUrl.test.js
@@ -50,4 +50,20 @@ describe('resolveApiBaseUrl', () => {
     window.__ENV__ = { API_URL: 'http://localhost:4000' };
     expect(resolveApiBaseUrl()).to.equal('http://localhost:4000');
   });
+
+  it('does not treat 127.0.0.1 in query string as local API host', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'app.example.com',
+        protocol: 'https:',
+      },
+      configurable: true,
+    });
+    window.__ENV__ = {
+      API_URL: 'https://api.example.com/callback?next=127.0.0.1',
+    };
+    expect(resolveApiBaseUrl()).to.equal(
+      'https://api.example.com/callback?next=127.0.0.1'
+    );
+  });
 });

--- a/apps/dashboard/tests/unit/resolveApiBaseUrl.test.js
+++ b/apps/dashboard/tests/unit/resolveApiBaseUrl.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveApiBaseUrl } from '../../src/utils/resolveApiBaseUrl.js';
+
+describe('resolveApiBaseUrl', () => {
+  const originalEnv = globalThis.window?.__ENV__;
+
+  beforeEach(() => {
+    delete globalThis.window.__ENV__;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      globalThis.window.__ENV__ = originalEnv;
+    } else {
+      delete globalThis.window.__ENV__;
+    }
+  });
+
+  it('defaults to same hostname on 127.0.0.1 when unconfigured', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '127.0.0.1',
+        protocol: 'http:',
+      },
+      configurable: true,
+    });
+    expect(resolveApiBaseUrl()).to.equal('http://127.0.0.1:4000');
+  });
+
+  it('rewrites configured localhost API URL to 127.0.0.1 when page is on 127.0.0.1', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '127.0.0.1',
+        protocol: 'http:',
+      },
+      configurable: true,
+    });
+    window.__ENV__ = { API_URL: 'http://localhost:4000' };
+    expect(resolveApiBaseUrl()).to.equal('http://127.0.0.1:4000');
+  });
+
+  it('keeps configured localhost URL when page is on localhost', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'localhost',
+        protocol: 'http:',
+      },
+      configurable: true,
+    });
+    window.__ENV__ = { API_URL: 'http://localhost:4000' };
+    expect(resolveApiBaseUrl()).to.equal('http://localhost:4000');
+  });
+});

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -383,6 +383,8 @@ services:
         VITE_API_URL: ${API_URL:-http://localhost:4000}
     container_name: tokentimer-dashboard
     restart: unless-stopped
+    environment:
+      API_URL: ${API_URL:-http://localhost:4000}
     depends_on:
       - api
     ports:

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.5.3
-appVersion: "0.5.3"
+version: 0.5.4
+appVersion: "0.5.4"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -156,7 +156,7 @@ Rendered ConfigMap data keys only (stable input for checksum/config).
 {{- define "tokentimer.configmapData" -}}
 NODE_ENV: {{ .Values.config.nodeEnv | default "production" | quote }}
 APP_URL: {{ .Values.config.baseUrl | quote }}
-API_URL: {{ .Values.config.apiUrl | quote }}
+API_URL: {{ .Values.config.apiUrl | default .Values.config.baseUrl | quote }}
 TRUST_PROXY_HOPS: {{ .Values.config.trustProxyHops | default 2 | quote }}
 {{- if or .Values.postgresql.cloudnative.enabled (not .Values.postgresql.external.existingSecret) }}
 DB_HOST: {{ include "tokentimer.databaseHost" . | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.5.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.4"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.5.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.4"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.5.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.5.4"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,9 +51,13 @@ Defaults come from code fallbacks in `apps/*` and `packages/config/*`, then from
 When `APP_URL` and `API_URL` differ on **HTTPS** (for example dashboard at
 `https://app.example.com` and API at `https://api.example.com`), the API:
 
-- Allows both origins in CORS (plus `API_URL` when set).
-- Sets session and CSRF cookies to `SameSite=None; Secure` automatically (requires
-  `SESSION_COOKIE_DOMAIN` such as `.example.com` so the browser sends cookies to both hosts).
+- Allows both origins in CORS (configured `APP_URL` and `API_URL` only in production;
+  localhost dev origins are omitted unless `ALLOW_LOCAL_DEV_CORS=true`).
+- Sets session and CSRF cookies to `SameSite=None; Secure` on the API host.
+  Host-only cookies (no `SESSION_COOKIE_DOMAIN`) are enough for credentialed
+  `withCredentials` calls from the dashboard to `api.example.com`. Set
+  `SESSION_COOKIE_DOMAIN` only when you intentionally need a parent-domain cookie
+  shared across multiple subdomains (broader scope; weaker isolation).
 
 **HTTP split-host** (including LAN IPs or internal DNS without TLS) does **not** use
 `SameSite=None`; cookies stay `Lax` because `None` requires `Secure` and is often blocked.
@@ -62,9 +66,9 @@ Use HTTPS for split-host production, or put UI and API behind one origin (ingres
 **Docker Compose** (`http://localhost:5173` + `http://localhost:4000`) and **Helm
 port-forward** (`http://localhost:8080` + `http://localhost:4000`) keep `SameSite=Lax`
 (same-site across ports on local HTTP). For plain HTTP + `NODE_ENV=production`, set
-`SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true` if the browser rejects `Secure` cookies.
-- Expects a shared parent cookie domain via `SESSION_COOKIE_DOMAIN` (for example
-  `.example.com`) so the browser sends the session cookie to both hosts.
+`SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true` only when **both** `APP_URL` and
+`API_URL` are local HTTP (`localhost` / `127.0.0.1`); the flag is ignored on
+internet-facing HTTPS URLs.
 
 Same-host installs (single ingress hostname for UI and API) can leave
 `SESSION_COOKIE_DOMAIN` unset. Helm defaults often use `baseUrl: http://localhost:8080`
@@ -97,8 +101,9 @@ the origins users and integrations actually use in the browser.
 | `REQUIRE_EMAIL_VERIFICATION`               | Require verified email before access                                            | `true`                                 | API auth     |
 | `TWO_FACTOR_ENABLED`                       | Enable 2FA features                                                             | `true`                                 | API auth     |
 | `SESSION_MAX_AGE`                          | Session max age in ms                                                           | `86400000`                             | API auth     |
-| `SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE` | Allow insecure session cookie only for local non-TLS production troubleshooting | `false`                                | API auth     |
-| `SESSION_COOKIE_DOMAIN`                    | Parent domain for session/CSRF cookies when `APP_URL` and `API_URL` differ (e.g. `.example.com`) | `unset`                                | API auth     |
+| `SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE` | Allow insecure session cookies in production only when `APP_URL` and `API_URL` are both local HTTP (`localhost` / `127.0.0.1`); ignored otherwise | `false`                                | API auth     |
+| `SESSION_COOKIE_DOMAIN`                    | Optional parent domain for session/CSRF cookies (e.g. `.example.com`) when you need cookies shared across subdomains; not required for typical split-host API calls | `unset`                                | API auth     |
+| `ALLOW_LOCAL_DEV_CORS`                     | In production, also allow `http://localhost:*` and `http://127.0.0.1:*` in CORS (local troubleshooting only) | `false`                                | API security |
 | `CSRF_ENABLED`                             | Enable CSRF protection                                                          | `true`                                 | API security |
 | `MIN_PASSWORD_LENGTH`                      | Minimum password length                                                         | `8`                                    | API auth     |
 | `REQUIRE_UPPERCASE`                        | Enforce uppercase in passwords                                                  | `true`                                 | API auth     |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,9 +33,44 @@ Defaults come from code fallbacks in `apps/*` and `packages/config/*`, then from
 | `OPENAPI_SPEC_PATH` | Optional absolute path to OpenAPI YAML           | `unset (auto-discovery)`        | API docs serving       |
 | `PUBLIC_BASE_URL`   | Public URL used for webhook signature validation | `unset (falls back to API_URL)` | API webhook auth       |
 
+**Helm vs Compose vs runtime**
+
+| Layer | `APP_URL` | `API_URL` when unset in your config |
+| ----- | --------- | ------------------------------------- |
+| Helm (`config.baseUrl` / `apiUrl`) | `baseUrl` | `apiUrl` if set, else **`baseUrl`** (same host) |
+| Helm stock `values.yaml` | `http://localhost:8080` | `http://localhost:4000` (both set explicitly) |
+| Docker Compose (`.env`) | `${APP_URL:-http://localhost:5173}` | `${API_URL:-http://localhost:4000}` (no cross-fallback in compose files) |
+| API process (env missing) | `http://localhost:5173` | `API_URL`, else **`APP_URL`**, else `http://localhost:4000` |
+
 > [!WARNING]
 > In local `http://localhost` with `NODE_ENV=production`, browser does not persist/send the secure session cookie for auth flow.
 > Use HTTPS in front of API and dashboard (reverse proxy with TLS), otherwise secure cookies are expected to fail in local HTTP.
+
+### Split-host deployments (dashboard and API on different origins)
+
+When `APP_URL` and `API_URL` differ on **HTTPS** (for example dashboard at
+`https://app.example.com` and API at `https://api.example.com`), the API:
+
+- Allows both origins in CORS (plus `API_URL` when set).
+- Sets session and CSRF cookies to `SameSite=None; Secure` automatically (requires
+  `SESSION_COOKIE_DOMAIN` such as `.example.com` so the browser sends cookies to both hosts).
+
+**HTTP split-host** (including LAN IPs or internal DNS without TLS) does **not** use
+`SameSite=None`; cookies stay `Lax` because `None` requires `Secure` and is often blocked.
+Use HTTPS for split-host production, or put UI and API behind one origin (ingress).
+
+**Docker Compose** (`http://localhost:5173` + `http://localhost:4000`) and **Helm
+port-forward** (`http://localhost:8080` + `http://localhost:4000`) keep `SameSite=Lax`
+(same-site across ports on local HTTP). For plain HTTP + `NODE_ENV=production`, set
+`SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true` if the browser rejects `Secure` cookies.
+- Expects a shared parent cookie domain via `SESSION_COOKIE_DOMAIN` (for example
+  `.example.com`) so the browser sends the session cookie to both hosts.
+
+Same-host installs (single ingress hostname for UI and API) can leave
+`SESSION_COOKIE_DOMAIN` unset. Helm defaults often use `baseUrl: http://localhost:8080`
+and `apiUrl: http://localhost:4000`; Compose maps the dashboard to host port `5173`
+by default (`APP_URL=http://localhost:5173`). Always set `APP_URL` and `API_URL` to
+the origins users and integrations actually use in the browser.
 
 ## Database and pooling
 
@@ -63,6 +98,7 @@ Defaults come from code fallbacks in `apps/*` and `packages/config/*`, then from
 | `TWO_FACTOR_ENABLED`                       | Enable 2FA features                                                             | `true`                                 | API auth     |
 | `SESSION_MAX_AGE`                          | Session max age in ms                                                           | `86400000`                             | API auth     |
 | `SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE` | Allow insecure session cookie only for local non-TLS production troubleshooting | `false`                                | API auth     |
+| `SESSION_COOKIE_DOMAIN`                    | Parent domain for session/CSRF cookies when `APP_URL` and `API_URL` differ (e.g. `.example.com`) | `unset`                                | API auth     |
 | `CSRF_ENABLED`                             | Enable CSRF protection                                                          | `true`                                 | API security |
 | `MIN_PASSWORD_LENGTH`                      | Minimum password length                                                         | `8`                                    | API auth     |
 | `REQUIRE_UPPERCASE`                        | Enforce uppercase in passwords                                                  | `true`                                 | API auth     |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {
@@ -77,7 +77,8 @@
       "ajv@6": "6.14.0",
       "lodash": "4.18.1",
       "follow-redirects": "1.16.0",
-      "postcss": "8.5.12"
+      "postcss": "8.5.12",
+      "qs": "6.15.2"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.5.3
+  version: 0.5.4
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   lodash: 4.18.1
   follow-redirects: 1.16.0
   postcss: 8.5.12
+  qs: 6.15.2
 
 importers:
 
@@ -3529,8 +3530,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -6443,7 +6444,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7221,7 +7222,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -8341,7 +8342,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -8889,7 +8890,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.0
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -156,6 +156,16 @@ describe("Authentication Integration Tests", () => {
         .expect(200);
 
       expect(response.body.message).to.equal("logged out successfully");
+
+      const setCookie = response.headers["set-cookie"];
+      expect(setCookie).to.exist;
+      const cleared = Array.isArray(setCookie)
+        ? setCookie.find((c) => String(c).startsWith("sessionId="))
+        : setCookie;
+      expect(cleared).to.exist;
+      const lowered = String(cleared).toLowerCase();
+      expect(lowered).to.not.include("samesite=strict");
+      expect(lowered).to.match(/samesite=(lax|none)/);
     });
   });
 });

--- a/tests/integration/auto-sync-import.test.js
+++ b/tests/integration/auto-sync-import.test.js
@@ -19,7 +19,11 @@ const crypto = require("crypto");
 const { TestUtils, request, expect } = require("./setup");
 
 const BASE = process.env.TEST_API_URL || "http://localhost:4000";
-const WORKER_SECRET = "auto-sync-import-test-secret";
+// Must match API/worker SESSION_SECRET in docker-compose.test.yml / .env.test
+const WORKER_SECRET =
+  process.env.WORKER_API_KEY ||
+  process.env.SESSION_SECRET ||
+  "test-session-secret-key";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -157,7 +161,7 @@ describe("Auto-sync import deduplication — with location", function () {
           },
         ],
       })
-      .expect(200);
+      .expect(201);
 
     expect(res.body.created).to.be.an("array").with.length(1);
     expect(res.body.updated).to.be.an("array").with.length(0);
@@ -182,7 +186,7 @@ describe("Auto-sync import deduplication — with location", function () {
           },
         ],
       })
-      .expect(200);
+      .expect(201);
 
     expect(res.body.created).to.be.an("array").with.length(0);
     expect(res.body.updated).to.be.an("array").with.length(1);
@@ -212,7 +216,7 @@ describe("Auto-sync import deduplication — with location", function () {
           },
         ],
       })
-      .expect(200);
+      .expect(201);
 
     expect(res.body.created).to.be.an("array").with.length(1);
     expect(await tokenCount(workspaceId)).to.equal(2);
@@ -251,7 +255,7 @@ describe("Auto-sync import deduplication — without location", function () {
       .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
       .set("Cookie", session.cookie)
       .send({ items: [{ name: "no-location-key", type: "api_key", category: "key_secret" }] })
-      .expect(200);
+      .expect(201);
 
     expect(await tokenCount(workspaceId)).to.equal(1);
   });
@@ -265,7 +269,7 @@ describe("Auto-sync import deduplication — without location", function () {
       .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
       .set("Cookie", session.cookie)
       .send({ items: [{ name: "no-location-key", type: "api_key", category: "key_secret" }] })
-      .expect(200);
+      .expect(201);
 
     expect(res.body.created).to.be.an("array").with.length(1);
     expect(await tokenCount(workspaceId)).to.equal(2);
@@ -397,7 +401,7 @@ describe("Auto-sync worker behaviours", function () {
           },
         ],
       })
-      .expect(200);
+      .expect(201);
 
     expect(res.body.created).to.be.an("array").with.length(1);
   });

--- a/tests/integration/runtime-labels.unit.test.js
+++ b/tests/integration/runtime-labels.unit.test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { expect } = require("chai");
+const {
+  getRuntimeLabels,
+  normalizeMode,
+  resetRuntimeLabelsCacheForTests,
+} = require("../../apps/api/config/runtime-labels");
+
+describe("runtime-labels", () => {
+  beforeEach(() => resetRuntimeLabelsCacheForTests("oss"));
+  afterEach(() => {
+    delete process.env.LOG_SERVICE_NAME;
+    delete process.env.API_RATE_LIMIT_LOG_LABEL;
+    resetRuntimeLabelsCacheForTests();
+  });
+
+  it("defaults to core/oss labels", () => {
+    expect(normalizeMode()).to.equal("oss");
+    expect(getRuntimeLabels()).to.deep.equal({
+      service: "tokentimer-core-api",
+      rateLabel: "oss",
+      plan: "oss",
+      limitsKey: "oss",
+    });
+  });
+
+  it("uses enterprise labels when TT_MODE=enterprise", () => {
+    resetRuntimeLabelsCacheForTests("enterprise");
+    expect(getRuntimeLabels()).to.deep.equal({
+      service: "tokentimer-enterprise-api",
+      rateLabel: "enterprise",
+      plan: "enterprise",
+      limitsKey: "enterprise",
+    });
+  });
+
+  it("honours explicit env overrides", () => {
+    resetRuntimeLabelsCacheForTests("enterprise");
+    process.env.LOG_SERVICE_NAME = "custom-api";
+    process.env.API_RATE_LIMIT_LOG_LABEL = "custom";
+    resetRuntimeLabelsCacheForTests("enterprise");
+    const labels = getRuntimeLabels();
+    expect(labels.service).to.equal("custom-api");
+    expect(labels.rateLabel).to.equal("custom");
+    expect(labels.plan).to.equal("enterprise");
+  });
+});

--- a/tests/integration/session-cookie-options.unit.test.js
+++ b/tests/integration/session-cookie-options.unit.test.js
@@ -1,0 +1,214 @@
+"use strict";
+
+const { expect } = require("chai");
+const {
+  resolveSessionCookieOptions,
+  resolveClearSessionCookieOptions,
+  resolveCsrfCookieName,
+  buildCorsOrigins,
+  resolveEffectiveOrigins,
+  shouldUseCrossOriginCookies,
+} = require("../../apps/api/session-cookie-options");
+
+describe("session-cookie-options", () => {
+  describe("shouldUseCrossOriginCookies", () => {
+    it("is false for same origin", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "https://tokentimer.example.com",
+          "https://tokentimer.example.com",
+        ),
+      ).to.equal(false);
+    });
+
+    it("is true for HTTPS split-host", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "https://api.example.com",
+          "https://app.example.com",
+        ),
+      ).to.equal(true);
+    });
+
+    it("is false for stock Compose localhost HTTP split ports", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "http://localhost:4000",
+          "http://localhost:5173",
+        ),
+      ).to.equal(false);
+    });
+
+    it("is false for Helm port-forward localhost HTTP (8080 + 4000)", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "http://localhost:4000",
+          "http://localhost:8080",
+        ),
+      ).to.equal(false);
+    });
+
+    it("is false for LAN HTTP split ports", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "http://192.168.1.10:4000",
+          "http://192.168.1.10:8080",
+        ),
+      ).to.equal(false);
+    });
+
+    it("is false for mixed-scheme split-host", () => {
+      expect(
+        shouldUseCrossOriginCookies(
+          "http://api.example.com",
+          "https://app.example.com",
+        ),
+      ).to.equal(false);
+    });
+  });
+
+  describe("resolveSessionCookieOptions", () => {
+    it("keeps lax for stock Compose localhost split ports", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "http://localhost:4000",
+        APP_URL: "http://localhost:5173",
+      });
+      expect(cookie.sameSite).to.equal("lax");
+      expect(cookie.secure).to.equal(true);
+    });
+
+    it("uses SameSite=None only for HTTPS split-host", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+      });
+      expect(cookie.sameSite).to.equal("none");
+      expect(cookie.secure).to.equal(true);
+    });
+
+    it("does not use SameSite=None for HTTP split-host on real hostnames", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "http://api.internal.corp",
+        APP_URL: "http://app.internal.corp",
+      });
+      expect(cookie.sameSite).to.equal("lax");
+    });
+
+    it("sets SESSION_COOKIE_DOMAIN when provided", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+        SESSION_COOKIE_DOMAIN: "example.com",
+      });
+      expect(cookie.domain).to.equal(".example.com");
+      expect(cookie.sameSite).to.equal("none");
+    });
+
+    it("honours SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE on local HTTP", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "http://localhost:4000",
+        APP_URL: "http://localhost:5173",
+        SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE: "true",
+      });
+      expect(cookie.sameSite).to.equal("lax");
+      expect(cookie.secure).to.equal(false);
+    });
+  });
+
+  describe("resolveCsrfCookieName", () => {
+    it("uses __Host- prefix only without session cookie Domain", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+      });
+      expect(
+        resolveCsrfCookieName({ NODE_ENV: "production" }, cookie),
+      ).to.equal("__Host-psifi.x-csrf-token");
+    });
+
+    it("avoids __Host- when SESSION_COOKIE_DOMAIN is set", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+        SESSION_COOKIE_DOMAIN: "example.com",
+      });
+      expect(
+        resolveCsrfCookieName({ NODE_ENV: "production" }, cookie),
+      ).to.equal("x-csrf-token");
+    });
+  });
+
+  describe("resolveClearSessionCookieOptions", () => {
+    it("matches session cookie attributes for logout", () => {
+      const env = {
+        NODE_ENV: "production",
+        API_URL: "http://localhost:4000",
+        APP_URL: "http://localhost:5173",
+        SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE: "true",
+      };
+      const session = resolveSessionCookieOptions(env);
+      const clearOpts = resolveClearSessionCookieOptions(env);
+      expect(clearOpts.sameSite).to.equal(session.sameSite);
+      expect(clearOpts.secure).to.equal(session.secure);
+      expect(clearOpts.path).to.equal("/");
+      expect(clearOpts.domain).to.equal(session.domain);
+    });
+
+    it("includes domain when SESSION_COOKIE_DOMAIN is set", () => {
+      const clearOpts = resolveClearSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+        SESSION_COOKIE_DOMAIN: "example.com",
+      });
+      expect(clearOpts.domain).to.equal(".example.com");
+      expect(clearOpts.sameSite).to.equal("none");
+    });
+
+    it("does not use SameSite=Strict (logout regression guard)", () => {
+      const clearOpts = resolveClearSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "http://localhost:4000",
+        APP_URL: "http://localhost:5173",
+      });
+      expect(clearOpts.sameSite).to.not.equal("strict");
+    });
+  });
+
+  describe("resolveEffectiveOrigins", () => {
+    it("falls back API origin to APP_URL when API_URL is unset", () => {
+      const { apiOrigin, appOrigin } = resolveEffectiveOrigins({
+        APP_URL: "https://tokentimer.example.com",
+      });
+      expect(apiOrigin).to.equal("https://tokentimer.example.com");
+      expect(appOrigin).to.equal("https://tokentimer.example.com");
+      expect(shouldUseCrossOriginCookies(apiOrigin, appOrigin)).to.equal(false);
+    });
+  });
+
+  describe("buildCorsOrigins", () => {
+    it("includes API_URL without trailing slash", () => {
+      const origins = buildCorsOrigins({
+        APP_URL: "https://app.example.com",
+        API_URL: "https://api.example.com/",
+      });
+      expect(origins).to.include("https://app.example.com");
+      expect(origins).to.include("https://api.example.com");
+      expect(origins).to.not.include("https://api.example.com/");
+    });
+
+    it("includes default local API port for dev CORS", () => {
+      const origins = buildCorsOrigins({
+        APP_URL: "http://localhost:5173",
+      });
+      expect(origins).to.include("http://localhost:4000");
+    });
+  });
+});

--- a/tests/integration/session-cookie-options.unit.test.js
+++ b/tests/integration/session-cookie-options.unit.test.js
@@ -118,6 +118,16 @@ describe("session-cookie-options", () => {
       expect(cookie.sameSite).to.equal("lax");
       expect(cookie.secure).to.equal(false);
     });
+    it("ignores SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE on public HTTPS", () => {
+      const cookie = resolveSessionCookieOptions({
+        NODE_ENV: "production",
+        API_URL: "https://api.example.com",
+        APP_URL: "https://app.example.com",
+        SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE: "true",
+      });
+      expect(cookie.secure).to.equal(true);
+      expect(cookie.sameSite).to.equal("none");
+    });
   });
 
   describe("resolveCsrfCookieName", () => {
@@ -210,5 +220,24 @@ describe("session-cookie-options", () => {
       });
       expect(origins).to.include("http://localhost:4000");
     });
+    it("omits localhost dev origins in production unless ALLOW_LOCAL_DEV_CORS", () => {
+      const origins = buildCorsOrigins({
+        NODE_ENV: "production",
+        APP_URL: "https://app.example.com",
+        API_URL: "https://api.example.com",
+      });
+      expect(origins).to.not.include("http://localhost:5173");
+      expect(origins).to.not.include("http://127.0.0.1:4000");
+    });
+
+    it("allows localhost dev origins in production when ALLOW_LOCAL_DEV_CORS=true", () => {
+      const origins = buildCorsOrigins({
+        NODE_ENV: "production",
+        APP_URL: "https://app.example.com",
+        API_URL: "https://api.example.com",
+        ALLOW_LOCAL_DEV_CORS: "true",
+      });
+      expect(origins).to.include("http://localhost:5173");
+    });  
   });
 });

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -1,6 +1,8 @@
 # Public OSS integration suite
 
 # Auth and account
+tests/integration/session-cookie-options.unit.test.js
+tests/integration/runtime-labels.unit.test.js
 tests/integration/auth.test.js
 tests/integration/auth-invite-reset.integration.test.js
 tests/integration/auth-session-invalidation.integration.test.js


### PR DESCRIPTION
## Summary

Fixes session/login/logout for split-host and Docker Compose deployments by centralising cookie, CSRF, and CORS behaviour. Adds runtime API labels for enterprise vs core builds, aligns Helm/Compose URL env wiring, and pins `qs@6.15.2` for a moderate Express advisory. Integration tests are updated for import `201` responses and worker bearer auth.

## Changes

### API
- New `session-cookie-options.js`: `SameSite`/`Secure`/`SESSION_COOKIE_DOMAIN`, CORS origins, logout `clearCookie` parity, HTTPS-only `SameSite=None`, startup warning when split-host lacks cookie domain.
- New `runtime-labels.js`; logger and rate limiter use `getRuntimeLabels()`.
- Logout and account deletion clear `sessionId` with the same attributes as express-session (fixes `SameSite=Strict` mismatch).
- `API_URL` → `APP_URL` fallback in cookie/CORS logic (matches `constants.js`).

### Dashboard
- `resolveApiBaseUrl.js` rewrites local `localhost` API URLs to the page hostname (`127.0.0.1` alignment).
- Domain checker modal: remove outdated Pro/Team badge copy.

### Infra
- Compose: dashboard `API_URL` for runtime `env.js`.
- Helm: `API_URL` defaults to `baseUrl` when `apiUrl` is omitted.

### Tests
- Mocha: `session-cookie-options.unit.test.js`, `runtime-labels.unit.test.js` (core suite).
- Vitest: `resolveApiBaseUrl.test.js`.
- Integration: logout clear-cookie regression; `auto-sync-import` expects `201` and test `SESSION_SECRET` for worker bearer.

### Docs / metadata
- `docs/CONFIGURATION.md`: split-host cookies and URL inheritance table.
- Version **0.5.4** across manifests, contracts, OpenAPI, Helm.
- `CHANGELOG.md` for 0.5.4.
- pnpm override `qs@6.15.2` ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26)).

## Test plan
- [X] CI passes 
- [X] Grype scans on api / dashboard / worker images
- [X] Manual: Compose login + logout on `http://localhost:5173` + `http://localhost:4000`