### PR TITLE
Release TokenTimer Core v0.6.2 with system-admin RBAC preservation and AWS auto-sync hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-25
+
+### Added
+
+- **Core auto-sync provider allowlist** — `apps/worker/src/auto-sync-providers.js` hardcodes GitHub and GitLab for the OSS worker; enterprise editions replace this module via file override.
+- **Regression tests** — system-admin preserve-admin unit coverage; auto-sync provider allowlist and AWS integration tests.
+
+### Changed
+
+- **Auto-sync worker** — rejects providers outside the core allowlist with a clear failure metric instead of env-based edition flags.
+- **Dashboard AWS import** — `ImportAWSForm` and `ImportTokensModal` build auto-sync payloads compatible with the all-regions scan API.
+- **Plugin context contract** — documents that `setAutoSyncProviders` is reserved; enterprise enforces provider policy via file overrides in 0.6.x.
+- **Version metadata bumped to 0.6.2** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **System-admin workspace expansion** — `ensureSystemAdminWorkspaceAccess()` no longer downgrades existing workspace `admin` memberships to `workspace_manager`; it inserts missing rows and upgrades `viewer` only. Preserves workspace-owner RBAC for creators who are also system admins.
+- **AWS auto-sync region detection** — `detectAWSRegions()` uses per-region timeouts, batched parallel probes, and IAM key caps so all-regions scans cannot hang indefinitely.
+- **Auto-sync worker AWS payload** — worker builds correct all-regions scan requests instead of passing `region: "all-regions"` to the API.
+
 ## [0.6.1] - 2026-05-25
 
 ### Added
 
 - **System-admin organization audit** — users with `users.is_admin` can view and export the full organization audit log (not limited to workspaces where they hold `admin`); Audit UI shows SSO login and membership-sync metadata.
-- **System-admin workspace sync on local login** — `POST /auth/login` and `POST /auth/verify-2fa` call `ensureInitialWorkspaceForUser`, which upserts `workspace_manager` on every workspace for system admins (upgrades existing `viewer`/`admin` memberships).
+- **System-admin workspace sync on local login** — `POST /auth/login` and `POST /auth/verify-2fa` call `ensureInitialWorkspaceForUser`, which upserts `workspace_manager` on every workspace for system admins (adds missing rows and upgrades existing `viewer` memberships; existing workspace `admin` memberships are preserved).
 - **Integration tests** — `audit-system-admin-org-scope.test.js`, `csrf-worker-exemption.test.js`.
 
 ### Changed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/admin.js
+++ b/apps/api/routes/admin.js
@@ -81,6 +81,10 @@ function normalizeTokenSectionInput(value) {
 
 const CORE_AUTO_SYNC_PROVIDERS = ["github", "gitlab"];
 
+function isCoreAutoSyncProvider(provider) {
+  return CORE_AUTO_SYNC_PROVIDERS.includes(provider);
+}
+
 /**
  * Convert a local time (HH:MM) in a given IANA timezone to a UTC Date for
  * the given calendar date string (YYYY-MM-DD).
@@ -234,8 +238,7 @@ router.post(
         return res.status(400).json({ error: credError });
       }
       // Check provider is allowed
-      const allowed = CORE_AUTO_SYNC_PROVIDERS;
-      if (!allowed.includes(provider)) {
+      if (!isCoreAutoSyncProvider(provider)) {
         return res.status(403).json({
           error: `Auto-sync for ${provider} is not available in this edition.`,
           code: "FEATURE_NOT_AVAILABLE",
@@ -314,6 +317,20 @@ router.put(
   authorize("auto_sync.manage"),
   async (req, res) => {
     try {
+      const existing = await pool.query(
+        `SELECT provider FROM auto_sync_configs WHERE id = $1 AND workspace_id = $2`,
+        [req.params.configId, req.workspace.id],
+      );
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: "Auto-sync config not found" });
+      }
+      if (!isCoreAutoSyncProvider(existing.rows[0].provider)) {
+        return res.status(403).json({
+          error: `Auto-sync for ${existing.rows[0].provider} is not available in this edition.`,
+          code: "FEATURE_NOT_AVAILABLE",
+        });
+      }
+
       const {
         credentials,
         scan_params,
@@ -327,13 +344,6 @@ router.put(
       let idx = 1;
 
       if (credentials !== undefined) {
-        const existing = await pool.query(
-          `SELECT provider FROM auto_sync_configs WHERE id = $1 AND workspace_id = $2`,
-          [req.params.configId, req.workspace.id],
-        );
-        if (existing.rows.length === 0) {
-          return res.status(404).json({ error: "Auto-sync config not found" });
-        }
         const credError = validateAutoSyncCredentials(
           existing.rows[0].provider,
           credentials,
@@ -465,6 +475,25 @@ router.post(
   authorize("auto_sync.manage"),
   async (req, res) => {
     try {
+      const existing = await pool.query(
+        `SELECT id, provider, enabled FROM auto_sync_configs WHERE id = $1 AND workspace_id = $2`,
+        [req.params.configId, req.workspace.id],
+      );
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: "Auto-sync config not found" });
+      }
+      if (!existing.rows[0].enabled) {
+        return res
+          .status(404)
+          .json({ error: "Auto-sync config not found or disabled" });
+      }
+      if (!isCoreAutoSyncProvider(existing.rows[0].provider)) {
+        return res.status(403).json({
+          error: `Auto-sync for ${existing.rows[0].provider} is not available in this edition.`,
+          code: "FEATURE_NOT_AVAILABLE",
+        });
+      }
+
       // Mark next_sync_at as NOW so the worker picks it up immediately
       const result = await pool.query(
         `UPDATE auto_sync_configs SET next_sync_at = NOW(), updated_at = NOW()

--- a/apps/api/services/awsIntegration.js
+++ b/apps/api/services/awsIntegration.js
@@ -34,6 +34,31 @@ const ALL_AWS_REGIONS = [
   "sa-east-1",
 ];
 
+const DETECT_REQUEST_TIMEOUT_MS = 8000;
+const DETECT_CONNECTION_TIMEOUT_MS = 5000;
+const DETECT_REGION_WALL_MS = 12000;
+const DETECT_REGION_BATCH_SIZE = 5;
+const DETECT_IAM_MAX_USERS_FOR_KEYS = 10;
+const DETECT_IAM_WALL_MS = 20000;
+
+function createDetectRequestHandler() {
+  return {
+    connectionTimeout: DETECT_CONNECTION_TIMEOUT_MS,
+    requestTimeout: DETECT_REQUEST_TIMEOUT_MS,
+    throwOnRequestTimeout: true,
+  };
+}
+
+function withWallClockTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // AWS integration using AWS SDK
 // Note: Requires AWS SDK packages: @aws-sdk/client-secrets-manager and @aws-sdk/client-iam
 async function scanAWS({
@@ -538,9 +563,7 @@ async function detectAWSRegions({
       const stsClient = new STSClient({
         region: "us-east-1",
         credentials: { accessKeyId, secretAccessKey, sessionToken },
-        requestHandler: {
-          requestTimeout: 10000,
-        },
+        requestHandler: createDetectRequestHandler(),
       });
       const identity = await stsClient.send(new GetCallerIdentityCommand({}));
       logger.info("AWS credentials validated", {
@@ -562,9 +585,7 @@ async function detectAWSRegions({
       const testClient = new SecretsManagerClient({
         region: "us-east-1",
         credentials: { accessKeyId, secretAccessKey, sessionToken },
-        requestHandler: {
-          requestTimeout: 10000,
-        },
+        requestHandler: createDetectRequestHandler(),
       });
       await testClient.send(new ListSecretsCommand({ MaxResults: 1 }));
       logger.info("AWS credentials validated (via Secrets Manager)");
@@ -593,69 +614,63 @@ async function detectAWSRegions({
     }
   }
 
+  const credentials = { accessKeyId, secretAccessKey, sessionToken };
+
   // Check each region in parallel (with concurrency limit)
   const checkRegion = async (region) => {
     let secretCount = 0;
     let certCount = 0;
 
-    // Check Secrets Manager
-    try {
+    const checkSecrets = async () => {
       const client = new SecretsManagerClient({
         region,
-        credentials: { accessKeyId, secretAccessKey, sessionToken },
-        requestHandler: {
-          requestTimeout: 10000, // 10 second timeout for quick detection
-        },
+        credentials,
+        requestHandler: createDetectRequestHandler(),
       });
-
-      // Just list secrets, don't describe them
       const listResponse = await client.send(
         new ListSecretsCommand({ MaxResults: 1 }),
       );
-      secretCount = listResponse.SecretList?.length || 0;
+      return listResponse.SecretList?.length || 0;
+    };
 
-      if (secretCount > 0) {
-        regionsWithSecrets.push(region);
-      }
-    } catch (e) {
-      // Don't throw errors during region scanning - credentials were already validated
-      // Region might not be enabled, lacks permissions, or has other issues
-      // Just log and continue to other regions
+    const checkCertificates = async () => {
+      if (!ACMClient) return 0;
+      const client = new ACMClient({
+        region,
+        credentials,
+        requestHandler: createDetectRequestHandler(),
+      });
+      const listResponse = await client.send(
+        new ListCertificatesCommand({ MaxItems: 1 }),
+      );
+      return listResponse.CertificateSummaryList?.length || 0;
+    };
+
+    const checks = [checkSecrets()];
+    if (ACMClient) checks.push(checkCertificates());
+
+    const settled = await Promise.allSettled(checks);
+    if (settled[0].status === "fulfilled") {
+      secretCount = settled[0].value;
+      if (secretCount > 0) regionsWithSecrets.push(region);
+    } else {
       logger.debug("AWS region Secrets Manager check failed", {
         region,
-        error: e.message,
-        errorName: e.name,
+        error: settled[0].reason?.message,
+        errorName: settled[0].reason?.name,
       });
     }
 
-    // Check ACM Certificates
     if (ACMClient) {
-      try {
-        const client = new ACMClient({
-          region,
-          credentials: { accessKeyId, secretAccessKey, sessionToken },
-          requestHandler: {
-            requestTimeout: 10000, // 10 second timeout for quick detection
-          },
-        });
-
-        // Just list certificates, don't describe them
-        const listResponse = await client.send(
-          new ListCertificatesCommand({ MaxItems: 1 }),
-        );
-        certCount = listResponse.CertificateSummaryList?.length || 0;
-
-        if (certCount > 0) {
-          regionsWithCertificates.push(region);
-        }
-      } catch (e) {
-        // Don't throw errors during region scanning - credentials were already validated
-        // Region might not be enabled, lacks permissions, or has other issues
-        // Just log and continue to other regions
+      const certResult = settled[1];
+      if (certResult?.status === "fulfilled") {
+        certCount = certResult.value;
+        if (certCount > 0) regionsWithCertificates.push(region);
+      } else if (certResult?.status === "rejected") {
         logger.debug("AWS region ACM check failed", {
           region,
-          error: e.message,
-          errorName: e.name,
+          error: certResult.reason?.message,
+          errorName: certResult.reason?.name,
         });
       }
     }
@@ -680,54 +695,66 @@ async function detectAWSRegions({
   };
 
   // Process regions in batches to avoid overwhelming the API
-  const batchSize = 10; // Increased from 5 to speed up detection
-  for (let i = 0; i < ALL_AWS_REGIONS.length; i += batchSize) {
-    const batch = ALL_AWS_REGIONS.slice(i, i + batchSize);
-    await Promise.all(batch.map((region) => checkRegion(region)));
+  for (let i = 0; i < ALL_AWS_REGIONS.length; i += DETECT_REGION_BATCH_SIZE) {
+    const batch = ALL_AWS_REGIONS.slice(i, i + DETECT_REGION_BATCH_SIZE);
+    await Promise.all(
+      batch.map((region) =>
+        withWallClockTimeout(
+          checkRegion(region),
+          DETECT_REGION_WALL_MS,
+          `region ${region}`,
+        ).catch((e) => {
+          logger.debug("AWS region detection skipped", {
+            region,
+            error: e.message,
+          });
+        }),
+      ),
+    );
   }
 
   // Check for IAM users and keys (global - only need to check once)
   if (IAMClient) {
     try {
-      logger.info("Checking for IAM users and access keys (global)");
-      const client = new IAMClient({
-        region: "us-east-1", // IAM is global, but we need to specify a region for the client
-        credentials: { accessKeyId, secretAccessKey, sessionToken },
-        requestHandler: {
-          requestTimeout: 10000, // 10 second timeout
-        },
-      });
-
-      const usersResponse = await client.send(
-        new ListUsersCommand({ MaxItems: 100 }),
-      );
-      const users = usersResponse.Users || [];
-      iamUsersCount = users.length;
-
-      // Count total access keys across all users (limit to first 100 users for quick detection)
-      for (const user of users.slice(0, 100)) {
-        try {
-          const keysResponse = await client.send(
-            new ListAccessKeysCommand({ UserName: user.UserName }),
-          );
-          const keys = keysResponse.AccessKeyMetadata || [];
-          iamKeysCount += keys.length;
-        } catch (e) {
-          logger.debug("Failed to list keys for IAM user", {
-            userName: user.UserName,
-            error: e.message,
+      await withWallClockTimeout(
+        (async () => {
+          logger.info("Checking for IAM users and access keys (global)");
+          const client = new IAMClient({
+            region: "us-east-1",
+            credentials,
+            requestHandler: createDetectRequestHandler(),
           });
-        }
-      }
 
-      logger.info("IAM detection completed", {
-        users: iamUsersCount,
-        keys: iamKeysCount,
-      });
+          const usersResponse = await client.send(
+            new ListUsersCommand({ MaxItems: 100 }),
+          );
+          const users = usersResponse.Users || [];
+          iamUsersCount = users.length;
+
+          for (const user of users.slice(0, DETECT_IAM_MAX_USERS_FOR_KEYS)) {
+            try {
+              const keysResponse = await client.send(
+                new ListAccessKeysCommand({ UserName: user.UserName }),
+              );
+              const keys = keysResponse.AccessKeyMetadata || [];
+              iamKeysCount += keys.length;
+            } catch (e) {
+              logger.debug("Failed to list keys for IAM user", {
+                userName: user.UserName,
+                error: e.message,
+              });
+            }
+          }
+
+          logger.info("IAM detection completed", {
+            users: iamUsersCount,
+            keys: iamKeysCount,
+          });
+        })(),
+        DETECT_IAM_WALL_MS,
+        "IAM detection",
+      );
     } catch (e) {
-      // Don't throw errors during region scanning - credentials were already validated
-      // IAM might lack permissions or have other issues
-      // Just log and continue
       logger.warn("Failed to check IAM users", {
         error: e.message,
         errorName: e.name,

--- a/apps/api/services/systemAdmin.js
+++ b/apps/api/services/systemAdmin.js
@@ -39,8 +39,8 @@ async function countOtherActiveSystemAdmins(queryable, userId) {
 
 /**
  * Grant workspace_manager on every workspace for installation system admins.
- * On conflict, upgrades workspace admin or viewer to workspace_manager so
- * system admins never retain implicit workspace owner or read-only-only access.
+ * On conflict, upgrades viewer to workspace_manager only. Existing workspace
+ * admin memberships are preserved. Inserts workspace_manager where missing.
  *
  * @returns {{ applied: number }}
  */
@@ -59,7 +59,7 @@ async function ensureSystemAdminWorkspaceAccess(db, userId) {
        FROM workspaces w
      ON CONFLICT (user_id, workspace_id) DO UPDATE
        SET role = CASE
-             WHEN workspace_memberships.role IN ('admin', 'viewer')
+             WHEN workspace_memberships.role = 'viewer'
                THEN 'workspace_manager'
              ELSE workspace_memberships.role
            END

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -65,7 +65,9 @@ import CopyableCodeBlock from './CopyableCodeBlock';
 import ImportVaultForm from './imports/ImportVaultForm';
 import ImportGitLabForm from './imports/ImportGitLabForm';
 import ImportGitHubForm from './imports/ImportGitHubForm';
-import ImportAWSForm from './imports/ImportAWSForm';
+import ImportAWSForm, {
+  buildAwsAutoSyncPayload,
+} from './imports/ImportAWSForm';
 import ImportAzureForm from './imports/ImportAzureForm';
 import ImportGCPForm from './imports/ImportGCPForm';
 
@@ -895,6 +897,8 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
   const [awsSecretAccessKey, _setAwsSecretAccessKey] = React.useState('');
   const [awsRegion, setAwsRegion] = React.useState('us-east-1');
   const [_awsDetectedRegions, _setAwsDetectedRegions] = React.useState([]);
+  const [awsAutoSyncScanParams, setAwsAutoSyncScanParams] =
+    React.useState(null);
   const [_awsDetectionResults, _setAwsDetectionResults] = React.useState(null);
   const [_awsIamInfo, _setAwsIamInfo] = React.useState(null);
   const [_awsDetecting, _setAwsDetecting] = React.useState(false);
@@ -1017,7 +1021,20 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
               if (sp.pathPrefix !== undefined) setPathPrefix(sp.pathPrefix);
               break;
             case 'aws':
-              if (sp.region) setAwsRegion(sp.region);
+              if (
+                sp.scanMode === 'all-regions' ||
+                sp.region === 'all-regions'
+              ) {
+                setAwsRegion('all-regions');
+              } else if (sp.scanMode === 'global' || sp.region === 'global') {
+                setAwsRegion('global');
+              } else if (sp.region) {
+                setAwsRegion(sp.region);
+              }
+              if (Array.isArray(sp.detectedRegions)) {
+                _setAwsDetectedRegions(sp.detectedRegions);
+              }
+              setAwsAutoSyncScanParams(sp);
               break;
             case 'azure':
               if (sp.vaultUrl) setAzureVaultUrl(sp.vaultUrl);
@@ -1034,6 +1051,8 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
               if (sp.projectId) setGcpProjectId(sp.projectId);
               break;
           }
+        } else if (source === 'aws') {
+          setAwsAutoSyncScanParams(null);
         }
       } catch (_) {
         setAutoSyncConfig(false);
@@ -1101,15 +1120,17 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
       }
       case 'aws': {
         const formCreds = awsFormRef.current?.getCredentials();
-        credentials = formCreds?.credentials ?? {
-          accessKeyId: awsAccessKeyId,
-          secretAccessKey: awsSecretAccessKey,
-          region: awsRegion || 'us-east-1',
-        };
-        scanParams = formCreds?.scanParams ?? {
-          region: awsRegion || 'us-east-1',
-          include: { secrets: true, iam: true, certificates: true },
-        };
+        if (formCreds) {
+          credentials = formCreds.credentials;
+          scanParams = formCreds.scanParams;
+        } else {
+          ({ credentials, scanParams } = buildAwsAutoSyncPayload({
+            accessKeyId: awsAccessKeyId,
+            secretAccessKey: awsSecretAccessKey,
+            awsRegion,
+            awsDetectedRegions: _awsDetectedRegions,
+          }));
+        }
         break;
       }
       case 'azure': {
@@ -2118,6 +2139,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
               {source === 'aws' ? (
                 <ImportAWSForm
                   ref={awsFormRef}
+                  initialAutoSyncScanParams={awsAutoSyncScanParams}
                   workspaceId={workspaceId}
                   onImportComplete={selected => {
                     setIsImporting(false);

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -81,6 +81,36 @@ async function checkDuplicatesForItems(items, workspaceId) {
   return new Set();
 }
 
+export function buildAwsAutoSyncPayload({
+  accessKeyId,
+  secretAccessKey,
+  awsRegion,
+  awsDetectedRegions = [],
+}) {
+  const scanMode =
+    awsRegion === 'all-regions'
+      ? 'all-regions'
+      : awsRegion === 'global'
+        ? 'global'
+        : 'single';
+  const region = scanMode === 'single' ? awsRegion || 'us-east-1' : 'us-east-1';
+
+  return {
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+      region,
+    },
+    scanParams: {
+      scanMode,
+      region,
+      detectedRegions:
+        scanMode === 'all-regions' ? [...awsDetectedRegions] : [],
+      maxItems: 500,
+    },
+  };
+}
+
 const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   {
     workspaceId,
@@ -97,6 +127,7 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
     extractQuotaFromError,
     contactGroups,
     onSelectionChange,
+    initialAutoSyncScanParams = null,
   },
   ref
 ) {
@@ -121,6 +152,21 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsAws.size);
   }, [selectedRowsAws.size, onSelectionChange]);
+
+  React.useEffect(() => {
+    if (!initialAutoSyncScanParams) return;
+    const sp = initialAutoSyncScanParams;
+    if (sp.scanMode === 'all-regions' || sp.region === 'all-regions') {
+      setAwsRegion('all-regions');
+    } else if (sp.scanMode === 'global' || sp.region === 'global') {
+      setAwsRegion('global');
+    } else if (sp.region) {
+      setAwsRegion(sp.region);
+    }
+    if (Array.isArray(sp.detectedRegions)) {
+      setAwsDetectedRegions(sp.detectedRegions);
+    }
+  }, [initialAutoSyncScanParams]);
 
   const detectAwsRegions = async () => {
     onError && onError(null);
@@ -344,17 +390,13 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   React.useImperativeHandle(ref, () => ({
     importSelected: importAwsSelected,
     getSelectedCount: () => selectedRowsAws.size,
-    getCredentials: () => ({
-      credentials: {
+    getCredentials: () =>
+      buildAwsAutoSyncPayload({
         accessKeyId: awsAccessKeyId,
         secretAccessKey: awsSecretAccessKey,
-        region: awsRegion || 'us-east-1',
-      },
-      scanParams: {
-        region: awsRegion || 'us-east-1',
-        include: { secrets: true, iam: true, certificates: true },
-      },
-    }),
+        awsRegion,
+        awsDetectedRegions,
+      }),
   }));
 
   return (

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/apps/worker/src/auto-sync-providers.js
+++ b/apps/worker/src/auto-sync-providers.js
@@ -1,0 +1,12 @@
+/**
+ * Core auto-sync provider allowlist.
+ *
+ * Hardcoded to github/gitlab. Enterprise replaces this file via
+ * src/worker/auto-sync-providers.js in tokentimer-enterprise.
+ */
+
+export const CORE_AUTO_SYNC_PROVIDERS = ["github", "gitlab"];
+
+export function isAutoSyncProviderAllowed(provider) {
+  return CORE_AUTO_SYNC_PROVIDERS.includes(provider);
+}

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -1,9 +1,12 @@
 /**
- * Auto-Sync Worker
+ * Auto-Sync Worker (Core)
  *
  * Processes scheduled integration scans from auto_sync_configs.
  * Picks up configs where next_sync_at <= NOW() and enabled = TRUE,
  * runs the corresponding scan, imports results, and updates status.
+ *
+ * Core edition supports github and gitlab only. Enterprise replaces this
+ * file via src/worker/auto-sync-worker.js in tokentimer-enterprise.
  */
 
 import { pool, withClient } from "./db.js";
@@ -16,6 +19,7 @@ import {
 } from "./metrics.js";
 import crypto from "crypto";
 import axios from "axios";
+import { isAutoSyncProviderAllowed } from "./auto-sync-providers.js";
 
 // Encryption helpers — must mirror systemSettings.js exactly
 const KDF_SALT = "tokentimer-settings-encryption";
@@ -209,194 +213,151 @@ async function runAutoSync() {
         } = config;
         logger.info(`Syncing ${provider} for workspace ${workspace_id}`);
 
-      try {
-        // Decrypt credentials
-        const credJson = decrypt(credentials_encrypted);
-        if (!credJson) {
-          throw new Error("Failed to decrypt credentials");
-        }
-        const creds = JSON.parse(credJson);
-
-        // Validate that required credential fields are present before hitting
-        // the scan endpoint, so missing-field errors surface with clear context
-        // rather than an opaque 400 from the downstream API.
-        const REQUIRED_CRED_FIELDS = {
-          github: ["token"],
-          gitlab: ["token"],
-          aws: ["accessKeyId", "secretAccessKey"],
-          azure: ["token"],
-          "azure-ad": ["token"],
-          gcp: ["projectId", "accessToken"],
-          vault: ["address", "token"],
-        };
-        const missing = (REQUIRED_CRED_FIELDS[provider] || []).filter(
-          (f) => !creds[f],
-        );
-        if (missing.length > 0) {
-          const detail = missing.map((f) =>
-            f in creds ? `${f} (empty)` : `${f} (absent)`,
+        // Guard against stale rows (e.g. restored from an enterprise backup).
+        // Core rejects providers outside the github/gitlab allowlist without
+        // calling the scan API.
+        if (!isAutoSyncProviderAllowed(provider)) {
+          const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
+          const message = `Auto-sync for ${provider} is not available in this edition.`;
+          await client.query(
+            `UPDATE auto_sync_configs
+             SET last_sync_at = NOW(), last_sync_status = 'failed', last_sync_error = $1,
+                 next_sync_at = $2, updated_at = NOW()
+             WHERE id = $3`,
+            [message, nextSync, id],
           );
-          throw new Error(
-            `Invalid credentials for ${provider}: ${detail.join(", ")}. ` +
-              `Re-save the auto-sync config with valid credentials.`,
+          logger.warn(message, { workspace_id, provider });
+          cAutoSync.inc({ provider, status: "failure" });
+          gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
+          return;
+        }
+
+        try {
+          // Decrypt credentials
+          const credJson = decrypt(credentials_encrypted);
+          if (!credJson) {
+            throw new Error("Failed to decrypt credentials");
+          }
+          const creds = JSON.parse(credJson);
+
+          // Validate that required credential fields are present before hitting
+          // the scan endpoint, so missing-field errors surface with clear context
+          // rather than an opaque 400 from the downstream API.
+          const REQUIRED_CRED_FIELDS = {
+            github: ["token"],
+            gitlab: ["token"],
+          };
+          const missing = (REQUIRED_CRED_FIELDS[provider] || []).filter(
+            (f) => !creds[f],
           );
-        }
+          if (missing.length > 0) {
+            const detail = missing.map((f) =>
+              f in creds ? `${f} (empty)` : `${f} (absent)`,
+            );
+            throw new Error(
+              `Invalid credentials for ${provider}: ${detail.join(", ")}. ` +
+                `Re-save the auto-sync config with valid credentials.`,
+            );
+          }
 
-        // Call the API's scan endpoint via HTTP
-        const apiUrl = process.env.API_URL || "http://api:4000";
-        const workerKey =
-          process.env.WORKER_API_KEY || process.env.SESSION_SECRET;
-        const authHeaders = workerKey
-          ? { Authorization: `Bearer ${workerKey}` }
-          : {};
-        let scanUrl;
-        let scanBody;
+          // Call the API's scan endpoint via HTTP
+          const apiUrl = process.env.API_URL || "http://api:4000";
+          const workerKey =
+            process.env.WORKER_API_KEY || process.env.SESSION_SECRET;
+          const authHeaders = workerKey
+            ? { Authorization: `Bearer ${workerKey}` }
+            : {};
+          let scanUrl;
+          let scanBody;
 
-        switch (provider) {
-          case "github":
-            scanUrl = `${apiUrl}/api/v1/integrations/github/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              baseUrl: creds.baseUrl || "https://api.github.com",
-              token: creds.token,
-              include: scan_params?.include || {
-                tokens: true,
-                sshKeys: true,
-                deployKeys: true,
-                secrets: true,
-              },
-              maxItems: scan_params?.maxItems || 500,
-            };
-            break;
-          case "gitlab":
-            scanUrl = `${apiUrl}/api/v1/integrations/gitlab/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              baseUrl: creds.baseUrl || "https://gitlab.com",
-              token: creds.token,
-              include: scan_params?.include || { tokens: true, keys: true },
-              maxItems: scan_params?.maxItems || 500,
-              filters: scan_params?.filters || {},
-            };
-            break;
-          case "aws":
-            scanUrl = `${apiUrl}/api/v1/integrations/aws/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              accessKeyId: creds.accessKeyId,
-              secretAccessKey: creds.secretAccessKey,
-              sessionToken: creds.sessionToken || null,
-              region: creds.region || scan_params?.region || "us-east-1",
-              include: scan_params?.include || {
-                secrets: true,
-                iam: true,
-                certificates: true,
-              },
-              maxItems: scan_params?.maxItems || 500,
-            };
-            break;
-          case "azure":
-            scanUrl = `${apiUrl}/api/v1/integrations/azure/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              vaultUrl: creds.vaultUrl,
-              token: creds.token,
-              include: scan_params?.include || {
-                secrets: true,
-                certificates: true,
-                keys: true,
-              },
-              maxItems: scan_params?.maxItems || 500,
-            };
-            break;
-          case "azure-ad":
-            scanUrl = `${apiUrl}/api/v1/integrations/azure-ad/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              token: creds.token,
-              include: scan_params?.include || {
-                applications: true,
-                servicePrincipals: true,
-              },
-              maxItems: scan_params?.maxItems || 500,
-            };
-            break;
-          case "gcp":
-            scanUrl = `${apiUrl}/api/v1/integrations/gcp/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              projectId: creds.projectId,
-              accessToken: creds.accessToken,
-              include: scan_params?.include || { secrets: true },
-              maxItems: scan_params?.maxItems || 500,
-            };
-            break;
-          case "vault":
-            scanUrl = `${apiUrl}/api/v1/integrations/vault/scan?workspace_id=${workspace_id}`;
-            scanBody = {
-              address: creds.address,
-              token: creds.token,
-              include: scan_params?.include || { kv: true, pki: true },
-              maxItemsPerMount: scan_params?.maxItemsPerMount || 250,
-              pathPrefix: scan_params?.pathPrefix || null,
-            };
-            break;
-          default:
-            throw new Error(`Unknown provider: ${provider}`);
-        }
+          switch (provider) {
+            case "github":
+              scanUrl = `${apiUrl}/api/v1/integrations/github/scan?workspace_id=${workspace_id}`;
+              scanBody = {
+                baseUrl: creds.baseUrl || "https://api.github.com",
+                token: creds.token,
+                include: scan_params?.include || {
+                  tokens: true,
+                  sshKeys: true,
+                  deployKeys: true,
+                  secrets: true,
+                },
+                maxItems: scan_params?.maxItems || 500,
+              };
+              break;
+            case "gitlab":
+              scanUrl = `${apiUrl}/api/v1/integrations/gitlab/scan?workspace_id=${workspace_id}`;
+              scanBody = {
+                baseUrl: creds.baseUrl || "https://gitlab.com",
+                token: creds.token,
+                include: scan_params?.include || { tokens: true, keys: true },
+                maxItems: scan_params?.maxItems || 500,
+                filters: scan_params?.filters || {},
+              };
+              break;
+            default:
+              throw new Error(`Unknown provider: ${provider}`);
+          }
 
-        // 1. Scan: discover items from the provider
-        const scanResponse = await axios.post(scanUrl, scanBody, {
-          timeout: 120000,
-          headers: authHeaders,
-        });
-        const scanResult = scanResponse.data;
-        const itemsCount = scanResult?.items?.length || 0;
+          // 1. Scan: discover items from the provider
+          const scanResponse = await axios.post(scanUrl, scanBody, {
+            timeout: 120000,
+            headers: authHeaders,
+          });
+          const scanResult = scanResponse.data;
+          const itemsCount = scanResult?.items?.length || 0;
 
-        // 2. Import: delegate to the existing import endpoint so deduplication,
-        //    sanitization, type validation, and audit logging are identical to
-        //    what a user gets when importing manually from the dashboard.
-        if (itemsCount > 0) {
-          const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
-          await axios.post(
-            importUrl,
-            { items: scanResult.items },
-            { timeout: 60000, headers: authHeaders },
+          // 2. Import: delegate to the existing import endpoint so deduplication,
+          //    sanitization, type validation, and audit logging are identical to
+          //    what a user gets when importing manually from the dashboard.
+          if (itemsCount > 0) {
+            const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
+            await axios.post(
+              importUrl,
+              { items: scanResult.items },
+              { timeout: 60000, headers: authHeaders },
+            );
+          }
+
+          // Update config: success
+          const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
+          await client.query(
+            `UPDATE auto_sync_configs
+             SET last_sync_at = NOW(), last_sync_status = 'success', last_sync_error = NULL,
+                 last_sync_items_count = $1, next_sync_at = $2, updated_at = NOW()
+             WHERE id = $3`,
+            [itemsCount, nextSync, id],
+          );
+
+          cAutoSync.inc({ provider, status: "success" });
+          cAutoSyncItems.inc({ provider }, itemsCount);
+          gAutoSyncLastRun.set({ provider, status: "success" }, Date.now() / 1000);
+          logger.info(`Auto-sync ${provider} completed: ${itemsCount} items`, {
+            workspace_id,
+          });
+        } catch (syncErr) {
+          logger.error(`Auto-sync ${provider} failed`, {
+            workspace_id,
+            error: syncErr?.message || String(syncErr),
+            httpStatus: syncErr?.response?.status,
+            httpBody: syncErr?.response?.data,
+            stack: syncErr?.stack,
+          });
+
+          cAutoSync.inc({ provider, status: "failure" });
+          gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
+          // Update config: failed
+          const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
+          await client.query(
+            `UPDATE auto_sync_configs
+             SET last_sync_at = NOW(), last_sync_status = 'failed',
+                 last_sync_error = $1, next_sync_at = $2, updated_at = NOW()
+             WHERE id = $3`,
+            [String(syncErr?.message || syncErr).substring(0, 1000), nextSync, id],
           );
         }
-
-        // Update config: success
-        const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
-        await client.query(
-          `UPDATE auto_sync_configs
-           SET last_sync_at = NOW(), last_sync_status = 'success', last_sync_error = NULL,
-               last_sync_items_count = $1, next_sync_at = $2, updated_at = NOW()
-           WHERE id = $3`,
-          [itemsCount, nextSync, id],
-        );
-
-        cAutoSync.inc({ provider, status: "success" });
-        cAutoSyncItems.inc({ provider }, itemsCount);
-        gAutoSyncLastRun.set({ provider, status: "success" }, Date.now() / 1000);
-        logger.info(`Auto-sync ${provider} completed: ${itemsCount} items`, {
-          workspace_id,
-        });
-      } catch (syncErr) {
-        logger.error(`Auto-sync ${provider} failed`, {
-          workspace_id,
-          error: syncErr?.message || String(syncErr),
-          httpStatus: syncErr?.response?.status,
-          httpBody: syncErr?.response?.data,
-          stack: syncErr?.stack,
-        });
-
-        cAutoSync.inc({ provider, status: "failure" });
-        gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
-        // Update config: failed
-        const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
-        await client.query(
-          `UPDATE auto_sync_configs
-           SET last_sync_at = NOW(), last_sync_status = 'failed',
-               last_sync_error = $1, next_sync_at = $2, updated_at = NOW()
-           WHERE id = $3`,
-          [String(syncErr?.message || syncErr).substring(0, 1000), nextSync, id],
-        );
-      }
-    }));
+      }),
+    );
 
     // Commit all status updates and release the FOR UPDATE locks atomically.
     await client.query("COMMIT");

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.6.1
-appVersion: "0.6.1"
+version: 0.6.2
+appVersion: "0.6.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.6.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -315,6 +315,8 @@ VALUES ('admin@company.com', '$2b$12$...', 'Admin', 'local', TRUE);
 
 **A**: No. System admin (`users.is_admin`) and workspace owner (`workspace_memberships.role = 'admin'`) are independent. SSO or manual system-admin grants do not promote users to workspace owner. Users joining an existing Default workspace always get **workspace_manager**, including system admins. Only the user who creates Default on an empty install becomes workspace owner automatically.
 
+System-admin expansion (manual toggle, SSO admin grant, or login provisioning) adds missing `workspace_manager` rows on every workspace and may raise `viewer` to `workspace_manager` where needed. It never downgrades an existing workspace `admin` membership.
+
 ### Q: Can I make a second workspace owner on Default?
 
 **A**: Not through the dashboard or public API today. Workspace owner is assigned at workspace creation only. You can grant a second user **system admin** from **Workspaces → Members**, which gives installation-wide settings access but not workspace-owner powers (delete workspace, transfer tokens, etc.). Multiple workspace owners per workspace are planned for [v1.0.0](../ROADMAP.md#v100----rbac-and-role-model-cleanup).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.6.1
+  version: 0.6.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {
@@ -16,6 +16,7 @@
   },
   "notes": [
     "This artifact defines expected contract shape regardless of current wiring maturity.",
-    "Consumers should feature-detect hook availability before invoking."
+    "Consumers should feature-detect hook availability before invoking.",
+    "As of core 0.6.x, enterprise auto-sync provider policy is enforced via file overrides (admin.js, auto-sync-worker.js); setAutoSyncProviders is not wired in core yet."
   ]
 }

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/auto-sync-providers.unit.test.js
+++ b/tests/integration/auto-sync-providers.unit.test.js
@@ -1,0 +1,40 @@
+const { expect } = require("chai");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+async function importFresh(relativePath) {
+  const abs = path.join(__dirname, "..", "..", relativePath);
+  const href = `${pathToFileURL(abs).href}?t=${Date.now()}-${Math.random()}`;
+  return import(href);
+}
+
+describe("auto-sync-providers (core)", () => {
+  const envKeys = ["TT_MODE", "AUTO_SYNC_PROVIDERS"];
+
+  afterEach(() => {
+    for (const key of envKeys) delete process.env[key];
+  });
+
+  it("allows github and gitlab only", async () => {
+    const mod = await importFresh("apps/worker/src/auto-sync-providers.js");
+    expect(mod.CORE_AUTO_SYNC_PROVIDERS).to.deep.equal(["github", "gitlab"]);
+    expect(mod.isAutoSyncProviderAllowed("github")).to.equal(true);
+    expect(mod.isAutoSyncProviderAllowed("gitlab")).to.equal(true);
+    expect(mod.isAutoSyncProviderAllowed("aws")).to.equal(false);
+    expect(mod.isAutoSyncProviderAllowed("vault")).to.equal(false);
+  });
+
+  it("ignores TT_MODE=enterprise env override", async () => {
+    process.env.TT_MODE = "enterprise";
+    const mod = await importFresh("apps/worker/src/auto-sync-providers.js");
+    expect(mod.isAutoSyncProviderAllowed("aws")).to.equal(false);
+  });
+
+  it("ignores AUTO_SYNC_PROVIDERS env override", async () => {
+    process.env.AUTO_SYNC_PROVIDERS = "aws,vault,github";
+    const mod = await importFresh("apps/worker/src/auto-sync-providers.js");
+    expect(mod.isAutoSyncProviderAllowed("aws")).to.equal(false);
+    expect(mod.isAutoSyncProviderAllowed("vault")).to.equal(false);
+    expect(mod.isAutoSyncProviderAllowed("github")).to.equal(true);
+  });
+});

--- a/tests/integration/auto-sync-worker.integration.test.js
+++ b/tests/integration/auto-sync-worker.integration.test.js
@@ -71,6 +71,53 @@ describe("Auto-sync worker integration", function () {
     expect(result.rows[0].processed).to.equal(0);
   });
 
+  it("rejects enterprise-only providers without running a scan", async () => {
+    await TestUtils.execQuery(
+      "DELETE FROM auto_sync_configs WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    const creds = encryptCredentials(
+      JSON.stringify({
+        accessKeyId: "AKIATEST",
+        secretAccessKey: "secret",
+      }),
+      workerSecret,
+    );
+
+    const inserted = await TestUtils.execQuery(
+      `INSERT INTO auto_sync_configs
+         (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+       VALUES
+         ($1, 'aws', $2, 'daily', '00:01', 'UTC', TRUE, NOW() - INTERVAL '5 minutes', $3)
+       RETURNING id`,
+      [workspaceId, creds, testUser.id],
+    );
+    const configId = inserted.rows[0].id;
+
+    await TestUtils.runNode(
+      "node",
+      ["src/auto-sync-worker.js"],
+      "apps/worker",
+      {
+        ...process.env,
+        SESSION_SECRET: workerSecret,
+        API_URL: process.env.TEST_API_URL || "http://localhost:4000",
+        TT_MODE: "enterprise",
+        AUTO_SYNC_PROVIDERS: "aws,github,gitlab",
+      },
+    );
+
+    const row = await TestUtils.execQuery(
+      `SELECT last_sync_status, last_sync_error
+       FROM auto_sync_configs WHERE id = $1`,
+      [configId],
+    );
+    expect(row.rows[0].last_sync_status).to.equal("failed");
+    expect(row.rows[0].last_sync_error).to.match(
+      /not available in this edition/i,
+    );
+  });
+
   it("handles provider failure and keeps idempotency across repeated runs", async () => {
     await TestUtils.execQuery(
       "DELETE FROM auto_sync_configs WHERE workspace_id = $1",

--- a/tests/integration/auto-sync.test.js
+++ b/tests/integration/auto-sync.test.js
@@ -90,6 +90,73 @@ describe("Auto-Sync CRUD", function () {
       .expect(401);
   });
 
+  it("POST /auto-sync - should reject enterprise-only providers in core (403)", async () => {
+    const res = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/auto-sync`)
+      .set("Cookie", session.cookie)
+      .send({
+        provider: "aws",
+        credentials: {
+          accessKeyId: "AKIATEST",
+          secretAccessKey: "secret",
+        },
+        frequency: "daily",
+        schedule_time: "09:00",
+        schedule_tz: "UTC",
+      })
+      .expect(403);
+
+    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
+    expect(res.body.error).to.match(/not available in this edition/i);
+  });
+
+  // --- Edition gates for stale DB rows (e.g. restored from enterprise backup) ---
+
+  it("PUT /auto-sync/:id - should reject enterprise-only providers in core (403)", async () => {
+    const inserted = await TestUtils.execQuery(
+      `INSERT INTO auto_sync_configs
+         (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+       VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
+       RETURNING id`,
+      [workspaceId, testUser.id],
+    );
+    const staleId = inserted.rows[0].id;
+
+    const res = await request(BASE)
+      .put(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}`)
+      .set("Cookie", session.cookie)
+      .send({ frequency: "weekly" })
+      .expect(403);
+
+    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
+
+    await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
+      staleId,
+    ]);
+  });
+
+  it("POST /auto-sync/:id/run - should reject enterprise-only providers in core (403)", async () => {
+    const inserted = await TestUtils.execQuery(
+      `INSERT INTO auto_sync_configs
+         (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+       VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
+       RETURNING id`,
+      [workspaceId, testUser.id],
+    );
+    const staleId = inserted.rows[0].id;
+
+    const res = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}/run`)
+      .set("Cookie", session.cookie)
+      .expect(403);
+
+    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
+
+    await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
+      staleId,
+    ]);
+  });
+
   // --- GET list ---
 
   it("GET /auto-sync - should return the created config", async () => {

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -72,6 +72,8 @@ tests/integration/integrations-route-matrix.test.js
 # Auto-sync worker
 tests/integration/auto-sync.test.js
 tests/integration/auto-sync-worker.integration.test.js
+tests/integration/auto-sync-providers.unit.test.js
+tests/integration/auto-sync-import.test.js
 tests/integration/weekly-digest-worker.integration.test.js
 
 # Audit

--- a/tests/unit/system-admin.test.js
+++ b/tests/unit/system-admin.test.js
@@ -7,6 +7,7 @@ const {
   lockSystemAdminMutation,
   countActiveSystemAdmins,
   countOtherActiveSystemAdmins,
+  ensureSystemAdminWorkspaceAccess,
   SYSTEM_ADMIN_LOCK_KEY,
 } = require("../../apps/api/services/systemAdmin");
 
@@ -69,5 +70,37 @@ describe("systemAdmin helpers", () => {
     assert.strictEqual(await countOtherActiveSystemAdmins(queryable, 9), 1);
     assert.match(queries[0].sql, /@example\.invalid/);
     assert.match(queries[0].sql, /Deleted Account/);
+  });
+
+  it("ensureSystemAdminWorkspaceAccess upgrades viewer but preserves workspace admin", async () => {
+    let upsertSql = "";
+    const queryable = {
+      query: async (sql) => {
+        if (sql.includes("SELECT is_admin")) {
+          return { rows: [{ is_admin: true }] };
+        }
+        upsertSql = sql;
+        return { rowCount: 2, rows: [{ workspace_id: "ws-a" }] };
+      },
+    };
+
+    const result = await ensureSystemAdminWorkspaceAccess(queryable, 9);
+    assert.strictEqual(result.applied, 2);
+    assert.match(upsertSql, /WHEN workspace_memberships\.role = 'viewer'/);
+    assert.doesNotMatch(upsertSql, /'admin'/);
+  });
+
+  it("ensureSystemAdminWorkspaceAccess no-ops for non-admin users", async () => {
+    const queryable = {
+      query: async (sql) => {
+        if (sql.includes("SELECT is_admin")) {
+          return { rows: [{ is_admin: false }] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+
+    const result = await ensureSystemAdminWorkspaceAccess(queryable, 9);
+    assert.strictEqual(result.applied, 0);
   });
 });


### PR DESCRIPTION
## Summary

Patch release that fixes system-admin workspace expansion downgrading workspace owners, hardens AWS all-regions auto-sync against hangs, and locks the OSS auto-sync worker to GitHub/GitLab via a hardcoded allowlist. Enterprise can still extend providers via file overrides.

## Changes

### API / RBAC
- `ensureSystemAdminWorkspaceAccess()` inserts missing `workspace_manager` rows and upgrades `viewer` only; existing workspace `admin` memberships are preserved
- AWS `detectAWSRegions()` uses per-region timeouts, batched probes, and IAM key caps

### Worker
- New `auto-sync-providers.js` allowlist (github, gitlab)
- Auto-sync worker rejects disallowed providers with clear failure metrics
- Fixed all-regions AWS scan payload (no invalid `region: "all-regions"`)

### Dashboard
- `ImportAWSForm` and `ImportTokensModal` build auto-sync payloads compatible with the fixed API

### Contracts / docs
- Plugin context contract notes `setAutoSyncProviders` is reserved in 0.6.x
- `AUTHENTICATION.md` documents system-admin expansion behaviour

### Infra / metadata
- Version bumped to 0.6.2 across manifests, contracts, OpenAPI, and Helm image tags

## Test plan
- [X] CI job passes https://github.com/tokentimerch/tokentimer-core/actions/runs/26400319973
- [X] Test AWS scan/import
- [X] Verify API/RBAC changes