### PR TITLE
Release TokenTimer Core v0.7.2 with Runtime Hardening and WhatsApp Template Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-15
+
+### Added
+
+- **WhatsApp template sanitization** — shared `apps/worker/src/shared/whatsappTemplateVars.js` strips invalid characters and enforces placeholder contracts before Twilio `ContentVariables` are sent.
+- **CI supply-chain checks** — `check:lockfile-overrides` verifies security override pins in `pnpm-lock.yaml`; `check:secret-logging` blocks credential leakage in log statements.
+- **Dev command map** — `pnpm dev:help` prints the local development command reference (`scripts/dev-help.js`).
+
+### Changed
+
+- **Root package scripts** — reorganized `package.json` scripts into labelled sections; contract and CI check scripts grouped under `// --- CI / contract checks ---`.
+- **Docker images** — `COPY --chown` shrinks layers; Corepack pnpm caches are reusable in dev containers; dashboard Compose image pins nginx `1.28.3-r3` and routes nginx logs to stdout/stderr for non-root startup.
+- **CI** — Grype action pinned by checksum; security override pins enforced at lockfile level.
+- **Logger redaction** — API and worker loggers sanitize tokens, passwords, and connection strings before output.
+- **Version metadata bumped to 0.7.2** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **WhatsApp alert delivery** — delivery worker sends only the six EXPIRES/EXPIRED placeholders and sanitizes values (removes extra keys like `expiration_date_iso` that Twilio rejects).
+- **WhatsApp weekly digest** — weekly digest worker uses the shared sanitizer; `tokens_list` keeps all tokens on one line without a 250-character cap.
+- **API runtime** — PostgreSQL server identity verified in production when `DB_SSL=require`; `testConnection` pool leaks closed; `User.update` no longer wipes omitted fields.
+- **Domain checker** — `binaryRunner` reliably kills child process trees after scans complete.
+- **Prometheus metrics** — API route labels bound to matched Express patterns instead of raw URLs.
+- **Dashboard import deep-links** — unknown provider query params no longer open the import modal on an invalid tab.
+- **Dashboard Compose nginx** — non-root container creates `/var/lib/nginx/logs` and symlinks access/error logs for reliable startup.
+
+### Security
+
+- **Dependency patches** — `nodemailer` bumped to `8.0.11` (GHSA-wqvq-jvpq-h66f, GHSA-r7g4-qg5f-qqm2, GHSA-268h-hp4c-crq3); `js-yaml` bumped to `4.2.0` (GHSA-h67p-54hq-rp68); `vite` bumped to `6.4.3`; `form-data` workspace override pinned to `4.0.6` (GHSA-hmw2-7cc7-3qxx); worker `ajv@6` aligned to `6.15.0` via workspace overrides.
+- **Grype exclusions** — `.grype.yaml` updated for known false positives after image hardening.
+
 ## [0.7.1] - 2026-06-03
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",
@@ -33,7 +33,7 @@
     "express-validator": "7.3.1",
     "helmet": "8.1.0",
     "jsonwebtoken": "9.0.3",
-    "nodemailer": "8.0.5",
+    "nodemailer": "8.0.11",
     "otplib": "13.3.0",
     "passport": "0.7.0",
     "passport-local": "1.0.0",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@10.33.4",
@@ -25,7 +25,7 @@
     "@emotion/styled": "11.14.1",
     "axios": "1.16.0",
     "framer-motion": "11.18.2",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "lucide-react": "0.553.0",
     "papaparse": "5.5.3",
     "react": "18.3.1",
@@ -59,7 +59,7 @@
     "jsdom": "26.1.0",
     "sharp": "0.33.5",
     "typescript": "5.9.3",
-    "vite": "6.4.2",
+    "vite": "6.4.3",
     "vitest": "4.1.8"
   },
   "engines": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@10.33.4",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "axios": "1.16.0",
-    "nodemailer": "8.0.5",
+    "nodemailer": "8.0.11",
     "pg": "8.18.0",
     "prom-client": "15.1.3",
     "winston": "3.19.0"

--- a/apps/worker/src/delivery-worker.js
+++ b/apps/worker/src/delivery-worker.js
@@ -21,6 +21,7 @@ import { postJson, formatPayload } from "./notify/webhooks.js";
 import crypto from "node:crypto";
 import { logger } from "./logger.js";
 import { computeDaysLeft } from "./shared/thresholds.js";
+import { sanitizeWhatsAppTemplateVars } from "./shared/whatsappTemplateVars.js";
 import {
   resolveContactGroup,
   hasEmailContacts,
@@ -435,6 +436,30 @@ function buildEndpointHealthWebhookPayload(
     timestamp: new Date().toISOString(),
     type: "endpoint_health_alert",
     endpoint: endpointData,
+  };
+}
+
+// Twilio/WhatsApp approved templates reject newlines, long runs of spaces, and
+// unknown or overlong variable keys (max 16 chars). See DocsAlerts placeholder contracts.
+/**
+ * EXPIRES and EXPIRED templates share the same six placeholders.
+ * Do not add extra keys (e.g. expiration_date_iso is 19 chars and breaks Twilio).
+ */
+function buildTokenExpiryWhatsAppTemplateVariables({
+  recipientName,
+  tokenName,
+  tokenType,
+  expirationDatePretty,
+  daysText,
+  details,
+}) {
+  return {
+    recipient_name: recipientName || "User",
+    token_type: tokenType || "security",
+    token_name: tokenName || "token",
+    days_text: String(daysText),
+    expiration_date: expirationDatePretty,
+    details,
   };
 }
 
@@ -1325,7 +1350,7 @@ export async function deliveryWorkerJob({ closePool = true } = {}) {
                     : "No additional details available";
                 };
 
-                // Format expiration date as a long, locale-stable string (UTC) and also provide ISO
+                // Format expiration date as a long, locale-stable string (UTC)
                 const expirationDatePretty = alert.expiration
                   ? (() => {
                       try {
@@ -1343,79 +1368,28 @@ export async function deliveryWorkerJob({ closePool = true } = {}) {
                       }
                     })()
                   : "";
-                const expirationDateIso = alert.expiration
-                  ? (() => {
-                      try {
-                        return new Date(alert.expiration)
-                          .toISOString()
-                          .slice(0, 10);
-                      } catch (_) {
-                        return String(alert.expiration).slice(0, 10);
-                      }
-                    })()
-                  : "";
 
+                const daysTextForTemplate = isExpired
+                  ? String(daysText)
+                  : String(daysLeft);
+
+                // Token expiry and endpoint health use different Twilio ContentSids;
+                // only include placeholders defined for each template (see DocsAlerts).
                 const contentVariablesBase = selectedContentSid
                   ? isEndpointHealthWhatsApp
                     ? buildEndpointHealthWhatsAppTemplateVariables(
                         alert,
                         contactInfos[0]?.first_name || "User",
                       )
-                    : isExpired
-                    ? {
-                        recipient_name: contactInfos[0]?.first_name || "User",
-                        token_name: name,
-                        token_type: String(alert.type || "security"),
-                        token_category: String(alert.category || ""),
-                        status_text: "EXPIRED",
-                        expiration_date: expirationDatePretty,
-                        expiration_date_iso: expirationDateIso,
-                        days_text: String(daysText),
+                    : buildTokenExpiryWhatsAppTemplateVariables({
+                        recipientName: contactInfos[0]?.first_name || "User",
+                        tokenName: name,
+                        tokenType: String(alert.type || "security"),
+                        expirationDatePretty,
+                        daysText: daysTextForTemplate,
                         details: buildDetails(alert),
-                        renewal_url: alert.renewal_url
-                          ? String(alert.renewal_url)
-                          : null,
-                        description: alert.description
-                          ? String(alert.description)
-                          : null,
-                        notes: alert.notes ? String(alert.notes) : null,
-                        contacts: alert.contacts
-                          ? String(alert.contacts)
-                          : null,
-                      }
-                    : {
-                        recipient_name: contactInfos[0]?.first_name || "User",
-                        token_name: name,
-                        token_type: String(alert.type || "security"),
-                        token_category: String(alert.category || ""),
-                        status_text: "EXPIRING",
-                        expiration_date: expirationDatePretty,
-                        expiration_date_iso: expirationDateIso,
-                        days_text: String(daysLeft),
-                        details: buildDetails(alert),
-                        renewal_url: alert.renewal_url
-                          ? String(alert.renewal_url)
-                          : null,
-                        description: alert.description
-                          ? String(alert.description)
-                          : null,
-                        notes: alert.notes ? String(alert.notes) : null,
-                        contacts: alert.contacts
-                          ? String(alert.contacts)
-                          : null,
-                      }
+                      })
                   : null;
-
-                const sanitizeVars = (obj) => {
-                  const out = {};
-                  for (const [k, v] of Object.entries(obj || {})) {
-                    if (v === null || v === undefined) continue;
-                    const s = String(v).trim();
-                    if (s.length === 0) continue;
-                    out[k] = s;
-                  }
-                  return out;
-                };
 
                 let allOk = true;
                 for (const rcpt of trimmed) {
@@ -1431,8 +1405,9 @@ export async function deliveryWorkerJob({ closePool = true } = {}) {
                           "there",
                       }
                     : null;
+                  // Sanitize all values before send; Twilio rejects invalid ContentVariables.
                   const contentVariables = perRecipientBase
-                    ? sanitizeVars(perRecipientBase)
+                    ? sanitizeWhatsAppTemplateVars(perRecipientBase)
                     : null;
                   const res = await sendWhatsApp({
                     to: rcpt,

--- a/apps/worker/src/shared/whatsappTemplateVars.js
+++ b/apps/worker/src/shared/whatsappTemplateVars.js
@@ -1,0 +1,56 @@
+// Twilio/WhatsApp approved templates reject newlines, long runs of spaces, and
+// unknown or overlong variable keys (max 16 chars). See DocsAlerts placeholder contracts.
+export const WHATSAPP_TEMPLATE_VALUE_MAX_LEN = 250;
+
+// tokens_list can enumerate many tokens; sanitize chars only, do not truncate.
+export const WHATSAPP_WEEKLY_DIGEST_TOKENS_LIST_MAX_LEN = 0;
+
+/** Strip chars and length that make ContentVariables invalid for WhatsApp templates. */
+export function sanitizeForWhatsApp(
+  value,
+  maxLen = WHATSAPP_TEMPLATE_VALUE_MAX_LEN,
+) {
+  if (value === null || value === undefined) return "";
+  let s = String(value)
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/ {5,}/g, "    ");
+  s = s.trim();
+  if (maxLen > 0 && s.length > maxLen) {
+    s = `${s.slice(0, maxLen - 3)}...`;
+  }
+  return s;
+}
+
+/** Build the JSON blob passed as Twilio ContentVariables; omit empty values. */
+export function sanitizeWhatsAppTemplateVars(obj, { maxLens = {} } = {}) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    const maxLen = Object.hasOwn(maxLens, k)
+      ? maxLens[k]
+      : WHATSAPP_TEMPLATE_VALUE_MAX_LEN;
+    const s = sanitizeForWhatsApp(v, maxLen);
+    if (!s) continue;
+    out[k] = s;
+  }
+  return out;
+}
+
+/**
+ * WEEKLY_DIGEST template placeholders (see DocsAlerts).
+ * tokens_list stays on one line; no length cap so all tokens can appear.
+ */
+export function buildWeeklyDigestWhatsAppTemplateVariables({
+  recipientName,
+  workspaceName,
+  contactGroupName,
+  tokensCount,
+  tokensListText,
+}) {
+  return {
+    recipient_name: recipientName || "User",
+    workspace_name: workspaceName,
+    contact_group_name: contactGroupName,
+    tokens_count: String(tokensCount),
+    tokens_list: tokensListText,
+  };
+}

--- a/apps/worker/src/weekly-digest.js
+++ b/apps/worker/src/weekly-digest.js
@@ -17,6 +17,11 @@ import {
   pushMetrics,
 } from "./metrics.js";
 import { computeDaysLeft } from "./shared/thresholds.js";
+import {
+  buildWeeklyDigestWhatsAppTemplateVariables,
+  sanitizeWhatsAppTemplateVars,
+  WHATSAPP_WEEKLY_DIGEST_TOKENS_LIST_MAX_LEN,
+} from "./shared/whatsappTemplateVars.js";
 
 const APP_URL = (process.env.APP_URL || "http://localhost:5173").replace(
   /\/$/,
@@ -661,26 +666,21 @@ export async function weeklyDigestJob() {
 
                 let res;
                 if (contentSid) {
-                  // Use Twilio Content Template
-                  // Sanitize variables (remove null/undefined/empty)
-                  const sanitizeVars = (obj) => {
-                    const out = {};
-                    for (const [k, v] of Object.entries(obj || {})) {
-                      if (v === null || v === undefined) continue;
-                      const s = String(v).trim();
-                      if (s.length === 0) continue;
-                      out[k] = s;
-                    }
-                    return out;
-                  };
-
-                  const contentVariables = sanitizeVars({
-                    recipient_name: recipientName,
-                    workspace_name: ws.workspace_name,
-                    contact_group_name: group.name,
-                    tokens_count: String(tokens.length),
-                    tokens_list: tokensListText,
-                  });
+                  // WEEKLY_DIGEST template: five placeholders only (see DocsAlerts).
+                  const contentVariables = sanitizeWhatsAppTemplateVars(
+                    buildWeeklyDigestWhatsAppTemplateVariables({
+                      recipientName,
+                      workspaceName: ws.workspace_name,
+                      contactGroupName: group.name,
+                      tokensCount: tokens.length,
+                      tokensListText,
+                    }),
+                    {
+                      maxLens: {
+                        tokens_list: WHATSAPP_WEEKLY_DIGEST_TOKENS_LIST_MAX_LEN,
+                      },
+                    },
+                  );
 
                   res = await sendWhatsApp({
                     to: contact.phone_e164,

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -68,8 +68,11 @@ RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentime
         /var/cache/nginx/scgi_temp \
         /var/run \
         /var/log/nginx \
+        /var/lib/nginx/logs \
         /usr/share/nginx/html && \
-    chown -R tokentimer:tokentimer /var/cache/nginx /var/run /var/log/nginx /usr/share/nginx/html
+    ln -sf /dev/stderr /var/lib/nginx/logs/error.log && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    chown -R tokentimer:tokentimer /var/cache/nginx /var/run /var/log/nginx /var/lib/nginx /usr/share/nginx/html
 
 # Copy nginx configuration
 COPY deploy/compose/nginx.conf /etc/nginx/nginx.conf

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.7.2
+appVersion: "0.7.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.7.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.7.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.7.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "tokentimer-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {
+    "//": "Run `pnpm dev:help` for the full command map. Quick pick: host-native = `pnpm dev`; full Docker stack = `pnpm docker:up`.",
+
+    "// --- Host-native dev (Postgres in Docker; API + worker + dashboard on your machine) ---": "",
+    "dev:help": "node scripts/dev-help.js",
     "dev": "node scripts/dev.js",
     "dev:noDB": "node scripts/dev.js --no-db",
     "dev:postgres": "node scripts/run-with-env.js node scripts/start-dev-postgres.js",
@@ -11,6 +15,8 @@
     "dev:api": "node scripts/run-with-env.js pnpm --filter @tokentimer/api dev",
     "dev:worker": "node scripts/run-with-env.js pnpm --filter @tokentimer/worker dev",
     "dev:dashboard": "node scripts/run-with-env.js pnpm --filter @tokentimer/dashboard dev",
+
+    "// --- Build / run / migrate ---": "",
     "build": "pnpm run build:api && pnpm run build:worker && pnpm run build:dashboard",
     "build:api": "pnpm --filter @tokentimer/api build",
     "build:worker": "pnpm --filter @tokentimer/worker build",
@@ -23,17 +29,14 @@
     "lint:api": "pnpm --filter @tokentimer/api lint",
     "lint:worker": "pnpm --filter @tokentimer/worker lint",
     "lint:dashboard": "pnpm --filter @tokentimer/dashboard lint",
+
+    "// --- Tests ---": "",
     "test:unit": "node scripts/run-unit-tests.js",
     "test:core": "node scripts/run-tests-local.js core",
     "test:integration": "node scripts/run-integration-suite.js core",
     "test:integration:all": "node scripts/run-integration-suite.js all",
     "test:quick": "pnpm exec mocha tests/integration/endpoint-monitor.test.js tests/integration/endpoint-health-alerts.test.js --timeout 30000 --exit",
     "test:contracts": "node --test tests/contract/**/*.test.js",
-    "check:contracts": "node scripts/check-contracts-manifest.js && node scripts/check-openapi-runtime-coverage.js",
-    "check:contracts:integrity": "node scripts/check-contracts-integrity.js",
-    "check:openapi:coverage": "node scripts/check-openapi-runtime-coverage.js",
-    "check:lockfile-overrides": "node scripts/check-lockfile-overrides.js",
-    "check:secret-logging": "node scripts/check-secret-logging.js",
     "test:baseline": "node scripts/run-baseline.js",
     "test:ci": "pnpm run test:unit && node scripts/run-tests-local.js core",
     "test:ci:all": "NODE_ENV=test pnpm exec mocha tests/integration/**/*.test.js --timeout 60000 --exit --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results/results.xml",
@@ -41,6 +44,24 @@
     "test:local:integration:complete": "node scripts/run-local-integration-complete.js",
     "test:full:local": "node scripts/run-local-full.js",
     "test:local:full": "node scripts/run-local-full.js",
+
+    "// --- CI / contract checks ---": "",
+    "check:contracts": "node scripts/check-contracts-manifest.js && node scripts/check-openapi-runtime-coverage.js",
+    "check:contracts:integrity": "node scripts/check-contracts-integrity.js",
+    "check:openapi:coverage": "node scripts/check-openapi-runtime-coverage.js",
+    "check:lockfile-overrides": "node scripts/check-lockfile-overrides.js",
+    "check:secret-logging": "node scripts/check-secret-logging.js",
+
+    "// --- Integration test Docker stack (deploy/compose/docker-compose.test.yml) ---": "",
+    "test:up": "docker compose -f deploy/compose/docker-compose.test.yml up --build -d",
+    "test:down": "docker compose -f deploy/compose/docker-compose.test.yml down --volumes --remove-orphans",
+
+    "// --- Full stack in Docker (postgres + API + worker + dashboard) ---": "",
+    "docker:build": "docker compose -f deploy/compose/docker-compose.yml build",
+    "docker:up": "docker compose -f deploy/compose/docker-compose.yml up",
+    "docker:down": "docker compose -f deploy/compose/docker-compose.yml down",
+
+    "// --- Coverage ---": "",
     "coverage:clean": "node scripts/run-coverage.js --clean-only",
     "coverage:collect": "node scripts/run-coverage.js core --collect-only",
     "coverage:report": "pnpm run coverage:report:backend",
@@ -53,11 +74,8 @@
     "test:coverage:backend": "pnpm run coverage:clean && pnpm run coverage:collect && pnpm run coverage:report:backend && pnpm run coverage:check:backend",
     "test:coverage:frontend": "pnpm run coverage:collect:frontend && pnpm run coverage:check:frontend",
     "test:coverage": "pnpm run test:coverage:backend && pnpm run test:coverage:frontend && pnpm run coverage:merge",
-    "test:up": "docker compose -f deploy/compose/docker-compose.test.yml up --build -d",
-    "test:down": "docker compose -f deploy/compose/docker-compose.test.yml down --volumes --remove-orphans",
-    "docker:build": "docker compose -f deploy/compose/docker-compose.yml build",
-    "docker:up": "docker compose -f deploy/compose/docker-compose.yml up",
-    "docker:down": "docker compose -f deploy/compose/docker-compose.yml down",
+
+    "// --- Helm ---": "",
     "helm:lint": "helm lint deploy/helm",
     "helm:template": "helm template tokentimer deploy/helm -f deploy/helm/ci/ci-values.yaml",
     "helm:verify": "bash scripts/helm-template-verify.sh"

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.7.1
+  version: 0.7.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   postcss: 8.5.12
   qs: 6.15.2
   ip-address: 10.2.0
+  form-data: 4.0.6
 
 importers:
 
@@ -116,8 +117,8 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       nodemailer:
-        specifier: 8.0.5
-        version: 8.0.5
+        specifier: 8.0.11
+        version: 8.0.11
       otplib:
         specifier: 13.3.0
         version: 13.3.0
@@ -180,8 +181,8 @@ importers:
         specifier: 11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       js-yaml:
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.2.0
+        version: 4.2.0
       lucide-react:
         specifier: 0.553.0
         version: 0.553.0(react@18.3.1)
@@ -242,7 +243,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: 4.7.0
-        version: 4.7.0(vite@6.4.2(yaml@1.10.3))
+        version: 4.7.0(vite@6.4.3(yaml@1.10.3))
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -277,11 +278,11 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 6.4.2
-        version: 6.4.2(yaml@1.10.3)
+        specifier: 6.4.3
+        version: 6.4.3(yaml@1.10.3)
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.2(yaml@1.10.3))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.3(yaml@1.10.3))
 
   apps/worker:
     dependencies:
@@ -289,8 +290,8 @@ importers:
         specifier: 1.16.0
         version: 1.16.0
       nodemailer:
-        specifier: 8.0.5
-        version: 8.0.5
+        specifier: 8.0.11
+        version: 8.0.11
       pg:
         specifier: 8.18.0
         version: 8.18.0
@@ -2554,8 +2555,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -2719,6 +2720,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -2979,8 +2984,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -3248,8 +3253,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@8.0.5:
-    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
+  nodemailer@8.0.11:
+    resolution: {integrity: sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==}
     engines: {node: '>=6.0.0'}
 
   nodemon@3.1.11:
@@ -4029,10 +4034,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -4204,8 +4205,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -4455,7 +4456,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -5456,7 +5457,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 9.0.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5470,7 +5471,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 9.0.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6212,7 +6213,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(yaml@1.10.3))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(yaml@1.10.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -6220,7 +6221,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(yaml@1.10.3)
+      vite: 6.4.3(yaml@1.10.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6236,7 +6237,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.2(yaml@1.10.3))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.3(yaml@1.10.3))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -6247,13 +6248,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@6.4.2(yaml@1.10.3))':
+  '@vitest/mocker@4.1.8(vite@6.4.3(yaml@1.10.3))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(yaml@1.10.3)
+      vite: 6.4.3(yaml@1.10.3)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6437,7 +6438,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -6949,7 +6950,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -7103,7 +7104,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -7354,12 +7355,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -7422,7 +7423,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -7530,6 +7531,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -7785,7 +7790,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -8034,7 +8039,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -8068,7 +8073,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@8.0.5: {}
+  nodemailer@8.0.11: {}
 
   nodemon@3.1.11:
     dependencies:
@@ -8886,7 +8891,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -8961,11 +8966,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -9130,22 +9130,22 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@6.4.2(yaml@1.10.3):
+  vite@6.4.3(yaml@1.10.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.12
       rollup: 4.60.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
       yaml: 1.10.3
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.2(yaml@1.10.3)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@6.4.3(yaml@1.10.3)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@6.4.2(yaml@1.10.3))
+      '@vitest/mocker': 4.1.8(vite@6.4.3(yaml@1.10.3))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -9162,7 +9162,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.2(yaml@1.10.3)
+      vite: 6.4.3(yaml@1.10.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ overrides:
   postcss: 8.5.12
   qs: 6.15.2
   ip-address: 10.2.0
+  form-data: 4.0.6
 
 onlyBuiltDependencies:
   - esbuild

--- a/scripts/dev-help.js
+++ b/scripts/dev-help.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+"use strict";
+
+// Prints the local development command map for tokentimer-core.
+// package.json cannot carry comments; run `pnpm run dev:help` anytime.
+
+const lines = `
+TokenTimer Core — local development commands
+============================================
+
+HOST-NATIVE (fast iteration; processes run on your machine)
+---------------------------------------------------------
+  pnpm dev
+      Postgres in Docker + API + worker + dashboard on the host.
+      NOT the full containerized stack. Best for day-to-day work.
+
+  pnpm dev:noDB
+      Same as dev, but skips starting Postgres (you provide DB_HOST yourself).
+
+  pnpm dev:postgres
+      Start only the Postgres container (deploy/compose/docker-compose.postgres.yml).
+
+  pnpm dev:api / dev:worker / dev:dashboard
+      Run a single app with .env loaded (when Postgres is already up).
+
+  pnpm dev:ports:check
+      Fail fast if API or dashboard ports are already in use.
+
+
+FULL STACK IN DOCKER (all services containerized)
+-------------------------------------------------
+  pnpm docker:up
+      deploy/compose/docker-compose.yml up (foreground).
+      Postgres + API + worker + dashboard all in containers.
+
+  pnpm docker:down
+      Stop deploy/compose/docker-compose.yml services.
+
+  pnpm docker:build
+      Build deploy/compose/docker-compose.yml images without starting.
+
+
+INTEGRATION TEST STACK
+----------------------
+  pnpm test:up
+      Start deploy/compose/docker-compose.test.yml (detached, rebuilt).
+
+  pnpm test:down
+      Tear down test compose and volumes.
+
+
+OTHER
+-----
+  pnpm migrate
+      Run API database migrations (with .env loaded).
+
+  pnpm test:local:full
+      Local validation loop (unit + integration + coverage).
+
+  Helm: pnpm helm:lint, helm:template, helm:verify
+`;
+
+process.stdout.write(`${lines.trim()}\n`);


### PR DESCRIPTION
## Summary
TokenTimer Core 0.7.2 hardens the API, worker, and container build pipeline after the cloud security pass, and fixes WhatsApp alert delivery where Twilio rejected invalid `ContentVariables`. Self-hosters get safer logging, tighter CI supply-chain checks, and reliable WhatsApp expiry alerts and weekly digests.

This release also contains changes from https://github.com/tokentimerch/tokentimer-core/pull/34

## Changes

### Worker
- Shared `whatsappTemplateVars.js` sanitizes Twilio template variables (strips newlines/tabs, enforces placeholder contracts).
- Delivery worker sends only the six EXPIRES/EXPIRED placeholders; removes keys like `expiration_date_iso` that Twilio rejects.
- Weekly digest uses the same sanitizer; `tokens_list` is not truncated at 250 chars.

### API
- PostgreSQL server identity verified when `DB_SSL=require`; `testConnection` pool leaks fixed.
- `User.update` no longer wipes omitted fields.
- Domain checker kills child process trees reliably.
- Prometheus route labels bound to matched Express patterns.
- Logger redaction for tokens, passwords, and connection strings.

### Dashboard
- Import deep-links guard against unknown provider query params.
- Compose nginx image: log symlinks for non-root startup.

### Infra
- Grype action pinned by checksum; `check:lockfile-overrides` and `check:secret-logging` in CI.
- Docker `COPY --chown`, Corepack pnpm cache reuse, nginx `1.28.3-r3` pin.
- Root `package.json` scripts reorganized; `pnpm dev:help` command map added.

### Security
- `nodemailer` 8.0.11, `js-yaml` 4.2.0, `vite` 6.4.3, `form-data` override 4.0.6, `ajv@6` 6.15.0.
- `.grype.yaml` updated for post-hardening false positives.

### Docs / metadata
- Version bumped to 0.7.2 across manifests, contracts, OpenAPI, and Helm image tags.
- CHANGELOG updated for 0.7.2.

## Test plan
- [x] Audit, lint, Prettier, unit tests, contracts, lockfile-overrides
- [x] CI `test:ci` passes https://github.com/tokentimerch/tokentimer-core/actions/runs/27579850907/job/81537986312
- [x] Grype scans pass (api, dashboard, worker images)