### PR TITLE
Release TokenTimer Core v0.6.1 with CSRF Auto-Sync Fix and System-Admin Audit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-25
+
+### Added
+
+- **System-admin organization audit** — users with `users.is_admin` can view and export the full organization audit log (not limited to workspaces where they hold `admin`); Audit UI shows SSO login and membership-sync metadata.
+- **System-admin workspace sync on local login** — `POST /auth/login` and `POST /auth/verify-2fa` call `ensureInitialWorkspaceForUser`, which upserts `workspace_manager` on every workspace for system admins (upgrades existing `viewer`/`admin` memberships).
+- **Integration tests** — `audit-system-admin-org-scope.test.js`, `csrf-worker-exemption.test.js`.
+
+### Changed
+
+- **Dashboard audit access** — Audit nav and `/audit` route allow system admins (`session.isAdmin`) in addition to workspace admins and managers.
+- **Test WhatsApp authorization** — `POST /api/test-whatsapp` now requires `whatsapp.test` (minimum role `workspace_manager`) instead of `workspace.update` (`admin`), matching 0.6.0 role semantics.
+- **Version metadata bumped to 0.6.1** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **Auto-sync and worker API calls blocked by CSRF** — recent CSRF hardening required a token on all `/api` mutations; background worker requests (e.g. auto-sync import via `Authorization: Bearer WORKER_API_KEY`) had no session cookie and were rejected. Shared `internal-worker-auth` and `csrf-exempt` middleware restore the authenticated worker bypass; `requireAuth` accepts the same bearer.
+- **Test WhatsApp 403 for workspace managers** — managers and workspace managers on the shared Default workspace were denied because the route required workspace `admin`.
+- **Audit authorization fail-closed** — role-check errors on audit list/export now return **503** instead of continuing with a partial filter.
+- **System-admin workspace sync skipped** — `ensureInitialWorkspaceForUser` no longer returns early when the user already has memberships, so system-admin workspace upserts run on every login.
+- **Integration test suite (0.6.0 alignment)** — dedicated test workspaces for isolation on shared Default installs; audit cleanup respects immutable `audit_events`; import expiration assertions use PostgreSQL `::text` cast (avoids JS timezone drift on `DATE`); alert queue tests seed email contact groups required by queue-manager.
+
 ## [0.6.0] - 2026-05-23
 
 ### Added

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -31,6 +31,7 @@ const {
   loadWorkspace,
   requireWorkspaceMembership,
 } = require("./services/rbac");
+const { createCsrfExemptMiddleware } = require("./middleware/csrf-exempt");
 
 const swaggerOptions = {
   definition: {
@@ -357,6 +358,13 @@ app.get("/api/session", (req, res) => {
     }
 
     const displayEmail = req.user.email_original || req.user.email;
+    const authMethod = req.user.auth_method || "local";
+    const loginMethod =
+      authMethod === "local"
+        ? "email"
+        : ["sso", "saml", "oidc"].includes(authMethod)
+          ? "sso"
+          : authMethod;
 
     res.json({
       loggedIn: true,
@@ -365,8 +373,8 @@ app.get("/api/session", (req, res) => {
         email: displayEmail,
         displayName: req.user.display_name,
         plan: "oss",
-        authMethod: req.user.auth_method || "local",
-        loginMethod: "email",
+        authMethod,
+        loginMethod,
         emailVerified: !!req.user.email_verified,
         needsVerification: !req.user.email_verified,
         twoFactorEnabled: !!req.user.two_factor_enabled,
@@ -558,17 +566,7 @@ app.get("/api/csrf-token", (req, res) => {
 
 // Apply CSRF protection to API routes - Skip in development and test
 if (process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test") {
-  const csrfExempt = (req, res, next) => {
-    if (
-      req.method === "OPTIONS" ||
-      req.method === "GET" ||
-      req.method === "HEAD"
-    )
-      return next();
-    const path = req.path || "";
-    if (path === "/logout") return next();
-    return doubleCsrfProtection(req, res, next);
-  };
+  const csrfExempt = createCsrfExemptMiddleware(doubleCsrfProtection);
   app.use("/api", csrfExempt);
 }
 // Apply email verification enforcement to all API routes

--- a/apps/api/middleware/auth.js
+++ b/apps/api/middleware/auth.js
@@ -1,4 +1,7 @@
 const { logger, resolveClientIp } = require("../utils/logger");
+const {
+  authenticateInternalWorkerRequest,
+} = require("./internal-worker-auth");
 
 /**
  * Comprehensive authentication middleware.
@@ -8,25 +11,8 @@ const { logger, resolveClientIp } = require("../utils/logger");
  * @param {import("express").NextFunction} next
  */
 const requireAuth = (req, res, next) => {
-  // In test mode, allow manual retry endpoint without session
-  if (
-    process.env.NODE_ENV === "test" &&
-    req.method === "POST" &&
-    /^\/api\/alert-queue\/[0-9]+\/retry$/.test(req.path)
-  ) {
-    return next();
-  }
-
   // Allow internal worker calls authenticated via Bearer token
-  const authHeader = req.get("Authorization") || "";
-  const workerKey = process.env.WORKER_API_KEY || process.env.SESSION_SECRET;
-  if (workerKey && authHeader === `Bearer ${workerKey}`) {
-    req.isWorkerCall = true;
-    req.user = req.user || {
-      id: null,
-      role: "admin",
-      email: "worker@internal",
-    };
+  if (authenticateInternalWorkerRequest(req)) {
     logger.info("Internal worker call authenticated", {
       path: req.path,
       method: req.method,

--- a/apps/api/middleware/csrf-exempt.js
+++ b/apps/api/middleware/csrf-exempt.js
@@ -1,0 +1,26 @@
+const { isInternalWorkerRequest } = require("./internal-worker-auth");
+
+function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
+  const allowPath = options.allowPath || (() => false);
+
+  return (req, res, next) => {
+    if (
+      req.method === "OPTIONS" ||
+      req.method === "GET" ||
+      req.method === "HEAD"
+    ) {
+      return next();
+    }
+
+    const requestPath = req.path || "";
+    if (requestPath === "/logout") return next();
+    if (isInternalWorkerRequest(req)) return next();
+    if (allowPath(requestPath)) return next();
+
+    return doubleCsrfProtection(req, res, next);
+  };
+}
+
+module.exports = {
+  createCsrfExemptMiddleware,
+};

--- a/apps/api/middleware/internal-worker-auth.js
+++ b/apps/api/middleware/internal-worker-auth.js
@@ -1,0 +1,41 @@
+const crypto = require("crypto");
+
+function safeEqual(a, b) {
+  const left = Buffer.from(String(a || ""));
+  const right = Buffer.from(String(b || ""));
+
+  if (left.length !== right.length) return false;
+
+  return crypto.timingSafeEqual(left, right);
+}
+
+function getInternalWorkerKey() {
+  return process.env.WORKER_API_KEY || process.env.SESSION_SECRET;
+}
+
+function isInternalWorkerRequest(req) {
+  const authHeader = req.get("Authorization") || "";
+  const workerKey = getInternalWorkerKey();
+
+  if (!workerKey || !authHeader.startsWith("Bearer ")) return false;
+
+  return safeEqual(authHeader.slice("Bearer ".length), workerKey);
+}
+
+function authenticateInternalWorkerRequest(req) {
+  if (!isInternalWorkerRequest(req)) return false;
+
+  req.isWorkerCall = true;
+  req.user = req.user || {
+    id: null,
+    role: "admin",
+    email: "worker@internal",
+  };
+
+  return true;
+}
+
+module.exports = {
+  authenticateInternalWorkerRequest,
+  isInternalWorkerRequest,
+};

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -332,7 +332,7 @@ router.post(
         return res.status(200).json({ requires2FA: true, authMethod: "local" });
       }
 
-      req.login(user, (err) => {
+      req.login(user, async (err) => {
         if (err) {
           logger.error("Login session error", {
             ip: req.ip || req.socket?.remoteAddress,
@@ -340,6 +340,15 @@ router.post(
             userId: user.id,
           });
           return res.status(500).json({ error: "Login failed" });
+        }
+        try {
+          await ensureInitialWorkspaceForUser(
+            user.id,
+            user.email_original || user.email,
+            user.display_name,
+          );
+        } catch (_err) {
+          logger.debug("Non-critical operation failed", { error: _err.message });
         }
         // Audit: login success
         try {
@@ -564,7 +573,7 @@ router.post(
         return res.status(401).json({ error: "Invalid 2FA code" });
       }
 
-      req.login(user, (err) => {
+      req.login(user, async (err) => {
         if (err) {
           logger.error("2FA login session error", {
             error: err.message,
@@ -573,6 +582,16 @@ router.post(
           return res.status(500).json({ error: "Failed to finalize login" });
         }
         delete req.session.pending2FA;
+
+        try {
+          await ensureInitialWorkspaceForUser(
+            user.id,
+            user.email_original || user.email,
+            user.display_name,
+          );
+        } catch (_err) {
+          logger.debug("Non-critical operation failed", { error: _err.message });
+        }
 
         try {
           writeAudit({

--- a/apps/api/routes/usage.js
+++ b/apps/api/routes/usage.js
@@ -19,6 +19,87 @@ const Token = require("../db/models/Token");
 
 const router = require("express").Router();
 
+function isSystemAdminUser(user) {
+  return user?.is_admin === true;
+}
+
+async function loadOrganizationAuditRows({
+  userId,
+  systemAdmin = false,
+  limit,
+  offset = null,
+  since = null,
+  actionFilter = null,
+  searchQuery = null,
+}) {
+  let query = `SELECT ae.id,
+          ae.occurred_at AS occurred_at,
+          ae.actor_user_id,
+          u.display_name AS actor_display_name,
+          ae.subject_user_id,
+          ae.action,
+          ae.target_type,
+          ae.target_id,
+          ae.channel,
+          ae.metadata,
+          COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid) AS workspace_id,
+          w.name AS workspace_name
+     FROM audit_events ae
+     LEFT JOIN users u ON u.id = ae.actor_user_id
+     LEFT JOIN workspaces w ON w.id = COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid)`;
+  const params = [];
+  let paramIndex = 1;
+
+  if (systemAdmin) {
+    query += " WHERE 1=1";
+  } else {
+    const ws = await pool.query(
+      "SELECT workspace_id FROM workspace_memberships WHERE user_id=$1 AND role='admin'",
+      [userId],
+    );
+    const wsIds = ws.rows.map((r) => r.workspace_id);
+    if (wsIds.length === 0) {
+      return [];
+    }
+    query +=
+      " WHERE (ae.workspace_id = ANY($1) OR (ae.metadata->>'workspaceId')::uuid = ANY($1))";
+    params.push(wsIds);
+    paramIndex++;
+  }
+
+  if (since) {
+    query += ` AND ae.occurred_at >= $${paramIndex}`;
+    params.push(since);
+    paramIndex++;
+  }
+
+  if (actionFilter) {
+    query += ` AND ae.action = $${paramIndex}`;
+    params.push(actionFilter);
+    paramIndex++;
+  }
+
+  if (searchQuery) {
+    query += ` AND (ae.action ILIKE $${paramIndex} OR ae.metadata::text ILIKE $${paramIndex})`;
+    const escapedSearch = searchQuery.replace(/[%_\\]/g, "\\$&");
+    params.push(`%${escapedSearch}%`);
+    paramIndex++;
+  }
+
+  query += " ORDER BY ae.occurred_at DESC";
+  query += ` LIMIT $${paramIndex}`;
+  params.push(limit);
+  paramIndex++;
+
+  if (offset != null) {
+    query += ` OFFSET $${paramIndex}`;
+    params.push(offset);
+  }
+
+  const { rows } = await pool.query(query, params);
+  return rows;
+}
+
 // --- ACCOUNT MANAGEMENT ROUTES ---
 
 // Export user data (GDPR compliance)
@@ -400,68 +481,38 @@ router.get(
         ? String(req.query.query).trim()
         : null;
 
+      try {
+        if (!isSystemAdminUser(req.user)) {
+          const roleCheck = await pool.query(
+            `SELECT 1 FROM workspace_memberships
+           WHERE user_id = $1
+           AND role IN ('admin', 'workspace_manager')
+           LIMIT 1`,
+            [req.user.id],
+          );
+          if (roleCheck.rowCount === 0) {
+            return res.status(403).json({
+              error: "Forbidden: audit export requires manager, admin, or system admin role",
+            });
+          }
+        }
+      } catch (_err) {
+        logger.warn("Audit export role check failed", { error: _err.message });
+        return res.status(503).json({ error: "Audit export temporarily unavailable" });
+      }
+
       // Core: organization scope is available to all users (no plan gating)
 
       let items = [];
       if (scope === "organization") {
-        // Admins can export organization-wide audit (across their admin workspaces)
-        const ws = await pool.query(
-          "SELECT workspace_id FROM workspace_memberships WHERE user_id=$1 AND role='admin'",
-          [req.user.id],
-        );
-        const wsIds = ws.rows.map((r) => r.workspace_id);
-        if (wsIds.length === 0) {
-          items = [];
-        } else {
-          const params = [wsIds, limit];
-          const whereClauses = [];
-          let paramIndex = 3;
-
-          if (since) {
-            whereClauses.push(`ae.occurred_at >= $${paramIndex}`);
-            params.push(since);
-            paramIndex++;
-          }
-          if (actionFilter) {
-            whereClauses.push(`ae.action = $${paramIndex}`);
-            params.push(actionFilter);
-            paramIndex++;
-          }
-          if (searchQuery) {
-            whereClauses.push(
-              `(ae.action ILIKE $${paramIndex} OR ae.metadata::text ILIKE $${paramIndex})`,
-            );
-            const escapedSearch = searchQuery.replace(/[%_\\]/g, "\\$&");
-            params.push(`%${escapedSearch}%`);
-            paramIndex++;
-          }
-
-          const whereClause =
-            whereClauses.length > 0 ? ` AND ${whereClauses.join(" AND ")}` : "";
-
-          const { rows } = await pool.query(
-            `SELECT ae.id,
-                    ae.occurred_at AS occurred_at,
-                    ae.actor_user_id,
-                    u.display_name AS actor_display_name,
-                    ae.subject_user_id,
-                    ae.action,
-                    ae.target_type,
-                    ae.target_id,
-                    ae.channel,
-                    ae.metadata,
-                    COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid) AS workspace_id,
-                    w.name AS workspace_name
-               FROM audit_events ae
-               LEFT JOIN users u ON u.id = ae.actor_user_id
-               LEFT JOIN workspaces w ON w.id = COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid)
-              WHERE (ae.workspace_id = ANY($1) OR (ae.metadata->>'workspaceId')::uuid = ANY($1))${whereClause}
-              ORDER BY ae.occurred_at DESC
-              LIMIT $2`,
-            params,
-          );
-          items = rows;
-        }
+        items = await loadOrganizationAuditRows({
+          userId: req.user.id,
+          systemAdmin: isSystemAdminUser(req.user),
+          limit,
+          since,
+          actionFilter,
+          searchQuery,
+        });
       } else if (scope === "workspace" && workspaceIdParam) {
         // Check membership and role
         const m = await pool.query(
@@ -893,61 +944,35 @@ router.get(
       // Core: no paid plan gating; access is role-based.
       // Audit access requires manager or admin role in at least one workspace.
       try {
-        const roleCheck = await pool.query(
-          `SELECT 1 FROM workspace_memberships
-         WHERE user_id = $1
-         AND role IN ('admin', 'workspace_manager')
-         LIMIT 1`,
-          [req.user.id],
-        );
-        if (roleCheck.rowCount === 0) {
-          return res
-            .status(403)
-            .json({ error: "Forbidden: audit requires manager or admin role" });
+        if (!isSystemAdminUser(req.user)) {
+          const roleCheck = await pool.query(
+            `SELECT 1 FROM workspace_memberships
+           WHERE user_id = $1
+           AND role IN ('admin', 'workspace_manager')
+           LIMIT 1`,
+            [req.user.id],
+          );
+          if (roleCheck.rowCount === 0) {
+            return res.status(403).json({
+              error: "Forbidden: audit requires manager, admin, or system admin role",
+            });
+          }
         }
       } catch (_err) {
-        logger.warn("Audit write failed", { error: _err.message });
+        logger.warn("Audit events role check failed", { error: _err.message });
+        return res.status(503).json({ error: "Audit events temporarily unavailable" });
       }
 
       if (scope === "organization") {
-        // Admins can view organization-wide audit (across their admin workspaces)
-        const ws = await pool.query(
-          "SELECT workspace_id FROM workspace_memberships WHERE user_id=$1 AND role='admin'",
-          [req.user.id],
-        );
-        const wsIds = ws.rows.map((r) => r.workspace_id);
-        if (wsIds.length === 0) return res.json([]);
-
-        let query = `SELECT ae.id, ae.occurred_at, ae.actor_user_id, ae.subject_user_id, ae.action,
-                ae.target_type, ae.target_id, ae.channel, ae.metadata,
-                u.display_name AS actor_display_name,
-                COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid) AS workspace_id,
-                w.name AS workspace_name
-         FROM audit_events ae
-         LEFT JOIN users u ON u.id = ae.actor_user_id
-         LEFT JOIN workspaces w ON w.id = COALESCE(ae.workspace_id, (ae.metadata->>'workspaceId')::uuid)
-         WHERE (ae.workspace_id = ANY($1) OR (ae.metadata->>'workspaceId')::uuid = ANY($1))`;
-
-        const params = [wsIds, limit, offset];
-        let paramIndex = 4;
-
-        if (actionFilter) {
-          query += ` AND ae.action = $${paramIndex}`;
-          params.push(actionFilter);
-          paramIndex++;
-        }
-
-        if (searchQuery) {
-          query += ` AND (ae.action ILIKE $${paramIndex} OR ae.metadata::text ILIKE $${paramIndex})`;
-          const escapedSearch = searchQuery.replace(/[%_\\]/g, "\\$&");
-          params.push(`%${escapedSearch}%`);
-          paramIndex++;
-        }
-
-        query += ` ORDER BY ae.occurred_at DESC LIMIT $2 OFFSET $3`;
-
-        const rows = await pool.query(query, params);
-        return res.json(rows.rows);
+        const rows = await loadOrganizationAuditRows({
+          userId: req.user.id,
+          systemAdmin: isSystemAdminUser(req.user),
+          limit,
+          offset,
+          actionFilter,
+          searchQuery,
+        });
+        return res.json(rows);
       }
 
       // Default: user-only view (backwards-compatible)

--- a/apps/api/routes/whatsapp.js
+++ b/apps/api/routes/whatsapp.js
@@ -96,7 +96,7 @@ router.post(
   },
   loadWorkspace,
   requireWorkspaceMembership,
-  authorize("workspace.update"),
+  authorize("whatsapp.test"),
   async (req, res) => {
     try {
       const { phone_e164 } = req.body || {};

--- a/apps/api/services/rbac.js
+++ b/apps/api/services/rbac.js
@@ -29,6 +29,7 @@ const actionPolicy = {
   "workspace.view": "viewer",
   "workspace.create": "viewer",
   "workspace.update": "admin",
+  "whatsapp.test": "workspace_manager",
   "workspace.delete": "admin",
   "membership.invite": "workspace_manager",
   "membership.change_role": "workspace_manager",

--- a/apps/api/services/systemAdmin.js
+++ b/apps/api/services/systemAdmin.js
@@ -37,6 +37,38 @@ async function countOtherActiveSystemAdmins(queryable, userId) {
   return rows[0]?.c || 0;
 }
 
+/**
+ * Grant workspace_manager on every workspace for installation system admins.
+ * On conflict, upgrades workspace admin or viewer to workspace_manager so
+ * system admins never retain implicit workspace owner or read-only-only access.
+ *
+ * @returns {{ applied: number }}
+ */
+async function ensureSystemAdminWorkspaceAccess(db, userId) {
+  const { rows: adminRows } = await db.query(
+    "SELECT is_admin FROM users WHERE id = $1 LIMIT 1",
+    [userId],
+  );
+  if (adminRows.length === 0 || adminRows[0].is_admin !== true) {
+    return { applied: 0 };
+  }
+
+  const result = await db.query(
+    `INSERT INTO workspace_memberships (user_id, workspace_id, role, invited_by)
+     SELECT $1::int, w.id, 'workspace_manager', NULL
+       FROM workspaces w
+     ON CONFLICT (user_id, workspace_id) DO UPDATE
+       SET role = CASE
+             WHEN workspace_memberships.role IN ('admin', 'viewer')
+               THEN 'workspace_manager'
+             ELSE workspace_memberships.role
+           END
+     RETURNING workspace_id`,
+    [userId],
+  );
+  return { applied: result.rowCount || 0 };
+}
+
 module.exports = {
   SYSTEM_ADMIN_LOCK_KEY,
   ACTIVE_SYSTEM_ADMIN_WHERE,
@@ -44,4 +76,5 @@ module.exports = {
   lockSystemAdminMutation,
   countActiveSystemAdmins,
   countOtherActiveSystemAdmins,
+  ensureSystemAdminWorkspaceAccess,
 };

--- a/apps/api/services/workspace.js
+++ b/apps/api/services/workspace.js
@@ -1,6 +1,7 @@
 const { pool } = require("../db/database");
 const { logger } = require("../utils/logger");
 const { writeAudit } = require("./audit");
+const { ensureSystemAdminWorkspaceAccess } = require("./systemAdmin");
 
 const DEFAULT_WORKSPACE_NAME = "Default workspace";
 const INSTALLATION_DEFAULT_LOCK_KEY = 0x5454_5744; // TTWD
@@ -92,11 +93,8 @@ async function ensureInitialWorkspaceForUser(userId, userEmail, displayName) {
       `SELECT 1 FROM workspace_memberships WHERE user_id = $1 LIMIT 1`,
       [userId],
     );
-    if (membershipCheck.rowCount > 0) {
-      return;
-    }
-
-    const client = await pool.connect();
+    if (membershipCheck.rowCount === 0) {
+      const client = await pool.connect();
     let workspaceId;
     let created = false;
     let joinRole = "admin";
@@ -221,11 +219,21 @@ async function ensureInitialWorkspaceForUser(userId, userEmail, displayName) {
         });
       }
     }
+    }
   } catch (err) {
     logger.error("ensureInitialWorkspaceForUser failed", {
       userId,
       error: err.message,
       stack: err.stack,
+    });
+  }
+
+  try {
+    await ensureSystemAdminWorkspaceAccess(pool, userId);
+  } catch (_err) {
+    logger.warn("ensureSystemAdminWorkspaceAccess failed after provisioning", {
+      userId,
+      error: _err.message,
     });
   }
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -153,15 +153,16 @@ function RequireManagerRoute({ session, children }) {
         if (!cancelled) setIsAllowed(false);
         return;
       }
+      const isSystemAdmin = session?.isAdmin === true;
       try {
         const ws = await workspaceAPI.list(50, 0);
         const items = ws?.items || [];
         const roles = items.map(w => String(w.role || '').toLowerCase());
         const hasManagerOrAdmin =
           roles.includes('admin') || roles.includes('workspace_manager');
-        if (!cancelled) setIsAllowed(hasManagerOrAdmin);
+        if (!cancelled) setIsAllowed(isSystemAdmin || hasManagerOrAdmin);
       } catch (_) {
-        if (!cancelled) setIsAllowed(false);
+        if (!cancelled) setIsAllowed(isSystemAdmin);
       }
     })();
     return () => {

--- a/apps/dashboard/src/components/Navigation.jsx
+++ b/apps/dashboard/src/components/Navigation.jsx
@@ -636,7 +636,7 @@ const Navigation = ({
           items.length > 0 && !adminAny && !roles.includes('workspace_manager');
         setHasManagerOrAdminAny(managerAny);
         setIsViewerOnly(viewerOnly);
-        const showAudit = items.length ? managerAny : true;
+        const showAudit = isSystemAdmin || (items.length ? managerAny : true);
         const showWorkspaces = items.length ? managerAny : true;
         setCanSeeAudit(showAudit);
         setCanSeeWorkspaces(showWorkspaces);

--- a/apps/dashboard/src/pages/Account.jsx
+++ b/apps/dashboard/src/pages/Account.jsx
@@ -36,7 +36,34 @@ import { useWorkspace } from '../utils/WorkspaceContext.jsx';
 import { Link as RouterLink } from 'react-router-dom';
 import { trackEvent } from '../utils/analytics.js';
 
+function resolveLoginMethodDisplay(session) {
+  const providerSlug = session?.ssoProviderSlug;
+  const method = String(session?.authMethod || 'local').toLowerCase();
+  const isSsoSession =
+    providerSlug ||
+    session?.loginMethod === 'sso' ||
+    ['sso', 'saml', 'oidc'].includes(method);
+
+  if (isSsoSession) {
+    const providerLabel = providerSlug
+      ? ` (${providerSlug.replace(/-/g, ' ')})`
+      : '';
+    return {
+      label: `Single Sign-On${providerLabel}`,
+      colorScheme: 'purple',
+    };
+  }
+  if (method === 'local') {
+    return { label: 'Email & Password', colorScheme: 'green' };
+  }
+  if (method === 'google') {
+    return { label: 'Google', colorScheme: 'blue' };
+  }
+  return { label: method, colorScheme: 'gray' };
+}
+
 function Account({ session, onAccountDeleted }) {
+  const loginMethodDisplay = resolveLoginMethodDisplay(session);
   const { selectWorkspace: _selectWorkspace } = useWorkspace();
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState('');
@@ -212,8 +239,11 @@ function Account({ session, onAccountDeleted }) {
                   Login Method:
                 </Text>
                 <Spacer display={{ base: 'none', sm: 'block' }} />
-                <Badge colorScheme='green' maxW='fit-content'>
-                  Email & Password
+                <Badge
+                  colorScheme={loginMethodDisplay.colorScheme}
+                  maxW='fit-content'
+                >
+                  {loginMethodDisplay.label}
                 </Badge>
               </Flex>
               <Flex

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -515,7 +515,9 @@ export default function Audit({
       if (md.idp_groups_seen != null)
         parts.push(`IdP groups seen: ${md.idp_groups_seen}`);
       if (Array.isArray(md.idp_groups_sample)) {
-        parts.push(`Observed groups: ${formatArrayValue(md.idp_groups_sample)}`);
+        parts.push(
+          `Observed groups: ${formatArrayValue(md.idp_groups_sample)}`
+        );
       }
       if (Array.isArray(md.configured_admin_idp_groups)) {
         parts.push(

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -56,6 +56,7 @@ const ACTION_COLORS = {
   LOGIN_SUCCESS: 'green',
   LOGIN_FAILED: 'red',
   LOGIN_SUCCESS_2FA: 'green',
+  MEMBERSHIP_SYNCED_FROM_SSO: 'blue',
 };
 
 // Exhaustive list of all possible audit actions
@@ -65,6 +66,7 @@ const ALL_ACTION_TYPES = [
   'LOGIN_SUCCESS',
   'LOGIN_FAILED',
   'LOGIN_SUCCESS_2FA',
+  'MEMBERSHIP_SYNCED_FROM_SSO',
   'LOGOUT',
   'PASSWORD_CHANGED',
   'PASSWORD_RESET_REQUESTED',
@@ -179,6 +181,8 @@ export default function Audit({
   const cardBg = useColorModeValue('rgba(255, 255, 255, 0.95)', 'gray.800');
   const borderColor = useColorModeValue('gray.400', 'gray.600');
   const emptyTextColor = useColorModeValue('gray.600', 'gray.400');
+  const isSystemAdmin = session?.isAdmin === true;
+  const canViewOrganizationAudit = isSystemAdmin || (isAdminAny && isAdminOrg);
 
   const load = useCallback(
     async (isMore = false) => {
@@ -191,7 +195,7 @@ export default function Audit({
           pageOffsetRef.current = 0;
         }
         setError('');
-        const viewerOnly = !isManagerOrAdminAny && !isAdminAny;
+        const viewerOnly = !isManagerOrAdminAny && !isSystemAdmin;
         // Core: block viewers (no backend calls)
         if (viewerOnly) {
           setEvents([]);
@@ -199,10 +203,7 @@ export default function Audit({
         }
         // Core: non-admins cannot view organization scope
         let effectiveScope = scope;
-        if (!isAdminAny && effectiveScope === 'organization') {
-          effectiveScope = 'workspace';
-        }
-        if (!isAdminOrg && effectiveScope === 'organization') {
+        if (!canViewOrganizationAudit && effectiveScope === 'organization') {
           effectiveScope = 'workspace';
         }
         const effectiveWorkspaceId = auditWorkspaceId || workspaceId || null;
@@ -240,6 +241,8 @@ export default function Audit({
       isAdminAny,
       actionFilter,
       isAdminOrg,
+      isSystemAdmin,
+      canViewOrganizationAudit,
       query,
     ]
   );
@@ -256,6 +259,8 @@ export default function Audit({
     isAdminAny,
     actionFilter,
     isAdminOrg,
+    isSystemAdmin,
+    canViewOrganizationAudit,
     query,
   ]);
 
@@ -265,7 +270,7 @@ export default function Audit({
       _rolesLoaded &&
       workspaces.length > 0 &&
       !isManagerOrAdminAny &&
-      !isAdminAny
+      !isSystemAdmin
     ) {
       try {
         navigate('/dashboard', { replace: true });
@@ -275,7 +280,7 @@ export default function Audit({
     _rolesLoaded,
     workspaces.length,
     isManagerOrAdminAny,
-    isAdminAny,
+    isSystemAdmin,
     navigate,
   ]);
 
@@ -328,7 +333,7 @@ export default function Audit({
         const adminAny = roles.includes('admin');
         // Core: authorize by role. When list empty allow access (bootstrap admin / list not loaded yet).
         const managerAny = adminAny || roles.includes('workspace_manager');
-        const allow = items.length === 0 ? true : managerAny;
+        const allow = isSystemAdmin || (items.length === 0 ? true : managerAny);
         setAuthorized(allow);
         if (!allow) {
           try {
@@ -336,16 +341,18 @@ export default function Audit({
           } catch (_) {}
         }
       } catch (_) {
-        setAuthorized(false);
-        try {
-          navigate('/dashboard', { replace: true });
-        } catch (_) {}
+        setAuthorized(isSystemAdmin);
+        if (!isSystemAdmin) {
+          try {
+            navigate('/dashboard', { replace: true });
+          } catch (_) {}
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [navigate, isSystemAdmin]);
 
   // Both action filtering and search are now handled by backend, so no client-side filtering needed
   // Events from backend are already filtered based on actionFilter and query parameters
@@ -365,6 +372,14 @@ export default function Audit({
 
   function boolLabel(v) {
     return v ? 'Enabled' : 'Disabled';
+  }
+
+  function formatArrayValue(values, limit = 5) {
+    if (!Array.isArray(values) || values.length === 0) return 'none';
+    return values
+      .slice(0, limit)
+      .map(v => String(v))
+      .join(', ');
   }
 
   function formatWorkspaceSettingsMetadata(ev) {
@@ -485,6 +500,69 @@ export default function Audit({
       if (md.user_agent) parts.push(`User agent: ${md.user_agent}`);
       if (md.email) parts.push(`Email: ${md.email}`);
       return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatSsoLoginMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.method) parts.push(`Method: ${md.method}`);
+      if (md.provider_slug) parts.push(`Provider: ${md.provider_slug}`);
+      if (md.protocol) parts.push(`Protocol: ${md.protocol}`);
+      if (md.idp_groups_seen != null)
+        parts.push(`IdP groups seen: ${md.idp_groups_seen}`);
+      if (Array.isArray(md.idp_groups_sample)) {
+        parts.push(`Observed groups: ${formatArrayValue(md.idp_groups_sample)}`);
+      }
+      if (Array.isArray(md.configured_admin_idp_groups)) {
+        parts.push(
+          `Configured admin groups: ${formatArrayValue(md.configured_admin_idp_groups)}`
+        );
+      }
+      if (Array.isArray(md.matched_groups)) {
+        parts.push(`Matched groups: ${formatArrayValue(md.matched_groups)}`);
+      }
+      if (md.is_admin_resolved != null) {
+        parts.push(
+          `Admin mapping: ${md.is_admin_resolved ? 'matched' : 'not matched'}`
+        );
+      }
+      if (md.is_admin_after_login != null) {
+        parts.push(
+          `System admin after login: ${md.is_admin_after_login ? 'yes' : 'no'}`
+        );
+      }
+      if (md.admin_granted != null) {
+        parts.push(`Admin granted: ${md.admin_granted ? 'yes' : 'no'}`);
+      }
+      if (md.workspace_grants_count != null) {
+        parts.push(`Workspace grants: ${md.workspace_grants_count}`);
+      }
+      if (md.workspace_revocations_count != null) {
+        parts.push(`Workspace revocations: ${md.workspace_revocations_count}`);
+      }
+      return parts.join(' | ');
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatSsoMembershipMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.provider_slug) parts.push(`Provider: ${md.provider_slug}`);
+      if (md.change) parts.push(`Change: ${md.change}`);
+      if (md.role) parts.push(`Role: ${md.role}`);
+      if (Array.isArray(md.matched_groups)) {
+        parts.push(`Matched groups: ${formatArrayValue(md.matched_groups)}`);
+      }
+      if (md.previous_role) parts.push(`Previous role: ${md.previous_role}`);
+      if (md.reason) parts.push(`Reason: ${md.reason}`);
+      return parts.join(' | ');
     } catch (_) {
       return '';
     }
@@ -741,6 +819,16 @@ export default function Audit({
       if (formatted) return formatted;
     }
 
+    if (
+      action === 'LOGIN_SUCCESS' &&
+      ['saml', 'oidc', 'sso'].includes(
+        String(ev?.metadata?.method || '').toLowerCase()
+      )
+    ) {
+      const formatted = formatSsoLoginMetadata(ev);
+      if (formatted) return formatted;
+    }
+
     // Authentication events
     if (
       action === 'LOGIN_SUCCESS' ||
@@ -758,6 +846,11 @@ export default function Audit({
       action === 'TWO_FACTOR_DISABLED'
     ) {
       const formatted = formatAuthMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'MEMBERSHIP_SYNCED_FROM_SSO') {
+      const formatted = formatSsoMembershipMetadata(ev);
       if (formatted) return formatted;
     }
 
@@ -882,12 +975,11 @@ export default function Audit({
 
   async function exportJson() {
     try {
-      const effectiveScope =
-        isAdminAny && isAdminOrg
-          ? scope
-          : scope === 'organization'
-            ? 'workspace'
-            : scope;
+      const effectiveScope = canViewOrganizationAudit
+        ? scope
+        : scope === 'organization'
+          ? 'workspace'
+          : scope;
       const effectiveWorkspaceId = auditWorkspaceId || workspaceId || null;
       const { blob, filename, contentType } = await alertAPI.exportAudit({
         scope: effectiveScope,
@@ -913,12 +1005,11 @@ export default function Audit({
 
   async function exportCsv() {
     try {
-      const effectiveScope =
-        isAdminAny && isAdminOrg
-          ? scope
-          : scope === 'organization'
-            ? 'workspace'
-            : scope;
+      const effectiveScope = canViewOrganizationAudit
+        ? scope
+        : scope === 'organization'
+          ? 'workspace'
+          : scope;
       const effectiveWorkspaceId = auditWorkspaceId || workspaceId || null;
       const { blob, filename, contentType } = await alertAPI.exportAudit({
         scope: effectiveScope,
@@ -945,7 +1036,7 @@ export default function Audit({
   // UI scope:
   // - Admins: respect selected scope
   // - Non-admins: allow 'user' and 'workspace'; coerce 'organization' to 'workspace'
-  const scopeUI = isAdminAny
+  const scopeUI = canViewOrganizationAudit
     ? scope
     : scope === 'organization'
       ? 'workspace'
@@ -1001,7 +1092,7 @@ export default function Audit({
                   ))}
                 </Select>
                 {/* Scope selector: admins can choose; managers can choose between user/workspace */}
-                {isAdminAny && isAdminOrg ? (
+                {canViewOrganizationAudit ? (
                   <Select
                     value={scope}
                     onChange={e => {

--- a/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
+++ b/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
@@ -175,6 +175,66 @@ describe('Dashboard page smoke tests', () => {
     );
   });
 
+  it('renders SSO audit metadata in Audit route', async () => {
+    workspaceListMock.mockResolvedValue({
+      items: [{ id: 'ws-1', name: 'Workspace', role: 'admin' }],
+    });
+    alertGetAuditEventsMock.mockResolvedValue([
+      {
+        id: 'ev-sso-1',
+        occurred_at: new Date().toISOString(),
+        action: 'LOGIN_SUCCESS',
+        actor_display_name: 'Test User',
+        workspace_name: 'Workspace',
+        metadata: {
+          method: 'saml',
+          provider_slug: 'entra',
+          protocol: 'saml',
+          idp_groups_seen: 2,
+          idp_groups_sample: ['TokenTimer-Admins', 'TokenTimer-Users'],
+          matched_groups: ['TokenTimer-Admins'],
+          is_admin_resolved: true,
+          is_admin_after_login: true,
+          admin_granted: true,
+          workspace_grants_count: 3,
+          workspace_revocations_count: 0,
+        },
+      },
+    ]);
+
+    renderWithProviders(<Audit {...baseProps} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Provider: entra/)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Observed groups:/)).toBeInTheDocument();
+    expect(screen.getByText(/System admin after login: yes/)).toBeInTheDocument();
+  });
+
+  it('shows organization scope for system admins on Audit route', async () => {
+    workspaceListMock.mockResolvedValue({
+      items: [{ id: 'ws-1', name: 'Workspace', role: 'viewer' }],
+    });
+    alertGetAuditEventsMock.mockResolvedValue([]);
+
+    renderWithProviders(
+      <Audit
+        {...baseProps}
+        session={{
+          ...baseProps.session,
+          isAdmin: true,
+        }}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Audit Log')).toBeInTheDocument()
+    );
+    expect(
+      screen.getByRole('option', { name: 'Organization (admin)' })
+    ).toBeInTheDocument();
+  });
+
   it('renders Account route fallback when session is missing', async () => {
     renderWithProviders(<Account session={null} onAccountDeleted={vi.fn()} />);
     expect(screen.getByText('Account Settings')).toBeInTheDocument();

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.6.1
+appVersion: "0.6.1"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.6.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.6.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.6.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.6.0
+  version: 0.6.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/alert-bug-fixes.test.js
+++ b/tests/integration/alert-bug-fixes.test.js
@@ -15,13 +15,47 @@ describe("Alert Bug Fixes", function () {
   let user;
   let cookie;
   let workspaceId;
+  let emailContactId;
 
   before(async () => {
     await TestEnvironment.setup();
     const u = await TestUtils.createAuthenticatedUser();
     user = u;
     cookie = u.cookie;
-    workspaceId = await TestUtils.ensureTestWorkspace(cookie);
+    workspaceId = await TestUtils.ensureDedicatedTestWorkspace(
+      cookie,
+      "Alert Bug Fixes",
+    );
+
+    const contactRes = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/contacts`)
+      .set("Cookie", cookie)
+      .send({
+        first_name: "Alert",
+        last_name: "Tester",
+        details: { email: user.email },
+      })
+      .expect(201);
+    emailContactId = contactRes.body.id;
+
+    await request(BASE)
+      .put(`/api/v1/workspaces/${workspaceId}/alert-settings`)
+      .set("Cookie", cookie)
+      .send({
+        email_alerts_enabled: true,
+        delivery_window_start: "00:00",
+        delivery_window_end: "23:59",
+        delivery_window_tz: "UTC",
+        contact_groups: [
+          {
+            id: "alert-bug-fixes-default",
+            name: "Alert Bug Fixes Default",
+            email_contact_ids: [emailContactId],
+          },
+        ],
+        default_contact_group_id: "alert-bug-fixes-default",
+      })
+      .expect(200);
   });
 
   after(async () => {
@@ -77,7 +111,8 @@ describe("Alert Bug Fixes", function () {
     await request(BASE)
       .put(`/api/v1/workspaces/${workspaceId}/alert-settings`)
       .set("Cookie", cookie)
-      .send({ alert_thresholds: [30, 7, 1, 0, -1, -2] });
+      .send({ alert_thresholds: [30, 7, 1, 0, -1, -2] })
+      .expect(200);
 
     // Create a token that expired 1 day ago
     const expiredDate = new Date();
@@ -198,7 +233,8 @@ describe("Alert Bug Fixes", function () {
     await request(BASE)
       .put(`/api/v1/workspaces/${workspaceId}/alert-settings`)
       .set("Cookie", cookie)
-      .send({ alert_thresholds: [30, 7, 1, 0, -1, -2, -3] });
+      .send({ alert_thresholds: [30, 7, 1, 0, -1, -2, -3] })
+      .expect(200);
 
     // Run queue discovery
     await TestUtils.runNode(

--- a/tests/integration/audit-system-admin-org-scope.test.js
+++ b/tests/integration/audit-system-admin-org-scope.test.js
@@ -1,0 +1,107 @@
+const { expect, request, TestEnvironment, TestUtils } = require("./setup");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+const TEST_ACTION = "ORG_AUDIT_SYSTEM_ADMIN_TEST";
+
+describe("Audit organization scope for system admins", function () {
+  this.timeout(60000);
+
+  let systemAdminUser;
+  let otherUser;
+  let systemAdminCookie;
+  let otherWorkspaceId;
+
+  before(async () => {
+    await TestEnvironment.setup();
+
+    systemAdminUser = await TestUtils.createVerifiedTestUser(
+      null,
+      "SecureTest123!@#",
+      null,
+      "oss",
+    );
+    const systemAdminSession = await TestUtils.loginTestUser(
+      systemAdminUser.email,
+      systemAdminUser.password,
+    );
+    systemAdminCookie = systemAdminSession.cookie;
+
+    otherUser = await TestUtils.createVerifiedTestUser(
+      null,
+      "SecureTest123!@#",
+      null,
+      "oss",
+    );
+
+    const wsResult = await TestUtils.execQuery(
+      "SELECT id FROM workspaces WHERE created_by = $1 LIMIT 1",
+      [otherUser.id],
+    );
+    otherWorkspaceId = wsResult.rows[0]?.id;
+
+    await TestUtils.execQuery(
+      "UPDATE users SET is_admin = TRUE WHERE id = $1",
+      [systemAdminUser.id],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM workspace_memberships WHERE user_id = $1",
+      [systemAdminUser.id],
+    );
+    await TestUtils.execQuery(
+      `INSERT INTO audit_events
+         (actor_user_id, subject_user_id, action, target_type, target_id, channel, metadata, workspace_id)
+       VALUES
+         ($1, $2, $3, 'workspace', NULL, NULL, '{"source":"system-admin-org-scope"}', $4)`,
+      [systemAdminUser.id, otherUser.id, TEST_ACTION, otherWorkspaceId],
+    );
+  });
+
+  after(async () => {
+    const userIds = [systemAdminUser.id, otherUser.id];
+    await TestUtils.execQuery("DELETE FROM audit_events WHERE action = $1", [
+      TEST_ACTION,
+    ]);
+    await TestUtils.execQuery(
+      `DELETE FROM audit_events
+       WHERE actor_user_id = ANY($1::int[]) OR subject_user_id = ANY($1::int[])`,
+      [userIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM workspace_memberships WHERE user_id = ANY($1::int[])",
+      [userIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM workspaces WHERE created_by = ANY($1::int[])",
+      [userIds],
+    );
+    await TestUtils.execQuery("DELETE FROM users WHERE id = ANY($1::int[])", [
+      userIds,
+    ]);
+  });
+
+  it("allows a pure system admin to view organization audit events", async () => {
+    const res = await request(BASE)
+      .get(`/api/audit-events?scope=organization&action=${TEST_ACTION}`)
+      .set("Cookie", systemAdminCookie)
+      .expect(200);
+
+    expect(res.body).to.be.an("array");
+    expect(res.body.length).to.equal(1);
+    expect(res.body[0].action).to.equal(TEST_ACTION);
+    expect(res.body[0].workspace_id).to.equal(otherWorkspaceId);
+  });
+
+  it("allows a pure system admin to export organization audit events", async () => {
+    const res = await request(BASE)
+      .get(
+        `/api/account/export-audit?scope=organization&format=json&action=${TEST_ACTION}`,
+      )
+      .set("Cookie", systemAdminCookie)
+      .expect(200);
+
+    expect(res.body).to.have.property("events");
+    expect(res.body.events).to.be.an("array");
+    expect(res.body.events.length).to.equal(1);
+    expect(res.body.events[0].action).to.equal(TEST_ACTION);
+  });
+});

--- a/tests/integration/auto-sync-import.test.js
+++ b/tests/integration/auto-sync-import.test.js
@@ -194,10 +194,12 @@ describe("Auto-sync import deduplication — with location", function () {
     // Token count must stay at 1 — no duplicate inserted
     expect(await tokenCount(workspaceId)).to.equal(1);
 
-    // Expiration must have been refreshed (pg returns DATE/TIMESTAMP objects)
-    const tokens = await getTokens(workspaceId);
-    const expirationIso = new Date(tokens[0].expiration).toISOString();
-    expect(expirationIso).to.include(newExpiry);
+    // Expiration must have been refreshed (compare via SQL to avoid JS timezone drift on DATE)
+    const expiryRow = await TestUtils.execQuery(
+      "SELECT expiration::text AS expiration FROM tokens WHERE workspace_id = $1 ORDER BY id LIMIT 1",
+      [workspaceId],
+    );
+    expect(expiryRow.rows[0].expiration).to.equal(newExpiry);
   });
 
   it("POST /api/v1/integrations/import - same name but different location creates a new token", async () => {

--- a/tests/integration/contact-group-default-fallback.test.js
+++ b/tests/integration/contact-group-default-fallback.test.js
@@ -32,7 +32,10 @@ describe("Contact group default fallback", function () {
     await TestEnvironment.setup();
     user = await TestUtils.createAuthenticatedUser();
     cookie = user.cookie;
-    wsId = await TestUtils.ensureTestWorkspace(cookie);
+    wsId = await TestUtils.ensureDedicatedTestWorkspace(
+      cookie,
+      "Contact Group Fallback",
+    );
   });
 
   after(async () => {
@@ -258,6 +261,10 @@ describe("Contact group default fallback", function () {
       if ([200, 202].includes(res.status)) {
         retryOk = true;
         break;
+      }
+      if (res.status === 403) {
+        await TestUtils.wait(1000 * (attempt + 1));
+        continue;
       }
       if (res.status === 400) {
         // Some runs can return "not retryable" if state changed between checks.

--- a/tests/integration/csrf-worker-exemption.test.js
+++ b/tests/integration/csrf-worker-exemption.test.js
@@ -1,0 +1,114 @@
+const { createRequire } = require("module");
+const supertest = require("supertest");
+const { expect } = require("chai");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
+const cookieParser = apiRequire("cookie-parser");
+const { doubleCsrf } = apiRequire("csrf-csrf");
+const {
+  createCsrfExemptMiddleware,
+} = require("../../apps/api/middleware/csrf-exempt");
+const { requireAuth } = require("../../apps/api/middleware/auth");
+
+function buildProductionCsrfApp() {
+  const app = express();
+  const {
+    doubleCsrfProtection,
+  } = doubleCsrf({
+    getSecret: () => process.env.SESSION_SECRET,
+    cookieName: "csrf-token",
+    cookieOptions: {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: true,
+    },
+    getTokenFromRequest: (req) => req.headers["x-csrf-token"],
+  });
+
+  app.use(cookieParser());
+  app.use(express.json());
+  app.use("/api", createCsrfExemptMiddleware(doubleCsrfProtection));
+  app.post("/api/v1/integrations/azure-ad/scan", requireAuth, (req, res) => {
+    const { token } = req.body || {};
+
+    if (!token) {
+      return res.status(400).json({ error: "token is required" });
+    }
+
+    return res.status(200).json({ ok: true });
+  });
+
+  app.use((err, req, res, next) => {
+    if (err?.code === "EBADCSRFTOKEN") {
+      return res.status(403).json({
+        error: "Invalid CSRF token",
+        code: err.code,
+      });
+    }
+
+    return next(err);
+  });
+
+  return app;
+}
+
+describe("Production CSRF worker exemption", () => {
+  const originalWorkerApiKey = process.env.WORKER_API_KEY;
+  const originalSessionSecret = process.env.SESSION_SECRET;
+
+  afterEach(() => {
+    if (originalWorkerApiKey === undefined) {
+      delete process.env.WORKER_API_KEY;
+    } else {
+      process.env.WORKER_API_KEY = originalWorkerApiKey;
+    }
+
+    if (originalSessionSecret === undefined) {
+      delete process.env.SESSION_SECRET;
+    } else {
+      process.env.SESSION_SECRET = originalSessionSecret;
+    }
+  });
+
+  it("allows worker-authenticated Azure AD scan POSTs past CSRF", async () => {
+    process.env.WORKER_API_KEY = "worker-key";
+    process.env.SESSION_SECRET = "session-secret";
+
+    const res = await supertest(buildProductionCsrfApp())
+      .post("/api/v1/integrations/azure-ad/scan")
+      .set("Authorization", "Bearer worker-key")
+      .send({});
+
+    expect(res.status).to.equal(400);
+    expect(res.body.error).to.equal("token is required");
+  });
+
+  it("still rejects browser-style POSTs without CSRF in production mode", async () => {
+    process.env.WORKER_API_KEY = "worker-key";
+    process.env.SESSION_SECRET = "session-secret";
+
+    const res = await supertest(buildProductionCsrfApp())
+      .post("/api/v1/integrations/azure-ad/scan")
+      .send({});
+
+    expect(res.status).to.equal(403);
+    expect(res.body.code).to.equal("EBADCSRFTOKEN");
+  });
+
+  it("does not exempt mismatched bearer tokens from CSRF", async () => {
+    process.env.WORKER_API_KEY = "worker-key";
+    process.env.SESSION_SECRET = "session-secret";
+
+    const res = await supertest(buildProductionCsrfApp())
+      .post("/api/v1/integrations/azure-ad/scan")
+      .set("Authorization", "Bearer wrong-key")
+      .send({});
+
+    expect(res.status).to.equal(403);
+    expect(res.body.code).to.equal("EBADCSRFTOKEN");
+  });
+});

--- a/tests/integration/multi-dataset.test.js
+++ b/tests/integration/multi-dataset.test.js
@@ -150,8 +150,16 @@ describe("Multi-Dataset Test Suite", () => {
       // Test token retrieval for each session
       for (let i = 0; i < scenario.sessions.length; i++) {
         const session = scenario.sessions[i];
+        const userTokens = scenario.tokens.filter(
+          (t) => t.sessionId === session.user.id,
+        );
+        const workspaceId = userTokens[0]?.workspaceId;
+        expect(workspaceId, "scenario tokens should carry workspaceId").to
+          .exist;
+
         const response = await request(TEST_CONFIG.API_URL)
           .get("/api/tokens")
+          .query({ workspace_id: workspaceId })
           .set("Cookie", session.cookie || "");
 
         if (response.status !== 200) {
@@ -167,10 +175,11 @@ describe("Multi-Dataset Test Suite", () => {
         const items = response.body.items || response.body;
         expect(items).to.be.an("array");
 
-        const userTokens = scenario.tokens.filter(
-          (t) => t.sessionId === session.user.id,
+        const scenarioTokenIds = new Set(userTokens.map((t) => t.id));
+        const visibleScenarioTokens = items.filter((t) =>
+          scenarioTokenIds.has(t.id),
         );
-        expect(items).to.have.length(userTokens.length);
+        expect(visibleScenarioTokens).to.have.length(userTokens.length);
       }
 
       logger.info("✅ Token operations tested across multiple datasets");
@@ -293,10 +302,12 @@ describe("Multi-Dataset Test Suite", () => {
       // Verify isolation - users from dataset1 should not see tokens from dataset2
       const response1 = await request(TEST_CONFIG.API_URL)
         .get("/api/tokens")
+        .query({ workspace_id: tokens1[0]?.workspaceId })
         .set("Cookie", sessions1[0].cookie || "");
 
       const response2 = await request(TEST_CONFIG.API_URL)
         .get("/api/tokens")
+        .query({ workspace_id: tokens2[0]?.workspaceId })
         .set("Cookie", sessions2[0].cookie || "");
 
       if (response1.status !== 200) {

--- a/tests/integration/setup.js
+++ b/tests/integration/setup.js
@@ -333,6 +333,23 @@ const TestUtils = {
     return create.body.id || create.body?.workspace?.id || create.body?.id;
   },
 
+  // Create a dedicated workspace for isolation (avoids shared Default workspace pollution)
+  ensureDedicatedTestWorkspace: async (cookie, label = "Test WS") => {
+    const base = TEST_CONFIG.API_URL;
+    const create = await request(base)
+      .post("/api/v1/workspaces")
+      .set("Cookie", cookie)
+      .send({ name: `${label} ${Date.now()}` });
+    const workspaceId =
+      create.body.id || create.body?.workspace?.id || create.body?.id;
+    if (!workspaceId) {
+      throw new Error(
+        `Failed to create dedicated test workspace: ${JSON.stringify(create.body)}`,
+      );
+    }
+    return workspaceId;
+  },
+
   // Supertest agent for session-bound flows
   newAgent: async () => {
     return request.agent(TEST_CONFIG.API_URL);

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -76,6 +76,7 @@ tests/integration/weekly-digest-worker.integration.test.js
 
 # Audit
 tests/integration/audit-filtering.test.js
+tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
 tests/integration/database-schema.test.js
@@ -110,3 +111,4 @@ tests/integration/admin-system-settings.test.js
 tests/integration/security.test.js
 tests/integration/rate-limit-security.test.js
 tests/integration/csrf-and-rate-limit.test.js
+tests/integration/csrf-worker-exemption.test.js

--- a/tests/integration/test-data-manager.js
+++ b/tests/integration/test-data-manager.js
@@ -290,22 +290,16 @@ class TestDataManager {
 
     const tokens = [];
 
-    // Resolve workspace_id for the session once
+    // Resolve a dedicated workspace for this dataset session
     let workspaceId = null;
     try {
       const base = TEST_CONFIG.API_URL;
-      const list = await request(base)
-        .get("/api/v1/workspaces?limit=50&offset=0")
-        .set("Cookie", session.cookie || "");
-      workspaceId = list?.body?.items?.[0]?.id || null;
-      if (!workspaceId) {
-        const create = await request(base)
-          .post("/api/v1/workspaces")
-          .set("Cookie", session.cookie || "")
-          .send({ name: `Test WS ${Date.now()}` });
-        workspaceId =
-          create.body.id || create.body?.workspace?.id || create.body?.id;
-      }
+      const create = await request(base)
+        .post("/api/v1/workspaces")
+        .set("Cookie", session.cookie || "")
+        .send({ name: `Dataset WS ${datasetId}-${Date.now()}` });
+      workspaceId =
+        create.body.id || create.body?.workspace?.id || create.body?.id;
     } catch (_) {}
 
     for (let i = 0; i < tokenCount; i++) {
@@ -325,6 +319,7 @@ class TestDataManager {
           response: response,
           datasetId: datasetId,
           sessionId: session.user.id,
+          workspaceId,
           created: Date.now(),
         };
 

--- a/tests/unit/ensure-default-workspace.test.js
+++ b/tests/unit/ensure-default-workspace.test.js
@@ -268,12 +268,12 @@ describe("ensureInitialWorkspaceForUser (shared default workspace)", () => {
       "system admin must never receive workspace admin role automatically",
     );
 
-    // Belt-and-braces: ensureInitialWorkspaceForUser must no longer consult
-    // users.is_admin to derive a join role for the shared Default workspace.
+    // Belt-and-braces: resolveJoinRole / default-workspace join must not read
+    // users.is_admin (post-provisioning ensureSystemAdminWorkspaceAccess may).
     assert.strictEqual(
-      queryLog.some((q) => q.text.includes("is_admin FROM users")),
+      queryLog.some((q) => q.tx && q.text.includes("is_admin FROM users")),
       false,
-      "resolveJoinRole must not read users.is_admin in 0.6.0",
+      "default-workspace join must not read users.is_admin in 0.6.0",
     );
   });
 


### PR DESCRIPTION
## Summary
Patch release fixing auto-sync and other worker API calls broken by recent CSRF hardening, expanding system-admin audit visibility, and aligning authorization and integration tests with 0.6.0 shared Default workspace roles.

## Changes

### API
- Shared `internal-worker-auth` and `csrf-exempt` middleware restore authenticated worker bypass (`Authorization: Bearer WORKER_API_KEY`)
- System admins (`users.is_admin`) get full org audit list/export scope; role-check errors fail closed (503)
- Local login and 2FA trigger `ensureInitialWorkspaceForUser` with system-admin workspace sync on every login
- `POST /api/test-whatsapp` uses new `whatsapp.test` RBAC action (minimum `workspace_manager`, not workspace `admin`)

### Dashboard
- Audit nav and `/audit` route open to system admins
- SSO login and membership-sync metadata rendered in audit events

### Tests
- `csrf-worker-exemption.test.js`, `audit-system-admin-org-scope.test.js`
- Integration suite aligned with shared Default workspace: dedicated test workspaces, audit cleanup, UTC date assertions, alert contact-group seeding

### Infra
- Version bumped to 0.6.1 across manifests, contracts, OpenAPI, and Helm image tags

## Test plan
- [x] CI job passes (unit + integration)
- [X] Auto-sync import succeeds with worker bearer auth
- [x] System admin sees org-wide audit log and SSO metadata
- [x] Workspace manager can send test WhatsApp on Default workspace
- [x] Local system admin gets `workspace_manager` on all workspaces after login