### PR TITLE
feat(certops): add public certificate parser m1-a2

### DIFF
--- a/apps/api/services/certops/parser.js
+++ b/apps/api/services/certops/parser.js
@@ -1,0 +1,218 @@
+"use strict";
+
+const { createHash, X509Certificate } = require("crypto");
+const {
+  containsPrivateKeyMaterial,
+} = require("../../utils/secretMaterial");
+
+const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
+const CERTOPS_CERTIFICATE_PARSE_FAILED = "CERTOPS_CERTIFICATE_PARSE_FAILED";
+
+const CERTIFICATE_PEM_BLOCK_PATTERN =
+  /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+class CertOpsCertificateParserError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = "CertOpsCertificateParserError";
+    this.code = code;
+  }
+}
+
+function createParserError(message, code) {
+  return new CertOpsCertificateParserError(message, code);
+}
+
+function rejectPrivateKeyMaterial(value) {
+  if (!containsPrivateKeyMaterial(value)) return;
+  throw createParserError(
+    "Private key material is not accepted by CertOps certificate parsing",
+    PRIVATE_KEY_MATERIAL_REJECTED,
+  );
+}
+
+function normalizePemBlock(pemBlock) {
+  const body = pemBlock
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s+/g, "");
+  const lines = body.match(/.{1,64}/g) || [];
+  return [
+    "-----BEGIN CERTIFICATE-----",
+    ...lines,
+    "-----END CERTIFICATE-----",
+  ].join("\n");
+}
+
+function extractCertificatePemBlocks(input) {
+  if (typeof input !== "string") {
+    throw createParserError(
+      "Certificate input must be a PEM string",
+      CERTOPS_CERTIFICATE_PARSE_FAILED,
+    );
+  }
+
+  const matches = [...input.matchAll(CERTIFICATE_PEM_BLOCK_PATTERN)];
+  if (matches.length === 0) {
+    throw createParserError(
+      "Certificate input must contain at least one PEM certificate block",
+      CERTOPS_CERTIFICATE_PARSE_FAILED,
+    );
+  }
+
+  const remainder = input.replace(CERTIFICATE_PEM_BLOCK_PATTERN, "");
+  if (remainder.trim().length > 0) {
+    throw createParserError(
+      "Certificate input contains unsupported PEM or non-certificate content",
+      CERTOPS_CERTIFICATE_PARSE_FAILED,
+    );
+  }
+
+  return matches.map((match) => normalizePemBlock(match[0]));
+}
+
+function normalizeFingerprint(value) {
+  if (!value) return null;
+  return String(value).replace(/:/g, "").toLowerCase();
+}
+
+function hashHex(algorithm, value) {
+  return createHash(algorithm).update(value).digest("hex");
+}
+
+function dateToIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeDistinguishedName(value) {
+  if (!value) return null;
+  return String(value)
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(", ");
+}
+
+function extractCommonName(subject) {
+  if (!subject) return null;
+  const match = /(?:^|,\s*)CN\s*=\s*([^,]+)/.exec(subject);
+  return match ? match[1].trim() : null;
+}
+
+function splitSubjectAltName(subjectAltName) {
+  if (!subjectAltName) return [];
+  return String(subjectAltName)
+    .split(/,\s*(?=(?:DNS|IP Address|URI|email|RID|Registered ID|DirName|othername):)/i)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function unquoteSanValue(value) {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseSubjectAltNames(subjectAltName) {
+  return splitSubjectAltName(subjectAltName).map((entry) => {
+    const match = /^([^:]+):(.+)$/.exec(entry);
+    if (!match) return entry;
+    return unquoteSanValue(match[2]);
+  });
+}
+
+function publicKeyMetadata(publicKey) {
+  if (!publicKey) return {};
+  const details = publicKey.asymmetricKeyDetails || {};
+  const metadata = {
+    asymmetricKeyType: publicKey.asymmetricKeyType || null,
+    modulusLength: details.modulusLength || null,
+    publicExponent: details.publicExponent
+      ? String(details.publicExponent)
+      : null,
+    namedCurve: details.namedCurve || null,
+  };
+
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([_key, value]) => value !== null),
+  );
+}
+
+function publicKeySize(publicKey) {
+  if (!publicKey?.asymmetricKeyDetails) return null;
+  return publicKey.asymmetricKeyDetails.modulusLength || null;
+}
+
+function spkiFingerprintSha256(publicKey) {
+  if (!publicKey) return null;
+  try {
+    const spkiDer = publicKey.export({ type: "spki", format: "der" });
+    return hashHex("sha256", spkiDer);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function parseCertificateBlock(certificatePem, index) {
+  let certificate;
+  try {
+    certificate = new X509Certificate(certificatePem);
+  } catch (_err) {
+    throw createParserError(
+      `Certificate PEM block ${index + 1} is malformed`,
+      CERTOPS_CERTIFICATE_PARSE_FAILED,
+    );
+  }
+
+  const subject = normalizeDistinguishedName(certificate.subject);
+  const issuer = normalizeDistinguishedName(certificate.issuer);
+  const validFrom = dateToIso(certificate.validFromDate || certificate.validFrom);
+  const validTo = dateToIso(certificate.validToDate || certificate.validTo);
+  const fingerprint256 =
+    normalizeFingerprint(certificate.fingerprint256) ||
+    hashHex("sha256", certificate.raw);
+  const fingerprint512 =
+    normalizeFingerprint(certificate.fingerprint512) ||
+    hashHex("sha512", certificate.raw);
+
+  return {
+    subject,
+    issuer,
+    serialNumber: certificate.serialNumber || null,
+    commonName: extractCommonName(subject),
+    validFrom,
+    validTo,
+    notBefore: validFrom,
+    notAfter: validTo,
+    subjectAltName: certificate.subjectAltName || null,
+    subjectAltNames: parseSubjectAltNames(certificate.subjectAltName),
+    fingerprint256,
+    fingerprint512,
+    fingerprintSha256: fingerprint256,
+    spkiFingerprintSha256: spkiFingerprintSha256(certificate.publicKey),
+    publicKeyAlgorithm: certificate.publicKey?.asymmetricKeyType || null,
+    publicKeySize: publicKeySize(certificate.publicKey),
+    publicKeyMetadata: publicKeyMetadata(certificate.publicKey),
+    signatureAlgorithm: certificate.signatureAlgorithm || null,
+    signatureAlgorithmOid: certificate.signatureAlgorithmOid || null,
+    certificatePem,
+  };
+}
+
+function parsePublicCertificateMaterial(input) {
+  rejectPrivateKeyMaterial(input);
+  const pemBlocks = extractCertificatePemBlocks(input);
+  return pemBlocks.map(parseCertificateBlock);
+}
+
+module.exports = {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  CERTOPS_CERTIFICATE_PARSE_FAILED,
+  CertOpsCertificateParserError,
+  parsePublicCertificateMaterial,
+};

--- a/tests/unit/certops-parser.test.js
+++ b/tests/unit/certops-parser.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  CERTOPS_CERTIFICATE_PARSE_FAILED,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  parsePublicCertificateMaterial,
+} = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/parser.js"),
+);
+
+const PUBLIC_LEAF_CERT = `
+-----BEGIN CERTIFICATE-----
+MIIDgjCCAmqgAwIBAgIUKJShixxx/7TH81hKwHE3UsvIFMkwDQYJKoZIhvcNAQEL
+BQAwNDEYMBYGA1UEAwwPY2VydG9wcy5leGFtcGxlMRgwFgYDVQQKDA9Ub2tlblRp
+bWVyIFRlc3QwHhcNMjYwNjI2MDA0MDU5WhcNMjcwNjI2MDA0MDU5WjA0MRgwFgYD
+VQQDDA9jZXJ0b3BzLmV4YW1wbGUxGDAWBgNVBAoMD1Rva2VuVGltZXIgVGVzdDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANoaAIgElNelqNg6TsY++HnK
+rFeOgn7csJYu9AbFfQRAoFO592aVI9QdyejoGesSy+tDN06vJl411Ntz6caB2+fd
++qkllZ+c39IZEbp++PDp7dD+4aEC68tGoZ9F/9dOGRaZ4xSFp0W0+5hd8E5q4E9U
+MSdc4cUjQKuZX+jwBQqy+SRxhhNh6GPVWg3Cr6W0F53yFxWlb8q+4cwOZg0AP7sK
+2u8UvordGO3o4eiPsVtmRh87YeRnUDRuzPb4Mi/Fo9Cr+1Fq3Q3xdWH9LhP0DSmD
+89Ho84nvn+DfM+Dbnb7PsmNgqOVictn/LxHMOrl1F04BkvY9rNuBkh7wHC7TOR8C
+AwEAAaOBizCBiDAdBgNVHQ4EFgQUoOXgW3/xFso+3GDIpFqimZ2K2TUwHwYDVR0j
+BBgwFoAUoOXgW3/xFso+3GDIpFqimZ2K2TUwDwYDVR0TAQH/BAUwAwEB/zA1BgNV
+HREELjAsgg9jZXJ0b3BzLmV4YW1wbGWCE2FwaS5jZXJ0b3BzLmV4YW1wbGWHBH8A
+AAEwDQYJKoZIhvcNAQELBQADggEBAGi4XAScskH5bdxNbXwtEqlep2eDyseUyulF
+g2yILrkiA22+WveOZrmReuxHx+umHVAO4O6JtHwD1figZyKgCrMzrREqmRwGj6pb
+jgaW6Eeck+zFh1cKTH6ZUYlN6yOHOhKR0nBnseSuoh/gEangQVLRug3SqCCi6GQI
+aOAUKMHYsxTyfjtE2k7URQYy7fbfLW/k+68l+xI/ktwFlS+MncmrS+Lx+dWwxVCn
+EucPyYnACaKyw2oY6kCVaW9OReglxzoFzLxZvqxyrA1LpWjzgJiR7nIpZCappsi9
+gB1JS6DPep8dhLORucnHS/Opy2xOB0lB3kmNoh5bierJUVeReSc=
+-----END CERTIFICATE-----
+`;
+
+const PUBLIC_CA_CERT = `
+-----BEGIN CERTIFICATE-----
+MIIDaDCCAlCgAwIBAgIUdCT2l9wFjDoFlfsF97QP3v7uq5IwDQYJKoZIhvcNAQEL
+BQAwNDEYMBYGA1UEAwwPQ2VydE9wcyBUZXN0IENBMRgwFgYDVQQKDA9Ub2tlblRp
+bWVyIFRlc3QwHhcNMjYwNjI2MDA0MTA3WhcNMjgwNjI1MDA0MTA3WjA0MRgwFgYD
+VQQDDA9DZXJ0T3BzIFRlc3QgQ0ExGDAWBgNVBAoMD1Rva2VuVGltZXIgVGVzdDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANupE0mTV+O2+WJOXL/nj/Cw
+JzVE6KVygV/W8MZWg3yN+FFzO/o+AcCxJlRgnDdkF9P8CWmhsDZ4GfVZtTfjuQeT
+lu2Y5LG3fDGN3cxJovrbGjA1TbIRIODE7C5jAPJMvwmXE9PJO0nJnuhE15xKU7IZ
+2zk6fO/TwG7FfCqS9NBccbtHKB9sV/4dBf2GZ1eT8VMWLeUPrKFbAitQ7tgFb6h2
+MLKfMjfqbW+IYchp53YSPS8k/alXJRi84Ev6tDASrZoaYTjRO0Ps1QFa9tVBAQLg
+fa/4IpcXZmItiTYZlVAHN90WhbxZOiY5GiirZWWLkcUv9pSOHv07awzDolek/MkC
+AwEAAaNyMHAwHQYDVR0OBBYEFMET4X2O2V7eGtpu6k8TjKLtf6AxMB8GA1UdIwQY
+MBaAFMET4X2O2V7eGtpu6k8TjKLtf6AxMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0R
+BBYwFIISY2EuY2VydG9wcy5leGFtcGxlMA0GCSqGSIb3DQEBCwUAA4IBAQBUjILj
+UB9s79qPbzSVE4uZ+zMatfiOxG4PnF46iNJg1iRJJ1w3FOcjlj1FxO19RsRlqyOf
+2rICSmyiSGundtu7u7cFVK0OFhNr8Da9ugm0tqiHh5ZtwGCfbDirLDIwPuL2nelR
+8bk/cUepTFC1NAmRRa8cX3HgaEzY8YFThZ/JR1ps0/iWOMxC1MWdSNPgSrgX2DQ1
+Wyd4gytVWmsBFmV4Xvc2wshwjy56jm60KaaNAWN/N6xSL5ay5+ImaBm1g2rapCMU
+WXYC1Jw/NQfgLOwRIlX/AmpCib6udusu0XruVpYvBu9E2RxbaRto34iLQdUtrNN/
+o9wtTp83p6p21Okl
+-----END CERTIFICATE-----
+`;
+
+const FAKE_PRIVATE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
+const fakePem = (label) =>
+  `-----BEGIN ${label}-----\n${FAKE_PRIVATE_BODY}\n-----END ${label}-----`;
+
+function assertParserCode(input, code) {
+  assert.throws(
+    () => parsePublicCertificateMaterial(input),
+    (error) => error?.code === code,
+  );
+}
+
+function walkKeys(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkKeys(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    visit(key);
+    walkKeys(item, visit);
+  }
+}
+
+describe("CertOps public certificate parser", () => {
+  it("parses a valid single certificate PEM", () => {
+    const certificates = parsePublicCertificateMaterial(PUBLIC_LEAF_CERT);
+
+    assert.equal(certificates.length, 1);
+    assert.equal(certificates[0].commonName, "certops.example");
+    assert.match(certificates[0].subject, /CN=certops\.example/);
+    assert.match(certificates[0].issuer, /CN=certops\.example/);
+    assert.ok(certificates[0].certificatePem.startsWith("-----BEGIN CERTIFICATE-----"));
+    assert.ok(certificates[0].certificatePem.endsWith("-----END CERTIFICATE-----"));
+  });
+
+  it("parses a certificate chain with multiple certificates", () => {
+    const chain = `\n\n${PUBLIC_LEAF_CERT}\n\n${PUBLIC_CA_CERT}\n`;
+    const certificates = parsePublicCertificateMaterial(chain);
+
+    assert.equal(certificates.length, 2);
+    assert.equal(certificates[0].commonName, "certops.example");
+    assert.equal(certificates[1].commonName, "CertOps Test CA");
+  });
+
+  it("extracts SAN values", () => {
+    const [certificate] = parsePublicCertificateMaterial(PUBLIC_LEAF_CERT);
+
+    assert.equal(certificate.subjectAltName.includes("DNS:certops.example"), true);
+    assert.deepEqual(certificate.subjectAltNames, [
+      "certops.example",
+      "api.certops.example",
+      "127.0.0.1",
+    ]);
+  });
+
+  it("extracts validity dates", () => {
+    const [certificate] = parsePublicCertificateMaterial(PUBLIC_LEAF_CERT);
+
+    assert.match(certificate.validFrom, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(certificate.validTo, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(certificate.notBefore, certificate.validFrom);
+    assert.equal(certificate.notAfter, certificate.validTo);
+    assert.ok(Date.parse(certificate.validTo) > Date.parse(certificate.validFrom));
+  });
+
+  it("extracts certificate and public-key fingerprints", () => {
+    const [certificate] = parsePublicCertificateMaterial(PUBLIC_LEAF_CERT);
+
+    assert.match(certificate.fingerprint256, /^[a-f0-9]{64}$/);
+    assert.match(certificate.fingerprint512, /^[a-f0-9]{128}$/);
+    assert.equal(certificate.fingerprintSha256, certificate.fingerprint256);
+    assert.match(certificate.spkiFingerprintSha256, /^[a-f0-9]{64}$/);
+    assert.equal(certificate.publicKeyAlgorithm, "rsa");
+    assert.equal(certificate.publicKeySize, 2048);
+    assert.equal(certificate.publicKeyMetadata.asymmetricKeyType, "rsa");
+  });
+
+  it("rejects RSA private key PEM", () => {
+    assertParserCode(fakePem("RSA PRIVATE KEY"), PRIVATE_KEY_MATERIAL_REJECTED);
+  });
+
+  it("rejects EC private key PEM", () => {
+    assertParserCode(fakePem("EC PRIVATE KEY"), PRIVATE_KEY_MATERIAL_REJECTED);
+  });
+
+  it("rejects PKCS#8 private key PEM", () => {
+    assertParserCode(fakePem("PRIVATE KEY"), PRIVATE_KEY_MATERIAL_REJECTED);
+  });
+
+  it("rejects base64-wrapped private key PEM", () => {
+    const wrapped = Buffer.from(fakePem("RSA PRIVATE KEY")).toString("base64");
+    assertParserCode(wrapped, PRIVATE_KEY_MATERIAL_REJECTED);
+  });
+
+  it("rejects malformed certificate input with a stable code", () => {
+    const malformed = "not a public certificate";
+
+    assert.throws(
+      () => parsePublicCertificateMaterial(malformed),
+      (error) =>
+        error?.code === CERTOPS_CERTIFICATE_PARSE_FAILED &&
+        !error.message.includes(malformed),
+    );
+  });
+
+  it("does not accept PKCS#12/PFX-like binary input as a public certificate", () => {
+    const pfxLike = Buffer.from([0x30, 0x82, 0x01, 0x0a, 0x02, 0x01, 0x03]);
+
+    assertParserCode(pfxLike, CERTOPS_CERTIFICATE_PARSE_FAILED);
+  });
+
+  it("allows a public certificate but rejects the same payload when a private key is present", () => {
+    assert.doesNotThrow(() => parsePublicCertificateMaterial(PUBLIC_LEAF_CERT));
+    assertParserCode(
+      `${PUBLIC_LEAF_CERT}\n${fakePem("RSA PRIVATE KEY")}`,
+      PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  });
+
+  it("does not emit private-key-looking fields or values", () => {
+    const output = parsePublicCertificateMaterial(PUBLIC_LEAF_CERT);
+    const forbiddenFragments = [
+      "private",
+      "pkcs12",
+      "pfx",
+      "key_material",
+      "key_pem",
+      "key_der",
+      "raw_key",
+      "backup",
+      "secret",
+      "credential",
+      "password",
+    ];
+
+    walkKeys(output, (key) => {
+      for (const fragment of forbiddenFragments) {
+        assert.equal(
+          key.toLowerCase().includes(fragment),
+          false,
+          `${key} looks like a private-key custody field`,
+        );
+      }
+    });
+    assert.equal(JSON.stringify(output).includes("PRIVATE KEY"), false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the M1-A2 CertOps public certificate parser.

- Adds a reusable parser service for public PEM certificates.
- Supports single and multi-block PEM certificate input.
- Extracts normalized public metadata: subject, issuer, serial number, validity dates, SANs, SHA-256/SHA-512 fingerprints, SPKI fingerprint, public key metadata, signature algorithm, and normalized public certificate PEM.
- Rejects private key material through the shared secret material detector.
- Rejects malformed and PKCS#12/PFX-like input.

## Verification

- \`node --check apps/api/services/certops/parser.js\`: ok
- \`node --check tests/unit/certops-parser.test.js\`: ok
- \`node --test tests/unit/certops-parser.test.js\`: ok, 13 tests
- \`git diff --check\`: ok
- \`pnpm run test:unit\`: ok
- \`pnpm run check:contracts\`: ok
- \`pnpm run check:contracts:integrity\`: ok

## Notes for reviewer

- This PR is stacked on M1-A1: \`feature/certops-m1\`.
- No API routes, DB writes, migrations, dashboard/Cloud, executor, agent, ACME, cert-manager, Helm, or RBAC work is included.

## Test plan

- [ ] Review \`apps/api/services/certops/parser.js\`
- [ ] Review \`tests/unit/certops-parser.test.js\`
- [ ] Run \`node --test tests/unit/certops-parser.test.js\`
- [ ] Run \`pnpm run test:unit\`
- [ ] Run \`pnpm run check:contracts && pnpm run check:contracts:integrity\`"