### PR TITLE
Harden core runtime, CI supply chain, and container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Validate contracts integrity
         run: pnpm run check:contracts:integrity
 
+      - name: Validate security override pins in lockfile
+        run: pnpm run check:lockfile-overrides
+
       - name: Run contract tests
         env:
           CONTRACT_API_REQUIRED: "0"
@@ -401,9 +404,18 @@ jobs:
       #   run: trivy image --scanners vuln --format sarif --output trivy-results-worker.sarif "tokentimer/worker:${{ github.sha }}"
 
       # --- Grype (Trivy replacement) ---
+      # Download the release binary directly and verify its checksum instead of
+      # piping the mutable main-branch install.sh into a shell (same supply-chain
+      # class as the Trivy compromise that got Trivy disabled above).
       - name: Install Grype
+        env:
+          GRYPE_VERSION: "0.112.0"
+          GRYPE_SHA256: "acb14a030010fe9bdb9594b4ae108d9d14ef2f926d936aa0916dc62c89c058ea"
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.112.0
+          curl -sSfL -o /tmp/grype.tar.gz "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          echo "${GRYPE_SHA256}  /tmp/grype.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/grype.tar.gz -C /tmp grype
+          sudo install -m 0755 /tmp/grype /usr/local/bin/grype
           grype version
 
       - name: Scan API image with Grype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Validate security override pins in lockfile
         run: pnpm run check:lockfile-overrides
 
+      - name: Validate secret logging hygiene
+        run: pnpm run check:secret-logging
+
       - name: Run contract tests
         env:
           CONTRACT_API_REQUIRED: "0"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,7 +22,6 @@ ignore:
   # zlib 1.3.1-r2: fix is in alpine 3.23 base; resolved by base image pin
   - vulnerability: CVE-2026-27171
 
-  # ip-address 10.1.0 (GHSA-v2v4-37r5-5v8g, Medium): bundled inside express-rate-limit
-  # in the API image and inside npm's internal node_modules in the worker image.
-  # Severity is Medium — non-blocking under --fail-on high. Track for next dep refresh.
+  # ip-address 10.2.0: override pins patched release; express-rate-limit still
+  # bundles the dep and Grype may report stale 10.1.0 without the override.
   # - vulnerability: GHSA-v2v4-37r5-5v8g

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -35,11 +35,12 @@ ENV NODE_ENV=production
 RUN pnpm install --prod --frozen-lockfile && \
     pnpm audit --audit-level=high || true
 
-# Copy source code (node_modules should not be in build context)
-COPY . .
+# Copy source code (node_modules should not be in build context).
+# --chown instead of a later `RUN chown -R /app`: the blanket chown duplicated
+# every layer (source + node_modules) and roughly doubled the image size.
+# node_modules stays root-owned; the app only needs read access at runtime.
+COPY --chown=nodejs:nodejs . .
 
-# Change ownership to nodejs user
-RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Expose port

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,18 @@
-FROM golang:1.26.2-alpine3.23 AS subfinder-builder
+FROM golang:1.26.4-alpine3.23 AS subfinder-builder
 
-RUN apk add --no-cache ca-certificates git && \
-    CGO_ENABLED=0 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates git
+
+RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/subfinder.git /src
+
+WORKDIR /src/cmd/subfinder
+RUN go get \
+      golang.org/x/crypto@v0.52.0 \
+      golang.org/x/net@v0.55.0 \
+      golang.org/x/sys@v0.45.0 \
+      github.com/cloudflare/circl@v1.6.3 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
 FROM node:22.22.2-slim
 
@@ -18,7 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     && groupadd -r nodejs -g 1001 \
     && useradd -r -u 1001 -g nodejs nodejs
 
-# Install subfinder v2.13.0 for Domain Checker discovery.
+# Install subfinder v2.14.0 for Domain Checker discovery.
 COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,7 +1,18 @@
-FROM golang:1.26.2-alpine3.23 AS subfinder-builder
+FROM golang:1.26.4-alpine3.23 AS subfinder-builder
 
-RUN apk add --no-cache ca-certificates git && \
-    CGO_ENABLED=0 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates git
+
+RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/subfinder.git /src
+
+WORKDIR /src/cmd/subfinder
+RUN go get \
+      golang.org/x/crypto@v0.52.0 \
+      golang.org/x/net@v0.55.0 \
+      golang.org/x/sys@v0.45.0 \
+      github.com/cloudflare/circl@v1.6.3 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
 FROM node:22.22.2-slim
 
@@ -24,7 +35,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     && groupadd -r nodejs -g 1001 \
     && useradd -r -u 1001 -g nodejs -m nodejs
 
-# Install subfinder v2.13.0 for Domain Checker discovery.
+# Install subfinder v2.14.0 for Domain Checker discovery.
 COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -28,8 +28,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
-# Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+# Enable pnpm via corepack. COREPACK_HOME makes the prepared pnpm cache
+# world-readable so the non-root runtime user reuses it instead of
+# downloading pnpm again (or worse, an unpinned latest) at container start.
+ENV COREPACK_HOME=/opt/corepack
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate && chmod -R a+rX /opt/corepack
 
 # Copy package files
 COPY package.json ./
@@ -39,11 +42,14 @@ COPY package.json ./
 RUN pnpm install --no-frozen-lockfile && \
     (pnpm audit --audit-level=high || true)
 
-# Copy source code
-COPY . .
+# Copy source code. --chown instead of a later `RUN chown -R /app`: the
+# blanket chown duplicated every layer (source + node_modules) into a second
+# copy. node_modules stays root-owned; runtime only reads it.
+COPY --chown=nodejs:nodejs . .
+# Dev containers may write transient files into the project root; chown the
+# /app directory inode only (non-recursive: metadata, no layer duplication).
+RUN chown nodejs:nodejs /app
 
-# Change ownership to nodejs user
-RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Expose port

--- a/apps/api/db/database.js
+++ b/apps/api/db/database.js
@@ -7,6 +7,16 @@ const { logger } = require("../utils/logger.js");
 const caPath = process.env.PGSSLROOTCERT;
 const sslMode = process.env.DB_SSL;
 const hasCA = !!caPath;
+const isProduction = process.env.NODE_ENV === "production";
+
+// SSL semantics:
+//   verify (or a CA provided)  -> encrypted + server identity verified
+//   require                    -> encrypted; identity verified in production
+//                                 unless DB_SSL=require-no-verify is set
+//   require-no-verify          -> encrypted, identity NOT verified (explicit
+//                                 opt-in for controlled environments)
+// Plain "require" used to map to rejectUnauthorized:false everywhere, which
+// encrypts but does not authenticate the server.
 const sslConfig =
   sslMode === "verify" || hasCA
     ? {
@@ -15,8 +25,10 @@ const sslConfig =
         minVersion: "TLSv1.3",
       }
     : sslMode === "require"
-      ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
-      : false;
+      ? { rejectUnauthorized: isProduction, minVersion: "TLSv1.3" }
+      : sslMode === "require-no-verify"
+        ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
+        : false;
 
 const dbConfig = {
   user: process.env.DB_USER || "tokentimer",
@@ -126,10 +138,10 @@ pool.on("error", (err) => {
 
 // Enhanced connection test function
 async function testConnection() {
+  let dbClient;
   try {
-    const client = await pool.connect();
-    await client.query("SELECT 1");
-    client.release();
+    dbClient = await pool.connect();
+    await dbClient.query("SELECT 1");
     logger.info("Database connection test successful");
     return true;
   } catch (error) {
@@ -145,6 +157,8 @@ async function testConnection() {
       dbErrors.labels("test").inc();
     } catch (_) {}
     return false;
+  } finally {
+    if (dbClient) dbClient.release();
   }
 }
 

--- a/apps/api/db/models/User.js
+++ b/apps/api/db/models/User.js
@@ -34,10 +34,19 @@ const update = async (id, userData) => {
     tokenExpiry,
   } = userData;
 
+  // COALESCE so an update that omits a field (e.g. a routine login that does
+  // not carry tokens) does not erase the stored value with NULL.
   const query = `
     UPDATE users 
-    SET display_name = $2, first_name = $3, last_name = $4, email = $5, photo = $6, access_token = $7, 
-        refresh_token = $8, token_expiry = $9, updated_at = NOW()
+    SET display_name = COALESCE($2, display_name),
+        first_name = COALESCE($3, first_name),
+        last_name = COALESCE($4, last_name),
+        email = COALESCE($5, email),
+        photo = COALESCE($6, photo),
+        access_token = COALESCE($7, access_token),
+        refresh_token = COALESCE($8, refresh_token),
+        token_expiry = COALESCE($9, token_expiry),
+        updated_at = NOW()
     WHERE id = $1
     RETURNING *
   `;

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -101,7 +101,12 @@ if (metricsEnabled) {
   app.use((req, res, next) => {
     const start = process.hrtime.bigint();
     res.on("finish", () => {
-      const route = req.route?.path || req.path || "unknown";
+      // Bound metric label cardinality: only emit the matched Express route
+      // pattern (e.g. /api/v1/workspaces/:id), never the raw req.path, which
+      // would let arbitrary/404 URLs explode the label set.
+      const route = req.route?.path
+        ? (req.baseUrl || "") + req.route.path
+        : "unmatched";
       const { method } = req;
       const status = String(res.statusCode);
       try {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",
+  "packageManager": "pnpm@10.33.4",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",

--- a/apps/api/services/binaryRunner.js
+++ b/apps/api/services/binaryRunner.js
@@ -71,29 +71,72 @@ async function runBinary({
   let timedOut = false;
   const toolHome = createToolWorkspace();
   const effectiveArgs = args;
+  const isWindows = process.platform === "win32";
 
   const child = spawn(bin, effectiveArgs, {
     shell: false,
     stdio: ["ignore", "pipe", "pipe"],
     env: createToolEnv(toolHome),
+    // Own process group on POSIX so the whole tree (incl. grandchildren)
+    // can be killed, not just the direct child.
+    detached: !isWindows,
   });
 
-  const killChild = (signalName) => {
-    if (!child.killed) {
-      child.kill(signalName);
+  const killTree = (signalName) => {
+    if (isWindows) {
+      if (signalName === "SIGKILL") {
+        try {
+          spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+            stdio: "ignore",
+          });
+        } catch (_err) {
+          try {
+            child.kill("SIGKILL");
+          } catch (_e) {
+            /* already gone */
+          }
+        }
+      } else {
+        try {
+          child.kill(signalName);
+        } catch (_e) {
+          /* already gone */
+        }
+      }
+      return;
+    }
+    try {
+      process.kill(-child.pid, signalName);
+    } catch (_err) {
+      try {
+        child.kill(signalName);
+      } catch (_e) {
+        /* already gone */
+      }
+    }
+  };
+
+  // SIGTERM with SIGKILL escalation scheduled IMMEDIATELY (not after the
+  // close event): a child that ignores SIGTERM must not hang the runner.
+  let killEscalation = null;
+  const terminate = () => {
+    killTree("SIGTERM");
+    if (!killEscalation) {
+      killEscalation = setTimeout(() => killTree("SIGKILL"), 2000);
+      killEscalation.unref?.();
     }
   };
 
   const timeout = setTimeout(
     () => {
       timedOut = true;
-      killChild("SIGTERM");
+      terminate();
     },
     Math.max(1000, Number(timeoutMs) || 90000),
   );
 
   const abortHandler = () => {
-    killChild("SIGTERM");
+    terminate();
   };
   if (signal) {
     if (signal.aborted) abortHandler();
@@ -106,7 +149,7 @@ async function runBinary({
   child.stdout.on("data", (chunk) => {
     stdoutBytes += Buffer.byteLength(chunk, "utf8");
     if (stdoutBytes > maxStdoutBytes) {
-      killChild("SIGTERM");
+      terminate();
       return;
     }
     stdoutBuffer += chunk;
@@ -137,6 +180,7 @@ async function runBinary({
     child.once("close", (code) => resolve(code));
   }).finally(() => {
     clearTimeout(timeout);
+    if (killEscalation) clearTimeout(killEscalation);
     if (signal) signal.removeEventListener("abort", abortHandler);
     fs.rmSync(toolHome, { recursive: true, force: true });
   });
@@ -146,7 +190,6 @@ async function runBinary({
 
   const durationMs = Date.now() - startedAt;
   if (signal?.aborted) {
-    setTimeout(() => killChild("SIGKILL"), 2000).unref?.();
     throw createRunnerError(
       "Discovery process was aborted",
       "DOMAIN_CHECKER_ABORTED",
@@ -158,7 +201,6 @@ async function runBinary({
     );
   }
   if (timedOut) {
-    setTimeout(() => killChild("SIGKILL"), 2000).unref?.();
     throw createRunnerError(
       "Discovery process timed out",
       "DOMAIN_CHECKER_TOOL_TIMEOUT",

--- a/apps/api/utils/logger.js
+++ b/apps/api/utils/logger.js
@@ -29,6 +29,58 @@ function resolveClientIp(reqOrIp) {
   return String(raw).split(",")[0].trim() || null;
 }
 
+// Field-level redaction: any meta key matching one of these names (or
+// containing one of these fragments, case/word-separator insensitive) is
+// replaced with "[REDACTED]" before the record is serialized.
+const REDACT_FIELDS = [
+  "password",
+  "token",
+  "secret",
+  "apiKey",
+  "api_key",
+  "accessKey",
+  "access_key",
+  "accessKeyId",
+  "access_key_id",
+  "secretAccessKey",
+  "secret_access_key",
+  "sessionToken",
+  "session_token",
+  "authorization",
+  "cookie",
+  "credentials",
+  "privateKey",
+  "private_key",
+  "client_secret",
+  "clientSecret",
+];
+
+const REDACT_KEY_PATTERN =
+  /password|secret|api[-_]?key|access[-_]?key|authorization|cookie|credential|private[-_]?key|token/i;
+
+function isSensitiveKey(key) {
+  return REDACT_KEY_PATTERN.test(String(key));
+}
+
+function redactSensitiveFields(value, depth = 0) {
+  if (value === null || value === undefined || depth > 8) return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => redactSensitiveFields(v, depth + 1));
+  }
+  if (typeof value === "object" && !(value instanceof Error)) {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (isSensitiveKey(k)) {
+        out[k] = "[REDACTED]";
+      } else {
+        out[k] = redactSensitiveFields(v, depth + 1);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
 function sanitizeLogValue(value) {
   if (value === null || value === undefined) return value;
   const t = typeof value;
@@ -47,7 +99,7 @@ function sanitizeLogValue(value) {
     }
     try {
       JSON.stringify(value);
-      return value;
+      return redactSensitiveFields(value);
     } catch (_e) {
       return "[Circular or Non-Serializable]";
     }
@@ -60,6 +112,10 @@ function sanitizeLogRecord(record) {
   for (const [key, value] of Object.entries(record)) {
     if (key === "ip") {
       out[key] = resolveClientIp(value) ?? sanitizeLogValue(value);
+      continue;
+    }
+    if (isSensitiveKey(key) && key !== "message") {
+      out[key] = "[REDACTED]";
       continue;
     }
     out[key] = sanitizeLogValue(value);
@@ -152,5 +208,7 @@ module.exports = {
   logger,
   resolveClientIp,
   buildOrderedLogRecord,
+  redactSensitiveFields,
+  REDACT_FIELDS,
   LOG_FIELD_ORDER,
 };

--- a/apps/api/utils/sanitize.js
+++ b/apps/api/utils/sanitize.js
@@ -75,8 +75,36 @@ function sanitizeForLogging(value) {
   return redact(value);
 }
 
+/**
+ * Escape a value for safe interpolation into HTML.
+ * @param {*} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Strip ASCII control characters (incl. CR/LF) from a single-line value,
+ * e.g. email subject parts, to prevent header/format injection.
+ * @param {*} value
+ * @param {number} maxLength
+ * @returns {string}
+ */
+function sanitizeSingleLine(value, maxLength = 200) {
+  // eslint-disable-next-line no-control-regex
+  return String(value ?? "").replace(/[\x00-\x1f\x7f]+/g, " ").trim().slice(0, maxLength);
+}
+
 module.exports = {
   hashPhone,
   maskPhone,
   sanitizeForLogging,
+  escapeHtml,
+  sanitizeSingleLine,
 };

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -40,6 +40,7 @@ FROM nginx:1.28.3-alpine3.23
 # CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r3 (r2 superseded in Alpine 3.23 repos).
 # Drop unused nginx-module-* packages first; their r1 revisions block apk upgrades.
 RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
     && apk del --no-cache \
         nginx-module-acme \
         nginx-module-geoip \
@@ -47,6 +48,7 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-njs \
         nginx-module-xslt \
     && apk add --no-cache nginx=1.28.3-r3 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
     && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3" \
     # Alpine's nginx build defaults to pid /run/nginx/nginx.pid (the official image
     # used /var/run/nginx.pid); the directory only exists when created here.

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -37,7 +37,8 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256: pin nginx=1.28.3-r2 (remove unused nginx-module-* first to avoid r1/r2 conflict).
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r3 (r2 superseded in Alpine 3.23 repos).
+# Drop unused nginx-module-* packages first; their r1 revisions block apk upgrades.
 RUN apk update && apk upgrade --no-cache \
     && apk del --no-cache \
         nginx-module-acme \
@@ -45,8 +46,11 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r2 \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r2"
+    && apk add --no-cache nginx=1.28.3-r3 \
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3" \
+    # Alpine's nginx build defaults to pid /run/nginx/nginx.pid (the official image
+    # used /var/run/nginx.pid); the directory only exists when created here.
+    && mkdir -p /run/nginx
 
 # Create non-root user for Nginx
 RUN mkdir -p /usr/share/nginx/html && \

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,6 +1,9 @@
 FROM node:22.22.2-alpine3.23
 
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 # Create app directory
 WORKDIR /app

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -9,8 +9,11 @@ WORKDIR /app
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
-# Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+# Enable pnpm via corepack. COREPACK_HOME makes the prepared pnpm cache
+# world-readable so the non-root runtime user reuses it instead of
+# downloading pnpm again (or worse, an unpinned latest) at container start.
+ENV COREPACK_HOME=/opt/corepack
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate && chmod -R a+rX /opt/corepack
 
 # Copy package files
 COPY package.json ./
@@ -18,11 +21,16 @@ COPY package.json ./
 # Install dependencies (including dev dependencies for Vite)
 RUN pnpm install --no-frozen-lockfile
 
-# Copy source code
-COPY . .
+# Copy source code. --chown instead of a blanket `RUN chown -R /app`, which
+# duplicated source + node_modules into a second layer. Vite only writes its
+# dependency cache under node_modules/.vite, so that is the one path that
+# needs ownership; the rest of node_modules stays root-owned (read-only).
+COPY --chown=nodejs:nodejs . .
+# Vite writes its dep cache to node_modules/.vite and a transient bundled
+# config (vite.config.js.timestamp-*.mjs) into the project root, so chown the
+# /app directory inode (non-recursive: metadata only, no layer duplication).
+RUN mkdir -p node_modules/.vite && chown -R nodejs:nodejs node_modules/.vite && chown nodejs:nodejs /app
 
-# Change ownership to nodejs user
-RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Expose Vite dev server port

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "private": true,
   "license": "BUSL-1.1",
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -34,7 +35,7 @@
     "react-icons": "5.5.0",
     "react-joyride": "2.9.3",
     "react-query": "3.39.3",
-    "react-router-dom": "6.30.3"
+    "react-router-dom": "6.30.4"
   },
   "devDependencies": {
     "@babel/preset-react": "7.28.5",

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -5760,7 +5760,16 @@ function ImportTokensButton() {
   }, []);
 
   useEffect(() => {
-    const KNOWN_IMPORT_PROVIDERS = ['file', 'vault', 'gitlab', 'github', 'aws', 'azure', 'azure-ad', 'gcp'];
+    const KNOWN_IMPORT_PROVIDERS = [
+      'file',
+      'vault',
+      'gitlab',
+      'github',
+      'aws',
+      'azure',
+      'azure-ad',
+      'gcp',
+    ];
     const provider = searchParams.get('import');
     if (!provider) return;
     if (KNOWN_IMPORT_PROVIDERS.includes(provider)) {

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -5760,14 +5760,17 @@ function ImportTokensButton() {
   }, []);
 
   useEffect(() => {
+    const KNOWN_IMPORT_PROVIDERS = ['file', 'vault', 'gitlab', 'github', 'aws', 'azure', 'azure-ad', 'gcp'];
     const provider = searchParams.get('import');
     if (!provider) return;
-    const autoSyncManage = searchParams.get('autoSyncManage') === '1';
-    setOpenRequest({
-      provider,
-      integrationSubTab: autoSyncManage ? 'manage' : 'scan',
-    });
-    onOpen();
+    if (KNOWN_IMPORT_PROVIDERS.includes(provider)) {
+      const autoSyncManage = searchParams.get('autoSyncManage') === '1';
+      setOpenRequest({
+        provider,
+        integrationSubTab: autoSyncManage ? 'manage' : 'scan',
+      });
+      onOpen();
+    }
     const next = new URLSearchParams(searchParams);
     next.delete('import');
     next.delete('autoSyncManage');

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:22.22.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -18,9 +18,11 @@ ENV NODE_ENV=production
 # Copy workspace config, root package.json, and lockfile from repo root
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 
-# Copy workspace packages and the worker app
-COPY packages ./packages
-COPY apps/worker ./apps/worker
+# Copy workspace packages and the worker app. --chown instead of a later
+# `RUN chown -R /app`, which duplicated source + node_modules into a second
+# layer. node_modules stays root-owned; the worker only reads it at runtime.
+COPY --chown=nodejs:nodejs packages ./packages
+COPY --chown=nodejs:nodejs apps/worker ./apps/worker
 
 # Install production dependencies using frozen lockfile
 RUN pnpm install --prod --frozen-lockfile --filter @tokentimer/worker...
@@ -28,8 +30,6 @@ RUN pnpm install --prod --frozen-lockfile --filter @tokentimer/worker...
 # Set working directory to worker
 WORKDIR /app/apps/worker
 
-# Change ownership to nodejs user
-RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Default command (overridden by tests/orchestration)

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -14,9 +14,11 @@ RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 # Copy workspace config, root package.json, and lockfile from repo root
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 
-# Copy workspace packages (needed for pnpm workspace resolution)
-COPY packages ./packages
-COPY apps/worker ./apps/worker
+# Copy workspace packages (needed for pnpm workspace resolution). --chown
+# instead of a later `RUN chown -R /app`, which duplicated source +
+# node_modules into a second layer. node_modules stays root-owned (read-only).
+COPY --chown=nodejs:nodejs packages ./packages
+COPY --chown=nodejs:nodejs apps/worker ./apps/worker
 
 # Install all dependencies (including dev) using frozen lockfile
 RUN pnpm install --frozen-lockfile --filter @tokentimer/worker...
@@ -24,8 +26,6 @@ RUN pnpm install --frozen-lockfile --filter @tokentimer/worker...
 # Set working directory to worker
 WORKDIR /app/apps/worker
 
-# Change ownership to nodejs user
-RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Default command (overridden by tests/orchestration)

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,6 +1,9 @@
 FROM node:22.22.2-alpine3.23
 
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 WORKDIR /app
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "private": true,
   "license": "BUSL-1.1",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "main": "src/queue-manager.js",
   "scripts": {

--- a/apps/worker/src/db.js
+++ b/apps/worker/src/db.js
@@ -15,6 +15,14 @@ const { Pool } = pg;
 const caPath = process.env.PGSSLROOTCERT;
 const sslMode = process.env.DB_SSL;
 const hasCA = Boolean(caPath);
+const isProduction = process.env.NODE_ENV === "production";
+
+// SSL semantics:
+//   verify (or a CA provided)  -> encrypted + server identity verified
+//   require                    -> encrypted; identity verified in production
+//                                 unless DB_SSL=require-no-verify is set
+//   require-no-verify          -> encrypted, identity NOT verified (explicit
+//                                 opt-in for controlled environments)
 const sslConfig =
   sslMode === "verify" || hasCA
     ? {
@@ -23,8 +31,10 @@ const sslConfig =
         minVersion: "TLSv1.3",
       }
     : sslMode === "require"
-      ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
-      : false;
+      ? { rejectUnauthorized: isProduction, minVersion: "TLSv1.3" }
+      : sslMode === "require-no-verify"
+        ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
+        : false;
 
 export const pool = new Pool({
   user: process.env.DB_USER || "tokentimer",

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,17 +1,31 @@
 # TokenTimer API Dockerfile
-FROM golang:1.26.3-alpine3.23 AS subfinder-builder
+FROM golang:1.26.4-alpine3.23 AS subfinder-builder
 
-RUN apk add --no-cache ca-certificates git && \
-    CGO_ENABLED=0 go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates git
+
+RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/subfinder.git /src
+
+WORKDIR /src/cmd/subfinder
+RUN go get \
+      golang.org/x/crypto@v0.52.0 \
+      golang.org/x/net@v0.55.0 \
+      golang.org/x/sys@v0.45.0 \
+      github.com/cloudflare/circl@v1.6.3 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
 FROM node:22.22.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 RUN apk add --no-cache ca-certificates
 
-# Install subfinder v2.13.0 for Domain Checker discovery.
+# Install subfinder v2.14.0 for Domain Checker discovery.
 COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -40,7 +40,8 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256: pin nginx=1.28.3-r2. Drop unused nginx-module-* packages first; their r1
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r3 (r2 superseded in Alpine 3.23 repos).
+# Drop unused nginx-module-* packages first; their r1
 # revisions block apk from replacing nginx while those modules stay installed.
 RUN apk update && apk upgrade --no-cache \
     && apk del --no-cache \
@@ -49,8 +50,8 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r2 \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r2"
+    && apk add --no-cache nginx=1.28.3-r3 \
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3"
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -2,7 +2,10 @@
 FROM node:22.22.2-alpine3.23 AS builder
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
@@ -44,6 +47,7 @@ FROM nginx:1.28.3-alpine3.23
 # Drop unused nginx-module-* packages first; their r1
 # revisions block apk from replacing nginx while those modules stay installed.
 RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
     && apk del --no-cache \
         nginx-module-acme \
         nginx-module-geoip \
@@ -51,6 +55,7 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-njs \
         nginx-module-xslt \
     && apk add --no-cache nginx=1.28.3-r3 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
     && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3"
 
 # Create non-root nginx user and prepare writable directories

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -2,7 +2,10 @@
 FROM node:22.22.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-RUN apk update && apk upgrade --no-cache
+# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 # Install curl for optional probes / tooling
 RUN apk add --no-cache curl

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:contracts:integrity": "node scripts/check-contracts-integrity.js",
     "check:openapi:coverage": "node scripts/check-openapi-runtime-coverage.js",
     "check:lockfile-overrides": "node scripts/check-lockfile-overrides.js",
+    "check:secret-logging": "node scripts/check-secret-logging.js",
     "test:baseline": "node scripts/run-baseline.js",
     "test:ci": "pnpm run test:unit && node scripts/run-tests-local.js core",
     "test:ci:all": "NODE_ENV=test pnpm exec mocha tests/integration/**/*.test.js --timeout 60000 --exit --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results/results.xml",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:contracts": "node scripts/check-contracts-manifest.js && node scripts/check-openapi-runtime-coverage.js",
     "check:contracts:integrity": "node scripts/check-contracts-integrity.js",
     "check:openapi:coverage": "node scripts/check-openapi-runtime-coverage.js",
+    "check:lockfile-overrides": "node scripts/check-lockfile-overrides.js",
     "test:baseline": "node scripts/run-baseline.js",
     "test:ci": "pnpm run test:unit && node scripts/run-tests-local.js core",
     "test:ci:all": "NODE_ENV=test pnpm exec mocha tests/integration/**/*.test.js --timeout 60000 --exit --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results/results.xml",

--- a/packages/config/src/database.js
+++ b/packages/config/src/database.js
@@ -11,8 +11,14 @@ import { readFileSync, existsSync } from "fs";
 export function getDatabaseConfig() {
   const sslMode = process.env.DB_SSL;
   const caPath = process.env.PGSSLROOTCERT;
+  const isProduction = process.env.NODE_ENV === "production";
 
-  // Build SSL config
+  // Build SSL config.
+  //   verify (or a CA provided)  -> encrypted + server identity verified
+  //   require                    -> encrypted; identity verified in production
+  //                                 unless DB_SSL=require-no-verify is set
+  //   require-no-verify          -> encrypted, identity NOT verified (explicit
+  //                                 opt-in for controlled environments)
   let ssl = false;
   if (sslMode === "verify" || caPath) {
     ssl = {
@@ -22,6 +28,8 @@ export function getDatabaseConfig() {
       minVersion: "TLSv1.3",
     };
   } else if (sslMode === "require") {
+    ssl = { rejectUnauthorized: isProduction, minVersion: "TLSv1.3" };
+  } else if (sslMode === "require-no-verify") {
     ssl = { rejectUnauthorized: false, minVersion: "TLSv1.3" };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: 3.39.3
         version: 3.39.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
-        specifier: 6.30.3
-        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.30.4
+        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/preset-react':
         specifier: 7.28.5
@@ -1189,8 +1189,8 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
@@ -3652,15 +3652,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@6.30.3:
-    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.3:
-    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -5674,7 +5674,7 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@remix-run/router@1.23.2': {}
+  '@remix-run/router@1.23.3': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -8470,16 +8470,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.3(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
 
-  react-router@6.30.3(react@18.3.1):
+  react-router@6.30.4(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,12 @@ overrides:
   serialize-javascript: 7.0.5
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
-  ajv@6: 6.14.0
+  ajv@6: 6.15.0
   lodash: 4.18.1
   follow-redirects: 1.16.0
   postcss: 8.5.12
   qs: 6.15.2
+  ip-address: 10.2.0
 
 importers:
 
@@ -1737,8 +1738,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -5449,7 +5450,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.14.0
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
@@ -5463,7 +5464,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.14.0
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -6303,7 +6304,7 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.14.0:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -7081,7 +7082,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.14.0
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -7128,7 +7129,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.14.0
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,11 +15,12 @@ overrides:
   serialize-javascript: 7.0.5
   "picomatch@2": 2.3.2
   "picomatch@4": 4.0.4
-  "ajv@6": 6.14.0
+  "ajv@6": 6.15.0
   lodash: 4.18.1
   follow-redirects: 1.16.0
   postcss: 8.5.12
   qs: 6.15.2
+  ip-address: 10.2.0
 
 onlyBuiltDependencies:
   - esbuild

--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -26,11 +26,12 @@ const REQUIRED_PINS = {
   flatted: { "*": "3.4.2" },
   "serialize-javascript": { "*": "7.0.5" },
   picomatch: { 2: "2.3.2", 4: "4.0.4" },
-  ajv: { 6: "6.14.0" },
+  ajv: { 6: "6.15.0" },
   lodash: { "*": "4.18.1" },
   "follow-redirects": { "*": "1.16.0" },
   postcss: { "*": "8.5.12" },
   qs: { "*": "6.15.2" },
+  "ip-address": { "*": "10.2.0" },
 };
 
 function fail(message) {

--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+"use strict";
+
+// Asserts that pnpm-lock.yaml actually resolves the security-patched versions
+// pinned in pnpm-workspace.yaml overrides. This catches the failure mode where
+// override configuration moves (or is duplicated) and silently stops applying.
+// Mirror of the tokentimer-cloud checker, with the core override set.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const lockPath = path.join(repoRoot, "pnpm-lock.yaml");
+const pkgPath = path.join(repoRoot, "package.json");
+
+// name -> { major: expected version } ; major "*" means any major.
+// Keep in sync with the overrides block in pnpm-workspace.yaml.
+const REQUIRED_PINS = {
+  tar: { "*": "7.5.7" },
+  "fast-xml-parser": { "*": "5.7.3" },
+  minimatch: { "*": "9.0.9" },
+  "brace-expansion": { "*": "2.0.3" },
+  "path-to-regexp": { "*": "8.4.0" },
+  yaml: { "*": "1.10.3" },
+  rollup: { "*": "4.60.0" },
+  flatted: { "*": "3.4.2" },
+  "serialize-javascript": { "*": "7.0.5" },
+  picomatch: { 2: "2.3.2", 4: "4.0.4" },
+  ajv: { 6: "6.14.0" },
+  lodash: { "*": "4.18.1" },
+  "follow-redirects": { "*": "1.16.0" },
+  postcss: { "*": "8.5.12" },
+  qs: { "*": "6.15.2" },
+};
+
+function fail(message) {
+  console.error(`check-lockfile-overrides: ${message}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(lockPath)) {
+  fail("pnpm-lock.yaml not found");
+}
+
+// Guard against introducing a second override location: pnpm-workspace.yaml
+// is canonical.
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+if (pkg.pnpm && pkg.pnpm.overrides) {
+  fail(
+    "package.json contains pnpm.overrides; the canonical override location is pnpm-workspace.yaml (remove the package.json set to avoid two diverging sources)",
+  );
+}
+
+const lock = fs.readFileSync(lockPath, "utf8");
+const problems = [];
+let checked = 0;
+
+for (const [name, pins] of Object.entries(REQUIRED_PINS)) {
+  // Match resolved package keys, e.g. "  lodash@4.18.1:" or
+  // "  'brace-expansion@2.0.3':" and dependency specs "lodash: 4.18.1".
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const keyPattern = new RegExp(`^\\s+'?${escaped}@(\\d+)((?:\\.\\d+)+[^':\\s(]*)'?:`, "gm");
+  const found = new Set();
+  let match;
+  while ((match = keyPattern.exec(lock)) !== null) {
+    found.add(`${match[1]}${match[2]}`);
+  }
+  for (const version of found) {
+    checked++;
+    const major = version.split(".")[0];
+    const expected = pins[major] ?? pins["*"];
+    if (expected === undefined) {
+      continue; // major not covered by a pin
+    }
+    if (version !== expected) {
+      problems.push(`${name}@${version} resolved in lockfile but override requires ${expected}`);
+    }
+  }
+}
+
+if (problems.length > 0) {
+  for (const problem of problems) {
+    console.error(`check-lockfile-overrides: ${problem}`);
+  }
+  fail(`${problems.length} security override pin(s) not honored by pnpm-lock.yaml`);
+}
+
+console.log(`check-lockfile-overrides: ok (${checked} resolved version(s) checked against required pins)`);

--- a/scripts/check-secret-logging.js
+++ b/scripts/check-secret-logging.js
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const here = __dirname;
+const repoRoot = path.resolve(here, "..");
+const loggerPath = path.join(repoRoot, "apps/api/utils/logger.js");
+const scanRoots = [
+  path.join(repoRoot, "apps/api"),
+  path.join(repoRoot, "apps/worker/src"),
+];
+const integrationServicesDir = path.join(repoRoot, "apps/api/services");
+
+const REQUIRED_REDACTION_FIELDS = [
+  { name: "password", aliases: ["password"] },
+  { name: "token", aliases: ["token"] },
+  { name: "secret", aliases: ["secret"] },
+  { name: "apiKey", aliases: ["apiKey", "api_key"] },
+  { name: "accessKey", aliases: ["accessKey", "access_key", "accessKeyId", "access_key_id"] },
+  { name: "authorization", aliases: ["authorization"] },
+  { name: "cookie", aliases: ["cookie"] },
+  { name: "credentials", aliases: ["credentials"] },
+  { name: "privateKey", aliases: ["privateKey", "private_key"] },
+];
+
+const RAW_LOG_HEURISTIC_PATTERNS = [
+  { id: "req.body", re: /req\.body\b/ },
+  { id: "secretAccessKey", re: /\bsecretAccessKey\b/ },
+  { id: "client_secret", re: /\bclient_secret\b/ },
+  { id: "privateKey", re: /\bprivateKey\b/ },
+  { id: "personalAccessToken", re: /\bpersonalAccessToken\b/ },
+  { id: "personal_access_token", re: /\bpersonal_access_token\b/ },
+  { id: "vaultToken", re: /\bvaultToken\b/ },
+  { id: "vault_token", re: /\bvault_token\b/ },
+  { id: "apiToken+raw", re: /\bapiToken\b.*\braw\b|\braw\b.*\bapiToken\b/ },
+];
+
+const CREDENTIAL_METADATA_KEYS = new Set([
+  "password",
+  "token",
+  "secret",
+  "secretAccessKey",
+  "accessKeyId",
+  "access_key_id",
+  "apiKey",
+  "api_key",
+  "accessToken",
+  "refreshToken",
+  "sessionToken",
+  "client_secret",
+  "privateKey",
+  "private_key",
+  "credentials",
+  "vaultToken",
+  "vault_token",
+  "personal_access_token",
+  "personalAccessToken",
+  "authorization",
+]);
+
+// Verified safe logger call sites (file + regex on call text).
+const RAW_LOG_ALLOWLIST = [
+  {
+    file: "apps/api/middleware/rateLimit.js",
+    pattern: /normalizeEmail\s*\(\s*req\.body\?\.email\s*\)/,
+    reason:
+      "rate-limit logging extracts only the normalized email from req.body, never the credential fields",
+  },
+  {
+    file: "apps/api/routes/auth.js",
+    pattern: /req\.body\?\.email\s*\?\s*"provided"\s*:\s*"missing"/,
+    reason:
+      "auth attempt logging records only whether an email was provided, never its value or credentials",
+  },
+  {
+    file: "apps/api/routes/tokens.js",
+    pattern: /sanitizeForLogging\s*\(\s*req\.body\s*\)/,
+    reason: "req.body is passed through sanitizeForLogging before logging",
+  },
+  {
+    file: "apps/api/routes/workspaces.js",
+    pattern: /sanitizeForLogging\s*\(\s*req\.body\s*\)/,
+    reason: "req.body is passed through sanitizeForLogging before logging",
+  },
+  {
+    file: "apps/api/services/rbac.js",
+    pattern: /req\.body\?\.workspace_id/,
+    reason: "Only workspace_id is read from req.body, not credential fields",
+  },
+  {
+    file: "apps/api/routes/integrations.js",
+    pattern: /req\.body\?\.address[^;]*substring/,
+    reason: "Vault address is truncated to 100 chars; token is never logged",
+  },
+  {
+    file: "apps/api/routes/integrations.js",
+    pattern: /req\.body\?\.baseUrl/,
+    reason: "Only baseUrl is logged on scan failure, not tokens or keys",
+  },
+  {
+    file: "apps/api/routes/integrations.js",
+    pattern: /req\.body\?\.region/,
+    reason: "Only AWS region is logged on scan failure, not access keys",
+  },
+  {
+    file: "apps/api/routes/integrations.js",
+    pattern: /req\.body\?\.projectId/,
+    reason: "Only GCP projectId is logged on scan failure, not access tokens",
+  },
+];
+
+const ERROR_PATH_FORBIDDEN = [
+  { id: "err.config", re: /\berr\.config\b/ },
+  { id: "error.config", re: /\berror\.config\b/ },
+  { id: "request payload", re: /\b(req\.body|credentials|accessKeyId|secretAccessKey|sessionToken|client_secret|privateKey|personal_access_token|vaultToken|vault_token)\b/ },
+];
+
+let filesScanned = 0;
+
+function fail(message) {
+  console.error(`check-secret-logging: ${message}`);
+  process.exit(1);
+}
+
+function stripComments(source) {
+  let out = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  out = out.replace(/(^|[^:\\])\/\/.*$/gm, "$1");
+  return out;
+}
+
+function walkJsFiles(rootDir, relBase) {
+  const results = [];
+  if (!fs.existsSync(rootDir)) return results;
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "tests" || entry.name === "dist") {
+      continue;
+    }
+    const abs = path.join(rootDir, entry.name);
+    const rel = path.posix.join(relBase, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkJsFiles(abs, rel));
+    } else if (entry.name.endsWith(".js")) {
+      results.push({ abs, rel: rel.replace(/\\/g, "/") });
+    }
+  }
+  return results;
+}
+
+function extractLoggerCalls(source) {
+  const calls = [];
+  const re = /logger\.(info|warn|error|debug)\s*\(/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const start = match.index;
+    let i = re.lastIndex;
+    let depth = 1;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === "(") depth += 1;
+      else if (ch === ")") depth -= 1;
+      i += 1;
+    }
+    const end = i;
+    const line = source.slice(0, start).split("\n").length;
+    calls.push({
+      text: source.slice(start, end),
+      line,
+    });
+    re.lastIndex = end;
+  }
+  return calls;
+}
+
+function isAllowlisted(relFile, callText) {
+  return RAW_LOG_ALLOWLIST.some(
+    (entry) => entry.file === relFile && entry.pattern.test(callText),
+  );
+}
+
+function extractRedactionFields(loggerSource) {
+  const fields = new Set();
+  const setMatch = loggerSource.match(/sensitiveKeys\s*=\s*new\s+Set\s*\(\s*\[([\s\S]*?)\]\s*\)/);
+  if (setMatch) {
+    for (const m of setMatch[1].matchAll(/["'`]([^"'`]+)["'`]/g)) {
+      fields.add(m[1]);
+    }
+  }
+  for (const m of loggerSource.matchAll(/["'`]([^"'`]+)["'`]\s*:\s*["'`]?\[?REDACTED/g)) {
+    fields.add(m[1]);
+  }
+  for (const m of loggerSource.matchAll(/REDACT_FIELDS\s*=\s*\[([\s\S]*?)\]/g)) {
+    for (const f of m[1].matchAll(/["'`]([^"'`]+)["'`]/g)) {
+      fields.add(f[1]);
+    }
+  }
+  return fields;
+}
+
+function checkSanitizerPresence() {
+  if (!fs.existsSync(loggerPath)) {
+    fail(`missing ${loggerPath}`);
+  }
+  const loggerSource = fs.readFileSync(loggerPath, "utf8");
+  const hasSanitization =
+    /sanitizeLog(Value|Record)\b/.test(loggerSource) ||
+    /sanitizeForLogging\b/.test(loggerSource) ||
+    /sensitiveKeys\b/.test(loggerSource) ||
+    /REDACT_FIELDS\b/.test(loggerSource);
+
+  if (!hasSanitization) {
+    fail(
+      "apps/api/utils/logger.js must contain sanitization logic (sanitizeLogRecord, sensitiveKeys, or sanitizeForLogging)",
+    );
+  }
+
+  const present = extractRedactionFields(loggerSource);
+  const missing = [];
+  for (const field of REQUIRED_REDACTION_FIELDS) {
+    const covered = field.aliases.some((alias) => present.has(alias));
+    if (!covered) missing.push(field.name);
+  }
+  if (missing.length > 0) {
+    fail(
+      `logger.js redaction list missing required fields: ${missing.join(", ")}`,
+    );
+  }
+}
+
+function checkRawCredentialLogging() {
+  const violations = [];
+  for (const root of scanRoots) {
+    const relBase = path.relative(repoRoot, root).replace(/\\/g, "/");
+    for (const file of walkJsFiles(root, relBase)) {
+      filesScanned += 1;
+      const source = stripComments(fs.readFileSync(file.abs, "utf8"));
+      for (const call of extractLoggerCalls(source)) {
+        const matched = RAW_LOG_HEURISTIC_PATTERNS.filter((p) => p.re.test(call.text));
+        if (matched.length === 0) continue;
+        if (isAllowlisted(file.rel, call.text)) continue;
+        violations.push({
+          file: file.rel,
+          line: call.line,
+          patterns: matched.map((p) => p.id).join(", "),
+          excerpt: call.text.replace(/\s+/g, " ").slice(0, 160),
+        });
+      }
+    }
+  }
+  if (violations.length > 0) {
+    const detail = violations
+      .map(
+        (v) =>
+          `  ${v.file}:${v.line} [${v.patterns}] ${v.excerpt}`,
+      )
+      .join("\n");
+    fail(`raw credential logging heuristic matched unsafe logger calls:\n${detail}`);
+  }
+}
+
+function extractWriteAuditBlocks(source) {
+  const blocks = [];
+  const re = /writeAudit\s*\(\s*\{/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const start = match.index;
+    let i = re.lastIndex;
+    let depth = 1;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") depth -= 1;
+      i += 1;
+    }
+    const end = i;
+    const line = source.slice(0, start).split("\n").length;
+    blocks.push({
+      text: source.slice(start, end),
+      line,
+    });
+    re.lastIndex = end;
+  }
+  return blocks;
+}
+
+function checkAuditPersistence() {
+  const apiRoot = path.join(repoRoot, "apps/api");
+  const violations = [];
+  for (const file of walkJsFiles(apiRoot, "apps/api")) {
+    const source = stripComments(fs.readFileSync(file.abs, "utf8"));
+    for (const block of extractWriteAuditBlocks(source)) {
+      const metadataMatch = block.text.match(/metadata\s*:\s*(\{[\s\S]*?\})\s*,?\s*(?:workspaceId|channel|targetId|targetType|action|subjectUserId|actorUserId|\})/);
+      if (!metadataMatch) continue;
+      const metadataText = metadataMatch[1];
+      for (const key of CREDENTIAL_METADATA_KEYS) {
+        const keyRe = new RegExp(`\\b${key}\\s*:`);
+        if (keyRe.test(metadataText)) {
+          violations.push({
+            file: file.rel,
+            line: block.line,
+            key,
+            excerpt: metadataText.replace(/\s+/g, " ").slice(0, 120),
+          });
+        }
+      }
+    }
+  }
+  if (violations.length > 0) {
+    const detail = violations
+      .map((v) => `  ${v.file}:${v.line} metadata.${v.key} ${v.excerpt}`)
+      .join("\n");
+    fail(`writeAudit call sites pass raw credential fields in metadata:\n${detail}`);
+  }
+}
+
+function isInsideCatchBlock(source, index) {
+  const prefix = source.slice(0, index);
+  const catchIdx = prefix.lastIndexOf("catch");
+  if (catchIdx === -1) return false;
+  const tryIdx = prefix.lastIndexOf("try");
+  return catchIdx > tryIdx;
+}
+
+function checkIntegrationErrorPaths() {
+  if (!fs.existsSync(integrationServicesDir)) return;
+  const violations = [];
+  // Core keeps provider integrations as apps/api/services/*Integration.js
+  // rather than a dedicated integrations/ directory.
+  const integrationFiles = walkJsFiles(
+    integrationServicesDir,
+    "apps/api/services",
+  ).filter((file) => file.rel.endsWith("Integration.js"));
+  for (const file of integrationFiles) {
+    const source = stripComments(fs.readFileSync(file.abs, "utf8"));
+    const calls = extractLoggerCalls(source);
+    for (const call of calls) {
+      const callIndex = source.indexOf(call.text);
+      if (!isInsideCatchBlock(source, callIndex)) continue;
+      // Only match identifiers/expressions, not words inside log message
+      // strings (e.g. logger.info("AWS credentials validated")).
+      const codeOnly = call.text.replace(/(["'`])(?:\\.|(?!\1).)*\1/g, '""');
+      for (const rule of ERROR_PATH_FORBIDDEN) {
+        if (!rule.re.test(codeOnly)) continue;
+        if (rule.id === "request payload" && /\berror\s*:\s*(e|err|error)\.message\b/.test(call.text) && !/\b(req\.body|credentials)\s*[,}]/.test(call.text)) {
+          continue;
+        }
+        violations.push({
+          file: file.rel,
+          line: call.line,
+          rule: rule.id,
+          excerpt: call.text.replace(/\s+/g, " ").slice(0, 160),
+        });
+      }
+    }
+  }
+  if (violations.length > 0) {
+    const detail = violations
+      .map((v) => `  ${v.file}:${v.line} [${v.rule}] ${v.excerpt}`)
+      .join("\n");
+    fail(`integration catch blocks log unsafe axios/request data:\n${detail}`);
+  }
+}
+
+checkSanitizerPresence();
+checkRawCredentialLogging();
+checkAuditPersistence();
+checkIntegrationErrorPaths();
+
+console.log(
+  `check-secret-logging: ok (files scanned: ${filesScanned}, allowlist entries: ${RAW_LOG_ALLOWLIST.length})`,
+);

--- a/scripts/run-baseline.js
+++ b/scripts/run-baseline.js
@@ -17,7 +17,13 @@ function run(command, args, envPatch = {}) {
   return typeof result.status === "number" ? result.status : 1;
 }
 
-let code = run("pnpm", ["run", "check:contracts"]);
+let code = run("pnpm", ["run", "check:lockfile-overrides"]);
+if (code !== 0) process.exit(code);
+
+code = run("pnpm", ["run", "check:secret-logging"]);
+if (code !== 0) process.exit(code);
+
+code = run("pnpm", ["run", "check:contracts"]);
 if (code !== 0) process.exit(code);
 
 code = run("pnpm", ["run", "check:contracts:integrity"]);


### PR DESCRIPTION
## Summary

Improves runtime reliability, supply-chain checks, and container image builds
across the API, worker, and dashboard. This PR does not bump version or cut a
release; merge to main first, then run the release workflow when ready.

Self-hosters get more reliable domain-checker termination, safer partial user
updates, and smaller container images. Operators using `DB_SSL=require` in
production should review the SSL note below.

## Changes

### Security / logging

- **Logger redaction** — add `REDACT_FIELDS` and `redactSensitiveFields` so
  credentials and tokens are replaced with `[REDACTED]` before structured logs
  are serialized, even when a call site passes a raw payload by mistake.
- **Sanitize helpers** — add `escapeHtml` and `sanitizeSingleLine` for safe HTML
  interpolation and single-line header fields (e.g. email subjects).
- **Import deep-links** — ignore unknown `?import=` query values so arbitrary
  URLs cannot open the import modal with an invalid provider.
- **Dashboard routing** — bump `react-router-dom` 6.30.3 → 6.30.4 (GHSA-2j2x-hqr9-3h42
  open-redirect fix).

### API / runtime

- **PostgreSQL SSL** — `DB_SSL=require` now verifies the server certificate in
  production (`rejectUnauthorized: true`). New explicit escape hatch:
  `DB_SSL=require-no-verify` for self-signed DB certs in controlled
  environments. Applied in API pool, worker pool, and `packages/config`.
- **`testConnection`** — release the borrowed pool client in a `finally` block
  so failed probes do not leak connections.
- **`User.update`** — use `COALESCE` so partial updates (e.g. routine login
  without OAuth tokens) do not NULL out existing profile/token fields.
- **`binaryRunner`** — terminate process trees on timeout/abort (POSIX process
  groups + Windows `taskkill /T /F`), with immediate SIGKILL escalation so
  stubborn discovery tools cannot hang the API.
- **Metrics** — bound Prometheus route labels to matched Express patterns
  (`unmatched` for 404s) instead of raw `req.path`, avoiding label
  cardinality blow-up.

### CI / supply chain

- **Dependency pins** — bump `ajv@6` to 6.15.0 (align with cloud); lockfile
  regenerated.
- **`check:lockfile-overrides`** — assert `pnpm-workspace.yaml` security override
  pins resolve in `pnpm-lock.yaml` (validate job).
- **`check:secret-logging`** — enforce logger redaction coverage and scan for
  raw credential logging (validate job + `test:baseline`).
- **Grype install** — download the release tarball and verify SHA256 instead of
  piping `install.sh` from `main`.

### Infra / Docker

- **Layer size** — replace blanket `RUN chown -R /app` with `COPY --chown`
  (and targeted chown where dev containers need write access) on API, worker,
  and dashboard images to avoid duplicating layers.
- **Dev Corepack** — set `COREPACK_HOME=/opt/corepack` so non-root dev
  containers reuse the pinned pnpm instead of re-downloading at start.
- **Dashboard nginx** — pin `nginx=1.28.3-r3` (CVE-2026-9256 /
  CVE-2026-49975) and ensure `/run/nginx` exists for Alpine's default pid path.
- **`packageManager`** — pin `pnpm@10.33.4` on API, dashboard, and worker
  package manifests.

## Ops notes

Deployments using `DB_SSL=require` with a **self-signed** PostgreSQL cert and
`NODE_ENV=production` will need either a trusted CA (`PGSSLROOTCERT` /
`DB_SSL=verify`) or `DB_SSL=require-no-verify`.


## Test plan

- [X] CI job passes https://github.com/tokentimerch/tokentimer-core/actions/runs/27470119375
- [X] `pnpm run test:ci` (user/merge gate)
- [X] Rebuild API/worker/dashboard images; confirm non-root dev containers
      start without Corepack re-downloading pnpm
- [X] Smoke-test domain checker timeout/abort (binary runner exits cleanly)
- [X] Confirm DB connectivity with production SSL mode
      (`require` vs `require-no-verify`)
- [X] Dashboard: `?import=unknown` does not open import modal; `?import=vault`
      still works