### PR TITLE
feat(certops): Phase 0 foundation and contract freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,7 @@ reports/
 # Agent-skills setup (Matt Pocock skills, kept local-only per setup-matt-pocock-skills)
 /AGENTS.md
 /docs/agents/
-/.scratch/
+# Keep .scratch local-only, EXCEPT shared CertOps program docs (issue map,
+# cloud overlay verification) that dev B needs from git.
+/.scratch/*
+!/.scratch/certops/

--- a/.scratch/certops/cloud-overlay-verification.md
+++ b/.scratch/certops/cloud-overlay-verification.md
@@ -1,0 +1,65 @@
+# CertOps cloud overlay verification (P0.5)
+
+Status: verified 2026-06-25 against tokentimer-cloud working tree.
+Owner: Dev B. Reviewer: Dev A.
+
+Purpose: confirm the cloud path and manifest assumptions the CertOps plan was
+written against, and record corrections so M1/M2 overlay work is not blocked.
+
+## Verified facts
+
+| Assumption (plan) | Reality | Verdict |
+|---|---|---|
+| Cloud API at `apps/saas/` | `apps/saas/` exists (overlays core `apps/api/`) | Confirmed |
+| Cloud web at `apps/web/` | `apps/web/` exists (overlays core `apps/dashboard/src/`) | Confirmed |
+| Marketing surface | `apps/marketing/` (cloud-only) | Confirmed |
+| Worker overlay | `apps/worker/` (partial overrides) | Confirmed |
+| Override manifest | `overrides.manifest.json` at repo root | Confirmed |
+| Compatibility pin | `compatibility.manifest.json` (core `^0.8.1`, artifact SHA-256 digests) | Confirmed |
+| Composition manifest | NOT a source file; generated at `.build/stage/cloud/composition.manifest.json` | Corrected |
+
+## Corrections to plan assumptions
+
+1. **No `additiveFile` kind in cloud.** Cloud override `kind` values are:
+   `fileOverride`, `derivedDivergence`, `pluginBehaviorOverride`, `saaSOnly`,
+   `enterpriseOnly`. (`additiveFile` is an enterprise-manifest kind.) New
+   cloud-only CertOps files must be registered as `saaSOnly` (or
+   `derivedDivergence` when they diverge from a core counterpart), not
+   `additiveFile`.
+2. **Override entry fields** are `ownerPath`, `targetCorePath` (or `null`),
+   `kind`, `reason`, `confidence`, optional `coreParity`. There is no
+   `enterpriseOnly` entry in cloud's manifest today (valid kind, zero entries).
+3. **`check:contracts` does not live in cloud.** It runs against tokentimer-core
+   via cloud's `test:baseline` (`scripts/run-baseline.js`). Cloud's own manifest
+   gates are `check:overrides` and `check:compat`.
+4. **Core <-> cloud path mapping**: `apps/saas/*` -> core `apps/api/*`;
+   `apps/web/*` -> core `apps/dashboard/src/*`.
+
+## Plan-relevant precedents to reuse
+
+- **Plan gating (402)**: `requireDomainCheckerPlan` in
+  `apps/saas/routes/domains.js` returns 402 `PLAN_FEATURE_REQUIRED`. CertOps
+  cloud plan gates should mirror this shape. Token-limit gating uses 402
+  `PLAN_TOKEN_LIMIT`.
+- **Fail-closed freeze**: `apps/saas/services/rbac.js` `loadWorkspace` returns
+  403 `WORKSPACE_FROZEN` for frozen workspaces (no try/catch swallowing).
+- **Plan limits service**: `apps/saas/services/planLimits.js` (free/pro/team
+  ladders; production fail-closed `QUOTA_BACKEND_UNAVAILABLE`).
+- **Rate limiting**: authenticated `/api/*` is keyed `user-${id}` via
+  `authenticatedBaselineLimiter`; dev/test skips the global limiter on `/api`.
+
+## Manifest checklist for CertOps cloud overlays (M1+)
+
+- [ ] New cloud-only route file -> `overrides.manifest.json` entry, `kind: saaSOnly`, `targetCorePath: null`.
+- [ ] Overriding a core file -> `kind: fileOverride`, set `targetCorePath`.
+- [ ] New cloud-only page (`apps/web/pages/*.jsx`) -> `saaSOnly` entry + lazy route in `apps/web/App.jsx`.
+- [ ] Pin any new core contract artifact in `compatibility.manifest.json` (`requiredEntries` / `artifactDigests`).
+- [ ] Run `pnpm run check:overrides` and `pnpm run check:compat` before PR.
+- [ ] Run cloud `test:baseline` (invokes core `check:contracts` + contract tests).
+
+## Test commands (cloud)
+
+- `pnpm run check:overrides` - validate override manifest.
+- `pnpm run check:compat` - validate compatibility pin + artifact digests.
+- `pnpm run test` - core-aware test entry.
+- `pnpm run test:local:full` - full local suite (`scripts/run-local-full.js`).

--- a/.scratch/certops/issues.md
+++ b/.scratch/certops/issues.md
@@ -24,6 +24,9 @@ Legend: [A]=suited to Dev A, [B]=suited to Dev B, dep=depends on.
   and returns 422 `PRIVATE_KEY_MATERIAL_REJECTED`; mount on certops write routes.
 - AC (T1): nested/base64-wrapped private key in any field -> 422; certificate /
   public key passes. Integration test added.
+- AC (T1, detector hardening): extend `secretMaterial.js` with binary PKCS#12/PFX
+  (.p12/.pfx) DER sniffing (deferred from Phase 0) plus adversarial fixtures; the
+  plan forbids PKCS#12/PFX bundles, so a `.p12` body must be rejected (422).
 
 ### CERTOPS-M1-3 GET/POST certificates + GET by id [A]
 - dep: M1-1, M1-2.
@@ -95,16 +98,27 @@ Legend: [A]=suited to Dev A, [B]=suited to Dev B, dep=depends on.
   (`saaSOnly`).
 - AC (T12): frozen workspace -> 403; free plan over CertOps gate -> 402.
 
+### CERTOPS-M2-8 Dedicated machine-token / agent rate limiter [B]
+- dep: M2-2, cloud overlay verification.
+- Add a limiter keyed by token prefix / agent id / workspace id (clone the shape
+  of `createApiLimiter`), mounted before the executor and agent handlers,
+  independent of the session-user baseline limiter. Cloud's authenticated `/api`
+  limiter is keyed by `user-${id}`, which machine (token/agent) calls do not
+  have, so without this they ride the authenticated-user path unbounded.
+- AC (T10/abuse): executor and agent traffic is limited per token/agent/workspace,
+  not per user; high-volume machine traffic cannot bypass limits via the
+  session-user keying. Limiter is enforced even when no session user is present.
+
 ## Dependency order (critical path)
 
 M1-1 -> M1-2 -> M1-3 -> {M1-4, M1-5}; M1-6 parallel.
-M2-1 -> M2-2 -> M2-3 -> M2-4; M2-5 -> M2-6; M2-7 after M1-3.
+M2-1 -> M2-2 -> M2-3 -> M2-4; M2-5 -> M2-6; M2-7 after M1-3; M2-8 after M2-2.
 
 ## Parallelization
 
 - Dev A owns the data/contract spine: M1-1, M1-3, M1-5, M2-1, M2-3.
 - Dev B owns the safety boundary and overlays: M1-2, M1-4, M1-6, M2-2, M2-5,
-  M2-6, M2-7. M2-4 either.
+  M2-6, M2-7, M2-8. M2-4 either.
 - Overlap is minimized: A defines tables/signing; B owns rejection/auth/redaction
   and cloud gating. Shared touch points (`secretMaterial.js`, contracts) are
   frozen in Phase 0.

--- a/.scratch/certops/issues.md
+++ b/.scratch/certops/issues.md
@@ -1,0 +1,110 @@
+# CertOps M1/M2 issue map (P0.6)
+
+Status: ready-for-human (Dev A draft; Dev B to edit owners/estimates)
+Drafted: 2026-06-25. Drafted by Dev A; reviewer/editor Dev B.
+
+Scope: M1 (inventory) and M2 (jobs, tokens, executor). Tracer-bullet vertical
+slices: each ticket is independently grabbable and lands a thin end-to-end
+slice. Threat ids (T#) reference docs/adr/0005-certops-threat-model.md. Routes
+and schemas reference the Phase 0 contract freeze.
+
+Legend: [A]=suited to Dev A, [B]=suited to Dev B, dep=depends on.
+
+## M1 - Inventory (public material only)
+
+### CERTOPS-M1-1 Migration: CertOps inventory tables [A]
+- dep: none (core migrate.js highest version is 9; use 10+).
+- Add `managed_certificates` (+ supporting columns) per `certops-inventory.schema.json`.
+- AC: idempotent `CREATE TABLE IF NOT EXISTS`; migration runs clean twice; no
+  column intended to hold key material.
+
+### CERTOPS-M1-2 Private-key rejection middleware [B]
+- dep: secretMaterial.js (done in Phase 0).
+- Express middleware that scans request bodies via `containsPrivateKeyMaterial`
+  and returns 422 `PRIVATE_KEY_MATERIAL_REJECTED`; mount on certops write routes.
+- AC (T1): nested/base64-wrapped private key in any field -> 422; certificate /
+  public key passes. Integration test added.
+
+### CERTOPS-M1-3 GET/POST certificates + GET by id [A]
+- dep: M1-1, M1-2.
+- Implement `/api/v1/workspaces/{id}/certops/certificates` (GET, POST) and
+  `/certificates/{certId}` (GET). Public material only; parse PEM via
+  `X509Certificate` (reuse vaultIntegration helpers) for metadata.
+- AC: returns inventory matching schema; POST persists; conformance test asserts
+  routes documented in OpenAPI.
+
+### CERTOPS-M1-4 Import endpoint [B]
+- dep: M1-2, M1-3.
+- Implement `/api/v1/workspaces/{id}/certops/imports` (POST). Accept PEM public
+  material, dedupe, link to `tokens` where applicable.
+- AC (T1): import body with key material -> 422; valid cert chain imported.
+
+### CERTOPS-M1-5 Dashboard inventory view [A]
+- dep: M1-3.
+- Read-only inventory list + detail in dashboard (core `apps/dashboard`; cloud
+  overlays in `apps/web`).
+- AC: lists managed certs; never renders key fields (none exist).
+
+### CERTOPS-M1-6 Logger/evidence redaction guard test [B]
+- dep: secretMaterial.js.
+- AC (T2/T3): log + evidence paths render placeholder, never key material.
+
+## M2 - Jobs, tokens, executor
+
+### CERTOPS-M2-1 Scoped API token system [A]
+- dep: M1-1.
+- `api_tokens` table; issue/list/revoke scoped tokens; HMAC-protected storage;
+  plaintext returned once. Routes `/certops/tokens` (GET, POST).
+- AC (T10): token scoped to workspace A cannot act on workspace B; secrets never
+  returned after creation.
+
+### CERTOPS-M2-2 certOpsTokenAuth middleware [B]
+- dep: M2-1.
+- Bearer auth for `/api/v1/certops/executor/*` and `/agent/*`; constant-time
+  compare (mirror `internal-worker-auth.js`); CSRF-exempt these paths.
+- AC: invalid/expired token -> 401; valid scoped token authorizes only its scope.
+
+### CERTOPS-M2-3 Job model + signing [A]
+- dep: M2-1, ADR-0003.
+- `certificate_jobs` table; Ed25519 signing of job payloads per
+  `job-payload.schema.json`; `signingKeyId` lifecycle.
+- AC (T4): unsigned/HMAC/invalid-signature job rejected by verifier; signed job
+  verifies against pinned public key.
+
+### CERTOPS-M2-4 Job list endpoint [B]
+- dep: M2-3.
+- `/api/v1/workspaces/{id}/certops/jobs` (GET).
+- AC: lists workspace jobs with state; documented in OpenAPI.
+
+### CERTOPS-M2-5 Executor events endpoint [A]
+- dep: M2-2, M1-2.
+- `/api/v1/certops/executor/events` (POST). Accept progress + evidence metadata;
+  scrub via `redactGenericSecrets`; reject key material 422.
+- AC (T3/T5): evidence stored without secrets; replayed event (nonce/jobId)
+  rejected.
+
+### CERTOPS-M2-6 Replay protection [B]
+- dep: M2-3, M2-5.
+- Nonce + jobId replay cache; expiry-window enforcement.
+- AC (T5/T6): duplicate nonce rejected; out-of-window job rejected.
+
+### CERTOPS-M2-7 Cloud plan gating for CertOps [B]
+- dep: M1-3, cloud overlay verification.
+- Mirror `requireDomainCheckerPlan` (402 `PLAN_FEATURE_REQUIRED`) and fail-closed
+  freeze (403 `WORKSPACE_FROZEN`) for CertOps cloud routes; register overrides
+  (`saaSOnly`).
+- AC (T12): frozen workspace -> 403; free plan over CertOps gate -> 402.
+
+## Dependency order (critical path)
+
+M1-1 -> M1-2 -> M1-3 -> {M1-4, M1-5}; M1-6 parallel.
+M2-1 -> M2-2 -> M2-3 -> M2-4; M2-5 -> M2-6; M2-7 after M1-3.
+
+## Parallelization
+
+- Dev A owns the data/contract spine: M1-1, M1-3, M1-5, M2-1, M2-3.
+- Dev B owns the safety boundary and overlays: M1-2, M1-4, M1-6, M2-2, M2-5,
+  M2-6, M2-7. M2-4 either.
+- Overlap is minimized: A defines tables/signing; B owns rejection/auth/redaction
+  and cloud gating. Shared touch points (`secretMaterial.js`, contracts) are
+  frozen in Phase 0.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,74 @@
+# CONTEXT
+
+Domain language and core invariants for tokentimer-core. Decisions that shape
+the code live in `docs/adr/`. This file is the shared vocabulary; when a term
+here and the code disagree, that is a bug in one of them.
+
+This bootstrap is scoped to the CertOps program (the first feature to require a
+written domain model). It will grow to cover the rest of core over time.
+
+## Product invariant: zero private-key custody
+
+TokenTimer control planes (Core, Cloud, Enterprise) never store, generate,
+export, transmit, or process private key material. This is structural, not a
+policy toggle. It is enforced in depth:
+
+- field-name redaction in the logger (`apps/api/utils/logger.js`),
+- content-based detection and rejection (`apps/api/utils/secretMaterial.js`),
+- schema design (no inventory field is meant to hold key material),
+- the API rejection boundary (HTTP 422 `PRIVATE_KEY_MATERIAL_REJECTED`).
+
+The one private key the platform does hold is the platform operational signing
+key (Ed25519) used to sign jobs. It is never used for certificate issuance and
+never holds customer key material. See ADR-0003.
+
+## Control plane vs execution plane
+
+- **Control plane** - Core/Cloud/Enterprise backend and dashboard. Observes,
+  plans, signs jobs, records evidence. Holds no private keys.
+- **Execution plane** - the TokenTimer **agent** (and Kubernetes controller).
+  Generates keys locally, builds CSRs, runs ACME, deploys, reloads. Holds keys
+  on the host it runs on; TokenTimer never backs them up.
+
+The agent is **outbound-only**: it polls the control plane. The control plane
+never opens connections to agents.
+
+## Ubiquitous language (CertOps)
+
+- **Managed certificate** - a tracked certificate identity in a workspace.
+  Inventory stores public material only (see
+  `packages/contracts/certops/certops-inventory.schema.json`).
+- **Certificate instance** - a deployed copy of a managed certificate on a
+  target.
+- **Target** - a place a certificate is deployed (host, path, k8s secret ref).
+- **Agent** - the execution-plane process that performs key-bearing work.
+- **Proxy-agent** - an agent acting on behalf of targets it can reach.
+- **Job** - a signed unit of work dispatched to an agent. Carries replay
+  protection (jobId, nonce, issuedAt/expiresAt). See
+  `packages/contracts/certops/job-payload.schema.json` and ADR-0003.
+- **Evidence** - structured, size-limited proof of what happened. Scrubbed of
+  private keys and generic secrets before storage.
+- **Agent-local policy** - allowlists (commands, paths, CA endpoints, DNS
+  zones/providers) the agent enforces locally. Local policy wins over
+  control-plane intent; rejections are reported as evidence. See ADR-0002.
+
+## Rollout flag (frozen Phase 0)
+
+CertOps ships behind a rollout switch that is separate from edition/plan/license
+gating: `certops.enabled`, stored in a `certops_settings` JSONB column, with
+`env > DB > default` precedence and **default false**. While false, CertOps
+routes and UI are hidden, so milestone code can ship dark, Cloud can run staged
+per-workspace previews, and Enterprise enables it deliberately. Edition, plan,
+and license gating apply on top once the flag is on.
+
+## Editions
+
+- **Core** - source-available (BUSL-1.1), generous free base.
+- **Cloud** - production SaaS overlay of core (`apps/saas`, `apps/web`).
+- **Enterprise** - licensed overlay; restricted execution and connectors.
+
+## Where things live
+
+- API: `apps/api/` (core), `apps/saas/` (cloud), `src/api/` (enterprise).
+- Contracts: `packages/contracts/` (registered in `contracts.manifest.json`).
+- ADRs: `docs/adr/`.

--- a/apps/api/utils/secretMaterial.js
+++ b/apps/api/utils/secretMaterial.js
@@ -1,0 +1,168 @@
+"use strict";
+
+/**
+ * CertOps shared secret-material detector.
+ *
+ * Zero private-key custody is a structural rule for every TokenTimer control
+ * plane (see CONTEXT.md and docs/adr/0001-certops-zero-custody-enforcement.md).
+ * This module is the single source of truth for *content-based* detection of
+ * private key material. The existing logger (apps/api/utils/logger.js) already
+ * redacts by field name; this detector closes the gap where key material
+ * appears under an innocent field name, inside arrays, in raw command output,
+ * in evidence payloads, or base64-wrapped.
+ *
+ * Two distinct outcomes, by design:
+ *   - private key material  -> REJECT (hard 422 at the API boundary)
+ *   - other generic secrets -> REDACT (so legitimate operational output is kept)
+ *
+ * Scope note (Phase 0): PEM private-key blocks (all common variants) and
+ * base64-wrapped PEM are detected here. Binary PKCS#12/PFX (.p12/.pfx) DER
+ * sniffing is deliberately deferred to M1 hardening; it cannot be reliably
+ * distinguished from a DER certificate cheaply, and M1 adds dedicated fixtures.
+ * Do not weaken these patterns without updating tests/unit/secretMaterial.test.js.
+ */
+
+const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
+const GENERIC_SECRET_REDACTION_PLACEHOLDER = "[REDACTED]";
+
+// Matches PEM private-key opening lines for PKCS#8 (BEGIN PRIVATE KEY),
+// PKCS#1 (BEGIN RSA PRIVATE KEY), SEC1 (BEGIN EC PRIVATE KEY), DSA, OpenSSH,
+// and encrypted variants (BEGIN ENCRYPTED PRIVATE KEY / BEGIN RSA ENCRYPTED ...).
+// It must NOT match PUBLIC KEY, CERTIFICATE, or CERTIFICATE REQUEST blocks.
+const PRIVATE_KEY_PEM_PATTERN = /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----/;
+
+// Whole private-key PEM block (header to footer), used for redaction.
+const PRIVATE_KEY_PEM_BLOCK_PATTERN =
+  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g;
+
+// Conservative Authorization-header / bearer-token redaction for generic
+// secret scrubbing (extended in M2 evidence redaction work).
+const AUTHORIZATION_VALUE_PATTERN =
+  /\b(Authorization\s*[:=]\s*)(Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]+/gi;
+
+const MAX_SCAN_DEPTH = 12;
+
+/**
+ * Returns true if the string looks like base64 (and is long enough to plausibly
+ * wrap a PEM block). Whitespace is tolerated.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function looksBase64(value) {
+  if (typeof value !== "string") return false;
+  const compact = value.replace(/\s+/g, "");
+  if (compact.length < 64) return false;
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(compact);
+}
+
+/**
+ * Detects private key material in a single string, including base64-wrapped PEM.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function stringContainsPrivateKey(value) {
+  if (typeof value !== "string" || value.length === 0) return false;
+  if (PRIVATE_KEY_PEM_PATTERN.test(value)) return true;
+
+  if (looksBase64(value)) {
+    try {
+      const decoded = Buffer.from(value.replace(/\s+/g, ""), "base64").toString(
+        "utf8",
+      );
+      if (PRIVATE_KEY_PEM_PATTERN.test(decoded)) return true;
+    } catch (_err) {
+      // not valid base64 text; ignore
+    }
+  }
+  return false;
+}
+
+/**
+ * Deep-scans any value (string, array, or object) for private key material.
+ * @param {*} value
+ * @returns {boolean} true if private key material is detected anywhere
+ */
+function containsPrivateKeyMaterial(value, depth = 0) {
+  if (value === null || value === undefined) return false;
+  if (depth > MAX_SCAN_DEPTH) return false;
+
+  if (typeof value === "string") return stringContainsPrivateKey(value);
+
+  if (Buffer.isBuffer(value)) {
+    return stringContainsPrivateKey(value.toString("utf8"));
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsPrivateKeyMaterial(item, depth + 1));
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value).some((item) =>
+      containsPrivateKeyMaterial(item, depth + 1),
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Replaces any private key PEM blocks found in a string with a redaction
+ * placeholder. Returns the input unchanged when it is not a string.
+ * @param {*} value
+ * @returns {*}
+ */
+function redactPrivateKeyMaterial(value) {
+  if (typeof value !== "string") return value;
+  if (!PRIVATE_KEY_PEM_PATTERN.test(value)) return value;
+  return value.replace(
+    PRIVATE_KEY_PEM_BLOCK_PATTERN,
+    PRIVATE_KEY_REDACTION_PLACEHOLDER,
+  );
+}
+
+/**
+ * Generic secret redactor for evidence and log contexts (CertOps detector
+ * "second mode", plan 3.3 layer 6). Redacts private-key PEM blocks and
+ * Authorization/bearer header values. Deep-walks objects and arrays, returning
+ * a redacted copy without mutating the input.
+ *
+ * Phase 0 baseline; the secret pattern set expands in M2 evidence redaction.
+ * @param {*} value
+ * @returns {*} redacted copy
+ */
+function redactGenericSecrets(value, depth = 0) {
+  if (value === null || value === undefined) return value;
+  if (depth > MAX_SCAN_DEPTH) return value;
+
+  if (typeof value === "string") {
+    return redactPrivateKeyMaterial(value).replace(
+      AUTHORIZATION_VALUE_PATTERN,
+      (_match, prefix, scheme) =>
+        `${prefix}${scheme} ${GENERIC_SECRET_REDACTION_PLACEHOLDER}`,
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactGenericSecrets(item, depth + 1));
+  }
+
+  if (typeof value === "object") {
+    if (Buffer.isBuffer(value)) return value;
+    const out = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = redactGenericSecrets(item, depth + 1);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+module.exports = {
+  PRIVATE_KEY_REDACTION_PLACEHOLDER,
+  GENERIC_SECRET_REDACTION_PLACEHOLDER,
+  PRIVATE_KEY_PEM_PATTERN,
+  containsPrivateKeyMaterial,
+  redactPrivateKeyMaterial,
+  redactGenericSecrets,
+};

--- a/apps/api/utils/secretMaterial.js
+++ b/apps/api/utils/secretMaterial.js
@@ -113,11 +113,27 @@ function containsPrivateKeyMaterial(value, depth = 0) {
  */
 function redactPrivateKeyMaterial(value) {
   if (typeof value !== "string") return value;
-  if (!PRIVATE_KEY_PEM_PATTERN.test(value)) return value;
-  return value.replace(
-    PRIVATE_KEY_PEM_BLOCK_PATTERN,
-    PRIVATE_KEY_REDACTION_PLACEHOLDER,
-  );
+  if (PRIVATE_KEY_PEM_PATTERN.test(value)) {
+    return value.replace(
+      PRIVATE_KEY_PEM_BLOCK_PATTERN,
+      PRIVATE_KEY_REDACTION_PLACEHOLDER,
+    );
+  }
+  // Detection sees through base64-wrapped PEM, so redaction must too. The
+  // decoded key spans the entire blob, so the whole value is replaced.
+  if (looksBase64(value)) {
+    try {
+      const decoded = Buffer.from(value.replace(/\s+/g, ""), "base64").toString(
+        "utf8",
+      );
+      if (PRIVATE_KEY_PEM_PATTERN.test(decoded)) {
+        return PRIVATE_KEY_REDACTION_PLACEHOLDER;
+      }
+    } catch (_err) {
+      // not valid base64 text; ignore
+    }
+  }
+  return value;
 }
 
 /**
@@ -130,9 +146,11 @@ function redactPrivateKeyMaterial(value) {
  * @param {*} value
  * @returns {*} redacted copy
  */
-function redactGenericSecrets(value, depth = 0) {
+function redactGenericSecrets(value, depth = 0, seen = new WeakSet()) {
   if (value === null || value === undefined) return value;
-  if (depth > MAX_SCAN_DEPTH) return value;
+  // Bail with a marker (never the original subtree) so a hostile or accidental
+  // deep nesting cannot defeat redaction by sitting below the scan floor.
+  if (depth > MAX_SCAN_DEPTH) return "[REDACTED:max-depth]";
 
   if (typeof value === "string") {
     return redactPrivateKeyMaterial(value).replace(
@@ -142,17 +160,28 @@ function redactGenericSecrets(value, depth = 0) {
     );
   }
 
-  if (Array.isArray(value)) {
-    return value.map((item) => redactGenericSecrets(item, depth + 1));
+  if (Buffer.isBuffer(value)) {
+    return stringContainsPrivateKey(value.toString("utf8"))
+      ? PRIVATE_KEY_REDACTION_PLACEHOLDER
+      : value;
   }
 
   if (typeof value === "object") {
-    if (Buffer.isBuffer(value)) return value;
-    const out = {};
-    for (const [key, item] of Object.entries(value)) {
-      out[key] = redactGenericSecrets(item, depth + 1);
+    // Path-based cycle guard: a cyclic reference returns a marker, never the
+    // original (which could leak unredacted children of an evidence object).
+    if (seen.has(value)) return "[REDACTED:circular]";
+    seen.add(value);
+    let result;
+    if (Array.isArray(value)) {
+      result = value.map((item) => redactGenericSecrets(item, depth + 1, seen));
+    } else {
+      result = {};
+      for (const [key, item] of Object.entries(value)) {
+        result[key] = redactGenericSecrets(item, depth + 1, seen);
+      }
     }
-    return out;
+    seen.delete(value);
+    return result;
   }
 
   return value;

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -159,6 +159,35 @@
           "status": "existing"
         }
       ]
+    },
+    {
+      "name": "certops",
+      "entries": [
+        {
+          "id": "certops-inventory-schema",
+          "kind": "schema",
+          "path": "packages/contracts/certops/certops-inventory.schema.json",
+          "status": "existing"
+        },
+        {
+          "id": "certops-job-payload-schema",
+          "kind": "schema",
+          "path": "packages/contracts/certops/job-payload.schema.json",
+          "status": "existing"
+        },
+        {
+          "id": "certops-agent-protocol-schema",
+          "kind": "schema",
+          "path": "packages/contracts/certops/agent-protocol.schema.json",
+          "status": "existing"
+        },
+        {
+          "id": "certops-route-compat-contract",
+          "kind": "spec",
+          "path": "packages/contracts/api/certops-route-compat.contract.json",
+          "status": "existing"
+        }
+      ]
     }
   ]
 }

--- a/docs/adr/0001-certops-zero-custody-enforcement.md
+++ b/docs/adr/0001-certops-zero-custody-enforcement.md
@@ -1,0 +1,54 @@
+# ADR-0001: CertOps zero private-key custody enforcement
+
+## Status
+
+Proposed (2026-06-25). Phase 0 skeleton; finalize in M0.
+
+## Context
+
+CertOps orchestrates certificate lifecycles across many targets. The strongest
+trust and security claim TokenTimer can make is that its control planes never
+hold private key material. That claim is only credible if it is enforced
+structurally and tested, not stated in marketing copy.
+
+Key material can reach the control plane through many paths: an import body, a
+flexible JSONB field, raw command output captured as evidence, an agent message,
+or base64-wrapped content under an innocent field name.
+
+## Decision
+
+Zero private-key custody is a structural invariant of Core, Cloud, and
+Enterprise. Enforce it in multiple layers:
+
+1. **Field-name redaction** in `apps/api/utils/logger.js` (already present:
+   `privateKey`, `private_key`, and regex key matching).
+2. **Content-based detection** in `apps/api/utils/secretMaterial.js`
+   (`containsPrivateKeyMaterial`), covering PEM private-key variants (PKCS#8,
+   PKCS#1, SEC1, DSA, OpenSSH, encrypted) and base64-wrapped PEM, deep-scanning
+   nested objects, arrays, and Buffers.
+3. **API rejection boundary**: requests whose body contains private key material
+   are rejected with HTTP 422 `PRIVATE_KEY_MATERIAL_REJECTED` (see
+   `packages/contracts/api/certops-route-compat.contract.json`).
+4. **Schema design**: no inventory field is intended to hold key material;
+   inventory stores public material and opaque, non-secret references
+   (`certops-inventory.schema.json`). Flexible JSONB fields are protected by the
+   detector, not by the absence of a column.
+5. **Evidence scrubbing**: `redactGenericSecrets` runs before evidence storage.
+
+The single private key the platform holds is the **platform operational signing
+key** (ADR-0003), which signs jobs and is never used for certificate issuance or
+customer key custody.
+
+## Alternatives considered
+
+- Field-name redaction only - rejected: misses key material under innocent
+  field names and in raw output.
+- Trust the agent to never send keys - rejected: defense in depth requires the
+  control plane to reject regardless of sender.
+
+## Consequences
+
+- A shared, well-tested detector is a hard dependency for M1 and M2.
+- TODO (M0): define exact 422 error envelope; PKCS#12/PFX binary DER detection
+  scope; performance bounds for large evidence scans; where the rejection
+  middleware mounts relative to body parsing.

--- a/docs/adr/0002-certops-agent-protocol.md
+++ b/docs/adr/0002-certops-agent-protocol.md
@@ -1,0 +1,40 @@
+# ADR-0002: CertOps agent protocol and agent-local policy
+
+## Status
+
+Proposed (2026-06-25). Phase 0 skeleton; finalize in M0, detail in M4.
+
+## Context
+
+The agent is the only component that touches private keys. It must be safe by
+construction: a compromised or misconfigured control plane must not be able to
+make an agent do arbitrary things.
+
+## Decision
+
+- **Outbound-only**: the agent polls the control plane (`/api/v1/certops/agent/*`).
+  The control plane never connects to agents.
+- **Message envelope** frozen in `packages/contracts/certops/agent-protocol.schema.json`
+  (stub): `register`, `heartbeat`, `claim`, `result`, `evidence`. Bodies defined
+  in M4.
+- **Agent-local policy wins**: the agent executes only preconfigured/allowlisted
+  command profiles, paths, CA endpoints, and DNS zones/providers. When
+  control-plane intent exceeds local policy, the agent refuses and reports the
+  refusal as evidence.
+- **DNS-01 credential locality**: DNS provider API tokens are provisioned
+  agent-side only. The control plane stores references and allowlists
+  (`allowedDnsZones`, `allowedDnsProviders`), never the credentials.
+- **No key material in any message** (enforced by the detector at ingest).
+
+## Alternatives considered
+
+- Control-plane push to agents - rejected: widens attack surface and requires
+  inbound connectivity to execution hosts.
+- Control-plane-defined commands without local allowlists - rejected: removes
+  the agent's ability to be the final authority over what runs on its host.
+
+## Consequences
+
+- The agent is testable in isolation against the frozen envelope.
+- TODO (M4): per-message body schemas, registration/enrollment trust, agent
+  credential storage (0700/0600, rotation), supply-chain integrity.

--- a/docs/adr/0003-certops-job-signing-and-replay-protection.md
+++ b/docs/adr/0003-certops-job-signing-and-replay-protection.md
@@ -1,0 +1,40 @@
+# ADR-0003: CertOps job signing and replay protection
+
+## Status
+
+Proposed (2026-06-25). Phase 0 skeleton; finalize in M0, detail in M2/M4.
+
+## Context
+
+Jobs instruct an agent to perform key-bearing actions. A job must be provably
+issued by the control plane, must not be replayable, and must not be executable
+outside a bounded time window. Symmetric secrets (HMAC) shared with agents would
+let any agent forge jobs for any other; they are not acceptable.
+
+## Decision
+
+- **Asymmetric signing**: the control plane holds an Ed25519 **platform
+  operational signing key** and signs every job. Agents pin the corresponding
+  public key (`signingKeyId`) and verify the signature before execution. HMAC is
+  rejected.
+- This signing key is a platform operational key only. It is never used for
+  certificate issuance and never holds customer PKI/TLS key material.
+- **Replay protection** envelope frozen in
+  `packages/contracts/certops/job-payload.schema.json`: `jobId`, `attemptId`,
+  `issuedAt`, `expiresAt`, `workspaceId`, `agentId`/selector, `nonce`,
+  `signingKeyId`, `signature`. Agents keep a bounded replay cache keyed by
+  `nonce` + `jobId` and reject jobs outside `[issuedAt, expiresAt]`
+  (clock-drift aware via reported `clockOffsetMs`).
+
+## Alternatives considered
+
+- HMAC with per-agent secrets - rejected: key distribution and forgery surface.
+- No expiry, rely on nonce only - rejected: unbounded replay cache and no time
+  bound on captured jobs.
+
+## Consequences
+
+- The signature must cover a canonical serialization excluding the `signature`
+  field; canonicalization must be defined precisely to avoid verification drift.
+- TODO (M0): signing key rotation policy and `signingKeyId` lifecycle; canonical
+  serialization; replay-cache size/TTL; clock-drift thresholds.

--- a/docs/adr/0004-certops-certmanager-secret-handling.md
+++ b/docs/adr/0004-certops-certmanager-secret-handling.md
@@ -18,8 +18,16 @@ path, or it would break the zero-custody invariant.
   or transmits `tls.key`.
 - The controller reports public material and status as evidence to the control
   plane; key material stays in the cluster.
-- The controller ships the first Helm RBAC templates and is scoped to the
-  minimum verbs needed (no blanket Secret read).
+- The controller ships the first Helm RBAC templates, scoped to the minimum
+  verbs needed. Note the platform limitation: Kubernetes RBAC cannot restrict
+  access to individual data keys inside a `Secret`, so a controller able to
+  `get` a Secret can technically read both `tls.crt` and `tls.key`. RBAC
+  minimizes Secret access; it cannot prove per-key denial.
+- Per-key non-access is therefore enforced by a strict read hierarchy (prefer
+  Certificate/CertificateRequest status, then annotations, then `tls.crt` only),
+  by code-level enforcement that never reads/deserializes/logs/transmits
+  `tls.key`, by tests asserting that, and by the shared detector scanning
+  everything the controller reports upstream.
 
 ## Alternatives considered
 
@@ -28,6 +36,8 @@ path, or it would break the zero-custody invariant.
 
 ## Consequences
 
-- RBAC must be narrow enough to prove the controller cannot read `tls.key`.
+- RBAC narrows but cannot prove per-key denial; the load-bearing proof is the
+  test suite showing controller code never reads/deserializes/logs/transmits
+  `tls.key`, plus detector scanning of all upstream reports.
 - TODO (M8): exact RBAC verbs/resources, controller reconcile model, Helm chart
   layout, and how status maps to CertOps evidence.

--- a/docs/adr/0004-certops-certmanager-secret-handling.md
+++ b/docs/adr/0004-certops-certmanager-secret-handling.md
@@ -1,0 +1,33 @@
+# ADR-0004: CertOps Kubernetes cert-manager Secret handling
+
+## Status
+
+Proposed (2026-06-25). Phase 0 skeleton; finalize in M0, detail in M8.
+
+## Context
+
+In Kubernetes, cert-manager stores issued certificates as `Secret` objects that
+contain both `tls.crt` (public) and `tls.key` (private). A TokenTimer Kubernetes
+controller that watches certificate state must not become a private-key custody
+path, or it would break the zero-custody invariant.
+
+## Decision
+
+- The TokenTimer Kubernetes controller observes `Certificate` /
+  `CertificateRequest` status and reads `tls.crt` only. It never reads, copies,
+  or transmits `tls.key`.
+- The controller reports public material and status as evidence to the control
+  plane; key material stays in the cluster.
+- The controller ships the first Helm RBAC templates and is scoped to the
+  minimum verbs needed (no blanket Secret read).
+
+## Alternatives considered
+
+- Read whole Secrets for convenience - rejected: that is private-key custody.
+- Mutate cert-manager Secrets - rejected: out of scope and custody-bearing.
+
+## Consequences
+
+- RBAC must be narrow enough to prove the controller cannot read `tls.key`.
+- TODO (M8): exact RBAC verbs/resources, controller reconcile model, Helm chart
+  layout, and how status maps to CertOps evidence.

--- a/docs/adr/0005-certops-threat-model.md
+++ b/docs/adr/0005-certops-threat-model.md
@@ -33,7 +33,7 @@ Adopt the threat / mitigation table below. Every mitigation must have a test.
 | T6 | Clock skew used to widen validity | Reported clock offset; agent rejects out-of-window | Job outside `[issuedAt, expiresAt]` (offset-adjusted) is rejected |
 | T7 | Control plane over-reaches agent | Agent-local allowlists win | Job referencing a non-allowlisted command/path/CA/DNS zone is refused and reported as evidence |
 | T8 | DNS-01 credentials centralized | Credentials agent-local only; control plane stores references | No DNS provider secret is ever stored control-plane side |
-| T9 | k8s controller reads `tls.key` | Read `tls.crt` only; narrow RBAC | RBAC denies Secret `tls.key` access; controller code paths never read it |
+| T9 | k8s controller reads `tls.key` | Read hierarchy (status > annotations > `tls.crt`); narrow RBAC; code-level non-access; detector scan | RBAC minimizes Secret access (cannot prove per-key denial); tests prove controller code never reads/deserializes/logs/transmits `tls.key` |
 | T10 | Stolen agent token reused broadly | Scoped tokens; bounded scope per workspace/agent | A token scoped to workspace A cannot act on workspace B |
 | T11 | Compromised agent supply chain | Signed/checksummed images and packages | Release artifacts carry verifiable checksums/signatures |
 | T12 | Frozen/over-quota workspace still executes | Fail-closed plan/freeze guards (cloud) | Frozen workspace requests return 403 `WORKSPACE_FROZEN`; over-limit returns 402 |

--- a/docs/adr/0005-certops-threat-model.md
+++ b/docs/adr/0005-certops-threat-model.md
@@ -1,0 +1,50 @@
+# ADR-0005: CertOps threat model
+
+## Status
+
+Proposed (2026-06-25). Phase 0 skeleton (P0.2). Finalize in M0.
+
+## Context
+
+CertOps spans a control plane that holds no private keys and an execution plane
+(agent / k8s controller) that does. The boundary between them is the primary
+security surface. This ADR enumerates threats and the mitigation for each, with
+each mitigation expressed as something that can be tested. It is a living
+document; M0 fleshes out the TODOs and links each mitigation to a test id.
+
+Trust boundaries:
+
+- Internet / customer infra <-> control plane API
+- Control plane <-> agent (outbound-only, scoped-token)
+- Agent <-> host / CA / DNS provider
+- Kubernetes cluster <-> TokenTimer controller
+
+## Decision
+
+Adopt the threat / mitigation table below. Every mitigation must have a test.
+
+| # | Threat | Mitigation | Testable assertion |
+|---|--------|-----------|--------------------|
+| T1 | Private key reaches control plane via import/body | Content detector + 422 rejection at API boundary | A request body containing any PEM private-key variant (incl. base64-wrapped, nested) is rejected 422 `PRIVATE_KEY_MATERIAL_REJECTED` (unit tests for the detector already exist in `tests/unit/secretMaterial.test.js`) |
+| T2 | Key material leaks into logs | Field-name redaction + content redaction | Log records with key material render the placeholder, never the key |
+| T3 | Key material persisted in evidence | `redactGenericSecrets` before storage; size limits | Stored evidence never contains a private-key block |
+| T4 | Forged job dispatched to agent | Ed25519 signature, agent pins public key, HMAC rejected | Agent rejects a job whose signature fails or that is HMAC-signed |
+| T5 | Job replay | nonce + jobId replay cache; expiry window | Re-submitted job (same nonce/jobId) is rejected; expired job is rejected |
+| T6 | Clock skew used to widen validity | Reported clock offset; agent rejects out-of-window | Job outside `[issuedAt, expiresAt]` (offset-adjusted) is rejected |
+| T7 | Control plane over-reaches agent | Agent-local allowlists win | Job referencing a non-allowlisted command/path/CA/DNS zone is refused and reported as evidence |
+| T8 | DNS-01 credentials centralized | Credentials agent-local only; control plane stores references | No DNS provider secret is ever stored control-plane side |
+| T9 | k8s controller reads `tls.key` | Read `tls.crt` only; narrow RBAC | RBAC denies Secret `tls.key` access; controller code paths never read it |
+| T10 | Stolen agent token reused broadly | Scoped tokens; bounded scope per workspace/agent | A token scoped to workspace A cannot act on workspace B |
+| T11 | Compromised agent supply chain | Signed/checksummed images and packages | Release artifacts carry verifiable checksums/signatures |
+| T12 | Frozen/over-quota workspace still executes | Fail-closed plan/freeze guards (cloud) | Frozen workspace requests return 403 `WORKSPACE_FROZEN`; over-limit returns 402 |
+
+## Alternatives considered
+
+- Defer the threat model to implementation - rejected: the mitigations dictate
+  contract and schema shape, so they must be fixed in Phase 0.
+
+## Consequences
+
+- Each row becomes one or more tests, tracked in the M1/M2 issue map.
+- TODO (M0): assign a test id to every row; add abuse cases for T1 (PKCS#12),
+  T6 (drift thresholds), and T10 (scope matrix).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+One ADR per significant, hard-to-reverse decision. Numbering is `000N-kebab-slug.md`.
+Sections: Status, Context, Decision, Alternatives considered, Consequences.
+
+Status values: Proposed, Accepted, Superseded, Deprecated. Date each status change.
+
+## Index
+
+### CertOps (Phase 0 skeletons, to be finalized in M0)
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-certops-zero-custody-enforcement.md) | CertOps zero private-key custody enforcement | Proposed |
+| [0002](0002-certops-agent-protocol.md) | CertOps agent protocol and agent-local policy | Proposed |
+| [0003](0003-certops-job-signing-and-replay-protection.md) | CertOps job signing and replay protection | Proposed |
+| [0004](0004-certops-certmanager-secret-handling.md) | CertOps Kubernetes cert-manager Secret handling | Proposed |
+| [0005](0005-certops-threat-model.md) | CertOps threat model | Proposed |
+
+These skeletons freeze direction so M1/M2 can proceed in parallel. Each carries
+TODO markers for the content that is finalized during M0.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,15 @@ Status values: Proposed, Accepted, Superseded, Deprecated. Date each status chan
 
 These skeletons freeze direction so M1/M2 can proceed in parallel. Each carries
 TODO markers for the content that is finalized during M0.
+
+Two things are frozen at different strengths, on purpose:
+
+- The **contract surface** (route namespaces, auth model, JSON schemas, OpenAPI
+  skeletons) is frozen now (`status: frozen-skeleton`) so cloud, enterprise, the
+  executor, and the agent build against a stable shape without route churn.
+- The **ADR decisions** stay `Proposed` until **M0 ratification**, when they move
+  to `Accepted` and their TODOs are resolved. From M0 onward, changing a frozen
+  decision is a new/updated ADR, not a silent code edit.
+
+In short: Phase 0 is a pre-M0 scaffold that freezes the wire/contract shape while
+the rationale is still being ratified.

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,0 +1,57 @@
+{
+  "contractName": "api.certops-route-compat",
+  "version": "0.8.1",
+  "status": "frozen-skeleton",
+  "description": "Frozen CertOps route namespaces and stable routes for M1/M2. Routes are skeletons in Phase 0 (documented in OpenAPI, not yet implemented). This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn. Per-route request/response schemas are added in M1/M2.",
+  "namespacePolicy": {
+    "workspaceScoped": {
+      "prefix": "/api/v1/workspaces/{id}/certops",
+      "auth": "cookieAuth",
+      "notes": [
+        "Human/dashboard surface. Inherits global session + workspace membership + frozen-workspace guards.",
+        "Subject to CSRF protection like other workspace mutations."
+      ]
+    },
+    "executor": {
+      "prefix": "/api/v1/certops/executor",
+      "auth": "certOpsTokenAuth",
+      "notes": [
+        "Machine surface for the M2 executor. Scoped API-token (bearer) auth.",
+        "CSRF-exempt (token-authenticated, non-cookie), like internal worker requests.",
+        "Ingest payloads are scanned and rejected (422) if they contain private key material."
+      ]
+    },
+    "agent": {
+      "prefix": "/api/v1/certops/agent",
+      "auth": "certOpsTokenAuth",
+      "notes": [
+        "Outbound-only agent polling surface (M4). The control plane never connects to agents.",
+        "Scoped API-token (bearer) auth; CSRF-exempt.",
+        "Frozen in Phase 0 to reserve the namespace; bodies specified in M4."
+      ]
+    }
+  },
+  "guarantees": {
+    "stableRoutes": [
+      { "path": "/api/v1/workspaces/{id}/certops/certificates", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/certificates", "method": "POST" },
+      { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/imports", "method": "POST" },
+      { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "POST" },
+      { "path": "/api/v1/certops/executor/events", "method": "POST" },
+      { "path": "/api/v1/certops/agent/register", "method": "POST" },
+      { "path": "/api/v1/certops/agent/heartbeat", "method": "POST" },
+      { "path": "/api/v1/certops/agent/jobs/claim", "method": "POST" },
+      { "path": "/api/v1/certops/agent/jobs/results", "method": "POST" }
+    ],
+    "rejectionPolicy": {
+      "privateKeyMaterial": {
+        "status": 422,
+        "code": "PRIVATE_KEY_MATERIAL_REJECTED",
+        "notes": "Any request body containing private key material is rejected at the boundary. The control plane never stores, generates, exports, transmits, or processes private key material."
+      }
+    }
+  }
+}

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -23,13 +23,22 @@
     },
     "agent": {
       "prefix": "/api/v1/certops/agent",
-      "auth": "certOpsTokenAuth",
+      "auth": "split-by-route",
       "notes": [
         "Outbound-only agent polling surface (M4). The control plane never connects to agents.",
-        "Scoped API-token (bearer) auth; CSRF-exempt.",
-        "Frozen in Phase 0 to reserve the namespace; bodies specified in M4."
+        "Enrollment and steady state use different credentials, by design.",
+        "POST /agent/register uses agentBootstrapTokenAuth: a single-use, hashed, expiring bootstrap token an admin creates. Registration returns a per-agent credential, shown once.",
+        "/agent/heartbeat, /agent/jobs/claim, /agent/jobs/results use agentCredentialAuth: the issued per-agent credential (bearer). Bootstrap tokens do not authorize steady-state calls.",
+        "All routes CSRF-exempt (token-authenticated, non-cookie). Frozen in Phase 0 to reserve the namespace; bodies specified in M4."
       ]
     }
+  },
+  "routeAuth": {
+    "/api/v1/certops/executor/events": "certOpsTokenAuth",
+    "/api/v1/certops/agent/register": "agentBootstrapTokenAuth",
+    "/api/v1/certops/agent/heartbeat": "agentCredentialAuth",
+    "/api/v1/certops/agent/jobs/claim": "agentCredentialAuth",
+    "/api/v1/certops/agent/jobs/results": "agentCredentialAuth"
   },
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/certops/agent-protocol.schema.json
+++ b/packages/contracts/certops/agent-protocol.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tokentimer.io/contracts/certops/agent-protocol.schema.json",
+  "title": "CertOps Agent Protocol Message (STUB)",
+  "description": "STUB frozen in Phase 0. Freezes only the outbound message envelope shared by every agent/executor message so the M2 executor API and the M4 agent are not blocked. The agent is outbound-only (it polls the control plane); the control plane never opens connections to agents. Per-message bodies are specified in M4. Messages MUST NOT carry private key material (enforced by apps/api/utils/secretMaterial.js at the ingest boundary).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schemaVersion", "protocolVersion", "messageType", "agentId", "sentAt"],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "protocolVersion": {
+      "type": "string",
+      "description": "Agent protocol semver the agent speaks."
+    },
+    "messageType": {
+      "type": "string",
+      "enum": ["register", "heartbeat", "claim", "result", "evidence"],
+      "description": "register/heartbeat/claim/result/evidence. Bodies defined in M4."
+    },
+    "agentId": {
+      "type": "string"
+    },
+    "workspaceId": {
+      "type": ["string", "null"]
+    },
+    "sentAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "clockOffsetMs": {
+      "type": ["integer", "null"],
+      "description": "Agent-reported offset vs control-plane time, used for clock-drift detection (M4)."
+    },
+    "body": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "description": "Message-type-specific payload. Specified per messageType in M4."
+    }
+  }
+}

--- a/packages/contracts/certops/certops-inventory.schema.json
+++ b/packages/contracts/certops/certops-inventory.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tokentimer.io/contracts/certops/certops-inventory.schema.json",
+  "title": "CertOps Managed Certificate Inventory Record",
+  "description": "Public-material-only inventory record for a CertOps managed certificate. Frozen in Phase 0; descriptive fields expand in M1. A conforming record MUST NOT contain private key material under any property (enforced at runtime by apps/api/utils/secretMaterial.js and the API rejection boundary).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "id", "workspaceId", "status"],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "description": "Stable identifier for the managed certificate."
+    },
+    "workspaceId": {
+      "type": "string",
+      "description": "Owning workspace identifier."
+    },
+    "tokenId": {
+      "type": ["string", "null"],
+      "description": "Optional link to the underlying tokens row this certificate maps to."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "discovered",
+        "active",
+        "renewing",
+        "expiring",
+        "expired",
+        "revoked",
+        "decommissioned"
+      ]
+    },
+    "commonName": {
+      "type": ["string", "null"]
+    },
+    "subjectAltNames": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "issuer": {
+      "type": ["string", "null"]
+    },
+    "serialNumber": {
+      "type": ["string", "null"]
+    },
+    "fingerprintSha256": {
+      "type": ["string", "null"],
+      "description": "Lowercase hex SHA-256 of the DER certificate. Public material."
+    },
+    "notBefore": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "notAfter": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "keyMode": {
+      "type": ["string", "null"],
+      "enum": [
+        "agent-local",
+        "proxy-agent-local",
+        "cert-manager-managed",
+        "appliance-managed",
+        "hsm-managed",
+        "vault-managed",
+        "os-store-managed",
+        "external-unknown",
+        null
+      ],
+      "description": "Where the private key lives on the execution plane (plan section 9.1). The control plane records the mode only; it never holds the key."
+    },
+    "keyReference": {
+      "type": ["string", "null"],
+      "description": "Opaque, non-secret reference to where the key lives on the execution plane (e.g. agent id + path handle, pkcs11 URI, k8s secret ref). Never the key itself."
+    },
+    "createdAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    }
+  }
+}

--- a/packages/contracts/certops/certops-inventory.schema.json
+++ b/packages/contracts/certops/certops-inventory.schema.json
@@ -20,8 +20,8 @@
       "description": "Owning workspace identifier."
     },
     "tokenId": {
-      "type": ["string", "null"],
-      "description": "Optional link to the underlying tokens row this certificate maps to."
+      "type": ["integer", "null"],
+      "description": "Optional link to the underlying tokens row (tokens.id is INTEGER) this certificate maps to."
     },
     "status": {
       "type": "string",

--- a/packages/contracts/certops/job-payload.schema.json
+++ b/packages/contracts/certops/job-payload.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tokentimer.io/contracts/certops/job-payload.schema.json",
+  "title": "CertOps Signed Job Payload (STUB)",
+  "description": "STUB frozen in Phase 0. This freezes only the signing and replay-protection envelope so M2 (executor) and M4 (agent) can build against a stable outer shape. The per-job-type body (renew, deploy, reload, revoke) is intentionally left open (additionalProperties: true) and is specified in M2/M4. The signature covers the full payload excluding the signature field itself, using the control-plane Ed25519 platform operational signing key. This key is never used for certificate issuance or customer key custody.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schemaVersion",
+    "jobId",
+    "type",
+    "workspaceId",
+    "issuedAt",
+    "expiresAt",
+    "nonce",
+    "signingKeyId",
+    "signature"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "jobId": {
+      "type": "string",
+      "description": "Unique job identifier. Part of the replay-protection tuple."
+    },
+    "attemptId": {
+      "type": "string",
+      "description": "Per-dispatch attempt identifier for idempotent retries."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["renew", "deploy", "reload", "revoke", "noop"],
+      "description": "Job kind. The matching body shape is defined in M2/M4."
+    },
+    "workspaceId": {
+      "type": "string"
+    },
+    "agentId": {
+      "type": ["string", "null"],
+      "description": "Target agent id, or null when dispatched via selector."
+    },
+    "agentSelector": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "description": "Optional selector when not targeting a single agent id."
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Hard validity bound. Agents MUST reject jobs outside this window (clock-drift aware)."
+    },
+    "nonce": {
+      "type": "string",
+      "description": "Single-use nonce. Agents maintain a bounded replay cache keyed by nonce + jobId."
+    },
+    "signingKeyId": {
+      "type": "string",
+      "description": "Identifier of the control-plane Ed25519 signing key the agent pins."
+    },
+    "signature": {
+      "type": "string",
+      "description": "Base64 Ed25519 signature over the canonical payload excluding this field. HMAC is not accepted."
+    }
+  }
+}

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -28,6 +28,10 @@ tags:
     description: Alert rules, destinations, queue visibility, and preferences.
   - name: Integrations
     description: Integration scans, discovery, and import operations.
+  - name: CertOps
+    description: Certificate lifecycle orchestration (workspace-scoped). Control plane never stores private key material.
+  - name: CertOps Agent
+    description: Machine surface for the CertOps executor and outbound-only agent. Scoped-token authenticated.
 security:
   - cookieAuth: []
 paths:
@@ -2910,6 +2914,365 @@ paths:
                 additionalProperties: true
         "500":
           $ref: "#/components/responses/InternalError"
+  # ----------------------------------------------------------------------------
+  # CertOps route skeletons (Phase 0 freeze).
+  # Documented-but-not-yet-implemented. Frozen to keep M1/M2 unblocked.
+  # Request/response schemas are filled in during M1 (inventory) and M2 (jobs,
+  # tokens, executor). No CertOps runtime routes exist yet, so these do not
+  # affect openapi runtime-coverage (runtime -> spec direction only).
+  # ----------------------------------------------------------------------------
+  /api/v1/workspaces/{id}/certops/certificates:
+    get:
+      tags: [CertOps]
+      summary: List managed certificates
+      operationId: listCertOpsCertificates
+      description: Returns the workspace's managed certificate inventory (public material only). Skeleton; response schema lands in M1.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - $ref: "#/components/parameters/limitParam"
+        - $ref: "#/components/parameters/offsetParam"
+      responses:
+        "200":
+          description: Managed certificate inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags: [CertOps]
+      summary: Create or register a managed certificate
+      operationId: createCertOpsCertificate
+      description: Registers a managed certificate from public material. Bodies containing private key material are rejected (422). Skeleton; request schema lands in M1.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "201":
+          description: Managed certificate registered
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/certificates/{certId}:
+    get:
+      tags: [CertOps]
+      summary: Get a managed certificate
+      operationId: getCertOpsCertificate
+      description: Returns a single managed certificate (public material only). Skeleton; response schema lands in M1.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: certId
+          required: true
+          schema:
+            type: string
+          description: Managed certificate identifier.
+      responses:
+        "200":
+          description: Managed certificate detail
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/imports:
+    post:
+      tags: [CertOps]
+      summary: Import certificates from public material
+      operationId: createCertOpsImport
+      description: Imports certificates from PEM/public material. Private key material is rejected (422). Skeleton; request schema lands in M1.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "202":
+          description: Import accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/jobs:
+    get:
+      tags: [CertOps]
+      summary: List CertOps jobs
+      operationId: listCertOpsJobs
+      description: Returns orchestration jobs for the workspace. Skeleton; response schema lands in M2.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - $ref: "#/components/parameters/limitParam"
+        - $ref: "#/components/parameters/offsetParam"
+      responses:
+        "200":
+          description: Job list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/tokens:
+    get:
+      tags: [CertOps]
+      summary: List CertOps API tokens
+      operationId: listCertOpsTokens
+      description: Returns scoped CertOps API tokens (metadata only, never secrets). Skeleton; response schema lands in M2.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      responses:
+        "200":
+          description: API token metadata list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags: [CertOps]
+      summary: Issue a scoped CertOps API token
+      operationId: createCertOpsToken
+      description: Issues a scoped API token for executor/agent use. The plaintext token is returned once at creation and never stored in recoverable form. Skeleton; request/response schema lands in M2.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "201":
+          description: API token issued
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/certops/executor/events:
+    post:
+      tags: [CertOps Agent]
+      summary: Report executor events
+      operationId: createCertOpsExecutorEvent
+      description: Executor reports job progress and evidence metadata. Scoped-token authenticated. Payloads containing private key material are rejected (422). Skeleton; body schema lands in M2.
+      security:
+        - certOpsTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "202":
+          description: Event accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/certops/agent/register:
+    post:
+      tags: [CertOps Agent]
+      summary: Register an agent
+      operationId: createCertOpsAgentRegistration
+      description: Outbound-only agent registration. Scoped-token authenticated. Frozen namespace skeleton; body schema lands in M4.
+      security:
+        - certOpsTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "201":
+          description: Agent registered
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/certops/agent/heartbeat:
+    post:
+      tags: [CertOps Agent]
+      summary: Agent heartbeat
+      operationId: createCertOpsAgentHeartbeat
+      description: Agent heartbeat including reported clock offset (clock-drift detection). Scoped-token authenticated. Frozen skeleton; body schema lands in M4.
+      security:
+        - certOpsTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "200":
+          description: Heartbeat accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/certops/agent/jobs/claim:
+    post:
+      tags: [CertOps Agent]
+      summary: Claim pending jobs
+      operationId: createCertOpsAgentJobClaim
+      description: Agent polls for and claims signed jobs. Scoped-token authenticated. Frozen skeleton; returns signed job payloads (job-payload.schema.json) in M4.
+      security:
+        - certOpsTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "200":
+          description: Claimed jobs
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/certops/agent/jobs/results:
+    post:
+      tags: [CertOps Agent]
+      summary: Report job results and evidence
+      operationId: createCertOpsAgentJobResult
+      description: Agent reports job results and evidence metadata. Scoped-token authenticated. Payloads containing private key material are rejected (422). Frozen skeleton; body schema lands in M4.
+      security:
+        - certOpsTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "202":
+          description: Result accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "500":
+          $ref: "#/components/responses/InternalError"
 components:
   securitySchemes:
     cookieAuth:
@@ -2917,6 +3280,10 @@ components:
       in: cookie
       name: sessionId
       description: Session cookie authentication used by authenticated API routes.
+    certOpsTokenAuth:
+      type: http
+      scheme: bearer
+      description: Scoped CertOps API token (bearer) used by the executor and the outbound agent. Never a cookie; CSRF-exempt.
   parameters:
     workspaceIdParam:
       in: path

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3163,9 +3163,9 @@ paths:
       tags: [CertOps Agent]
       summary: Register an agent
       operationId: createCertOpsAgentRegistration
-      description: Outbound-only agent registration. Scoped-token authenticated. Frozen namespace skeleton; body schema lands in M4.
+      description: Outbound-only agent enrollment using a single-use bootstrap token; returns a per-agent credential shown once. Frozen namespace skeleton; body schema lands in M4.
       security:
-        - certOpsTokenAuth: []
+        - agentBootstrapTokenAuth: []
       requestBody:
         required: true
         content:
@@ -3190,9 +3190,9 @@ paths:
       tags: [CertOps Agent]
       summary: Agent heartbeat
       operationId: createCertOpsAgentHeartbeat
-      description: Agent heartbeat including reported clock offset (clock-drift detection). Scoped-token authenticated. Frozen skeleton; body schema lands in M4.
+      description: Agent heartbeat including reported clock offset (clock-drift detection). Per-agent credential authenticated. Frozen skeleton; body schema lands in M4.
       security:
-        - certOpsTokenAuth: []
+        - agentCredentialAuth: []
       requestBody:
         required: true
         content:
@@ -3217,9 +3217,9 @@ paths:
       tags: [CertOps Agent]
       summary: Claim pending jobs
       operationId: createCertOpsAgentJobClaim
-      description: Agent polls for and claims signed jobs. Scoped-token authenticated. Frozen skeleton; returns signed job payloads (job-payload.schema.json) in M4.
+      description: Agent polls for and claims signed jobs. Per-agent credential authenticated. Frozen skeleton; returns signed job payloads (job-payload.schema.json) in M4.
       security:
-        - certOpsTokenAuth: []
+        - agentCredentialAuth: []
       requestBody:
         required: true
         content:
@@ -3244,9 +3244,9 @@ paths:
       tags: [CertOps Agent]
       summary: Report job results and evidence
       operationId: createCertOpsAgentJobResult
-      description: Agent reports job results and evidence metadata. Scoped-token authenticated. Payloads containing private key material are rejected (422). Frozen skeleton; body schema lands in M4.
+      description: Agent reports job results and evidence metadata. Per-agent credential authenticated. Payloads containing private key material are rejected (422). Frozen skeleton; body schema lands in M4.
       security:
-        - certOpsTokenAuth: []
+        - agentCredentialAuth: []
       requestBody:
         required: true
         content:
@@ -3283,7 +3283,15 @@ components:
     certOpsTokenAuth:
       type: http
       scheme: bearer
-      description: Scoped CertOps API token (bearer) used by the executor and the outbound agent. Never a cookie; CSRF-exempt.
+      description: Scoped CertOps API token (bearer) used by the executor. Never a cookie; CSRF-exempt.
+    agentBootstrapTokenAuth:
+      type: http
+      scheme: bearer
+      description: Single-use, hashed, expiring bootstrap enrollment token used only by POST /api/v1/certops/agent/register. Exchanged for a per-agent credential at registration.
+    agentCredentialAuth:
+      type: http
+      scheme: bearer
+      description: Per-agent credential (bearer) issued at registration, used for agent heartbeat, job claim, and result/evidence calls. CSRF-exempt. Not valid for registration.
   parameters:
     workspaceIdParam:
       in: path

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -101,6 +101,13 @@ describe("secretMaterial.redactPrivateKeyMaterial", () => {
     assert.ok(out.endsWith("after"));
   });
 
+  it("redacts a base64-wrapped private key to the placeholder", () => {
+    const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    const out = redactPrivateKeyMaterial(wrapped);
+    assert.strictEqual(out, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+    assert.ok(!out.includes(wrapped));
+  });
+
   it("leaves non-key strings unchanged", () => {
     assert.strictEqual(redactPrivateKeyMaterial("plain text"), "plain text");
   });
@@ -124,10 +131,39 @@ describe("secretMaterial.redactGenericSecrets", () => {
     assert.ok(/Bearer \[REDACTED\]/.test(out));
   });
 
+  it("redacts a base64-wrapped private key nested in a structure", () => {
+    const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    const out = redactGenericSecrets({ evidence: { blob: wrapped } });
+    assert.strictEqual(out.evidence.blob, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+  });
+
+  it("redacts a Buffer carrying private key material", () => {
+    const out = redactGenericSecrets({ raw: Buffer.from(pem("PRIVATE KEY")) });
+    assert.strictEqual(out.raw, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+  });
+
   it("leaves ordinary content intact", () => {
     assert.strictEqual(
       redactGenericSecrets("renewal succeeded for example.com"),
       "renewal succeeded for example.com",
     );
+  });
+
+  it("does not throw or leak the original subtree on cyclic objects", () => {
+    const node = { label: "evidence" };
+    node.self = node;
+    const out = redactGenericSecrets(node);
+    assert.notStrictEqual(out, node, "must return a copy, not the original");
+    assert.notStrictEqual(out.self, node, "must not embed the original cycle");
+    assert.strictEqual(out.self, "[REDACTED:circular]");
+    assert.strictEqual(out.label, "evidence");
+  });
+
+  it("still redacts a key reachable before a cycle closes", () => {
+    const node = { secret: pem("RSA PRIVATE KEY") };
+    node.self = node;
+    const out = redactGenericSecrets(node);
+    assert.ok(out.secret.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.strictEqual(out.self, "[REDACTED:circular]");
   });
 });

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+
+const {
+  PRIVATE_KEY_REDACTION_PLACEHOLDER,
+  containsPrivateKeyMaterial,
+  redactPrivateKeyMaterial,
+  redactGenericSecrets,
+} = require(
+  path.resolve(__dirname, "../../apps/api/utils/secretMaterial.js"),
+);
+
+// Synthetic header/footer fixtures with fake bodies. No real key material is
+// committed: zero private-key custody applies to the test suite too.
+const FAKE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
+const pem = (label) =>
+  `-----BEGIN ${label}-----\n${FAKE_BODY}\n-----END ${label}-----`;
+
+const PRIVATE_KEY_LABELS = [
+  "PRIVATE KEY", // PKCS#8
+  "RSA PRIVATE KEY", // PKCS#1
+  "EC PRIVATE KEY", // SEC1
+  "DSA PRIVATE KEY",
+  "OPENSSH PRIVATE KEY",
+  "ENCRYPTED PRIVATE KEY",
+  "RSA ENCRYPTED PRIVATE KEY",
+];
+
+const NON_KEY_VALUES = [
+  pem("CERTIFICATE"),
+  pem("CERTIFICATE REQUEST"),
+  pem("PUBLIC KEY"),
+  "just a normal log line with no secrets",
+  "fingerprint: AA:BB:CC:DD",
+  "",
+  null,
+  undefined,
+  42,
+  true,
+];
+
+describe("secretMaterial.containsPrivateKeyMaterial", () => {
+  for (const label of PRIVATE_KEY_LABELS) {
+    it(`detects a ${label} PEM block`, () => {
+      assert.strictEqual(containsPrivateKeyMaterial(pem(label)), true);
+    });
+  }
+
+  it("detects base64-wrapped private key PEM", () => {
+    const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
+  });
+
+  it("detects key material under an innocent field name", () => {
+    const payload = { note: "harmless", attachment: pem("EC PRIVATE KEY") };
+    assert.strictEqual(containsPrivateKeyMaterial(payload), true);
+  });
+
+  it("detects key material nested in arrays and objects", () => {
+    const payload = {
+      evidence: [{ output: ["line1", pem("PRIVATE KEY")] }],
+    };
+    assert.strictEqual(containsPrivateKeyMaterial(payload), true);
+  });
+
+  it("detects key material inside a Buffer", () => {
+    assert.strictEqual(
+      containsPrivateKeyMaterial(Buffer.from(pem("PRIVATE KEY"))),
+      true,
+    );
+  });
+
+  for (const value of NON_KEY_VALUES) {
+    it(`does not flag non-key value: ${JSON.stringify(value)?.slice(0, 32)}`, () => {
+      assert.strictEqual(containsPrivateKeyMaterial(value), false);
+    });
+  }
+
+  it("does not flag a certificate nested in an object", () => {
+    const payload = { cert: pem("CERTIFICATE"), meta: { issuer: "Test CA" } };
+    assert.strictEqual(containsPrivateKeyMaterial(payload), false);
+  });
+
+  it("does not infinitely recurse on cyclic objects", () => {
+    const a = {};
+    a.self = a;
+    assert.strictEqual(containsPrivateKeyMaterial(a), false);
+  });
+});
+
+describe("secretMaterial.redactPrivateKeyMaterial", () => {
+  it("replaces a private key block with the placeholder", () => {
+    const input = `before\n${pem("RSA PRIVATE KEY")}\nafter`;
+    const out = redactPrivateKeyMaterial(input);
+    assert.ok(out.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.ok(!out.includes(FAKE_BODY));
+    assert.ok(out.startsWith("before"));
+    assert.ok(out.endsWith("after"));
+  });
+
+  it("leaves non-key strings unchanged", () => {
+    assert.strictEqual(redactPrivateKeyMaterial("plain text"), "plain text");
+  });
+
+  it("returns non-strings unchanged", () => {
+    assert.strictEqual(redactPrivateKeyMaterial(123), 123);
+  });
+});
+
+describe("secretMaterial.redactGenericSecrets", () => {
+  it("redacts private key blocks in nested structures without mutating input", () => {
+    const input = { logs: [pem("PRIVATE KEY")] };
+    const out = redactGenericSecrets(input);
+    assert.ok(out.logs[0].includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.ok(input.logs[0].includes(FAKE_BODY), "input must not be mutated");
+  });
+
+  it("redacts Authorization bearer header values", () => {
+    const out = redactGenericSecrets("Authorization: Bearer abc123tokenvalue");
+    assert.ok(!out.includes("abc123tokenvalue"));
+    assert.ok(/Bearer \[REDACTED\]/.test(out));
+  });
+
+  it("leaves ordinary content intact", () => {
+    assert.strictEqual(
+      redactGenericSecrets("renewal succeeded for example.com"),
+      "renewal succeeded for example.com",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Phase 0 establishes the common base for two developers to build CertOps in
parallel. It freezes the security invariant, the API/agent namespaces, the
contract artifacts, and the decision record, so M1 and M2 can start without
reworking shared surfaces.

- Zero private-key custody enforced by a shared content detector
  (`apps/api/utils/secretMaterial.js`): detects and rejects PEM/base64-wrapped
  private keys (and redacts them in evidence/log paths), with the 422 rejection
  policy frozen in the route-compat contract.
- Frozen namespaces: `/api/v1/workspaces/:id/certops` (cookie auth),
  `/api/v1/certops/executor` (scoped-token auth), and `/api/v1/certops/agent`
  with split auth — enrollment (`/agent/register`) uses a single-use bootstrap
  token; steady-state (heartbeat/claim/results) uses the issued per-agent
  credential.
- Contract skeletons registered in `contracts.manifest.json`: inventory schema,
  job-payload stub (signing/replay envelope), agent-protocol stub, route-compat
  contract, and OpenAPI route skeletons with three security schemes
  (`certOpsTokenAuth`, `agentBootstrapTokenAuth`, `agentCredentialAuth`).
- `CONTEXT.md` domain model and `docs/adr/0001-0005` (incl. threat model with
  testable mitigations). Phase 0 freezes the contract surface; the ADR decisions
  stay Proposed until M0 ratification, after which changes flow through ADRs.
- M1/M2 issue map and cloud overlay verification under `.scratch/certops/`,
  shared via a targeted `.gitignore` exception.

## Verification
- `pnpm run check:contracts` and `pnpm run check:contracts:integrity`: ok
  (7 namespaces, 25 files; openapi-coverage ok). New OpenAPI paths are
  documented-but-not-yet-implemented, which is safe (coverage is runtime-to-spec
  only).
- `pnpm run test:unit` (secretMaterial): 34/34 pass, incl. base64-wrapped PEM
  redaction, Buffer redaction, and cyclic-object hardening.
- Contract tests pass except `queue-schemas-ajv.test.js`, which fails locally
  only due to a missing `ajv` dependency in this workspace and passes in CI.

## Notes for reviewer
- Cloud path assumption corrected: cloud uses `apps/saas`/`apps/web`, override
  entries use `ownerPath`/`targetCorePath`/`kind` (`saaSOnly`, not
  `additiveFile`). See `.scratch/certops/cloud-overlay-verification.md`.
- Inventory schema uses `keyMode` (plan section 9.1 enum), not `keyCustody`;
  `tokenId` is `integer|null` to match `tokens.id`.
- cert-manager handling (ADR-0004/T9): RBAC minimizes Secret access but cannot
  prove per-key denial; per-key non-access is enforced by read hierarchy,
  code-level non-access, tests, and detector scanning.
- Routes are intentionally skeletons; request/response schemas land in M1/M2.

## Test plan
- [ ] `pnpm install && pnpm run check:contracts && pnpm run check:contracts:integrity`
- [ ] `pnpm run test:contracts` (after install, ajv present)
- [ ] `pnpm run test:unit`
- [ ] Review ADRs 0001-0005 and the M1/M2 issue map for owner/scope agreement