### PR TITLE
feat(certops): reject private key material at API boundary m1-a3

### DIFF
--- a/apps/api/middleware/reject-key-material.js
+++ b/apps/api/middleware/reject-key-material.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const {
+  containsPrivateKeyMaterial,
+} = require("../utils/secretMaterial");
+
+const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
+
+const REJECTION_RESPONSE = Object.freeze({
+  error: "Private key material is not accepted in CertOps requests",
+  code: PRIVATE_KEY_MATERIAL_REJECTED,
+});
+
+function rejectKeyMaterial(req, res, next) {
+  if (!containsPrivateKeyMaterial(req.body)) {
+    return next();
+  }
+
+  return res.status(422).json(REJECTION_RESPONSE);
+}
+
+module.exports = {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  rejectKeyMaterial,
+};

--- a/apps/api/middleware/reject-key-material.js
+++ b/apps/api/middleware/reject-key-material.js
@@ -3,23 +3,87 @@
 const {
   containsPrivateKeyMaterial,
 } = require("../utils/secretMaterial");
+const { writeAudit } = require("../services/audit");
+const { logger } = require("../utils/logger");
 
 const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
+const CERTOPS_KEY_MATERIAL_REJECTED = "CERTOPS_KEY_MATERIAL_REJECTED";
 
 const REJECTION_RESPONSE = Object.freeze({
   error: "Private key material is not accepted in CertOps requests",
   code: PRIVATE_KEY_MATERIAL_REJECTED,
 });
 
-function rejectKeyMaterial(req, res, next) {
-  if (!containsPrivateKeyMaterial(req.body)) {
-    return next();
-  }
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-  return res.status(422).json(REJECTION_RESPONSE);
+function requestBodyType(value) {
+  if (Buffer.isBuffer(value)) return "buffer";
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  return typeof value;
 }
+
+function workspaceIdFromRequest(req) {
+  const workspaceId = req.workspace?.id || req.params?.id || null;
+  if (typeof workspaceId !== "string") return null;
+  return UUID_PATTERN.test(workspaceId) ? workspaceId : null;
+}
+
+function safeRequestPath(req) {
+  return req.route?.path || req.path || null;
+}
+
+function buildAuditEvent(req) {
+  const actorUserId = req.user?.id || null;
+  return {
+    actorUserId,
+    subjectUserId: actorUserId,
+    action: CERTOPS_KEY_MATERIAL_REJECTED,
+    targetType: "certops_request",
+    targetId: null,
+    workspaceId: workspaceIdFromRequest(req),
+    metadata: {
+      code: PRIVATE_KEY_MATERIAL_REJECTED,
+      method: req.method || null,
+      path: safeRequestPath(req),
+      body_type: requestBodyType(req.body),
+    },
+  };
+}
+
+async function recordKeyMaterialRejection(req, auditWriter = writeAudit) {
+  await auditWriter(buildAuditEvent(req));
+}
+
+function createRejectKeyMaterialMiddleware({ auditWriter = writeAudit } = {}) {
+  return async function rejectKeyMaterial(req, res, next) {
+    if (!containsPrivateKeyMaterial(req.body)) {
+      return next();
+    }
+
+    try {
+      await recordKeyMaterialRejection(req, auditWriter);
+    } catch (err) {
+      logger.warn("Failed to record CertOps key-material rejection audit", {
+        error: err.message,
+        code: err.code || null,
+        path: safeRequestPath(req),
+        method: req.method || null,
+      });
+    }
+
+    return res.status(422).json(REJECTION_RESPONSE);
+  };
+}
+
+const rejectKeyMaterial = createRejectKeyMaterialMiddleware();
 
 module.exports = {
   PRIVATE_KEY_MATERIAL_REJECTED,
+  CERTOPS_KEY_MATERIAL_REJECTED,
+  buildAuditEvent,
+  createRejectKeyMaterialMiddleware,
+  recordKeyMaterialRejection,
   rejectKeyMaterial,
 };

--- a/apps/api/middleware/reject-key-material.js
+++ b/apps/api/middleware/reject-key-material.js
@@ -8,10 +8,17 @@ const { logger } = require("../utils/logger");
 
 const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
 const CERTOPS_KEY_MATERIAL_REJECTED = "CERTOPS_KEY_MATERIAL_REJECTED";
+const CERTOPS_SECURITY_AUDIT_UNAVAILABLE =
+  "CERTOPS_SECURITY_AUDIT_UNAVAILABLE";
 
 const REJECTION_RESPONSE = Object.freeze({
   error: "Private key material is not accepted in CertOps requests",
   code: PRIVATE_KEY_MATERIAL_REJECTED,
+});
+
+const AUDIT_UNAVAILABLE_RESPONSE = Object.freeze({
+  error: "Security audit unavailable",
+  code: CERTOPS_SECURITY_AUDIT_UNAVAILABLE,
 });
 
 const UUID_PATTERN =
@@ -66,11 +73,12 @@ function createRejectKeyMaterialMiddleware({ auditWriter = writeAudit } = {}) {
       await recordKeyMaterialRejection(req, auditWriter);
     } catch (err) {
       logger.warn("Failed to record CertOps key-material rejection audit", {
-        error: err.message,
         code: err.code || null,
+        error_name: err.name || null,
         path: safeRequestPath(req),
         method: req.method || null,
       });
+      return res.status(503).json(AUDIT_UNAVAILABLE_RESPONSE);
     }
 
     return res.status(422).json(REJECTION_RESPONSE);
@@ -82,6 +90,7 @@ const rejectKeyMaterial = createRejectKeyMaterialMiddleware();
 module.exports = {
   PRIVATE_KEY_MATERIAL_REJECTED,
   CERTOPS_KEY_MATERIAL_REJECTED,
+  CERTOPS_SECURITY_AUDIT_UNAVAILABLE,
   buildAuditEvent,
   createRejectKeyMaterialMiddleware,
   recordKeyMaterialRejection,

--- a/apps/api/utils/secretMaterial.js
+++ b/apps/api/utils/secretMaterial.js
@@ -15,11 +15,11 @@
  *   - private key material  -> REJECT (hard 422 at the API boundary)
  *   - other generic secrets -> REDACT (so legitimate operational output is kept)
  *
- * Scope note (Phase 0): PEM private-key blocks (all common variants) and
- * base64-wrapped PEM are detected here. Binary PKCS#12/PFX (.p12/.pfx) DER
- * sniffing is deliberately deferred to M1 hardening; it cannot be reliably
- * distinguished from a DER certificate cheaply, and M1 adds dedicated fixtures.
- * Do not weaken these patterns without updating tests/unit/secretMaterial.test.js.
+ * Scope note: PEM private-key blocks (all common variants), base64-wrapped PEM,
+ * and PKCS#12/PFX-like DER bundles are detected here. PKCS#12/PFX detection is
+ * intentionally a conservative structural sniff for the PFX version field, not
+ * a full ASN.1 parser. Do not weaken these patterns without updating
+ * tests/unit/secretMaterial.test.js.
  */
 
 const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
@@ -56,6 +56,59 @@ function looksBase64(value) {
 }
 
 /**
+ * Returns the length of a DER TLV header, or null for unsupported encodings.
+ * This intentionally supports only definite lengths used by DER.
+ * @param {Buffer} value
+ * @returns {number|null}
+ */
+function derHeaderLength(value) {
+  if (!Buffer.isBuffer(value) || value.length < 2) return null;
+  const lengthByte = value[1];
+  if ((lengthByte & 0x80) === 0) return 2;
+
+  const lengthBytes = lengthByte & 0x7f;
+  if (lengthBytes === 0 || lengthBytes > 4) return null;
+  if (value.length < 2 + lengthBytes) return null;
+  return 2 + lengthBytes;
+}
+
+/**
+ * Detects a PKCS#12/PFX-like DER envelope. PFX begins with an outer SEQUENCE
+ * followed by INTEGER 3. X.509 certificates begin with an outer SEQUENCE
+ * followed by another SEQUENCE, so this avoids flagging DER certificates.
+ * @param {Buffer} value
+ * @returns {boolean}
+ */
+function looksPkcs12Bundle(value) {
+  if (!Buffer.isBuffer(value) || value.length < 7) return false;
+  if (value[0] !== 0x30) return false;
+
+  const headerLength = derHeaderLength(value);
+  if (headerLength === null || value.length < headerLength + 3) return false;
+
+  return (
+    value[headerLength] === 0x02 &&
+    value[headerLength + 1] === 0x01 &&
+    value[headerLength + 2] === 0x03
+  );
+}
+
+function base64DecodeIfLikely(value) {
+  if (!looksBase64(value)) return null;
+  try {
+    return Buffer.from(value.replace(/\s+/g, ""), "base64");
+  } catch (_err) {
+    return null;
+  }
+}
+
+function bufferContainsPrivateKey(value) {
+  if (!Buffer.isBuffer(value)) return false;
+  if (looksPkcs12Bundle(value)) return true;
+  return stringContainsPrivateKey(value.toString("utf8"));
+}
+
+/**
  * Detects private key material in a single string, including base64-wrapped PEM.
  * @param {string} value
  * @returns {boolean}
@@ -64,15 +117,10 @@ function stringContainsPrivateKey(value) {
   if (typeof value !== "string" || value.length === 0) return false;
   if (PRIVATE_KEY_PEM_PATTERN.test(value)) return true;
 
-  if (looksBase64(value)) {
-    try {
-      const decoded = Buffer.from(value.replace(/\s+/g, ""), "base64").toString(
-        "utf8",
-      );
-      if (PRIVATE_KEY_PEM_PATTERN.test(decoded)) return true;
-    } catch (_err) {
-      // not valid base64 text; ignore
-    }
+  const decoded = base64DecodeIfLikely(value);
+  if (decoded) {
+    if (looksPkcs12Bundle(decoded)) return true;
+    if (PRIVATE_KEY_PEM_PATTERN.test(decoded.toString("utf8"))) return true;
   }
   return false;
 }
@@ -89,7 +137,7 @@ function containsPrivateKeyMaterial(value, depth = 0) {
   if (typeof value === "string") return stringContainsPrivateKey(value);
 
   if (Buffer.isBuffer(value)) {
-    return stringContainsPrivateKey(value.toString("utf8"));
+    return bufferContainsPrivateKey(value);
   }
 
   if (Array.isArray(value)) {
@@ -121,16 +169,13 @@ function redactPrivateKeyMaterial(value) {
   }
   // Detection sees through base64-wrapped PEM, so redaction must too. The
   // decoded key spans the entire blob, so the whole value is replaced.
-  if (looksBase64(value)) {
-    try {
-      const decoded = Buffer.from(value.replace(/\s+/g, ""), "base64").toString(
-        "utf8",
-      );
-      if (PRIVATE_KEY_PEM_PATTERN.test(decoded)) {
-        return PRIVATE_KEY_REDACTION_PLACEHOLDER;
-      }
-    } catch (_err) {
-      // not valid base64 text; ignore
+  const decoded = base64DecodeIfLikely(value);
+  if (decoded) {
+    if (
+      looksPkcs12Bundle(decoded) ||
+      PRIVATE_KEY_PEM_PATTERN.test(decoded.toString("utf8"))
+    ) {
+      return PRIVATE_KEY_REDACTION_PLACEHOLDER;
     }
   }
   return value;
@@ -161,7 +206,7 @@ function redactGenericSecrets(value, depth = 0, seen = new WeakSet()) {
   }
 
   if (Buffer.isBuffer(value)) {
-    return stringContainsPrivateKey(value.toString("utf8"))
+    return bufferContainsPrivateKey(value)
       ? PRIVATE_KEY_REDACTION_PLACEHOLDER
       : value;
   }
@@ -192,6 +237,7 @@ module.exports = {
   GENERIC_SECRET_REDACTION_PLACEHOLDER,
   PRIVATE_KEY_PEM_PATTERN,
   containsPrivateKeyMaterial,
+  looksPkcs12Bundle,
   redactPrivateKeyMaterial,
   redactGenericSecrets,
 };

--- a/docs/adr/0001-certops-zero-custody-enforcement.md
+++ b/docs/adr/0001-certops-zero-custody-enforcement.md
@@ -29,6 +29,13 @@ Enterprise. Enforce it in multiple layers:
 3. **API rejection boundary**: requests whose body contains private key material
    are rejected with HTTP 422 `PRIVATE_KEY_MATERIAL_REJECTED` (see
    `packages/contracts/api/certops-route-compat.contract.json`).
+   In M1 this guard is intentionally mounted on CertOps write routes rather
+   than globally, to avoid changing unrelated non-CertOps request behavior
+   during observe-only work. Domain-checker import keeps its own inline
+   `containsPrivateKeyMaterial` guard. Future CertOps write surfaces must attach
+   `rejectKeyMaterial` after `express.json()` and before feature gates, RBAC,
+   parsing, persistence, or other business logic. Global/content-wide
+   enforcement can be revisited later with logger content-scrub work.
 4. **Schema design**: no inventory field is intended to hold key material;
    inventory stores public material and opaque, non-secret references
    (`certops-inventory.schema.json`). Flexible JSONB fields are protected by the

--- a/tests/unit/certops-parser.test.js
+++ b/tests/unit/certops-parser.test.js
@@ -165,10 +165,10 @@ describe("CertOps public certificate parser", () => {
     );
   });
 
-  it("does not accept PKCS#12/PFX-like binary input as a public certificate", () => {
+  it("rejects PKCS#12/PFX-like binary input as key material", () => {
     const pfxLike = Buffer.from([0x30, 0x82, 0x01, 0x0a, 0x02, 0x01, 0x03]);
 
-    assertParserCode(pfxLike, CERTOPS_CERTIFICATE_PARSE_FAILED);
+    assertParserCode(pfxLike, PRIVATE_KEY_MATERIAL_REJECTED);
   });
 
   it("allows a public certificate but rejects the same payload when a private key is present", () => {

--- a/tests/unit/reject-key-material.test.js
+++ b/tests/unit/reject-key-material.test.js
@@ -6,10 +6,14 @@ const path = require("node:path");
 
 const {
   CERTOPS_KEY_MATERIAL_REJECTED,
+  CERTOPS_SECURITY_AUDIT_UNAVAILABLE,
   PRIVATE_KEY_MATERIAL_REJECTED,
   createRejectKeyMaterialMiddleware,
 } = require(
   path.resolve(__dirname, "../../apps/api/middleware/reject-key-material.js"),
+);
+const { logger } = require(
+  path.resolve(__dirname, "../../apps/api/utils/logger.js"),
 );
 
 const FAKE_PRIVATE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
@@ -177,18 +181,49 @@ describe("rejectKeyMaterial middleware", () => {
     assert.equal(JSON.stringify(auditEvent).includes("alert_queue"), false);
   });
 
-  it("still rejects when audit recording fails", async () => {
-    const result = await assertRejected(
-      { payload: fakePem("RSA PRIVATE KEY") },
-      {
-        auditWriter: async () => {
-          throw new Error("audit unavailable");
-        },
-        expectAuditEvent: false,
-      },
-    );
+  it("fails closed when audit recording fails", async () => {
+    const privateKey = fakePem("RSA PRIVATE KEY");
+    const warnings = [];
+    const originalWarn = logger.warn;
+    logger.warn = (message, meta) => {
+      warnings.push({ message, meta });
+    };
 
-    assert.equal(result.statusCode, 422);
+    try {
+      const result = await runMiddleware(
+        { payload: privateKey },
+        {
+          auditWriter: async () => {
+            throw new Error(`audit unavailable ${privateKey}`);
+          },
+        },
+      );
+
+      assert.equal(result.nextCalled, false);
+      assert.equal(result.statusCode, 503);
+      assert.deepEqual(result.responseBody, {
+        error: "Security audit unavailable",
+        code: CERTOPS_SECURITY_AUDIT_UNAVAILABLE,
+      });
+      assert.deepEqual(Object.keys(result.responseBody).sort(), [
+        "code",
+        "error",
+      ]);
+      assert.equal(JSON.stringify(result.responseBody).includes(privateKey), false);
+      assert.equal(JSON.stringify(result.responseBody).includes(FAKE_PRIVATE_BODY), false);
+
+      assert.equal(warnings.length, 1);
+      assert.equal(
+        warnings[0].message,
+        "Failed to record CertOps key-material rejection audit",
+      );
+      assert.equal(JSON.stringify(warnings).includes(privateKey), false);
+      assert.equal(JSON.stringify(warnings).includes(FAKE_PRIVATE_BODY), false);
+      assert.equal(warnings[0].meta.method, "POST");
+      assert.equal(warnings[0].meta.path, "/api/v1/workspaces/:id/certops/imports");
+    } finally {
+      logger.warn = originalWarn;
+    }
   });
 
   it("does not echo private key material in the response", async () => {

--- a/tests/unit/reject-key-material.test.js
+++ b/tests/unit/reject-key-material.test.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  rejectKeyMaterial,
+} = require(
+  path.resolve(__dirname, "../../apps/api/middleware/reject-key-material.js"),
+);
+
+const FAKE_PRIVATE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
+const fakePem = (label) =>
+  `-----BEGIN ${label}-----\n${FAKE_PRIVATE_BODY}\n-----END ${label}-----`;
+
+const PUBLIC_CERTIFICATE_PEM = fakePem("CERTIFICATE");
+const PUBLIC_KEY_PEM = fakePem("PUBLIC KEY");
+
+function fakePkcs12Buffer() {
+  return Buffer.concat([
+    Buffer.from([0x30, 0x5c, 0x02, 0x01, 0x03]),
+    Buffer.alloc(89, 0),
+  ]);
+}
+
+function runMiddleware(body) {
+  let statusCode = null;
+  let responseBody = null;
+  let nextCalled = false;
+  const req = { body };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      responseBody = payload;
+      return this;
+    },
+  };
+
+  rejectKeyMaterial(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { nextCalled, responseBody, statusCode };
+}
+
+function assertRejected(body) {
+  const result = runMiddleware(body);
+
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.statusCode, 422);
+  assert.deepEqual(result.responseBody, {
+    error: "Private key material is not accepted in CertOps requests",
+    code: PRIVATE_KEY_MATERIAL_REJECTED,
+  });
+  return result;
+}
+
+function assertAllowed(body) {
+  const result = runMiddleware(body);
+
+  assert.equal(result.nextCalled, true);
+  assert.equal(result.statusCode, null);
+  assert.equal(result.responseBody, null);
+}
+
+describe("rejectKeyMaterial middleware", () => {
+  it("rejects a direct private key field", () => {
+    assertRejected({ certificate: fakePem("RSA PRIVATE KEY") });
+  });
+
+  it("rejects nested private key material", () => {
+    assertRejected({
+      import: {
+        notes: "nested payload",
+        certificate: { pem: fakePem("EC PRIVATE KEY") },
+      },
+    });
+  });
+
+  it("rejects array-contained private key material", () => {
+    assertRejected({
+      certificates: [PUBLIC_CERTIFICATE_PEM, fakePem("PRIVATE KEY")],
+    });
+  });
+
+  it("rejects base64-wrapped private key PEM", () => {
+    const wrapped = Buffer.from(fakePem("ENCRYPTED PRIVATE KEY")).toString(
+      "base64",
+    );
+
+    assertRejected({ attachment: wrapped });
+  });
+
+  it("rejects PKCS#12/PFX-like binary request bodies", () => {
+    assertRejected(fakePkcs12Buffer());
+  });
+
+  it("rejects base64-wrapped PKCS#12/PFX-like payloads", () => {
+    assertRejected({ bundle: fakePkcs12Buffer().toString("base64") });
+  });
+
+  it("allows public certificate PEM input", () => {
+    assertAllowed({ certificatePem: PUBLIC_CERTIFICATE_PEM });
+  });
+
+  it("allows public key PEM input", () => {
+    assertAllowed({ publicKeyPem: PUBLIC_KEY_PEM });
+  });
+
+  it("allows malformed non-key input", () => {
+    assertAllowed({
+      certificatePem: "not a certificate and not private key material",
+    });
+  });
+
+  it("does not echo private key material in the response", () => {
+    const privateKey = fakePem("RSA PRIVATE KEY");
+    const result = assertRejected({ payload: privateKey });
+    const serialized = JSON.stringify(result.responseBody);
+
+    assert.equal(serialized.includes(privateKey), false);
+    assert.equal(serialized.includes(FAKE_PRIVATE_BODY), false);
+  });
+
+  it("does not introduce private-key-looking response fields", () => {
+    const result = assertRejected({ payload: fakePem("PRIVATE KEY") });
+    const responseKeys = Object.keys(result.responseBody);
+
+    assert.deepEqual(responseKeys.sort(), ["code", "error"]);
+  });
+});

--- a/tests/unit/reject-key-material.test.js
+++ b/tests/unit/reject-key-material.test.js
@@ -5,8 +5,9 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 
 const {
+  CERTOPS_KEY_MATERIAL_REJECTED,
   PRIVATE_KEY_MATERIAL_REJECTED,
-  rejectKeyMaterial,
+  createRejectKeyMaterialMiddleware,
 } = require(
   path.resolve(__dirname, "../../apps/api/middleware/reject-key-material.js"),
 );
@@ -25,31 +26,52 @@ function fakePkcs12Buffer() {
   ]);
 }
 
-function runMiddleware(body) {
+const WORKSPACE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+async function runMiddleware(body, options = {}) {
   let statusCode = null;
   let responseBody = null;
   let nextCalled = false;
-  const req = { body };
+  const auditEvents = [];
+  const order = [];
+  const req = {
+    body,
+    method: "POST",
+    params: { id: WORKSPACE_ID },
+    path: "/api/v1/workspaces/:id/certops/imports",
+    user: { id: 123 },
+    ...(options.req || {}),
+  };
+  const auditWriter =
+    options.auditWriter ||
+    (async (event) => {
+      order.push("audit");
+      auditEvents.push(event);
+    });
   const res = {
     status(code) {
+      order.push("status");
       statusCode = code;
       return this;
     },
     json(payload) {
+      order.push("json");
       responseBody = payload;
       return this;
     },
   };
+  const middleware = createRejectKeyMaterialMiddleware({ auditWriter });
 
-  rejectKeyMaterial(req, res, () => {
+  await middleware(req, res, () => {
+    order.push("next");
     nextCalled = true;
   });
 
-  return { nextCalled, responseBody, statusCode };
+  return { auditEvents, nextCalled, order, responseBody, statusCode };
 }
 
-function assertRejected(body) {
-  const result = runMiddleware(body);
+async function assertRejected(body, options) {
+  const result = await runMiddleware(body, options);
 
   assert.equal(result.nextCalled, false);
   assert.equal(result.statusCode, 422);
@@ -57,24 +79,28 @@ function assertRejected(body) {
     error: "Private key material is not accepted in CertOps requests",
     code: PRIVATE_KEY_MATERIAL_REJECTED,
   });
+  if (options?.expectAuditEvent !== false) {
+    assert.equal(result.auditEvents.length, 1);
+  }
   return result;
 }
 
-function assertAllowed(body) {
-  const result = runMiddleware(body);
+async function assertAllowed(body) {
+  const result = await runMiddleware(body);
 
   assert.equal(result.nextCalled, true);
   assert.equal(result.statusCode, null);
   assert.equal(result.responseBody, null);
+  assert.deepEqual(result.auditEvents, []);
 }
 
 describe("rejectKeyMaterial middleware", () => {
-  it("rejects a direct private key field", () => {
-    assertRejected({ certificate: fakePem("RSA PRIVATE KEY") });
+  it("rejects a direct private key field", async () => {
+    await assertRejected({ certificate: fakePem("RSA PRIVATE KEY") });
   });
 
-  it("rejects nested private key material", () => {
-    assertRejected({
+  it("rejects nested private key material", async () => {
+    await assertRejected({
       import: {
         notes: "nested payload",
         certificate: { pem: fakePem("EC PRIVATE KEY") },
@@ -82,53 +108,100 @@ describe("rejectKeyMaterial middleware", () => {
     });
   });
 
-  it("rejects array-contained private key material", () => {
-    assertRejected({
+  it("rejects array-contained private key material", async () => {
+    await assertRejected({
       certificates: [PUBLIC_CERTIFICATE_PEM, fakePem("PRIVATE KEY")],
     });
   });
 
-  it("rejects base64-wrapped private key PEM", () => {
+  it("rejects base64-wrapped private key PEM", async () => {
     const wrapped = Buffer.from(fakePem("ENCRYPTED PRIVATE KEY")).toString(
       "base64",
     );
 
-    assertRejected({ attachment: wrapped });
+    await assertRejected({ attachment: wrapped });
   });
 
-  it("rejects PKCS#12/PFX-like binary request bodies", () => {
-    assertRejected(fakePkcs12Buffer());
+  it("rejects PKCS#12/PFX-like binary request bodies", async () => {
+    await assertRejected(fakePkcs12Buffer());
   });
 
-  it("rejects base64-wrapped PKCS#12/PFX-like payloads", () => {
-    assertRejected({ bundle: fakePkcs12Buffer().toString("base64") });
+  it("rejects base64-wrapped PKCS#12/PFX-like payloads", async () => {
+    await assertRejected({ bundle: fakePkcs12Buffer().toString("base64") });
   });
 
-  it("allows public certificate PEM input", () => {
-    assertAllowed({ certificatePem: PUBLIC_CERTIFICATE_PEM });
+  it("allows public certificate PEM input", async () => {
+    await assertAllowed({ certificatePem: PUBLIC_CERTIFICATE_PEM });
   });
 
-  it("allows public key PEM input", () => {
-    assertAllowed({ publicKeyPem: PUBLIC_KEY_PEM });
+  it("allows public key PEM input", async () => {
+    await assertAllowed({ publicKeyPem: PUBLIC_KEY_PEM });
   });
 
-  it("allows malformed non-key input", () => {
-    assertAllowed({
+  it("allows malformed non-key input", async () => {
+    await assertAllowed({
       certificatePem: "not a certificate and not private key material",
     });
   });
 
-  it("does not echo private key material in the response", () => {
+  it("records a synchronous audit event without alert_queue dependency", async () => {
+    const result = await assertRejected({
+      payload: fakePem("RSA PRIVATE KEY"),
+    });
+    const auditEvent = result.auditEvents[0];
+
+    assert.deepEqual(result.order, ["audit", "status", "json"]);
+    assert.equal(auditEvent.action, CERTOPS_KEY_MATERIAL_REJECTED);
+    assert.equal(auditEvent.actorUserId, 123);
+    assert.equal(auditEvent.subjectUserId, 123);
+    assert.equal(auditEvent.targetType, "certops_request");
+    assert.equal(auditEvent.workspaceId, WORKSPACE_ID);
+    assert.equal(auditEvent.metadata.code, PRIVATE_KEY_MATERIAL_REJECTED);
+    assert.equal(auditEvent.metadata.method, "POST");
+    assert.equal(auditEvent.metadata.body_type, "object");
+    assert.equal(JSON.stringify(auditEvent).includes("alert_queue"), false);
+    assert.equal(JSON.stringify(auditEvent).includes(FAKE_PRIVATE_BODY), false);
+  });
+
+  it("records tokenless rejection events without requiring a user or alert queue", async () => {
+    const result = await assertRejected(
+      { payload: fakePem("RSA PRIVATE KEY") },
+      { req: { user: null } },
+    );
+    const auditEvent = result.auditEvents[0];
+
+    assert.equal(auditEvent.action, CERTOPS_KEY_MATERIAL_REJECTED);
+    assert.equal(auditEvent.actorUserId, null);
+    assert.equal(auditEvent.subjectUserId, null);
+    assert.equal(auditEvent.workspaceId, WORKSPACE_ID);
+    assert.equal(JSON.stringify(auditEvent).includes("alert_queue"), false);
+  });
+
+  it("still rejects when audit recording fails", async () => {
+    const result = await assertRejected(
+      { payload: fakePem("RSA PRIVATE KEY") },
+      {
+        auditWriter: async () => {
+          throw new Error("audit unavailable");
+        },
+        expectAuditEvent: false,
+      },
+    );
+
+    assert.equal(result.statusCode, 422);
+  });
+
+  it("does not echo private key material in the response", async () => {
     const privateKey = fakePem("RSA PRIVATE KEY");
-    const result = assertRejected({ payload: privateKey });
+    const result = await assertRejected({ payload: privateKey });
     const serialized = JSON.stringify(result.responseBody);
 
     assert.equal(serialized.includes(privateKey), false);
     assert.equal(serialized.includes(FAKE_PRIVATE_BODY), false);
   });
 
-  it("does not introduce private-key-looking response fields", () => {
-    const result = assertRejected({ payload: fakePem("PRIVATE KEY") });
+  it("does not introduce private-key-looking response fields", async () => {
+    const result = await assertRejected({ payload: fakePem("PRIVATE KEY") });
     const responseKeys = Object.keys(result.responseBody);
 
     assert.deepEqual(responseKeys.sort(), ["code", "error"]);

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 const {
   PRIVATE_KEY_REDACTION_PLACEHOLDER,
   containsPrivateKeyMaterial,
+  looksPkcs12Bundle,
   redactPrivateKeyMaterial,
   redactGenericSecrets,
 } = require(
@@ -18,6 +19,13 @@ const {
 const FAKE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
 const pem = (label) =>
   `-----BEGIN ${label}-----\n${FAKE_BODY}\n-----END ${label}-----`;
+
+function fakePkcs12Buffer() {
+  return Buffer.concat([
+    Buffer.from([0x30, 0x5c, 0x02, 0x01, 0x03]),
+    Buffer.alloc(89, 0),
+  ]);
+}
 
 const PRIVATE_KEY_LABELS = [
   "PRIVATE KEY", // PKCS#8
@@ -51,6 +59,19 @@ describe("secretMaterial.containsPrivateKeyMaterial", () => {
 
   it("detects base64-wrapped private key PEM", () => {
     const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
+  });
+
+  it("detects PKCS#12/PFX-like DER bundles", () => {
+    const pfxLike = fakePkcs12Buffer();
+
+    assert.strictEqual(looksPkcs12Bundle(pfxLike), true);
+    assert.strictEqual(containsPrivateKeyMaterial(pfxLike), true);
+  });
+
+  it("detects base64-wrapped PKCS#12/PFX-like DER bundles", () => {
+    const wrapped = fakePkcs12Buffer().toString("base64");
+
     assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
   });
 
@@ -108,6 +129,12 @@ describe("secretMaterial.redactPrivateKeyMaterial", () => {
     assert.ok(!out.includes(wrapped));
   });
 
+  it("redacts a base64-wrapped PKCS#12/PFX-like bundle to the placeholder", () => {
+    const wrapped = fakePkcs12Buffer().toString("base64");
+    const out = redactPrivateKeyMaterial(wrapped);
+    assert.strictEqual(out, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+  });
+
   it("leaves non-key strings unchanged", () => {
     assert.strictEqual(redactPrivateKeyMaterial("plain text"), "plain text");
   });
@@ -139,6 +166,11 @@ describe("secretMaterial.redactGenericSecrets", () => {
 
   it("redacts a Buffer carrying private key material", () => {
     const out = redactGenericSecrets({ raw: Buffer.from(pem("PRIVATE KEY")) });
+    assert.strictEqual(out.raw, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+  });
+
+  it("redacts a Buffer carrying PKCS#12/PFX-like material", () => {
+    const out = redactGenericSecrets({ raw: fakePkcs12Buffer() });
     assert.strictEqual(out.raw, PRIVATE_KEY_REDACTION_PLACEHOLDER);
   });
 


### PR DESCRIPTION
## Summary

This PR adds the M1-A3 CertOps private-key rejection boundary.

* Adds reusable middleware to reject private key material in CertOps API request bodies.
* Deep-scans request bodies for direct, nested, array-contained, and base64-wrapped private keys.
* Extends the shared secret material detector to reject PKCS#12/PFX-like payloads.
* Returns HTTP 422 with code `PRIVATE_KEY_MATERIAL_REJECTED`.
* Records a synchronous audit/security event with action `CERTOPS_KEY_MATERIAL_REJECTED` before returning the rejection response.
* Supports tokenless rejection events with `actorUserId` and `subjectUserId` set to `null`.
* Uses safe audit metadata only: method, route path, body type, and response code.
* Does not depend on `alert_queue` for key-material rejection events.
* Keeps error messages and audit metadata safe; no raw request body or key material is echoed.
* Allows public certificate PEM, public key PEM, and malformed non-key input.

## Verification

* `node --check apps/api/middleware/reject-key-material.js`: ok
* `node --check apps/api/utils/secretMaterial.js`: ok
* `node --check tests/unit/reject-key-material.test.js`: ok
* `node --test tests/unit/reject-key-material.test.js tests/unit/secretMaterial.test.js tests/unit/certops-parser.test.js`: ok
* `pnpm run test:unit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok
* `git diff --check`: ok

## Notes for reviewer

* This PR is stacked on M1-A2: `feature/certops-m1-a2-parser`.
* The parser test expectation was updated because PKCS#12/PFX-like input is now classified as `PRIVATE_KEY_MATERIAL_REJECTED` after detector hardening.
* Private-key rejection now writes a synchronous `CERTOPS_KEY_MATERIAL_REJECTED` audit/security event without using `alert_queue`.
* If audit storage fails, the middleware logs sanitized metadata and fails closed with 503 CERTOPS_SECURITY_AUDIT_UNAVAILABLE.
* No API routes, DB writes, migrations, dashboard/Cloud, executor, agent, ACME, cert-manager, Helm, or RBAC work is included.

## Test plan

* [ ] Review `apps/api/middleware/reject-key-material.js`
* [ ] Review `apps/api/utils/secretMaterial.js`
* [ ] Review `tests/unit/reject-key-material.test.js`
* [ ] Review `tests/unit/secretMaterial.test.js`
* [ ] Run `node --test tests/unit/reject-key-material.test.js tests/unit/secretMaterial.test.js tests/unit/certops-parser.test.js`
* [ ] Run `pnpm run test:unit`
* [ ] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
