### PR TITLE
feat(certops): add inventory schema migration m1

### DIFF
--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -615,7 +615,7 @@ const migrations = [
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
         token_id INTEGER NULL REFERENCES tokens(id) ON DELETE SET NULL,
-        profile_id UUID NULL REFERENCES certificate_profiles(id) ON DELETE SET NULL,
+        profile_id UUID NULL,
         status TEXT NOT NULL DEFAULT 'discovered'
           CHECK (status IN ('discovered', 'active', 'renewing', 'expiring', 'expired', 'revoked', 'decommissioned')),
         source TEXT NOT NULL DEFAULT 'manual'
@@ -652,6 +652,10 @@ const migrations = [
         created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT fk_managed_certificates_profile
+          FOREIGN KEY (workspace_id, profile_id)
+          REFERENCES certificate_profiles(workspace_id, id)
+          ON DELETE SET NULL (profile_id),
         CONSTRAINT uq_managed_certificates_workspace_id UNIQUE (workspace_id, id)
       );
       CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace
@@ -678,7 +682,7 @@ const migrations = [
       CREATE TABLE IF NOT EXISTS certificate_targets (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-        profile_id UUID NULL REFERENCES certificate_profiles(id) ON DELETE SET NULL,
+        profile_id UUID NULL,
         domain_monitor_id UUID NULL REFERENCES domain_monitors(id) ON DELETE SET NULL,
         token_id INTEGER NULL REFERENCES tokens(id) ON DELETE SET NULL,
         name TEXT NOT NULL,
@@ -697,6 +701,10 @@ const migrations = [
         created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT fk_certificate_targets_profile
+          FOREIGN KEY (workspace_id, profile_id)
+          REFERENCES certificate_profiles(workspace_id, id)
+          ON DELETE SET NULL (profile_id),
         CONSTRAINT uq_certificate_targets_workspace_id UNIQUE (workspace_id, id)
       );
       CREATE INDEX IF NOT EXISTS idx_certificate_targets_workspace

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -563,6 +563,208 @@ const migrations = [
         ON tokens(workspace_id, expiration);
     `,
   },
+  {
+    version: 10,
+    name: "certops_inventory_schema",
+    sql: `
+      -- CertOps profiles contain public/non-secret policy metadata only.
+      CREATE TABLE IF NOT EXISTS certificate_profiles (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        description TEXT NULL,
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'disabled', 'archived')),
+        source TEXT NOT NULL DEFAULT 'manual'
+          CHECK (source IN ('manual', 'api', 'import', 'domain_checker', 'endpoint_monitor', 'integration', 'auto_sync')),
+        source_ref TEXT NULL,
+        issuer TEXT NULL,
+        subject_template TEXT NULL,
+        san_templates TEXT[] NOT NULL DEFAULT '{}',
+        validity_days INTEGER NULL CHECK (validity_days IS NULL OR validity_days > 0),
+        renew_before_days INTEGER NULL CHECK (renew_before_days IS NULL OR renew_before_days >= 0),
+        key_mode TEXT NULL CHECK (
+          key_mode IS NULL OR key_mode IN (
+            'agent-local',
+            'proxy-agent-local',
+            'cert-manager-managed',
+            'appliance-managed',
+            'hsm-managed',
+            'vault-managed',
+            'os-store-managed',
+            'external-unknown'
+          )
+        ),
+        key_reference TEXT NULL,
+        public_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_certificate_profiles_workspace_id UNIQUE (workspace_id, id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_certificate_profiles_workspace
+        ON certificate_profiles(workspace_id);
+      CREATE INDEX IF NOT EXISTS idx_certificate_profiles_workspace_status
+        ON certificate_profiles(workspace_id, status);
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_certificate_profiles_workspace_name
+        ON certificate_profiles(workspace_id, LOWER(name));
+
+      -- Managed certificates are inventory identities. They store public
+      -- certificate material and metadata only; never customer private keys.
+      CREATE TABLE IF NOT EXISTS managed_certificates (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        token_id INTEGER NULL REFERENCES tokens(id) ON DELETE SET NULL,
+        profile_id UUID NULL REFERENCES certificate_profiles(id) ON DELETE SET NULL,
+        status TEXT NOT NULL DEFAULT 'discovered'
+          CHECK (status IN ('discovered', 'active', 'renewing', 'expiring', 'expired', 'revoked', 'decommissioned')),
+        source TEXT NOT NULL DEFAULT 'manual'
+          CHECK (source IN ('manual', 'api', 'import', 'domain_checker', 'endpoint_monitor', 'integration', 'auto_sync')),
+        source_ref TEXT NULL,
+        name TEXT NULL,
+        common_name TEXT NULL,
+        subject_alt_names TEXT[] NOT NULL DEFAULT '{}',
+        issuer TEXT NULL,
+        subject TEXT NULL,
+        serial_number TEXT NULL,
+        certificate_pem TEXT NULL,
+        fingerprint_sha256 TEXT NULL,
+        spki_fingerprint_sha256 TEXT NULL,
+        public_key_algorithm TEXT NULL,
+        public_key_size INTEGER NULL CHECK (public_key_size IS NULL OR public_key_size > 0),
+        signature_algorithm TEXT NULL,
+        not_before TIMESTAMPTZ NULL,
+        not_after TIMESTAMPTZ NULL,
+        key_mode TEXT NULL CHECK (
+          key_mode IS NULL OR key_mode IN (
+            'agent-local',
+            'proxy-agent-local',
+            'cert-manager-managed',
+            'appliance-managed',
+            'hsm-managed',
+            'vault-managed',
+            'os-store-managed',
+            'external-unknown'
+          )
+        ),
+        key_reference TEXT NULL,
+        public_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_managed_certificates_workspace_id UNIQUE (workspace_id, id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace
+        ON managed_certificates(workspace_id);
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace_status
+        ON managed_certificates(workspace_id, status);
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace_token
+        ON managed_certificates(workspace_id, token_id)
+        WHERE token_id IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace_expiry
+        ON managed_certificates(workspace_id, not_after);
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_serial
+        ON managed_certificates(workspace_id, serial_number)
+        WHERE serial_number IS NOT NULL;
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_managed_certificates_workspace_fingerprint
+        ON managed_certificates(workspace_id, fingerprint_sha256)
+        WHERE fingerprint_sha256 IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_managed_certificates_workspace_san
+        ON managed_certificates USING GIN(subject_alt_names);
+
+      -- Certificate targets are deployment references. They may point at
+      -- hosts, endpoints, appliances, or cluster references, but never hold key
+      -- material.
+      CREATE TABLE IF NOT EXISTS certificate_targets (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        profile_id UUID NULL REFERENCES certificate_profiles(id) ON DELETE SET NULL,
+        domain_monitor_id UUID NULL REFERENCES domain_monitors(id) ON DELETE SET NULL,
+        token_id INTEGER NULL REFERENCES tokens(id) ON DELETE SET NULL,
+        name TEXT NOT NULL,
+        target_type TEXT NOT NULL
+          CHECK (target_type IN ('endpoint', 'domain', 'host', 'kubernetes-secret', 'load-balancer', 'cdn', 'appliance', 'hsm', 'vault', 'other')),
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'inactive', 'decommissioned', 'error')),
+        source TEXT NOT NULL DEFAULT 'manual'
+          CHECK (source IN ('manual', 'api', 'import', 'domain_checker', 'endpoint_monitor', 'integration', 'auto_sync')),
+        source_ref TEXT NULL,
+        hostname TEXT NULL,
+        url TEXT NULL,
+        deployment_reference TEXT NULL,
+        environment TEXT NULL,
+        public_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_certificate_targets_workspace_id UNIQUE (workspace_id, id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_certificate_targets_workspace
+        ON certificate_targets(workspace_id);
+      CREATE INDEX IF NOT EXISTS idx_certificate_targets_workspace_status
+        ON certificate_targets(workspace_id, status);
+      CREATE INDEX IF NOT EXISTS idx_certificate_targets_workspace_type
+        ON certificate_targets(workspace_id, target_type);
+      CREATE INDEX IF NOT EXISTS idx_certificate_targets_workspace_hostname
+        ON certificate_targets(workspace_id, hostname)
+        WHERE hostname IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_certificate_targets_domain_monitor
+        ON certificate_targets(workspace_id, domain_monitor_id)
+        WHERE domain_monitor_id IS NOT NULL;
+
+      -- Certificate instances are observed/deployed public certificate copies
+      -- on a target.
+      CREATE TABLE IF NOT EXISTS certificate_instances (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        managed_certificate_id UUID NOT NULL,
+        target_id UUID NOT NULL,
+        domain_monitor_id UUID NULL REFERENCES domain_monitors(id) ON DELETE SET NULL,
+        token_id INTEGER NULL REFERENCES tokens(id) ON DELETE SET NULL,
+        status TEXT NOT NULL DEFAULT 'discovered'
+          CHECK (status IN ('discovered', 'active', 'deployed', 'stale', 'drifted', 'expiring', 'expired', 'revoked', 'missing', 'decommissioned', 'error')),
+        source TEXT NOT NULL DEFAULT 'manual'
+          CHECK (source IN ('manual', 'api', 'import', 'domain_checker', 'endpoint_monitor', 'integration', 'auto_sync')),
+        source_ref TEXT NULL,
+        observed_fingerprint_sha256 TEXT NULL,
+        observed_serial_number TEXT NULL,
+        observed_subject TEXT NULL,
+        observed_issuer TEXT NULL,
+        observed_not_before TIMESTAMPTZ NULL,
+        observed_not_after TIMESTAMPTZ NULL,
+        deployment_reference TEXT NULL,
+        observed_at TIMESTAMPTZ NULL,
+        public_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT fk_certificate_instances_managed_certificate
+          FOREIGN KEY (workspace_id, managed_certificate_id)
+          REFERENCES managed_certificates(workspace_id, id)
+          ON DELETE CASCADE,
+        CONSTRAINT fk_certificate_instances_target
+          FOREIGN KEY (workspace_id, target_id)
+          REFERENCES certificate_targets(workspace_id, id)
+          ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_workspace
+        ON certificate_instances(workspace_id);
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_certificate
+        ON certificate_instances(workspace_id, managed_certificate_id);
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_target
+        ON certificate_instances(workspace_id, target_id);
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_domain_monitor
+        ON certificate_instances(workspace_id, domain_monitor_id)
+        WHERE domain_monitor_id IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_workspace_status
+        ON certificate_instances(workspace_id, status);
+      CREATE INDEX IF NOT EXISTS idx_certificate_instances_workspace_fingerprint
+        ON certificate_instances(workspace_id, observed_fingerprint_sha256)
+        WHERE observed_fingerprint_sha256 IS NOT NULL;
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_certificate_instances_workspace_target_cert
+        ON certificate_instances(workspace_id, target_id, managed_certificate_id);
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/packages/contracts/certops/certops-inventory.schema.json
+++ b/packages/contracts/certops/certops-inventory.schema.json
@@ -23,6 +23,10 @@
       "type": ["integer", "null"],
       "description": "Optional link to the underlying tokens row (tokens.id is INTEGER) this certificate maps to."
     },
+    "profileId": {
+      "type": ["string", "null"],
+      "description": "Optional certificate profile identifier used for non-secret issuance/deployment policy metadata."
+    },
     "status": {
       "type": "string",
       "enum": [
@@ -34,6 +38,24 @@
         "revoked",
         "decommissioned"
       ]
+    },
+    "source": {
+      "type": ["string", "null"],
+      "enum": [
+        "manual",
+        "api",
+        "import",
+        "domain_checker",
+        "endpoint_monitor",
+        "integration",
+        "auto_sync",
+        null
+      ],
+      "description": "How this public certificate inventory record entered the control plane."
+    },
+    "sourceRef": {
+      "type": ["string", "null"],
+      "description": "Opaque non-secret source reference, such as a domain monitor id or integration item id."
     },
     "commonName": {
       "type": ["string", "null"]
@@ -51,6 +73,24 @@
     "fingerprintSha256": {
       "type": ["string", "null"],
       "description": "Lowercase hex SHA-256 of the DER certificate. Public material."
+    },
+    "spkiFingerprintSha256": {
+      "type": ["string", "null"],
+      "description": "Lowercase hex SHA-256 fingerprint of the SubjectPublicKeyInfo. Public material."
+    },
+    "certificatePem": {
+      "type": ["string", "null"],
+      "description": "Optional public certificate PEM. Private-key PEM blocks are forbidden and rejected at the API boundary."
+    },
+    "publicKeyAlgorithm": {
+      "type": ["string", "null"]
+    },
+    "publicKeySize": {
+      "type": ["integer", "null"],
+      "minimum": 1
+    },
+    "signatureAlgorithm": {
+      "type": ["string", "null"]
     },
     "notBefore": {
       "type": ["string", "null"],

--- a/packages/contracts/db/baseline-minimum.schema.json
+++ b/packages/contracts/db/baseline-minimum.schema.json
@@ -10,7 +10,15 @@
     "tables": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["users", "workspaces", "workspace_memberships"],
+      "required": [
+        "users",
+        "workspaces",
+        "workspace_memberships",
+        "certificate_profiles",
+        "managed_certificates",
+        "certificate_targets",
+        "certificate_instances"
+      ],
       "properties": {
         "users": {
           "$ref": "#/definitions/tableUsers"
@@ -20,6 +28,18 @@
         },
         "workspace_memberships": {
           "$ref": "#/definitions/tableMemberships"
+        },
+        "certificate_profiles": {
+          "$ref": "#/definitions/tableCertificateProfiles"
+        },
+        "managed_certificates": {
+          "$ref": "#/definitions/tableManagedCertificates"
+        },
+        "certificate_targets": {
+          "$ref": "#/definitions/tableCertificateTargets"
+        },
+        "certificate_instances": {
+          "$ref": "#/definitions/tableCertificateInstances"
         }
       }
     }
@@ -61,6 +81,152 @@
           "items": { "type": "string" },
           "contains": { "const": "workspace_id" },
           "minItems": 3
+        }
+      }
+    },
+    "certOpsSafeRequiredColumns": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "not": {
+        "contains": {
+          "enum": [
+            "privateKey",
+            "private_key",
+            "privateKeyPem",
+            "private_key_pem",
+            "key_pem",
+            "key_der",
+            "key_material",
+            "raw_key",
+            "pkcs12",
+            "pfx",
+            "backup",
+            "secret",
+            "credential",
+            "password"
+          ]
+        }
+      }
+    },
+    "tableCertificateProfiles": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredColumns"],
+      "properties": {
+        "requiredColumns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "not": { "$ref": "#/definitions/certOpsSafeRequiredColumns/not" },
+          "minItems": 8,
+          "allOf": [
+            { "contains": { "const": "id" } },
+            { "contains": { "const": "workspace_id" } },
+            { "contains": { "const": "name" } },
+            { "contains": { "const": "status" } },
+            { "contains": { "const": "source" } },
+            { "contains": { "const": "public_metadata" } },
+            { "contains": { "const": "created_at" } },
+            { "contains": { "const": "updated_at" } }
+          ]
+        }
+      }
+    },
+    "tableManagedCertificates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredColumns"],
+      "properties": {
+        "requiredColumns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "not": { "$ref": "#/definitions/certOpsSafeRequiredColumns/not" },
+          "minItems": 16,
+          "allOf": [
+            { "contains": { "const": "id" } },
+            { "contains": { "const": "workspace_id" } },
+            { "contains": { "const": "token_id" } },
+            { "contains": { "const": "profile_id" } },
+            { "contains": { "const": "status" } },
+            { "contains": { "const": "source" } },
+            { "contains": { "const": "common_name" } },
+            { "contains": { "const": "subject_alt_names" } },
+            { "contains": { "const": "fingerprint_sha256" } },
+            { "contains": { "const": "spki_fingerprint_sha256" } },
+            { "contains": { "const": "certificate_pem" } },
+            { "contains": { "const": "key_mode" } },
+            { "contains": { "const": "key_reference" } },
+            { "contains": { "const": "public_metadata" } },
+            { "contains": { "const": "created_at" } },
+            { "contains": { "const": "updated_at" } }
+          ]
+        }
+      }
+    },
+    "tableCertificateTargets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredColumns"],
+      "properties": {
+        "requiredColumns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "not": { "$ref": "#/definitions/certOpsSafeRequiredColumns/not" },
+          "minItems": 15,
+          "allOf": [
+            { "contains": { "const": "id" } },
+            { "contains": { "const": "workspace_id" } },
+            { "contains": { "const": "profile_id" } },
+            { "contains": { "const": "domain_monitor_id" } },
+            { "contains": { "const": "token_id" } },
+            { "contains": { "const": "name" } },
+            { "contains": { "const": "target_type" } },
+            { "contains": { "const": "status" } },
+            { "contains": { "const": "source" } },
+            { "contains": { "const": "hostname" } },
+            { "contains": { "const": "url" } },
+            { "contains": { "const": "deployment_reference" } },
+            { "contains": { "const": "public_metadata" } },
+            { "contains": { "const": "created_at" } },
+            { "contains": { "const": "updated_at" } }
+          ]
+        }
+      }
+    },
+    "tableCertificateInstances": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredColumns"],
+      "properties": {
+        "requiredColumns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "not": { "$ref": "#/definitions/certOpsSafeRequiredColumns/not" },
+          "minItems": 18,
+          "allOf": [
+            { "contains": { "const": "id" } },
+            { "contains": { "const": "workspace_id" } },
+            { "contains": { "const": "managed_certificate_id" } },
+            { "contains": { "const": "target_id" } },
+            { "contains": { "const": "domain_monitor_id" } },
+            { "contains": { "const": "token_id" } },
+            { "contains": { "const": "status" } },
+            { "contains": { "const": "source" } },
+            { "contains": { "const": "observed_fingerprint_sha256" } },
+            { "contains": { "const": "observed_serial_number" } },
+            { "contains": { "const": "observed_subject" } },
+            { "contains": { "const": "observed_issuer" } },
+            { "contains": { "const": "observed_not_after" } },
+            { "contains": { "const": "deployment_reference" } },
+            { "contains": { "const": "observed_at" } },
+            { "contains": { "const": "public_metadata" } },
+            { "contains": { "const": "created_at" } },
+            { "contains": { "const": "updated_at" } }
+          ]
         }
       }
     }

--- a/tests/integration/certops-migration.test.js
+++ b/tests/integration/certops-migration.test.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const crypto = require("crypto");
 
 const { loadRootEnv } = require("../../scripts/load-root-env");
 
@@ -19,6 +20,75 @@ const CERTOPS_TABLES = [
 const CERTOPS_MIGRATION = migrations.find(
   (migration) => migration.name === "certops_inventory_schema",
 );
+
+function quoteIdentifier(identifier) {
+  return `"${String(identifier).replace(/"/g, '""')}"`;
+}
+
+async function createWorkspacePair(label) {
+  const ownerEmail = `${label}-${Date.now()}-${crypto.randomUUID()}@example.com`;
+  const owner = await TestUtils.execQuery(
+    `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+     VALUES ($1, $2, $3, $4, 'local', TRUE)
+     RETURNING id`,
+    [
+      ownerEmail.toLowerCase(),
+      ownerEmail,
+      label,
+      "not-used-in-migration-test",
+    ],
+  );
+  const ownerId = owner.rows[0].id;
+  const workspaceA = crypto.randomUUID();
+  const workspaceB = crypto.randomUUID();
+
+  await TestUtils.execQuery(
+    `INSERT INTO workspaces (id, name, created_by, plan)
+     VALUES ($1, $2, $3, 'oss'), ($4, $5, $3, 'oss')`,
+    [
+      workspaceA,
+      `${label} A`,
+      ownerId,
+      workspaceB,
+      `${label} B`,
+    ],
+  );
+
+  return { ownerId, workspaceA, workspaceB };
+}
+
+async function cleanupWorkspacePair(ownerId, workspaceIds) {
+  await TestUtils.execQuery("DELETE FROM workspaces WHERE id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+}
+
+async function withScratchCertOpsSchema(callback) {
+  const schemaName = `certops_migration_${crypto
+    .randomUUID()
+    .replace(/-/g, "")}`;
+  const quotedSchema = quoteIdentifier(schemaName);
+
+  await TestUtils.execQuery(`CREATE SCHEMA ${quotedSchema}`);
+  try {
+    await TestUtils.execQuery(
+      `SET search_path TO ${quotedSchema}, public; ${CERTOPS_MIGRATION.sql}; RESET search_path;`,
+    );
+    return await callback(quotedSchema);
+  } finally {
+    await TestUtils.execQuery(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE`);
+  }
+}
+
+async function expectForeignKeyViolation(query, params) {
+  try {
+    await TestUtils.execQuery(query, params);
+    throw new Error("Expected foreign key violation");
+  } catch (error) {
+    expect(error.code).to.equal("23503");
+  }
+}
 
 describe("CertOps inventory migration", function () {
   this.timeout(60000);
@@ -151,6 +221,117 @@ describe("CertOps inventory migration", function () {
       "fk_certificate_instances_managed_certificate",
       "fk_certificate_instances_target",
     ]);
+  });
+
+  it("enforces profile links within the same workspace", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-profile-fk",
+    );
+
+    try {
+      await withScratchCertOpsSchema(async (schema) => {
+        const profileA = crypto.randomUUID();
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.certificate_profiles (id, workspace_id, name)
+           VALUES ($1, $2, $3)`,
+          [profileA, workspaceA, "Workspace A profile"],
+        );
+
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.managed_certificates (workspace_id, profile_id)
+           VALUES ($1, $2)`,
+          [workspaceA, profileA],
+        );
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.certificate_targets (workspace_id, profile_id, name, target_type)
+           VALUES ($1, $2, $3, 'endpoint')`,
+          [workspaceA, profileA, "Workspace A target"],
+        );
+
+        await expectForeignKeyViolation(
+          `INSERT INTO ${schema}.managed_certificates (workspace_id, profile_id)
+           VALUES ($1, $2)`,
+          [workspaceB, profileA],
+        );
+        await expectForeignKeyViolation(
+          `INSERT INTO ${schema}.certificate_targets (workspace_id, profile_id, name, target_type)
+           VALUES ($1, $2, $3, 'endpoint')`,
+          [workspaceB, profileA, "Cross-workspace target"],
+        );
+      });
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("allows null profile links and preserves workspace ownership when profiles are deleted", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-profile-delete",
+    );
+
+    try {
+      await withScratchCertOpsSchema(async (schema) => {
+        const profileA = crypto.randomUUID();
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.certificate_profiles (id, workspace_id, name)
+           VALUES ($1, $2, $3)`,
+          [profileA, workspaceA, "Delete profile"],
+        );
+
+        const managed = await TestUtils.execQuery(
+          `INSERT INTO ${schema}.managed_certificates (workspace_id, profile_id)
+           VALUES ($1, $2)
+           RETURNING id`,
+          [workspaceA, profileA],
+        );
+        const target = await TestUtils.execQuery(
+          `INSERT INTO ${schema}.certificate_targets (workspace_id, profile_id, name, target_type)
+           VALUES ($1, $2, $3, 'endpoint')
+           RETURNING id`,
+          [workspaceA, profileA, "Delete profile target"],
+        );
+
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.managed_certificates (workspace_id, profile_id)
+           VALUES ($1, NULL)`,
+          [workspaceB],
+        );
+        await TestUtils.execQuery(
+          `INSERT INTO ${schema}.certificate_targets (workspace_id, profile_id, name, target_type)
+           VALUES ($1, NULL, $2, 'endpoint')`,
+          [workspaceB, "Null profile target"],
+        );
+
+        await TestUtils.execQuery(
+          `DELETE FROM ${schema}.certificate_profiles WHERE id = $1`,
+          [profileA],
+        );
+
+        const managedAfterDelete = await TestUtils.execQuery(
+          `SELECT workspace_id::text AS workspace_id, profile_id
+             FROM ${schema}.managed_certificates
+            WHERE id = $1`,
+          [managed.rows[0].id],
+        );
+        const targetAfterDelete = await TestUtils.execQuery(
+          `SELECT workspace_id::text AS workspace_id, profile_id
+             FROM ${schema}.certificate_targets
+            WHERE id = $1`,
+          [target.rows[0].id],
+        );
+
+        expect(managedAfterDelete.rows[0]).to.deep.equal({
+          workspace_id: workspaceA,
+          profile_id: null,
+        });
+        expect(targetAfterDelete.rows[0]).to.deep.equal({
+          workspace_id: workspaceA,
+          profile_id: null,
+        });
+      });
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
   });
 
   it("adds useful workspace and fingerprint indexes", async () => {

--- a/tests/integration/certops-migration.test.js
+++ b/tests/integration/certops-migration.test.js
@@ -1,0 +1,180 @@
+const path = require("path");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { runMigrations, migrations } = require(
+  path.resolve(__dirname, "../../apps/api/migrations/migrate.js"),
+);
+
+const CERTOPS_TABLES = [
+  "managed_certificates",
+  "certificate_instances",
+  "certificate_profiles",
+  "certificate_targets",
+];
+
+const CERTOPS_MIGRATION = migrations.find(
+  (migration) => migration.name === "certops_inventory_schema",
+);
+
+describe("CertOps inventory migration", function () {
+  this.timeout(60000);
+
+  before(async () => {
+    await runMigrations();
+  });
+
+  it("creates the CertOps inventory tables", async () => {
+    const res = await TestUtils.execQuery(
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = ANY($1::text[])
+        ORDER BY table_name`,
+      [CERTOPS_TABLES],
+    );
+
+    expect(res.rows.map((row) => row.table_name).sort()).to.deep.equal(
+      CERTOPS_TABLES.slice().sort(),
+    );
+  });
+
+  it("can run the migration body repeatedly", async () => {
+    expect(CERTOPS_MIGRATION).to.exist;
+
+    await TestUtils.execQuery(CERTOPS_MIGRATION.sql);
+    await TestUtils.execQuery(CERTOPS_MIGRATION.sql);
+
+    const res = await TestUtils.execQuery(
+      "SELECT COUNT(*)::int AS count FROM migrations WHERE version = $1",
+      [CERTOPS_MIGRATION.version],
+    );
+    expect(res.rows[0].count).to.equal(1);
+  });
+
+  it("does not create private-key custody columns", async () => {
+    const res = await TestUtils.execQuery(
+      `SELECT table_name, column_name
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = ANY($1::text[])
+        ORDER BY table_name, ordinal_position`,
+      [CERTOPS_TABLES],
+    );
+
+    const forbiddenFragments = [
+      "private",
+      "pkcs12",
+      "pfx",
+      "key_material",
+      "key_pem",
+      "key_der",
+      "raw_key",
+      "backup",
+      "secret",
+      "credential",
+      "password",
+    ];
+
+    for (const row of res.rows) {
+      const hit = forbiddenFragments.find((fragment) =>
+        row.column_name.includes(fragment),
+      );
+      expect(
+        hit,
+        `${row.table_name}.${row.column_name} looks like private-key custody`,
+      ).to.equal(undefined);
+    }
+  });
+
+  it("keeps workspace isolation possible from the schema", async () => {
+    const columns = await TestUtils.execQuery(
+      `SELECT table_name, is_nullable
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = ANY($1::text[])
+          AND column_name = 'workspace_id'`,
+      [CERTOPS_TABLES],
+    );
+
+    const byTable = new Map(
+      columns.rows.map((row) => [row.table_name, row.is_nullable]),
+    );
+    for (const tableName of CERTOPS_TABLES) {
+      expect(byTable.get(tableName), `${tableName}.workspace_id`).to.equal(
+        "NO",
+      );
+    }
+
+    const workspaceFks = await TestUtils.execQuery(
+      `SELECT DISTINCT tc.table_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           ON tc.constraint_schema = kcu.constraint_schema
+          AND tc.constraint_name = kcu.constraint_name
+          AND tc.table_name = kcu.table_name
+         JOIN information_schema.constraint_column_usage ccu
+           ON tc.constraint_schema = ccu.constraint_schema
+          AND tc.constraint_name = ccu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_schema = 'public'
+          AND tc.table_name = ANY($1::text[])
+          AND kcu.column_name = 'workspace_id'
+          AND ccu.table_name = 'workspaces'
+          AND ccu.column_name = 'id'`,
+      [CERTOPS_TABLES],
+    );
+
+    expect(workspaceFks.rows.map((row) => row.table_name).sort()).to.deep.equal(
+      CERTOPS_TABLES.slice().sort(),
+    );
+
+    const instanceFks = await TestUtils.execQuery(
+      `SELECT constraint_name
+         FROM information_schema.table_constraints
+        WHERE table_schema = 'public'
+          AND table_name = 'certificate_instances'
+          AND constraint_type = 'FOREIGN KEY'
+          AND constraint_name = ANY($1::text[])
+        ORDER BY constraint_name`,
+      [
+        [
+          "fk_certificate_instances_managed_certificate",
+          "fk_certificate_instances_target",
+        ],
+      ],
+    );
+    expect(instanceFks.rows.map((row) => row.constraint_name)).to.deep.equal([
+      "fk_certificate_instances_managed_certificate",
+      "fk_certificate_instances_target",
+    ]);
+  });
+
+  it("adds useful workspace and fingerprint indexes", async () => {
+    const res = await TestUtils.execQuery(
+      `SELECT indexname
+         FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = ANY($1::text[])`,
+      [CERTOPS_TABLES],
+    );
+    const indexes = new Set(res.rows.map((row) => row.indexname));
+
+    for (const indexName of [
+      "idx_managed_certificates_workspace",
+      "idx_managed_certificates_workspace_expiry",
+      "uq_managed_certificates_workspace_fingerprint",
+      "idx_certificate_instances_certificate",
+      "idx_certificate_instances_workspace_fingerprint",
+      "idx_certificate_targets_domain_monitor",
+      "idx_certificate_profiles_workspace_status",
+    ]) {
+      expect(indexes.has(indexName), `missing index ${indexName}`).to.equal(
+        true,
+      );
+    }
+  });
+});

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -86,6 +86,7 @@ tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
 tests/integration/database-schema.test.js
+tests/integration/certops-migration.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js
 tests/integration/vault.parsing.unit.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -84,6 +84,7 @@ tests/integration/audit-filtering.test.js
 tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
+tests/integration/certops-migration.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -1,0 +1,140 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { migrations } = require(
+  path.resolve(__dirname, "../../apps/api/migrations/migrate.js"),
+);
+
+const CERTOPS_TABLES = [
+  "managed_certificates",
+  "certificate_instances",
+  "certificate_profiles",
+  "certificate_targets",
+];
+
+const certOpsMigration = migrations.find(
+  (migration) => migration.name === "certops_inventory_schema",
+);
+
+function getTableBlock(tableName) {
+  const marker = `CREATE TABLE IF NOT EXISTS ${tableName} (`;
+  const start = certOpsMigration.sql.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${marker}`);
+  const bodyStart = start + marker.length;
+  const end = certOpsMigration.sql.indexOf("\n      );", bodyStart);
+  assert.notEqual(end, -1, `missing end of ${tableName} definition`);
+  return certOpsMigration.sql.slice(bodyStart, end);
+}
+
+function getColumnNames(tableName) {
+  return getTableBlock(tableName)
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/,$/, ""))
+    .map((line) => /^([a-z][a-z0-9_]*)\s+/i.exec(line)?.[1])
+    .filter(Boolean)
+    .filter(
+      (name) =>
+        ![
+          "CHECK",
+          "CONSTRAINT",
+          "FOREIGN",
+          "ON",
+          "REFERENCES",
+        ].includes(name.toUpperCase()),
+    );
+}
+
+describe("CertOps inventory migration", () => {
+  it("defines the M1 inventory migration", () => {
+    assert.ok(certOpsMigration, "expected certops_inventory_schema migration");
+    assert.equal(certOpsMigration.version, 10);
+  });
+
+  it("creates every CertOps table idempotently", () => {
+    for (const tableName of CERTOPS_TABLES) {
+      assert.match(
+        certOpsMigration.sql,
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${tableName} \\(`),
+      );
+    }
+    assert.doesNotMatch(
+      certOpsMigration.sql,
+      /CREATE TABLE (?!IF NOT EXISTS)/,
+    );
+    assert.doesNotMatch(
+      certOpsMigration.sql,
+      /CREATE (?:UNIQUE )?INDEX (?!IF NOT EXISTS)/,
+    );
+  });
+
+  it("keeps every CertOps table workspace-scoped", () => {
+    for (const tableName of CERTOPS_TABLES) {
+      assert.match(
+        getTableBlock(tableName),
+        /workspace_id UUID NOT NULL REFERENCES workspaces\(id\) ON DELETE CASCADE/,
+        `${tableName} must have a non-null workspace FK`,
+      );
+    }
+  });
+
+  it("does not define private-key custody columns", () => {
+    const forbiddenFragments = [
+      "private",
+      "pkcs12",
+      "pfx",
+      "key_material",
+      "key_pem",
+      "key_der",
+      "raw_key",
+      "backup",
+      "secret",
+      "credential",
+      "password",
+    ];
+
+    for (const tableName of CERTOPS_TABLES) {
+      for (const columnName of getColumnNames(tableName)) {
+        const hit = forbiddenFragments.find((fragment) =>
+          columnName.includes(fragment),
+        );
+        assert.equal(
+          hit,
+          undefined,
+          `${tableName}.${columnName} looks like private-key custody`,
+        );
+      }
+    }
+  });
+
+  it("links certificates to existing tokens without making tokens depend on CertOps", () => {
+    assert.match(
+      getTableBlock("managed_certificates"),
+      /token_id INTEGER NULL REFERENCES tokens\(id\) ON DELETE SET NULL/,
+    );
+    assert.match(
+      getTableBlock("certificate_targets"),
+      /token_id INTEGER NULL REFERENCES tokens\(id\) ON DELETE SET NULL/,
+    );
+    assert.match(
+      getTableBlock("certificate_instances"),
+      /token_id INTEGER NULL REFERENCES tokens\(id\) ON DELETE SET NULL/,
+    );
+  });
+
+  it("adds lookup and dedupe indexes for inventory queries", () => {
+    for (const indexName of [
+      "idx_managed_certificates_workspace",
+      "idx_managed_certificates_workspace_expiry",
+      "uq_managed_certificates_workspace_fingerprint",
+      "idx_certificate_instances_certificate",
+      "idx_certificate_instances_workspace_fingerprint",
+      "idx_certificate_targets_domain_monitor",
+      "idx_certificate_profiles_workspace_status",
+    ]) {
+      assert.match(certOpsMigration.sql, new RegExp(indexName));
+    }
+  });
+});

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -2,10 +2,20 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 
 const { migrations } = require(
   path.resolve(__dirname, "../../apps/api/migrations/migrate.js"),
+);
+const baselineMinimumSchema = JSON.parse(
+  fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../packages/contracts/db/baseline-minimum.schema.json",
+    ),
+    "utf8",
+  ),
 );
 
 const CERTOPS_TABLES = [
@@ -13,6 +23,91 @@ const CERTOPS_TABLES = [
   "certificate_instances",
   "certificate_profiles",
   "certificate_targets",
+];
+
+const BASELINE_CERTOPS_COLUMNS = {
+  certificate_profiles: [
+    "id",
+    "workspace_id",
+    "name",
+    "status",
+    "source",
+    "public_metadata",
+    "created_at",
+    "updated_at",
+  ],
+  managed_certificates: [
+    "id",
+    "workspace_id",
+    "token_id",
+    "profile_id",
+    "status",
+    "source",
+    "common_name",
+    "subject_alt_names",
+    "fingerprint_sha256",
+    "spki_fingerprint_sha256",
+    "certificate_pem",
+    "key_mode",
+    "key_reference",
+    "public_metadata",
+    "created_at",
+    "updated_at",
+  ],
+  certificate_targets: [
+    "id",
+    "workspace_id",
+    "profile_id",
+    "domain_monitor_id",
+    "token_id",
+    "name",
+    "target_type",
+    "status",
+    "source",
+    "hostname",
+    "url",
+    "deployment_reference",
+    "public_metadata",
+    "created_at",
+    "updated_at",
+  ],
+  certificate_instances: [
+    "id",
+    "workspace_id",
+    "managed_certificate_id",
+    "target_id",
+    "domain_monitor_id",
+    "token_id",
+    "status",
+    "source",
+    "observed_fingerprint_sha256",
+    "observed_serial_number",
+    "observed_subject",
+    "observed_issuer",
+    "observed_not_after",
+    "deployment_reference",
+    "observed_at",
+    "public_metadata",
+    "created_at",
+    "updated_at",
+  ],
+};
+
+const FORBIDDEN_CUSTODY_COLUMNS = [
+  "privateKey",
+  "private_key",
+  "privateKeyPem",
+  "private_key_pem",
+  "key_pem",
+  "key_der",
+  "key_material",
+  "raw_key",
+  "pkcs12",
+  "pfx",
+  "backup",
+  "secret",
+  "credential",
+  "password",
 ];
 
 const certOpsMigration = migrations.find(
@@ -45,6 +140,18 @@ function getColumnNames(tableName) {
           "REFERENCES",
         ].includes(name.toUpperCase()),
     );
+}
+
+function resolveBaselineSchema(schema) {
+  if (!schema.$ref) {
+    return schema;
+  }
+  const prefix = "#/definitions/";
+  assert.ok(
+    schema.$ref.startsWith(prefix),
+    `unsupported schema ref ${schema.$ref}`,
+  );
+  return baselineMinimumSchema.definitions[schema.$ref.slice(prefix.length)];
 }
 
 describe("CertOps inventory migration", () => {
@@ -80,25 +187,30 @@ describe("CertOps inventory migration", () => {
     }
   });
 
-  it("does not define private-key custody columns", () => {
-    const forbiddenFragments = [
-      "private",
-      "pkcs12",
-      "pfx",
-      "key_material",
-      "key_pem",
-      "key_der",
-      "raw_key",
-      "backup",
-      "secret",
-      "credential",
-      "password",
-    ];
+  it("uses workspace-scoped profile foreign keys", () => {
+    assert.match(
+      getTableBlock("managed_certificates"),
+      /CONSTRAINT fk_managed_certificates_profile\s+FOREIGN KEY \(workspace_id, profile_id\)\s+REFERENCES certificate_profiles\(workspace_id, id\)\s+ON DELETE SET NULL \(profile_id\)/,
+    );
+    assert.match(
+      getTableBlock("certificate_targets"),
+      /CONSTRAINT fk_certificate_targets_profile\s+FOREIGN KEY \(workspace_id, profile_id\)\s+REFERENCES certificate_profiles\(workspace_id, id\)\s+ON DELETE SET NULL \(profile_id\)/,
+    );
+    assert.doesNotMatch(
+      getTableBlock("managed_certificates"),
+      /profile_id UUID NULL REFERENCES certificate_profiles\(id\)/,
+    );
+    assert.doesNotMatch(
+      getTableBlock("certificate_targets"),
+      /profile_id UUID NULL REFERENCES certificate_profiles\(id\)/,
+    );
+  });
 
+  it("does not define private-key custody columns", () => {
     for (const tableName of CERTOPS_TABLES) {
       for (const columnName of getColumnNames(tableName)) {
-        const hit = forbiddenFragments.find((fragment) =>
-          columnName.includes(fragment),
+        const hit = FORBIDDEN_CUSTODY_COLUMNS.find((fragment) =>
+          columnName.toLowerCase().includes(fragment.toLowerCase()),
         );
         assert.equal(
           hit,
@@ -106,6 +218,44 @@ describe("CertOps inventory migration", () => {
           `${tableName}.${columnName} looks like private-key custody`,
         );
       }
+    }
+  });
+
+  it("includes the CertOps inventory tables in the baseline DB contract", () => {
+    const tableSchema =
+      baselineMinimumSchema.properties.tables.properties;
+    const requiredTables = baselineMinimumSchema.properties.tables.required;
+
+    for (const [tableName, expectedColumns] of Object.entries(
+      BASELINE_CERTOPS_COLUMNS,
+    )) {
+      assert.ok(
+        requiredTables.includes(tableName),
+        `${tableName} must be required by the baseline contract`,
+      );
+      assert.ok(tableSchema[tableName], `${tableName} schema is missing`);
+
+      const resolvedTableSchema = resolveBaselineSchema(tableSchema[tableName]);
+      const requiredColumns =
+        resolvedTableSchema.properties.requiredColumns;
+      for (const columnName of expectedColumns) {
+        assert.match(
+          JSON.stringify(requiredColumns),
+          new RegExp(`"const":"${columnName}"`),
+          `${tableName} must require ${columnName}`,
+        );
+      }
+
+      const forbiddenHit = FORBIDDEN_CUSTODY_COLUMNS.find((columnName) =>
+        JSON.stringify(requiredColumns)
+          .toLowerCase()
+          .includes(`"${columnName.toLowerCase()}"`),
+      );
+      assert.equal(
+        forbiddenHit,
+        undefined,
+        `${tableName} baseline contract allows ${forbiddenHit}`,
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

This PR adds the M1-A1 CertOps inventory database foundation.

* Adds the CertOps inventory migration (`version: 10`) with the core tables:
  `certificate_profiles`, `managed_certificates`, `certificate_targets`, and
  `certificate_instances`.
* Stores public/non-secret certificate metadata only: subject, issuer, SANs,
  validity dates, fingerprints, public key metadata, deployment references, and
  workspace-scoped relationships.
* Updates `certops-inventory.schema.json` to reflect the new inventory fields.
* Adds unit and integration coverage for migration shape, idempotency, schema
  safety, and no private-key custody columns.

## Verification

* `git diff --check`: ok
* `pnpm run migrate`: ok
* `pnpm run migrate` again: ok, idempotent
* `pnpm run test:unit`: ok
* `pnpm exec mocha tests/integration/certops-migration.test.js --timeout 60000 --exit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* Migration version is `10`, following the source migration order after
  `version: 9`.
* This PR intentionally stores public certificate material and metadata only.
  It does not introduce private-key custody fields.
* No parser, API routes, dashboard/Cloud, executor, agent, ACME, or
  cert-manager work is included.

## Test plan

* [ ] Review `apps/api/migrations/migrate.js`
* [ ] Review `packages/contracts/certops/certops-inventory.schema.json`
* [ ] Run `pnpm run migrate`
* [ ] Run `pnpm run test:unit`
* [ ] Run `pnpm exec mocha tests/integration/certops-migration.test.js --timeout 60000 --exit`
* [ ] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
