### PR TITLE
Release TokenTimer Core v0.8.0 with Dashboard Redesign and Control Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-22
+
+### Added
+
+- **Control Center** — new `/control-center` route (replaces `/usage`) with expiry health buckets, needs-attention list, asset-source panels, perpetual-asset and privilege-highlight insight panels, and auto-sync health rows with deep links into token detail and Import manage.
+- **`GET /api/v1/workspaces/:id/control-center/stats`** — workspace admin / manager RBAC; returns aggregated stats via `controlCenterStats.js` and shared `expiryBuckets` / `controlCenterStatsHelpers`.
+- **Dashboard shell** — shared collapsible sidebar/topbar (`DashboardShell`), page layout primitives (`DashboardPageLayout`, `SettingsPageShell`), and inventory URL state sync (`useInventoryUrlState`).
+- **Category-aware asset inventory** — `AssetFilters` + `AssetInventoryTable` with per-category columns, contact-group column, editable key/secret privileges, and multi-section OR filter semantics (API uses PostgreSQL `&&` overlap).
+- **ThresholdDaysEditor** — chip-based alert threshold editing for workspace defaults and contact-group overrides; shared `alertThresholds.js` parse/validate helpers.
+- **User preferences route** — `/preferences` for theme and display options.
+- **Integration tests** — `control-center-stats`, `control-center-stats-rbac`, extended `audit-filtering`; suites registered in `core.txt` and `cloud-compatible.txt`.
+- **Docs assets** — updated dashboard GIFs and new Control Center, workspace preferences, and system settings screenshots.
+
+### Changed
+
+- **Dashboard IA** — slimmed `/dashboard` to filters + inventory table; audit page full-width redesign; Help page removed; product tour and navigation updated for new routes.
+- **Modal and toast UX** — centralized modal styling in `theme.js` via `useDashboardModalProps`; toasts moved bottom-right; Import modal light-theme parity and full-card source clicks.
+- **Auto-sync worker schedule** — default cron aligned to `*/1 * * * *` across Compose, Helm, and worker runner (was hourly).
+- **Dashboard XLSX dependency** — `xlsx` aliased to patched `@e965/xlsx@0.20.3` for import/export flows.
+- **Docker images** — dashboard nginx Alpine pin updated to `1.28.3-r1` (Alpine 3.23 repo revision; fixes CI image build after `r3` removal).
+- **Version metadata bumped to 0.8.0** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **Settings UX** — sticky auth footers, disabled-button tooltips, workspace delete confirmation, duplicate webhook test toast removed, 2FA success toast with session refresh, contact groups mobile formatting.
+- **Control Center deep links** — token modal via `?token-id=` supports string IDs; auto-sync rows open Import manage tab via `?import=&autoSyncManage=1`.
+- **Inventory reload** — 100 ms debounced token reload on filter changes; prior rows kept visible until new data arrives.
+
+### Security
+
+- **SheetJS / xlsx** — dashboard import/export uses `@e965/xlsx@0.20.3` via pnpm alias (addresses GHSA-4r6h-8v6p-xvw6 and GHSA-5pgg-2g8v-p4x9 in legacy `xlsx@0.18.5`).
+
 ## [0.7.2] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Modal and toast UX** — centralized modal styling in `theme.js` via `useDashboardModalProps`; toasts moved bottom-right; Import modal light-theme parity and full-card source clicks.
 - **Auto-sync worker schedule** — default cron aligned to `*/1 * * * *` across Compose, Helm, and worker runner (was hourly).
 - **Dashboard XLSX dependency** — `xlsx` aliased to patched `@e965/xlsx@0.20.3` for import/export flows.
-- **Docker images** — dashboard nginx Alpine pin updated to `1.28.3-r1` (Alpine 3.23 repo revision; fixes CI image build after `r3` removal).
+- **Docker images** — dashboard nginx Alpine pin updated to `1.28.3-r4` (CVE-2026-9256 / CVE-2026-49975; Alpine 3.23 patched revision).
 - **Version metadata bumped to 0.8.0** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
 
 ### Fixed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -37,7 +37,7 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r1 (current Alpine 3.23 revision).
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r4 (patched Alpine 3.23 revision).
 # Drop unused nginx-module-* packages first; their r1 revisions block apk upgrades.
 RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
@@ -47,9 +47,9 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r1 \
+    && apk add --no-cache nginx=1.28.3-r4 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r1" \
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4" \
     # Alpine's nginx build defaults to pid /run/nginx/nginx.pid (the official image
     # used /var/run/nginx.pid); the directory only exists when created here.
     && mkdir -p /run/nginx

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -37,7 +37,7 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r3 (r2 superseded in Alpine 3.23 repos).
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r1 (current Alpine 3.23 revision).
 # Drop unused nginx-module-* packages first; their r1 revisions block apk upgrades.
 RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
@@ -47,9 +47,9 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r3 \
+    && apk add --no-cache nginx=1.28.3-r1 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3" \
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r1" \
     # Alpine's nginx build defaults to pid /run/nginx/nginx.pid (the official image
     # used /var/run/nginx.pid); the directory only exists when created here.
     && mkdir -p /run/nginx

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@10.33.4",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@10.33.4",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -43,7 +43,7 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r3 (r2 superseded in Alpine 3.23 repos).
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r1 (current Alpine 3.23 revision).
 # Drop unused nginx-module-* packages first; their r1
 # revisions block apk from replacing nginx while those modules stay installed.
 RUN apk update && apk upgrade --no-cache \
@@ -54,9 +54,9 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r3 \
+    && apk add --no-cache nginx=1.28.3-r1 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r3"
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r1"
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -43,7 +43,7 @@ RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r1 (current Alpine 3.23 revision).
+# CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r4 (patched Alpine 3.23 revision).
 # Drop unused nginx-module-* packages first; their r1
 # revisions block apk from replacing nginx while those modules stay installed.
 RUN apk update && apk upgrade --no-cache \
@@ -54,9 +54,9 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r1 \
+    && apk add --no-cache nginx=1.28.3-r4 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r1"
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4"
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.7.2
-appVersion: "0.7.2"
+version: 0.8.0
+appVersion: "0.8.0"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.7.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.7.2
+  version: 0.8.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
Ship TokenTimer Core 0.8.0 with the merged dashboard redesign (#33): a shared collapsible shell, new Control Center route replacing `/usage`, category-aware asset inventory, and a workspace stats API for expiry health and operational insight panels. Also fixes the dashboard Docker image build by aligning the nginx Alpine pin to the revision currently in Alpine 3.23 repos.

## Changes

### Dashboard
- Shared shell (`DashboardShell`), page layout primitives, and settings shell
- `/control-center` with expiry buckets, needs-attention list, source panels, perpetual/privilege/auto-sync insight panels, and deep links
- Slimmed `/dashboard` with `AssetFilters` + `AssetInventoryTable`, URL-synced filters, category columns, and editable key/secret privileges
- Threshold chip editor, preferences route, audit page redesign, modal/toast harmonization

### API
- `GET /api/v1/workspaces/:id/control-center/stats` (admin / workspace_manager RBAC)
- Token section filter uses PostgreSQL overlap for multi-section OR semantics

### Infra
- Auto-sync worker default cron `*/1 * * * *` aligned across Compose, Helm, and runner
- Dashboard nginx pin `1.28.3-r3` → `1.28.3-r1` (fixes Docker Build & Security Scan)

### Docs / metadata
- Updated README GIFs and new screenshot assets
- Version bumped to 0.8.0 across manifests, contracts, OpenAPI, and Helm

## Test plan
- [x] CI passes on `release/0.8.0` (including Docker Build & Security Scan / Grype)
- [x] Tag `v0.8.0` and publish GitHub release