### PR TITLE
feat(release): v0.7.0 — auto-sync failure notifications, manage tab, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-26
+
+### Added
+
+- **Operational notifications API** — `GET /api/v1/workspaces/:id/notifications` returns dashboard bell items for workspace admins and managers: failed auto-sync configs (with API error text) and alerts waiting for the delivery window (`OUT_OF_WINDOW`).
+- **Auto-sync failure pipeline** — worker `formatAutoSyncError()` surfaces integration API error bodies in `last_sync_error`; `recordAutoSyncFailure()` writes `AUTO_SYNC_FAILED` audit events on the first transition into failed state (no hourly duplicates).
+- **Manage auto-sync tab** — Import modal sub-tabs **Scan & Import** | **Manage auto-sync** when auto-sync is enabled: view failure status, edit schedule, update credentials, disable without separate modals.
+- **Dashboard bell** — Navigation loads operational notifications alongside alert-settings warnings; auto-sync failure items deep-link into Import tokens on the **Manage auto-sync** tab (`?import={provider}&autoSyncManage=1`); deferred alerts link to Usage.
+- **Bell refresh hook** — Navigation listens for `tt:notifications-refresh` so the bell can reload without a full page refresh.
+- **Audit UI** — labels and colours for `AUTO_SYNC_*` actions including `AUTO_SYNC_FAILED`.
+- **Unit tests** — `auto-sync-failure.unit.test.js`, `rbac-require-not-viewer.test.js`.
+
+### Changed
+
+- **Import modal deep-link** — `ImportTokensButton` reads dashboard query params and opens the modal on the correct provider and Manage auto-sync tab when arriving from a bell notification.
+- **Import GitHub/GitLab forms** — `autoSyncManageMode` hides scan UI on the Manage tab while keeping credentials and sync filters visible.
+- **Auto-sync worker** — delegates failure persistence to shared `apps/worker/src/shared/autoSyncFailure.js`.
+- **RBAC** — `requireNotViewer` bypasses viewer check for authenticated worker API calls (`req.isWorkerCall`).
+- **Version metadata bumped to 0.7.0** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **Import modal footer** — import action buttons no longer appear on the Manage auto-sync tab.
+- **Import modal reset** — closing the modal resets the integration sub-tab to Scan & Import.
+- **Bell notification UX** — auto-sync failure subtext matches deep-link behaviour; `openRequest` is cleared after the modal consumes it; Manage tab deep-link no longer sticks when auto-sync is not configured for the provider.
+
 ## [0.6.2] - 2026-05-25
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/admin.js
+++ b/apps/api/routes/admin.js
@@ -534,6 +534,80 @@ router.post(
   },
 );
 
+// Operational notifications for the dashboard bell (auto-sync failures, deferred alerts)
+router.get(
+  "/api/v1/workspaces/:id/notifications",
+  getApiLimiter(),
+  requireAuth,
+  loadWorkspace,
+  requireWorkspaceMembership,
+  async (req, res) => {
+    try {
+      const roleRes = await pool.query(
+        "SELECT role FROM workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+        [req.workspace.id, req.user.id],
+      );
+      const role = roleRes.rows?.[0]?.role || null;
+      const isPrivileged =
+        role === "admin" || role === "workspace_manager";
+
+      const items = [];
+
+      if (isPrivileged) {
+        const failedSync = await pool.query(
+          `SELECT provider, last_sync_error, last_sync_at
+           FROM auto_sync_configs
+           WHERE workspace_id = $1 AND enabled = TRUE AND last_sync_status = 'failed'
+           ORDER BY last_sync_at DESC NULLS LAST`,
+          [req.workspace.id],
+        );
+        for (const row of failedSync.rows) {
+          const provider = row.provider || "integration";
+          const errText = String(row.last_sync_error || "Unknown error").trim();
+          items.push({
+            id: `auto-sync-failed-${provider}`,
+            kind: "error",
+            text: `Auto-sync failed for ${provider}: ${errText}`,
+            href: `/dashboard?import=${encodeURIComponent(provider)}&autoSyncManage=1`,
+            provider,
+          });
+        }
+
+        const deferred = await pool.query(
+          `SELECT COUNT(*)::int AS count
+           FROM alert_queue aq
+           JOIN tokens t ON t.id = aq.token_id
+           WHERE t.workspace_id = $1
+             AND aq.status = 'pending'
+             AND aq.error_message = 'OUT_OF_WINDOW'`,
+          [req.workspace.id],
+        );
+        const deferredCount = deferred.rows?.[0]?.count || 0;
+        if (deferredCount > 0) {
+          items.push({
+            id: "alerts-out-of-window",
+            kind: "info",
+            text:
+              deferredCount === 1
+                ? "1 alert waiting for delivery window"
+                : `${deferredCount} alerts waiting for delivery window`,
+            href: "/usage",
+            count: deferredCount,
+          });
+        }
+      }
+
+      res.json({ items });
+    } catch (e) {
+      logger.error("Workspace notifications error", {
+        error: e.message,
+        workspaceId: req.workspace.id,
+      });
+      res.status(500).json({ error: "Failed to load notifications" });
+    }
+  },
+);
+
 // ============================================================
 // ENDPOINT (SSL) MONITORING ENDPOINTS
 // ============================================================

--- a/apps/api/services/rbac.js
+++ b/apps/api/services/rbac.js
@@ -285,6 +285,8 @@ function getIntegrationQuotaInfo(req, res, next) {
  */
 async function requireNotViewer(req, res, next) {
   try {
+    if (req.isWorkerCall) return next();
+
     // Get workspace_id from query if present (for integration endpoints)
     const workspaceId = req.query?.workspace_id || req.body?.workspace_id;
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -5751,7 +5751,29 @@ function DashboardView({
 }
 function ImportTokensButton() {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [openRequest, setOpenRequest] = useState(null);
   const [_created, setCreated] = useState([]);
+
+  const handleOpenRequestHandled = useCallback(() => {
+    setOpenRequest(null);
+  }, []);
+
+  useEffect(() => {
+    const provider = searchParams.get('import');
+    if (!provider) return;
+    const autoSyncManage = searchParams.get('autoSyncManage') === '1';
+    setOpenRequest({
+      provider,
+      integrationSubTab: autoSyncManage ? 'manage' : 'scan',
+    });
+    onOpen();
+    const next = new URLSearchParams(searchParams);
+    next.delete('import');
+    next.delete('autoSyncManage');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, onOpen, setSearchParams]);
+
   const onImported = newOnes => {
     try {
       if (Array.isArray(newOnes) && newOnes.length > 0) {
@@ -5778,7 +5800,12 @@ function ImportTokensButton() {
       </Button>
       <ImportTokensModal
         isOpen={isOpen}
-        onClose={onClose}
+        onClose={() => {
+          setOpenRequest(null);
+          onClose();
+        }}
+        openRequest={openRequest}
+        onOpenRequestHandled={handleOpenRequestHandled}
         onImported={onImported}
       />
     </>

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -8,6 +8,7 @@ import {
   ModalBody,
   ModalFooter,
   Button,
+  ButtonGroup,
   Box,
   VStack,
   HStack,
@@ -38,6 +39,7 @@ import {
   Select,
   FormControl,
   FormLabel,
+  Divider,
 } from '@chakra-ui/react';
 import { logger } from '../utils/logger';
 import apiClient, {
@@ -716,7 +718,55 @@ function _getGCPItemDetails(item) {
   return details;
 }
 
-export default function ImportTokensModal({ isOpen, onClose, onImported }) {
+function dispatchNotificationsRefresh() {
+  try {
+    window.dispatchEvent(new CustomEvent('tt:notifications-refresh'));
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+const AUTO_SYNC_POLL_INTERVAL_MS = 3000;
+const AUTO_SYNC_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function pollAutoSyncAfterRun({
+  workspaceId,
+  provider,
+  baselineLastSyncAt,
+  onUpdate,
+  isCancelled,
+}) {
+  const deadline = Date.now() + AUTO_SYNC_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (isCancelled()) return 'cancelled';
+    await new Promise(resolve =>
+      setTimeout(resolve, AUTO_SYNC_POLL_INTERVAL_MS)
+    );
+    if (isCancelled()) return 'cancelled';
+    const res = await apiClient.get(
+      `/api/v1/workspaces/${workspaceId}/auto-sync`
+    );
+    const configs = res.data?.items || [];
+    const cfg = configs.find(c => c.provider === provider) || false;
+    onUpdate(cfg);
+    if (!cfg || !cfg.id) return 'missing';
+    const completed =
+      cfg.last_sync_at &&
+      String(cfg.last_sync_at) !== String(baselineLastSyncAt ?? '');
+    if (completed) {
+      return cfg.last_sync_status || 'unknown';
+    }
+  }
+  return 'timeout';
+}
+
+export default function ImportTokensModal({
+  isOpen,
+  onClose,
+  onImported,
+  openRequest,
+  onOpenRequestHandled,
+}) {
   const { workspaceId } = useWorkspace();
   const { colorMode } = useColorMode();
   const isLight = colorMode === 'light';
@@ -948,6 +998,8 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
   // Auto-sync state
   const [autoSyncConfig, setAutoSyncConfig] = React.useState(null); // null = not loaded, false = not exists, object = exists
   const [savingAutoSync, setSavingAutoSync] = React.useState(false);
+  const [runningAutoSyncNow, setRunningAutoSyncNow] = React.useState(false);
+  const autoSyncPollCancelRef = React.useRef(false);
 
   // Available providers in core
   const CORE_AUTO_SYNC_PROVIDERS = ['github', 'gitlab'];
@@ -956,6 +1008,27 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
   const autoSyncTokenPlaceholder = hasAutoSync
     ? 'Credentials saved for auto-sync'
     : null;
+  const [integrationSubTab, setIntegrationSubTab] = React.useState('scan');
+  const [pendingManageTab, setPendingManageTab] = React.useState(false);
+  const autoSyncManageMode =
+    integrationSubTab === 'manage' && hasAutoSync && source !== 'file';
+
+  React.useEffect(
+    () => () => {
+      autoSyncPollCancelRef.current = true;
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    if (isOpen) {
+      autoSyncPollCancelRef.current = false;
+      return undefined;
+    }
+    autoSyncPollCancelRef.current = true;
+    setRunningAutoSyncNow(false);
+    return undefined;
+  }, [isOpen]);
 
   // Load auto-sync config when source changes and restore form fields from scan_params
   React.useEffect(() => {
@@ -1059,6 +1132,32 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
       }
     })();
   }, [workspaceId, source]);
+
+  React.useEffect(() => {
+    if (!isOpen || !openRequest?.provider) return;
+    if (openRequest.integrationSubTab === 'manage') {
+      setPendingManageTab(true);
+    }
+    setSource(openRequest.provider);
+    onOpenRequestHandled?.();
+  }, [isOpen, openRequest, onOpenRequestHandled]);
+
+  React.useEffect(() => {
+    if (pendingManageTab) return;
+    setIntegrationSubTab('scan');
+    // Only reset when the provider changes, not when pendingManageTab clears after deep-link
+  }, [source]);
+
+  React.useEffect(() => {
+    if (!pendingManageTab) return;
+    if (autoSyncConfig === false) {
+      setPendingManageTab(false);
+      return;
+    }
+    if (!hasAutoSync) return;
+    setIntegrationSubTab('manage');
+    setPendingManageTab(false);
+  }, [pendingManageTab, hasAutoSync, autoSyncConfig]);
 
   // Build credentials from current form state
   const getAutoSyncCredentials = () => {
@@ -1182,13 +1281,130 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
     Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
   );
 
-  const handleEnableAutoSync = () => {
-    if (!workspaceId || source === 'file') return;
-    // Reset defaults when opening
+  React.useEffect(() => {
+    if (integrationSubTab === 'manage' && autoSyncConfig?.id) {
+      setEnableSyncFrequency(autoSyncConfig.frequency || 'daily');
+      setEnableSyncTime(autoSyncConfig.schedule_time || '09:00');
+      setEnableSyncTz(
+        autoSyncConfig.schedule_tz ||
+          Intl.DateTimeFormat().resolvedOptions().timeZone ||
+          'UTC'
+      );
+    }
+  }, [integrationSubTab, autoSyncConfig]);
+
+  const credentialsHasSecrets = (credentials, providerName) => {
+    if (!credentials || typeof credentials !== 'object') return false;
+    switch (providerName) {
+      case 'github':
+      case 'gitlab':
+      case 'vault':
+      case 'azure':
+      case 'azure-ad':
+      case 'gcp':
+        return Boolean(String(credentials.token || '').trim());
+      case 'aws':
+        return Boolean(
+          String(
+            credentials.secretAccessKey || credentials.secret_access_key || ''
+          ).trim()
+        );
+      default:
+        return Object.values(credentials).some(v =>
+          Boolean(String(v || '').trim())
+        );
+    }
+  };
+
+  const openEnableAutoSyncModal = () => {
     setEnableSyncFrequency('daily');
     setEnableSyncTime('09:00');
     setEnableSyncTz(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC');
     onEnableAutoSyncOpen();
+  };
+
+  const handleEnableAutoSync = () => {
+    if (!workspaceId || source === 'file') return;
+    openEnableAutoSyncModal();
+  };
+
+  const handleSaveAutoSyncChanges = async () => {
+    if (!workspaceId || !autoSyncConfig?.id) return;
+    const { credentials, scanParams } = getAutoSyncCredentials();
+    const payload = {
+      frequency: enableSyncFrequency,
+      schedule_time: enableSyncTime,
+      schedule_tz: enableSyncTz,
+    };
+    if (credentialsHasSecrets(credentials, source)) {
+      payload.credentials = credentials;
+      payload.scan_params = scanParams;
+    }
+    setSavingAutoSync(true);
+    try {
+      await apiClient.put(
+        `/api/v1/workspaces/${workspaceId}/auto-sync/${autoSyncConfig.id}`,
+        payload
+      );
+      const res = await apiClient.get(
+        `/api/v1/workspaces/${workspaceId}/auto-sync`
+      );
+      const configs = res.data?.items || [];
+      setAutoSyncConfig(configs.find(c => c.provider === source) || false);
+      showSuccess(`Auto-sync settings updated for ${source}`);
+    } catch (e) {
+      showWarning(
+        e?.response?.data?.error || 'Failed to update auto-sync settings'
+      );
+    } finally {
+      setSavingAutoSync(false);
+    }
+  };
+
+  const handleRunAutoSyncNow = async () => {
+    if (!workspaceId || !autoSyncConfig?.id) return;
+    const baselineLastSyncAt = autoSyncConfig.last_sync_at || null;
+    autoSyncPollCancelRef.current = false;
+    setRunningAutoSyncNow(true);
+    try {
+      await apiClient.post(
+        `/api/v1/workspaces/${workspaceId}/auto-sync/${autoSyncConfig.id}/run`
+      );
+      const outcome = await pollAutoSyncAfterRun({
+        workspaceId,
+        provider: source,
+        baselineLastSyncAt,
+        onUpdate: setAutoSyncConfig,
+        isCancelled: () => autoSyncPollCancelRef.current,
+      });
+      if (outcome === 'cancelled') return;
+      if (outcome === 'success' || outcome === 'partial') {
+        showSuccess(`Auto-sync completed (${outcome})`);
+        dispatchNotificationsRefresh();
+        return;
+      }
+      if (outcome === 'failed') {
+        const res = await apiClient.get(
+          `/api/v1/workspaces/${workspaceId}/auto-sync`
+        );
+        const cfg =
+          (res.data?.items || []).find(c => c.provider === source) || null;
+        showWarning(cfg?.last_sync_error || 'Auto-sync failed again');
+        dispatchNotificationsRefresh();
+        return;
+      }
+      if (outcome === 'timeout') {
+        showSuccess(
+          'Sync queued. Status will update when the worker finishes.'
+        );
+        return;
+      }
+      showWarning('Auto-sync config is no longer available');
+    } catch (e) {
+      showWarning(e?.response?.data?.error || 'Failed to queue sync');
+    } finally {
+      setRunningAutoSyncNow(false);
+    }
   };
 
   const confirmEnableAutoSync = async () => {
@@ -1204,13 +1420,13 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
         schedule_time: enableSyncTime,
         schedule_tz: enableSyncTz,
       });
-      // Reload config
+      showSuccess(`Auto-sync enabled for ${source}`);
       const res = await apiClient.get(
         `/api/v1/workspaces/${workspaceId}/auto-sync`
       );
       const configs = res.data?.items || [];
       setAutoSyncConfig(configs.find(c => c.provider === source) || false);
-      showSuccess(`Auto-sync enabled for ${source}`);
+      setIntegrationSubTab('manage');
     } catch (e) {
       showWarning(e?.response?.data?.error || 'Failed to enable auto-sync');
     } finally {
@@ -1238,7 +1454,10 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
         `/api/v1/workspaces/${workspaceId}/auto-sync/${autoSyncConfig.id}`
       );
       setAutoSyncConfig(false);
+      setIntegrationSubTab('scan');
+      setPendingManageTab(false);
       showSuccess(`Auto-sync disabled for ${source}`);
+      dispatchNotificationsRefresh();
     } catch (e) {
       showWarning(e?.response?.data?.error || 'Failed to disable auto-sync');
     } finally {
@@ -1308,6 +1527,8 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
     setAzureDuplicates(new Set());
     setGcpDuplicates(new Set());
     setAzureADDuplicates(new Set());
+    setIntegrationSubTab('scan');
+    setPendingManageTab(false);
   }, []);
 
   const onSelectFile = async e => {
@@ -2005,6 +2226,136 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 </Box>
               </Box>
 
+              {source !== 'file' && hasAutoSync && !isViewer ? (
+                <ButtonGroup size='sm' isAttached variant='outline'>
+                  <Button
+                    colorScheme={
+                      integrationSubTab === 'scan' ? 'blue' : undefined
+                    }
+                    variant={integrationSubTab === 'scan' ? 'solid' : 'outline'}
+                    onClick={() => setIntegrationSubTab('scan')}
+                  >
+                    Scan & Import
+                  </Button>
+                  <Button
+                    colorScheme={
+                      integrationSubTab === 'manage' ? 'blue' : undefined
+                    }
+                    variant={
+                      integrationSubTab === 'manage' ? 'solid' : 'outline'
+                    }
+                    onClick={() => setIntegrationSubTab('manage')}
+                  >
+                    Manage auto-sync
+                  </Button>
+                </ButtonGroup>
+              ) : null}
+
+              {autoSyncManageMode ? (
+                <Box
+                  border='1px solid'
+                  borderColor={borderColor}
+                  borderRadius='md'
+                  p={4}
+                >
+                  <VStack align='stretch' spacing={4}>
+                    {autoSyncConfig.last_sync_status === 'failed' ? (
+                      <Alert status='error' borderRadius='md'>
+                        <AlertIcon />
+                        <Box fontSize='sm'>
+                          <Text fontWeight='semibold'>
+                            Last auto-sync failed
+                          </Text>
+                          {autoSyncConfig.last_sync_error ? (
+                            <Text mt={1}>{autoSyncConfig.last_sync_error}</Text>
+                          ) : null}
+                        </Box>
+                      </Alert>
+                    ) : null}
+                    <Box>
+                      <Text fontSize='sm' fontWeight='semibold' mb={2}>
+                        Status
+                      </Text>
+                      <Text fontSize='sm'>
+                        Provider: {autoSyncConfig.provider}
+                      </Text>
+                      {autoSyncConfig.last_sync_at ? (
+                        <Text fontSize='sm'>
+                          Last sync:{' '}
+                          {new Date(
+                            autoSyncConfig.last_sync_at
+                          ).toLocaleString()}
+                          {autoSyncConfig.last_sync_status
+                            ? ` (${autoSyncConfig.last_sync_status})`
+                            : ''}
+                        </Text>
+                      ) : (
+                        <Text fontSize='sm' color={helpTextColor}>
+                          No sync run yet
+                        </Text>
+                      )}
+                    </Box>
+                    <Divider />
+                    <Box>
+                      <Text fontSize='sm' fontWeight='semibold' mb={3}>
+                        Schedule
+                      </Text>
+                      <VStack align='stretch' spacing={3}>
+                        <HStack spacing={4} align='flex-end' flexWrap='wrap'>
+                          <FormControl flex='1' minW='140px'>
+                            <FormLabel fontSize='sm'>Frequency</FormLabel>
+                            <Select
+                              size='sm'
+                              value={enableSyncFrequency}
+                              onChange={e =>
+                                setEnableSyncFrequency(e.target.value)
+                              }
+                            >
+                              <option value='daily'>Daily</option>
+                              <option value='weekly'>Weekly</option>
+                              <option value='monthly'>Monthly</option>
+                            </Select>
+                          </FormControl>
+                          <FormControl flex='1' minW='140px'>
+                            <FormLabel fontSize='sm'>Time</FormLabel>
+                            <Input
+                              size='sm'
+                              type='time'
+                              value={enableSyncTime}
+                              onChange={e => setEnableSyncTime(e.target.value)}
+                            />
+                          </FormControl>
+                        </HStack>
+                        <FormControl>
+                          <FormLabel fontSize='sm'>Timezone</FormLabel>
+                          <Select
+                            size='sm'
+                            value={enableSyncTz}
+                            onChange={e => setEnableSyncTz(e.target.value)}
+                          >
+                            {timezoneList.map(tz => (
+                              <option key={tz} value={tz}>
+                                {tz.replace(/_/g, ' ')}
+                              </option>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </VStack>
+                    </Box>
+                    <Divider />
+                    <Box>
+                      <Text fontSize='sm' fontWeight='semibold' mb={1}>
+                        Credentials
+                      </Text>
+                      <Text fontSize='sm' color={helpTextColor}>
+                        Enter a new token or API key to rotate stored
+                        credentials. Leave blank to keep the current secret.
+                      </Text>
+                    </Box>
+                  </VStack>
+                </Box>
+              ) : null}
+
               {source === 'file' ? (
                 <>
                   <Box>
@@ -2052,7 +2403,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 </>
               ) : null}
 
-              {source === 'vault' ? (
+              {source === 'vault' && !autoSyncManageMode ? (
                 <ImportVaultForm
                   ref={vaultFormRef}
                   workspaceId={workspaceId}
@@ -2104,6 +2455,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                   isQuotaExceededError={isQuotaExceededError}
                   formatQuotaError={formatQuotaError}
                   extractQuotaFromError={extractQuotaFromError}
+                  autoSyncManageMode={autoSyncManageMode}
                   contactGroups={contactGroups}
                 />
               ) : null}
@@ -2127,6 +2479,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                   borderColor={borderColor}
                   helpTextColor={helpTextColor}
                   autoSyncTokenPlaceholder={autoSyncTokenPlaceholder}
+                  autoSyncManageMode={autoSyncManageMode}
                   updateQuotaFromResponse={updateQuotaFromResponse}
                   refreshIntegrationQuota={refreshIntegrationQuota}
                   isQuotaExceededError={isQuotaExceededError}
@@ -2136,7 +2489,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 />
               ) : null}
 
-              {source === 'aws' ? (
+              {source === 'aws' && !autoSyncManageMode ? (
                 <ImportAWSForm
                   ref={awsFormRef}
                   initialAutoSyncScanParams={awsAutoSyncScanParams}
@@ -2165,7 +2518,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 />
               ) : null}
 
-              {source === 'azure' ? (
+              {source === 'azure' && !autoSyncManageMode ? (
                 <ImportAzureForm
                   ref={azureFormRef}
                   workspaceId={workspaceId}
@@ -2193,7 +2546,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 />
               ) : null}
 
-              {source === 'gcp' ? (
+              {source === 'gcp' && !autoSyncManageMode ? (
                 <ImportGCPForm
                   ref={gcpFormRef}
                   workspaceId={workspaceId}
@@ -2221,7 +2574,7 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 />
               ) : null}
 
-              {source === 'azure-ad' ? (
+              {source === 'azure-ad' && !autoSyncManageMode ? (
                 <VStack align='stretch' spacing={3}>
                   <Box>
                     <Text fontSize='sm' color={helpTextColor}>
@@ -2643,6 +2996,36 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 </Box>
               ) : null}
 
+              {autoSyncManageMode && !isViewer ? (
+                <HStack justify='flex-end' spacing={3} pt={2}>
+                  <Button
+                    colorScheme='red'
+                    variant='outline'
+                    onClick={handleDisableAutoSync}
+                    isLoading={savingAutoSync}
+                    isDisabled={runningAutoSyncNow}
+                  >
+                    Disable auto-sync
+                  </Button>
+                  <Button
+                    variant='outline'
+                    onClick={handleRunAutoSyncNow}
+                    isLoading={runningAutoSyncNow}
+                    isDisabled={savingAutoSync}
+                  >
+                    Sync now
+                  </Button>
+                  <Button
+                    colorScheme='blue'
+                    onClick={handleSaveAutoSyncChanges}
+                    isLoading={savingAutoSync}
+                    isDisabled={runningAutoSyncNow}
+                  >
+                    Save changes
+                  </Button>
+                </HStack>
+              ) : null}
+
               {isImporting ? (
                 <Box>
                   <HStack justify='space-between' mb={1}>
@@ -2662,158 +3045,143 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
               ) : null}
             </VStack>
           </ModalBody>
-          <ModalFooter>
-            <HStack>
-              {source === 'file' ? (
-                !isImporting ? (
+          <ModalFooter flexDirection='column' alignItems='stretch' gap={3}>
+            <HStack w='full' justify='flex-end' flexWrap='wrap'>
+              {!autoSyncManageMode ? (
+                source === 'file' ? (
+                  !isImporting ? (
+                    <Button
+                      onClick={onStartImport}
+                      colorScheme='blue'
+                      isDisabled={selectedRowsFile.size === 0}
+                    >
+                      Import {selectedRowsFile.size} selected
+                    </Button>
+                  ) : (
+                    <Button onClick={onCancelImport} variant='outline'>
+                      Cancel
+                    </Button>
+                  )
+                ) : source === 'vault' ? (
                   <Button
-                    onClick={onStartImport}
-                    colorScheme='blue'
-                    isDisabled={selectedRowsFile.size === 0}
+                    onClick={() => {
+                      setIsImporting(true);
+                      vaultFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
                   >
-                    Import {selectedRowsFile.size} selected
+                    Import selected
                   </Button>
-                ) : (
-                  <Button onClick={onCancelImport} variant='outline'>
-                    Cancel
+                ) : source === 'gitlab' ? (
+                  <Button
+                    onClick={() => {
+                      setIsImporting(true);
+                      gitlabFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
                   </Button>
-                )
-              ) : source === 'vault' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    vaultFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'gitlab' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    gitlabFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'github' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    githubFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'aws' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    awsFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'azure' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    azureFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'azure-ad' ? (
-                <Button
-                  onClick={importAzureADSelected}
-                  colorScheme='green'
-                  isDisabled={selectedRowsAzureAD.size === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
-              ) : source === 'gcp' ? (
-                <Button
-                  onClick={() => {
-                    setIsImporting(true);
-                    gcpFormRef.current?.importSelected();
-                  }}
-                  colorScheme='green'
-                  isDisabled={integrationSelectedCount === 0 || isImporting}
-                  isLoading={isImporting}
-                >
-                  Import selected
-                </Button>
+                ) : source === 'github' ? (
+                  <Button
+                    onClick={() => {
+                      setIsImporting(true);
+                      githubFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
+                  </Button>
+                ) : source === 'aws' ? (
+                  <Button
+                    onClick={() => {
+                      setIsImporting(true);
+                      awsFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
+                  </Button>
+                ) : source === 'azure' ? (
+                  <Button
+                    onClick={() => {
+                      setIsImporting(true);
+                      azureFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
+                  </Button>
+                ) : source === 'azure-ad' ? (
+                  <Button
+                    onClick={importAzureADSelected}
+                    colorScheme='green'
+                    isDisabled={selectedRowsAzureAD.size === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
+                  </Button>
+                ) : source === 'gcp' ? (
+                  <Button
+                    onClick={() => {
+                      setIsImporting(true);
+                      gcpFormRef.current?.importSelected();
+                    }}
+                    colorScheme='green'
+                    isDisabled={integrationSelectedCount === 0 || isImporting}
+                    isLoading={isImporting}
+                  >
+                    Import selected
+                  </Button>
+                ) : null
               ) : null}
               <Button onClick={onCloseInternal}>Close</Button>
-              {/* Auto-sync button - shown for integration sources */}
-              {source !== 'file' &&
-                !isViewer &&
-                (autoSyncConfig && autoSyncConfig.id ? (
-                  <Tooltip
-                    label={`Syncs ${autoSyncConfig.frequency || 'daily'} at ${autoSyncConfig.schedule_time || '09:00'} ${autoSyncConfig.schedule_tz || 'UTC'}${autoSyncConfig.last_sync_at ? ` | Last: ${new Date(autoSyncConfig.last_sync_at).toLocaleDateString()}` : ''}`}
-                    fontSize='xs'
-                  >
-                    <Button
-                      colorScheme='red'
-                      variant='outline'
-                      onClick={handleDisableAutoSync}
-                      isLoading={savingAutoSync}
-                    >
-                      Disable auto-sync
-                    </Button>
-                  </Tooltip>
-                ) : (
-                  <Tooltip
-                    label={
-                      !isAutoSyncAllowed
-                        ? 'Auto-sync for this provider is not available in this edition'
-                        : !scanSucceededFor.has(source)
-                          ? 'Run a successful scan first to enable auto-sync'
-                          : 'Save current credentials for scheduled automatic scans'
+              {source !== 'file' && !isViewer && !hasAutoSync ? (
+                <Tooltip
+                  label={
+                    !isAutoSyncAllowed
+                      ? 'Auto-sync for this provider is not available in this edition'
+                      : !scanSucceededFor.has(source)
+                        ? 'Run a successful scan first to enable auto-sync'
+                        : 'Save current credentials for scheduled automatic scans'
+                  }
+                  fontSize='xs'
+                >
+                  <Button
+                    colorScheme='blue'
+                    variant='outline'
+                    onClick={handleEnableAutoSync}
+                    isLoading={savingAutoSync}
+                    isDisabled={
+                      !isAutoSyncAllowed || !scanSucceededFor.has(source)
                     }
-                    fontSize='xs'
+                    opacity={
+                      isAutoSyncAllowed && scanSucceededFor.has(source)
+                        ? 1
+                        : 0.5
+                    }
                   >
-                    <Button
-                      colorScheme='blue'
-                      variant='outline'
-                      onClick={handleEnableAutoSync}
-                      isLoading={savingAutoSync}
-                      isDisabled={
-                        !isAutoSyncAllowed || !scanSucceededFor.has(source)
-                      }
-                      opacity={
-                        isAutoSyncAllowed && scanSucceededFor.has(source)
-                          ? 1
-                          : 0.5
-                      }
-                    >
-                      Enable auto-sync
-                      {!isAutoSyncAllowed && ' (unavailable)'}
-                    </Button>
-                  </Tooltip>
-                ))}
+                    Enable auto-sync
+                    {!isAutoSyncAllowed && ' (unavailable)'}
+                  </Button>
+                </Tooltip>
+              ) : null}
             </HStack>
           </ModalFooter>
         </ModalContent>
       </Modal>
 
-      {/* Enable auto-sync confirmation modal */}
+      {/* Enable auto-sync modal */}
       <Modal
         isOpen={isEnableAutoSyncOpen}
         onClose={onEnableAutoSyncClose}
@@ -2830,7 +3198,8 @@ export default function ImportTokensModal({ isOpen, onClose, onImported }) {
                 <AlertIcon />
                 <Text fontSize='sm'>
                   Your credentials will be encrypted and stored to run scheduled
-                  scans automatically.
+                  scans automatically. You can change the schedule and
+                  credentials later from the Manage auto-sync tab.
                 </Text>
               </Alert>
               <Box p={3} bg={confirmBoxBg} borderRadius='md'>

--- a/apps/dashboard/src/components/Navigation.jsx
+++ b/apps/dashboard/src/components/Navigation.jsx
@@ -557,8 +557,13 @@ const Navigation = ({
         return;
       }
       try {
-        const res = await workspaceAPI.getAlertSettings(currentWorkspace.id);
-        const data = res?.data || res || {};
+        const [settingsRes, notificationsRes] = await Promise.all([
+          workspaceAPI.getAlertSettings(currentWorkspace.id),
+          workspaceAPI
+            .getNotifications(currentWorkspace.id)
+            .catch(() => ({ items: [] })),
+        ]);
+        const data = settingsRes?.data || settingsRes || {};
         const emailEnabled = data.email_alerts_enabled === true;
         const webhooks = data.webhook_urls;
         const hasWebhooks = Array.isArray(webhooks) && webhooks.length > 0;
@@ -577,7 +582,29 @@ const Navigation = ({
           return emailIds.length > 0 || waIds.length > 0;
         });
         if (cancelled) return;
+        const currentRole = String(currentWorkspace?.role || '').toLowerCase();
+        const canManageWorkspaceAlerts =
+          isSystemAdmin ||
+          currentRole === 'admin' ||
+          currentRole === 'workspace_manager';
         const list = [];
+        if (canManageWorkspaceAlerts) {
+          const operational = Array.isArray(notificationsRes?.items)
+            ? notificationsRes.items
+            : [];
+          for (const item of operational) {
+            list.push({
+              id: item.id,
+              kind: item.kind === 'error' ? 'error' : 'warning',
+              text: item.text,
+              href: item.href || null,
+            });
+          }
+        }
+        if (!canManageWorkspaceAlerts) {
+          setNotifications(list);
+          return;
+        }
         if (!smtpConfigured) {
           list.push({
             id: 'smtp-not-configured',
@@ -593,6 +620,7 @@ const Navigation = ({
             id: 'alerts-disabled',
             kind: 'warning',
             text: 'Alerts are disabled until a channel is defined.',
+            href: '/preferences',
           });
         }
         if (!hasAnyContact) {
@@ -609,8 +637,16 @@ const Navigation = ({
       }
     }
     load();
+    const refreshNotifications = () => {
+      load();
+    };
+    window.addEventListener('tt:notifications-refresh', refreshNotifications);
     return () => {
       cancelled = true;
+      window.removeEventListener(
+        'tt:notifications-refresh',
+        refreshNotifications
+      );
     };
   }, [user, currentWorkspace?.id, isSystemAdmin]);
 
@@ -1157,13 +1193,22 @@ const Navigation = ({
                       const isClickable =
                         (n && typeof n.onClick === 'function') ||
                         Boolean(n?.href);
-                      let subText =
-                        'Go to Preferences to enable a notification channel.';
-                      if (n.id === 'smtp-not-configured') {
-                        subText = n.href
-                          ? 'Go to System Settings to configure SMTP.'
-                          : 'Contact a system administrator to configure SMTP.';
-                      }
+                      const subText =
+                        n.id === 'smtp-not-configured'
+                          ? n.href
+                            ? 'Go to System Settings to configure SMTP.'
+                            : 'Contact a system administrator to configure SMTP.'
+                          : n.id?.startsWith('auto-sync-failed-')
+                            ? 'Opens Import tokens on the Manage auto-sync tab.'
+                            : n.id === 'alerts-out-of-window'
+                              ? 'View the alert queue on the Usage page.'
+                              : n.id === 'alerts-disabled'
+                                ? 'Go to Preferences to enable a notification channel.'
+                                : n.id === 'no-contacts-defined'
+                                  ? 'Go to Preferences to assign contacts to contact groups.'
+                                  : isClickable
+                                    ? 'Go to Preferences to enable a notification channel.'
+                                    : 'No action available from this notification.';
                       return (
                         <MenuItem
                           key={n.id}
@@ -1185,7 +1230,7 @@ const Navigation = ({
                         >
                           <VStack align='start' spacing='0'>
                             <Text fontSize='sm' fontWeight='medium'>
-                              ⚠️ {n.text}
+                              {n.kind === 'error' ? '🔴' : '⚠️'} {n.text}
                             </Text>
                             <Text fontSize='xs' color={gray400}>
                               {subText}

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -96,6 +96,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     extractQuotaFromError,
     contactGroups,
     onSelectionChange,
+    autoSyncManageMode = false,
   },
   ref
 ) {
@@ -245,30 +246,32 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
 
   return (
     <VStack align='stretch' spacing={3}>
-      <Box>
-        <Text fontSize='sm' color={helpTextColor}>
-          Scans GitHub for tokens, secrets, SSH keys or deploy tokens. The
-          read-only PAT is used for scanning and stored encrypted if auto-sync
-          is enabled.
-        </Text>
-        <Text fontSize='sm' mt={1}>
-          <ChakraLink
-            onClick={() =>
-              window.open(
-                'https://tokentimer.ch/docs/tokens#import-github',
-                '_blank',
-                'noopener,noreferrer'
-              )
-            }
-            cursor='pointer'
-            color='blue.500'
-            textDecoration='underline'
-            isExternal
-          >
-            Learn more about importing from GitHub →
-          </ChakraLink>
-        </Text>
-      </Box>
+      {!autoSyncManageMode ? (
+        <Box>
+          <Text fontSize='sm' color={helpTextColor}>
+            Scans GitHub for tokens, secrets, SSH keys or deploy tokens. The
+            read-only PAT is used for scanning and stored encrypted if auto-sync
+            is enabled.
+          </Text>
+          <Text fontSize='sm' mt={1}>
+            <ChakraLink
+              onClick={() =>
+                window.open(
+                  'https://tokentimer.ch/docs/tokens#import-github',
+                  '_blank',
+                  'noopener,noreferrer'
+                )
+              }
+              cursor='pointer'
+              color='blue.500'
+              textDecoration='underline'
+              isExternal
+            >
+              Learn more about importing from GitHub →
+            </ChakraLink>
+          </Text>
+        </Box>
+      ) : null}
       <HStack spacing={3} align='flex-end' flexWrap='wrap'>
         <Box minW='280px'>
           <Text fontSize='sm' mb={1}>
@@ -302,17 +305,19 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
             </InputRightElement>
           </InputGroup>
         </Box>
-        <Button
-          colorScheme='blue'
-          onClick={doGithubScan}
-          isLoading={isScanning}
-        >
-          Scan
-        </Button>
+        {!autoSyncManageMode ? (
+          <Button
+            colorScheme='blue'
+            onClick={doGithubScan}
+            isLoading={isScanning}
+          >
+            Scan
+          </Button>
+        ) : null}
       </HStack>
       <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
         <Text fontSize='sm' fontWeight='medium' mb={3}>
-          Scan Filters
+          {autoSyncManageMode ? 'Sync filters' : 'Scan Filters'}
         </Text>
         <VStack align='stretch' spacing={2}>
           <Checkbox
@@ -345,7 +350,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
           </Checkbox>
         </VStack>
       </Box>
-      {githubSummary.length > 0 && (
+      {!autoSyncManageMode && githubSummary.length > 0 && (
         <Box
           border='1px solid'
           borderColor={borderColor}
@@ -368,7 +373,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
           </VStack>
         </Box>
       )}
-      {githubItems.length > 0 && (
+      {!autoSyncManageMode && githubItems.length > 0 && (
         <>
           <IntegrationImportTable
             items={githubItems}

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -91,6 +91,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     extractQuotaFromError,
     contactGroups,
     onSelectionChange,
+    autoSyncManageMode = false,
   },
   ref
 ) {
@@ -256,30 +257,32 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
 
   return (
     <VStack align='stretch' spacing={3}>
-      <Box>
-        <Text fontSize='sm' color={helpTextColor}>
-          Scans GitLab for Personal Access Tokens, Project Access Tokens, Deploy
-          Tokens, and SSH Keys. Token is used for scanning and stored encrypted
-          if auto-sync is enabled.
-        </Text>
-        <Text fontSize='sm' mt={1}>
-          <ChakraLink
-            onClick={() =>
-              window.open(
-                'https://tokentimer.ch/docs/tokens#import-gitlab',
-                '_blank',
-                'noopener,noreferrer'
-              )
-            }
-            cursor='pointer'
-            color='blue.500'
-            textDecoration='underline'
-            isExternal
-          >
-            Learn more about importing from GitLab →
-          </ChakraLink>
-        </Text>
-      </Box>
+      {!autoSyncManageMode ? (
+        <Box>
+          <Text fontSize='sm' color={helpTextColor}>
+            Scans GitLab for Personal Access Tokens, Project Access Tokens,
+            Deploy Tokens, and SSH Keys. Token is used for scanning and stored
+            encrypted if auto-sync is enabled.
+          </Text>
+          <Text fontSize='sm' mt={1}>
+            <ChakraLink
+              onClick={() =>
+                window.open(
+                  'https://tokentimer.ch/docs/tokens#import-gitlab',
+                  '_blank',
+                  'noopener,noreferrer'
+                )
+              }
+              cursor='pointer'
+              color='blue.500'
+              textDecoration='underline'
+              isExternal
+            >
+              Learn more about importing from GitLab →
+            </ChakraLink>
+          </Text>
+        </Box>
+      ) : null}
       <HStack spacing={3} align='flex-end' flexWrap='wrap'>
         <Box minW='280px'>
           <Text fontSize='sm' mb={1}>
@@ -313,17 +316,19 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
             </InputRightElement>
           </InputGroup>
         </Box>
-        <Button
-          colorScheme='blue'
-          onClick={doGitlabScan}
-          isLoading={isScanning}
-        >
-          Scan
-        </Button>
+        {!autoSyncManageMode ? (
+          <Button
+            colorScheme='blue'
+            onClick={doGitlabScan}
+            isLoading={isScanning}
+          >
+            Scan
+          </Button>
+        ) : null}
       </HStack>
       <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
         <Text fontSize='sm' fontWeight='medium' mb={3}>
-          Scan Filters
+          {autoSyncManageMode ? 'Sync filters' : 'Scan Filters'}
         </Text>
         <VStack align='stretch' spacing={3}>
           <Box>
@@ -403,7 +408,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
           </Box>
         </VStack>
       </Box>
-      {gitlabSummary.length > 0 && (
+      {!autoSyncManageMode && gitlabSummary.length > 0 && (
         <Box
           border='1px solid'
           borderColor={borderColor}
@@ -424,7 +429,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
           </VStack>
         </Box>
       )}
-      {gitlabItems.length > 0 && (
+      {!autoSyncManageMode && gitlabItems.length > 0 && (
         <>
           <IntegrationImportTable
             items={gitlabItems}

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -52,6 +52,11 @@ const ACTION_COLORS = {
   ALERT_SENT: 'green',
   ALERT_SEND_FAILED: 'red',
   ALERT_SKIPPED_LIMIT: 'orange',
+  AUTO_SYNC_FAILED: 'red',
+  AUTO_SYNC_CREATED: 'green',
+  AUTO_SYNC_UPDATED: 'blue',
+  AUTO_SYNC_DELETED: 'orange',
+  AUTO_SYNC_TRIGGERED: 'purple',
   LIMIT_REMINDER_SENT: 'purple',
   LOGIN_SUCCESS: 'green',
   LOGIN_FAILED: 'red',
@@ -119,6 +124,11 @@ const ALL_ACTION_TYPES = [
   // Integrations
   'INTEGRATION_SCAN',
   'INTEGRATION_DETECT_REGIONS',
+  'AUTO_SYNC_CREATED',
+  'AUTO_SYNC_UPDATED',
+  'AUTO_SYNC_DELETED',
+  'AUTO_SYNC_TRIGGERED',
+  'AUTO_SYNC_FAILED',
   // WhatsApp
   'WHATSAPP_TEST_SENT',
   'WHATSAPP_TEST_FAILED',
@@ -797,6 +807,22 @@ export default function Audit({
     }
   }
 
+  function formatAutoSyncMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.provider) parts.push(`Provider: ${md.provider}`);
+      if (md.error) parts.push(`Error: ${md.error}`);
+      if (md.http_status != null) parts.push(`HTTP status: ${md.http_status}`);
+      if (md.config_id) parts.push(`Config ID: ${md.config_id}`);
+      if (md.enabled != null)
+        parts.push(`Enabled: ${md.enabled ? 'yes' : 'no'}`);
+      return parts.join(' | ');
+    } catch (_) {
+      return '';
+    }
+  }
+
   function formatMetadata(ev) {
     const action = String(ev?.action || '');
 
@@ -907,12 +933,23 @@ export default function Audit({
       if (formatted) return formatted;
     }
 
-    // Integration events
+    // Integration / auto-sync events
     if (
       action === 'INTEGRATION_SCAN' ||
       action === 'INTEGRATION_DETECT_REGIONS'
     ) {
       const formatted = formatIntegrationMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (
+      action === 'AUTO_SYNC_CREATED' ||
+      action === 'AUTO_SYNC_UPDATED' ||
+      action === 'AUTO_SYNC_DELETED' ||
+      action === 'AUTO_SYNC_TRIGGERED' ||
+      action === 'AUTO_SYNC_FAILED'
+    ) {
+      const formatted = formatAutoSyncMetadata(ev);
       if (formatted) return formatted;
     }
 

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -502,6 +502,7 @@ export const API_ENDPOINTS = {
   WORKSPACE_INVITATION: (id, invitationId) =>
     `/api/v1/workspaces/${id}/invitations/${invitationId}`,
   WORKSPACE_ALERT_SETTINGS: id => `/api/v1/workspaces/${id}/alert-settings`,
+  WORKSPACE_NOTIFICATIONS: id => `/api/v1/workspaces/${id}/notifications`,
   WORKSPACE_TRANSFER_TOKENS: id => `/api/v1/workspaces/${id}/transfer-tokens`,
   // Vault integration (workspace_id required for scan)
   VAULT_SCAN: workspaceId =>
@@ -1036,6 +1037,16 @@ export const workspaceAPI = {
     try {
       const res = await apiClient.get(
         API_ENDPOINTS.WORKSPACE_ALERT_SETTINGS(id)
+      );
+      return res.data;
+    } catch (e) {
+      throw new Error(handleApiError(e));
+    }
+  },
+  getNotifications: async id => {
+    try {
+      const res = await apiClient.get(
+        API_ENDPOINTS.WORKSPACE_NOTIFICATIONS(id)
       );
       return res.data;
     } catch (e) {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/apps/worker/queue-architecture.md
+++ b/apps/worker/queue-architecture.md
@@ -75,7 +75,7 @@ Schedules are configurable via Helm values (`worker.cronjobs.*`) or Docker Compo
 | Job | Default schedule | Helm value |
 |-----|-----------------|------------|
 | Alert Discovery | `*/5 * * * *` | `worker.cronjobs.discovery.schedule` |
-| Alert Delivery | `*/5 * * * *` | `worker.cronjobs.delivery.schedule` |
+| Alert Delivery | `1/5 * * * *` | `worker.cronjobs.delivery.schedule` |
 | Weekly Digest | `0 9 * * 1` | `worker.cronjobs.weeklyDigest.schedule` |
 | Endpoint Check | `*/1 * * * *` | `worker.cronjobs.endpointCheck.schedule` |
 | Auto Sync | `0 * * * *` | `worker.cronjobs.autoSync.schedule` |
@@ -91,7 +91,7 @@ Day 1 - Token expires in 30 days:
   Queues alert: status='pending', channels=['email','slack']
   Audit: ALERT_QUEUED
 
-5 minutes later:
+1 minute later:
   Delivery Job runs
   Finds pending alert
   Sends email: success

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -20,6 +20,10 @@ import {
 import crypto from "crypto";
 import axios from "axios";
 import { isAutoSyncProviderAllowed } from "./auto-sync-providers.js";
+import {
+  formatAutoSyncError,
+  recordAutoSyncFailure,
+} from "./shared/autoSyncFailure.js";
 
 // Encryption helpers — must mirror systemSettings.js exactly
 const KDF_SALT = "tokentimer-settings-encryption";
@@ -210,6 +214,8 @@ async function runAutoSync() {
           frequency,
           schedule_time,
           schedule_tz,
+          last_sync_status: previousStatus,
+          created_by: createdBy,
         } = config;
         logger.info(`Syncing ${provider} for workspace ${workspace_id}`);
 
@@ -219,13 +225,15 @@ async function runAutoSync() {
         if (!isAutoSyncProviderAllowed(provider)) {
           const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
           const message = `Auto-sync for ${provider} is not available in this edition.`;
-          await client.query(
-            `UPDATE auto_sync_configs
-             SET last_sync_at = NOW(), last_sync_status = 'failed', last_sync_error = $1,
-                 next_sync_at = $2, updated_at = NOW()
-             WHERE id = $3`,
-            [message, nextSync, id],
-          );
+          await recordAutoSyncFailure(client, {
+            configId: id,
+            workspaceId: workspace_id,
+            provider,
+            createdBy,
+            previousStatus,
+            errorMessage: message,
+            nextSync,
+          });
           logger.warn(message, { workspace_id, provider });
           cAutoSync.inc({ provider, status: "failure" });
           gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
@@ -346,15 +354,17 @@ async function runAutoSync() {
 
           cAutoSync.inc({ provider, status: "failure" });
           gAutoSyncLastRun.set({ provider, status: "failure" }, Date.now() / 1000);
-          // Update config: failed
           const nextSync = computeNextSync(frequency, schedule_time, schedule_tz);
-          await client.query(
-            `UPDATE auto_sync_configs
-             SET last_sync_at = NOW(), last_sync_status = 'failed',
-                 last_sync_error = $1, next_sync_at = $2, updated_at = NOW()
-             WHERE id = $3`,
-            [String(syncErr?.message || syncErr).substring(0, 1000), nextSync, id],
-          );
+          await recordAutoSyncFailure(client, {
+            configId: id,
+            workspaceId: workspace_id,
+            provider,
+            createdBy,
+            previousStatus,
+            errorMessage: formatAutoSyncError(syncErr),
+            httpStatus: syncErr?.response?.status || null,
+            nextSync,
+          });
         }
       }),
     );

--- a/apps/worker/src/shared/autoSyncFailure.js
+++ b/apps/worker/src/shared/autoSyncFailure.js
@@ -1,0 +1,99 @@
+import { logger } from "../logger.js";
+
+/**
+ * Prefer API error body over generic Axios message for last_sync_error / audit.
+ */
+export function formatAutoSyncError(err) {
+  const body = err?.response?.data;
+  if (body && typeof body.error === "string" && body.error.trim()) {
+    return body.error.trim().substring(0, 1000);
+  }
+  if (body && typeof body.message === "string" && body.message.trim()) {
+    return body.message.trim().substring(0, 1000);
+  }
+  return String(err?.message || err).substring(0, 1000);
+}
+
+async function resolveAuditSubjectUserId(client, workspaceId, createdBy) {
+  if (createdBy) return createdBy;
+  const adminRes = await client.query(
+    `SELECT user_id FROM workspace_memberships
+     WHERE workspace_id = $1 AND role = 'admin'
+     ORDER BY user_id ASC LIMIT 1`,
+    [workspaceId],
+  );
+  if (adminRes.rows[0]?.user_id) return adminRes.rows[0].user_id;
+  const mgrRes = await client.query(
+    `SELECT user_id FROM workspace_memberships
+     WHERE workspace_id = $1 AND role = 'workspace_manager'
+     ORDER BY user_id ASC LIMIT 1`,
+    [workspaceId],
+  );
+  return mgrRes.rows[0]?.user_id || null;
+}
+
+async function writeAutoSyncAudit(
+  client,
+  { workspaceId, subjectUserId, action, metadata },
+) {
+  if (!subjectUserId) return;
+  await client.query(
+    `INSERT INTO audit_events
+       (actor_user_id, subject_user_id, action, target_type, target_id, channel, metadata, workspace_id)
+     VALUES (NULL, $1, $2, 'auto_sync_config', NULL, NULL, $3, $4)`,
+    [subjectUserId, action, metadata, workspaceId],
+  );
+}
+
+/**
+ * Persist auto-sync failure and emit AUTO_SYNC_FAILED audit on first transition
+ * into failed state (avoids hourly duplicate audit rows).
+ */
+export async function recordAutoSyncFailure(
+  client,
+  {
+    configId,
+    workspaceId,
+    provider,
+    createdBy = null,
+    previousStatus = null,
+    errorMessage,
+    httpStatus = null,
+    nextSync,
+  },
+) {
+  await client.query(
+    `UPDATE auto_sync_configs
+     SET last_sync_at = NOW(), last_sync_status = 'failed',
+         last_sync_error = $1, next_sync_at = $2, updated_at = NOW()
+     WHERE id = $3`,
+    [errorMessage, nextSync, configId],
+  );
+
+  if (previousStatus === "failed") return;
+
+  try {
+    const subjectUserId = await resolveAuditSubjectUserId(
+      client,
+      workspaceId,
+      createdBy,
+    );
+    await writeAutoSyncAudit(client, {
+      workspaceId,
+      subjectUserId,
+      action: "AUTO_SYNC_FAILED",
+      metadata: {
+        provider,
+        error: errorMessage,
+        http_status: httpStatus,
+        config_id: configId,
+      },
+    });
+  } catch (err) {
+    logger.warn("Audit write failed (AUTO_SYNC_FAILED)", {
+      error: err.message,
+      workspace_id: workspaceId,
+      provider,
+    });
+  }
+}

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.6.2
-appVersion: "0.6.2"
+version: 0.7.0
+appVersion: "0.7.0"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.6.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -175,7 +175,7 @@ worker:
     # Alert Discovery -- scans tokens and queues expiry alerts
     discovery:
       enabled: true
-      schedule: "*/5 * * * *" # Every 5 minutes
+      schedule: "*/5 * * * *" # Every 5 min (:00, :05, :10, ...)
       concurrencyPolicy: Forbid
       startingDeadlineSeconds: 300
       successfulJobsHistoryLimit: 3
@@ -192,7 +192,7 @@ worker:
     # Alert Delivery -- processes alert queue and sends notifications
     delivery:
       enabled: true
-      schedule: "*/5 * * * *" # Every 5 minutes
+      schedule: "1/5 * * * *" # 1 min after discovery (:01, :06, :11, ...)
       concurrencyPolicy: Forbid
       startingDeadlineSeconds: 300
       successfulJobsHistoryLimit: 3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.6.2
+  version: 0.7.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.
@@ -2725,6 +2725,47 @@ paths:
                     type: integer
         "400":
           $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/notifications:
+    get:
+      tags: [Alerts]
+      summary: List workspace operational notifications
+      operationId: listWorkspaceNotifications
+      description: >-
+        Returns operational notifications for the dashboard bell, including
+        auto-sync failures and alerts waiting for the delivery window.
+        Workspace admins and managers receive provider-specific items; other
+        members receive an empty list.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      responses:
+        "200":
+          description: Notification list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        kind:
+                          type: string
+                          enum: [error, warning, info]
+                        text:
+                          type: string
+                        href:
+                          type: string
+                          nullable: true
+                        provider:
+                          type: string
+                        count:
+                          type: integer
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/alert-settings:

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/auto-sync.test.js
+++ b/tests/integration/auto-sync.test.js
@@ -13,6 +13,11 @@ const { logger } = require("./logger");
 
 const BASE = process.env.TEST_API_URL || "http://localhost:4000";
 
+// Enterprise baseline runs this core suite against the enterprise API, which
+// correctly allows aws/azure/etc. Skip core-only edition gates in that context.
+const describeCoreEditionGates =
+  process.env.TT_TEST_RUNTIME === "enterprise" ? describe.skip : describe;
+
 // ---------------------------------------------------------------------------
 // 1. Auto-Sync CRUD
 // ---------------------------------------------------------------------------
@@ -90,71 +95,72 @@ describe("Auto-Sync CRUD", function () {
       .expect(401);
   });
 
-  it("POST /auto-sync - should reject enterprise-only providers in core (403)", async () => {
-    const res = await request(BASE)
-      .post(`/api/v1/workspaces/${workspaceId}/auto-sync`)
-      .set("Cookie", session.cookie)
-      .send({
-        provider: "aws",
-        credentials: {
-          accessKeyId: "AKIATEST",
-          secretAccessKey: "secret",
-        },
-        frequency: "daily",
-        schedule_time: "09:00",
-        schedule_tz: "UTC",
-      })
-      .expect(403);
+  describeCoreEditionGates("core edition gates for enterprise-only providers", function () {
+    it("POST /auto-sync - should reject enterprise-only providers in core (403)", async () => {
+      const res = await request(BASE)
+        .post(`/api/v1/workspaces/${workspaceId}/auto-sync`)
+        .set("Cookie", session.cookie)
+        .send({
+          provider: "aws",
+          credentials: {
+            accessKeyId: "AKIATEST",
+            secretAccessKey: "secret",
+          },
+          frequency: "daily",
+          schedule_time: "09:00",
+          schedule_tz: "UTC",
+        })
+        .expect(403);
 
-    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
-    expect(res.body.error).to.match(/not available in this edition/i);
-  });
+      expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
+      expect(res.body.error).to.match(/not available in this edition/i);
+    });
 
-  // --- Edition gates for stale DB rows (e.g. restored from enterprise backup) ---
+    // Stale DB rows (e.g. restored from enterprise backup)
+    it("PUT /auto-sync/:id - should reject enterprise-only providers in core (403)", async () => {
+      const inserted = await TestUtils.execQuery(
+        `INSERT INTO auto_sync_configs
+           (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+         VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
+         RETURNING id`,
+        [workspaceId, testUser.id],
+      );
+      const staleId = inserted.rows[0].id;
 
-  it("PUT /auto-sync/:id - should reject enterprise-only providers in core (403)", async () => {
-    const inserted = await TestUtils.execQuery(
-      `INSERT INTO auto_sync_configs
-         (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
-       VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
-       RETURNING id`,
-      [workspaceId, testUser.id],
-    );
-    const staleId = inserted.rows[0].id;
+      const res = await request(BASE)
+        .put(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}`)
+        .set("Cookie", session.cookie)
+        .send({ frequency: "weekly" })
+        .expect(403);
 
-    const res = await request(BASE)
-      .put(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}`)
-      .set("Cookie", session.cookie)
-      .send({ frequency: "weekly" })
-      .expect(403);
+      expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
 
-    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
+      await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
+        staleId,
+      ]);
+    });
 
-    await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
-      staleId,
-    ]);
-  });
+    it("POST /auto-sync/:id/run - should reject enterprise-only providers in core (403)", async () => {
+      const inserted = await TestUtils.execQuery(
+        `INSERT INTO auto_sync_configs
+           (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
+         VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
+         RETURNING id`,
+        [workspaceId, testUser.id],
+      );
+      const staleId = inserted.rows[0].id;
 
-  it("POST /auto-sync/:id/run - should reject enterprise-only providers in core (403)", async () => {
-    const inserted = await TestUtils.execQuery(
-      `INSERT INTO auto_sync_configs
-         (workspace_id, provider, credentials_encrypted, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_by)
-       VALUES ($1, 'aws', 'dummy', 'daily', '09:00', 'UTC', TRUE, NOW() + INTERVAL '1 day', $2)
-       RETURNING id`,
-      [workspaceId, testUser.id],
-    );
-    const staleId = inserted.rows[0].id;
+      const res = await request(BASE)
+        .post(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}/run`)
+        .set("Cookie", session.cookie)
+        .expect(403);
 
-    const res = await request(BASE)
-      .post(`/api/v1/workspaces/${workspaceId}/auto-sync/${staleId}/run`)
-      .set("Cookie", session.cookie)
-      .expect(403);
+      expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
 
-    expect(res.body).to.have.property("code", "FEATURE_NOT_AVAILABLE");
-
-    await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
-      staleId,
-    ]);
+      await TestUtils.execQuery("DELETE FROM auto_sync_configs WHERE id = $1", [
+        staleId,
+      ]);
+    });
   });
 
   // --- GET list ---

--- a/tests/integration/integrations-route-matrix.test.js
+++ b/tests/integration/integrations-route-matrix.test.js
@@ -1,6 +1,10 @@
 const { request, expect, TestUtils } = require("./setup");
 
 const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+const WORKER_SECRET =
+  process.env.WORKER_API_KEY ||
+  process.env.SESSION_SECRET ||
+  "test-session-secret-key";
 
 describe("Integrations route matrix", function () {
   this.timeout(90000);
@@ -64,6 +68,17 @@ describe("Integrations route matrix", function () {
         .send(route.body);
       expect([401, 403]).to.include(res.status);
     }
+  });
+
+  it("allows worker bearer on aws detect-regions without workspace_id", async () => {
+    const res = await request(BASE)
+      .post("/api/v1/integrations/aws/detect-regions")
+      .set("Authorization", `Bearer ${WORKER_SECRET}`)
+      .send({});
+
+    expect(res.status).to.equal(400);
+    expect(res.body.error).to.match(/accessKeyId and secretAccessKey/i);
+    expect(res.body.code).to.not.equal("VIEWER_NOT_ALLOWED");
   });
 
   it("enforces role guard for viewer on import endpoints", async () => {

--- a/tests/unit/auto-sync-failure.unit.test.js
+++ b/tests/unit/auto-sync-failure.unit.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+async function importFresh(relativePath) {
+  const abs = path.join(__dirname, "..", "..", relativePath);
+  const href = `${pathToFileURL(abs).href}?t=${Date.now()}-${Math.random()}`;
+  return import(href);
+}
+
+describe("autoSyncFailure helpers", () => {
+  it("formatAutoSyncError prefers API error body over Axios message", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const err = {
+      message: "Request failed with status code 401",
+      response: {
+        status: 401,
+        data: {
+          error:
+            "Authentication failed. Token may be expired (Azure CLI tokens expire quickly).",
+        },
+      },
+    };
+    assert.strictEqual(
+      mod.formatAutoSyncError(err),
+      "Authentication failed. Token may be expired (Azure CLI tokens expire quickly).",
+    );
+  });
+
+  it("formatAutoSyncError falls back to err.message", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    assert.strictEqual(
+      mod.formatAutoSyncError(new Error("Network timeout")),
+      "Network timeout",
+    );
+  });
+});

--- a/tests/unit/rbac-require-not-viewer.test.js
+++ b/tests/unit/rbac-require-not-viewer.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const { requireNotViewer } = require("../../apps/api/services/rbac");
+
+function mockRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe("requireNotViewer", () => {
+  it("allows internal worker calls without workspace membership", async () => {
+    let called = false;
+    const req = {
+      isWorkerCall: true,
+      user: { id: null, role: "admin", email: "worker@internal" },
+      query: {},
+      body: {},
+    };
+    const res = mockRes();
+
+    await requireNotViewer(req, res, () => {
+      called = true;
+    });
+
+    assert.strictEqual(called, true);
+    assert.strictEqual(res.statusCode, null);
+  });
+});


### PR DESCRIPTION
## Summary

Self-hosters get visibility when scheduled token imports fail: the worker records deduplicated `AUTO_SYNC_FAILED` audit events with API error text, the dashboard bell surfaces failed auto-sync configs and deferred alert deliveries, and clicking an auto-sync failure opens Import tokens directly on the **Manage auto-sync** tab to fix credentials or schedule without hunting through modals.

## Changes

### API
- `GET /api/v1/workspaces/:id/notifications` — operational bell items for workspace admins/managers (failed auto-sync with error text, `OUT_OF_WINDOW` deferred alerts)
- Auto-sync failure notification `href` — `/dashboard?import={provider}&autoSyncManage=1`

### Worker
- Shared `autoSyncFailure.js` — `formatAutoSyncError()`, `recordAutoSyncFailure()` (first transition into failed only, no hourly duplicates)
- Auto-sync worker delegates failure persistence to shared module
- `requireNotViewer` bypasses viewer check for authenticated worker API calls (`req.isWorkerCall`)

### Dashboard
- **Manage auto-sync tab** — Scan & Import | Manage auto-sync when auto-sync is enabled; edit schedule, credentials, disable without separate modals
- **Bell** — loads operational notifications alongside alert-settings warnings; auto-sync failures deep-link to Manage tab; deferred alerts link to Usage
- **`tt:notifications-refresh`** listener on Navigation (hook for future in-app refresh)
- **Import modal deep-link** — `ImportTokensButton` reads `?import=` and `?autoSyncManage=1` query params
- **GitHub/GitLab forms** — `autoSyncManageMode` hides scan UI on Manage tab
- **Audit UI** — labels/colours for `AUTO_SYNC_*` actions including `AUTO_SYNC_FAILED`

### Fixed
- Import footer buttons hidden on Manage auto-sync tab
- Modal reset returns integration sub-tab to Scan & Import on close
- Bell subtext matches deep-link behaviour; `openRequest` cleared after modal consumes it; Manage tab deep-link no longer sticks when auto-sync is not configured

### Tests
- `auto-sync-failure.unit.test.js`, `rbac-require-not-viewer.test.js`

### Docs / metadata
- Version bumped to **0.7.0** across package manifests, contracts, OpenAPI, Helm chart `version` / `appVersion` / image tags
- `CHANGELOG.md` updated

## Test plan
- [x] CI job passes https://github.com/tokentimerch/tokentimer-core/actions/runs/26461841622
- [X] Enable auto-sync on GitHub or GitLab, break credentials, wait for failure bell item
- [X] Click bell item — Import modal opens on correct provider, Manage auto-sync tab
- [X] Fix credentials and successful sync — bell item clears
- [X] Deferred alert (`OUT_OF_WINDOW`) bell item links to Usage