### PR TITLE
feat(certops): add gated inventory routes m1-a4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ ADMIN_NAME=Administrator
 APP_URL=http://localhost:5173
 API_URL=http://localhost:4000
 
+# CertOps rollout flag. Default is false when unset.
+CERTOPS_ENABLED=false
+
 # Optional: worker cron schedules (defaults match Kubernetes Helm).
 # Cron mode is default; *_INTERVAL_MS vars apply only when *_CRON=interval.
 # Worker Compose services set TZ from docker-compose.yml (default UTC).

--- a/.env.test
+++ b/.env.test
@@ -14,6 +14,9 @@ TT_TEST_MAILHOG_UI_PORT=8025
 # --- API target (from the host / test runner perspective) ---
 TEST_API_URL=http://localhost:4000
 
+# CertOps route tests intentionally enable the dark-launch flag.
+CERTOPS_ENABLED=true
+
 # --- Database (host-side access to Postgres container) ------
 DB_HOST=localhost
 DB_PORT=5432

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,21 @@ routes and UI are hidden, so milestone code can ship dark, Cloud can run staged
 per-workspace previews, and Enterprise enables it deliberately. Edition, plan,
 and license gating apply on top once the flag is on.
 
+M1 Core is dark-launched and env-gated: `CERTOPS_ENABLED` is the authoritative
+Core rollout control for M1. The optional
+`system_settings.certops_settings.enabled` read path is forward-compatible only;
+the JSONB column and admin settings persistence are deferred. The resolver must
+continue to fall back safely when that column is absent.
+
+## M1 follow-ups
+
+- Certificate instance history needs a public, workspace-scoped read endpoint
+  after the monitor bridge writes `certificate_instances`, preferably in #46 or
+  a focused follow-up. It should return public observation fields only, such as
+  `observedAt`, `status`, `deploymentReference`, `observedSubject`,
+  `observedIssuer`, `observedSerialNumber`, `observedFingerprintSha256`, and
+  `source`; it must never expose private key material or secret fields.
+
 ## Editions
 
 - **Core** - source-available (BUSL-1.1), generous free base.

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -594,6 +594,8 @@ app.use(require("./routes/alerts"));
 app.use(require("./routes/account"));
 // --- INTEGRATIONS (extracted to routes/integrations.js) ---
 app.use(require("./routes/integrations"));
+// --- CERTOPS (extracted to routes/certops.js) ---
+app.use(require("./routes/certops"));
 // --- ADMIN (extracted to routes/admin.js) ---
 app.use(require("./routes/admin"));
 

--- a/apps/api/middleware/require-certops-enabled.js
+++ b/apps/api/middleware/require-certops-enabled.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const {
+  CERTOPS_DISABLED,
+  isCertOpsEnabled,
+} = require("../services/certops/settings");
+const { logger } = require("../utils/logger");
+
+const NOT_FOUND_RESPONSE = Object.freeze({
+  error: "Endpoint not found",
+  code: "NOT_FOUND",
+});
+
+function createRequireCertOpsEnabled({ flagResolver = isCertOpsEnabled } = {}) {
+  return async function requireCertOpsEnabled(req, res, next) {
+    try {
+      if (await flagResolver()) return next();
+      return res.status(404).json(NOT_FOUND_RESPONSE);
+    } catch (err) {
+      logger.error("CertOps rollout flag check failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        path: req.route?.path || req.path,
+      });
+      return res.status(500).json({
+        error: "Failed to check CertOps availability",
+        code: CERTOPS_DISABLED,
+      });
+    }
+  };
+}
+
+const requireCertOpsEnabled = createRequireCertOpsEnabled();
+
+module.exports = {
+  CERTOPS_DISABLED,
+  NOT_FOUND_RESPONSE,
+  createRequireCertOpsEnabled,
+  requireCertOpsEnabled,
+};

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -1,0 +1,238 @@
+"use strict";
+
+const router = require("express").Router();
+
+const { getApiLimiter } = require("../middleware/rateLimit");
+const {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  rejectKeyMaterial,
+} = require("../middleware/reject-key-material");
+const {
+  requireCertOpsEnabled,
+} = require("../middleware/require-certops-enabled");
+const { hasAtLeastRole } = require("../services/rbac");
+const {
+  CERTOPS_CERTIFICATE_PARSE_FAILED,
+  getManagedCertificate,
+  importPublicCertificates,
+  listManagedCertificates,
+} = require("../services/certops/inventory");
+const { writeAudit } = require("../services/audit");
+const { logger } = require("../utils/logger");
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function requireCertOpsWriteRole(req, res, next) {
+  if (req.isWorkerCall) return next();
+
+  if (!hasAtLeastRole(req.authz?.workspaceRole, "workspace_manager")) {
+    return res.status(403).json({
+      error: "Forbidden: insufficient role",
+      code: "INSUFFICIENT_ROLE",
+    });
+  }
+
+  return next();
+}
+
+function certificatePemFromBody(body) {
+  if (typeof body === "string") return body;
+  if (!body || typeof body !== "object") return null;
+
+  for (const field of ["certificatePem", "pem", "certificate", "chainPem"]) {
+    if (typeof body[field] === "string") return body[field];
+  }
+
+  if (
+    Array.isArray(body.certificates) &&
+    body.certificates.every((item) => typeof item === "string")
+  ) {
+    return body.certificates.join("\n");
+  }
+
+  return null;
+}
+
+function optionalTrimmedString(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function writeOptionsFromRequest(req, source) {
+  return {
+    workspaceId: req.workspace.id,
+    certificatePem: certificatePemFromBody(req.body),
+    source,
+    sourceRef: optionalTrimmedString(req.body?.sourceRef),
+    name: optionalTrimmedString(req.body?.name),
+    keyMode: optionalTrimmedString(req.body?.keyMode),
+    keyReference: optionalTrimmedString(req.body?.keyReference),
+    createdBy: req.user?.id || null,
+  };
+}
+
+function handleCertOpsError(res, err) {
+  if (err?.code === PRIVATE_KEY_MATERIAL_REJECTED) {
+    return res.status(422).json({
+      error: "Private key material is not accepted in CertOps requests",
+      code: PRIVATE_KEY_MATERIAL_REJECTED,
+    });
+  }
+
+  if (err?.code === CERTOPS_CERTIFICATE_PARSE_FAILED) {
+    return res.status(400).json({
+      error: "Certificate input could not be parsed",
+      code: CERTOPS_CERTIFICATE_PARSE_FAILED,
+    });
+  }
+
+  return null;
+}
+
+async function recordInventoryAudit(req, source, certificates) {
+  const actorUserId = req.user?.id || null;
+  await writeAudit({
+    actorUserId,
+    subjectUserId: actorUserId,
+    action:
+      source === "api"
+        ? "CERTOPS_CERTIFICATE_REGISTERED"
+        : "CERTOPS_CERTIFICATE_IMPORTED",
+    targetType: "managed_certificate",
+    targetId: null,
+    workspaceId: req.workspace.id,
+    metadata: {
+      source,
+      count: certificates.length,
+      certificate_ids: certificates.map((certificate) => certificate.id),
+      fingerprints_sha256: certificates.map(
+        (certificate) => certificate.fingerprintSha256,
+      ),
+    },
+  });
+}
+
+async function importCertificatesHandler(req, res, source, statusCode) {
+  const options = writeOptionsFromRequest(req, source);
+  if (!options.certificatePem) {
+    return res.status(400).json({
+      error: "certificatePem is required",
+      code: "CERTOPS_CERTIFICATE_PEM_REQUIRED",
+    });
+  }
+
+  try {
+    const certificates = await importPublicCertificates(options);
+    await recordInventoryAudit(req, source, certificates);
+    return res.status(statusCode).json({
+      items: certificates,
+      count: certificates.length,
+    });
+  } catch (err) {
+    const handled = handleCertOpsError(res, err);
+    if (handled) return handled;
+
+    logger.error("CertOps certificate import failed", {
+      error: err.message,
+      code: err.code || null,
+      workspaceId: req.workspace?.id,
+      userId: req.user?.id,
+    });
+    return res.status(500).json({
+      error: "Failed to import certificate",
+      code: "INTERNAL_ERROR",
+    });
+  }
+}
+
+router.get(
+  "/api/v1/workspaces/:id/certops/certificates",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    try {
+      const result = await listManagedCertificates({
+        workspaceId: req.workspace.id,
+        limit: req.query.limit,
+        offset: req.query.offset,
+      });
+      return res.json(result);
+    } catch (err) {
+      logger.error("CertOps certificate list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list certificates",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/certificates",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  (req, res) => importCertificatesHandler(req, res, "api", 201),
+);
+
+router.get(
+  "/api/v1/workspaces/:id/certops/certificates/:certId",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    if (!UUID_PATTERN.test(String(req.params.certId || ""))) {
+      return res.status(404).json({
+        error: "Certificate not found",
+        code: "CERTOPS_CERTIFICATE_NOT_FOUND",
+      });
+    }
+
+    try {
+      const certificate = await getManagedCertificate({
+        workspaceId: req.workspace.id,
+        certId: req.params.certId,
+      });
+
+      if (!certificate) {
+        return res.status(404).json({
+          error: "Certificate not found",
+          code: "CERTOPS_CERTIFICATE_NOT_FOUND",
+        });
+      }
+
+      return res.json({ certificate });
+    } catch (err) {
+      logger.error("CertOps certificate detail failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        certId: req.params?.certId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to load certificate",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/imports",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  (req, res) => importCertificatesHandler(req, res, "import", 202),
+);
+
+module.exports = router;

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -13,6 +13,7 @@ const {
 const { hasAtLeastRole } = require("../services/rbac");
 const {
   CERTOPS_CERTIFICATE_PARSE_FAILED,
+  CERTOPS_KEY_MODE_INVALID,
   getManagedCertificate,
   importPublicCertificates,
   listManagedCertificates,
@@ -86,6 +87,13 @@ function handleCertOpsError(res, err) {
     return res.status(400).json({
       error: "Certificate input could not be parsed",
       code: CERTOPS_CERTIFICATE_PARSE_FAILED,
+    });
+  }
+
+  if (err?.code === CERTOPS_KEY_MODE_INVALID) {
+    return res.status(400).json({
+      error: "Invalid CertOps key mode",
+      code: CERTOPS_KEY_MODE_INVALID,
     });
   }
 

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -8,6 +8,18 @@ const {
 } = require("./parser");
 
 const CERTOPS_CERTIFICATE_NOT_FOUND = "CERTOPS_CERTIFICATE_NOT_FOUND";
+const CERTOPS_KEY_MODE_INVALID = "CERTOPS_KEY_MODE_INVALID";
+
+const ALLOWED_KEY_MODES = new Set([
+  "agent-local",
+  "proxy-agent-local",
+  "cert-manager-managed",
+  "appliance-managed",
+  "hsm-managed",
+  "vault-managed",
+  "os-store-managed",
+  "external-unknown",
+]);
 
 function dateToIso(value) {
   if (!value) return null;
@@ -77,6 +89,31 @@ function normalizeOffset(value) {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed)) return 0;
   return Math.max(0, parsed);
+}
+
+function certOpsValidationError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function normalizeKeyMode(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    throw certOpsValidationError(
+      "Invalid CertOps key mode",
+      CERTOPS_KEY_MODE_INVALID,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (ALLOWED_KEY_MODES.has(trimmed)) return trimmed;
+
+  throw certOpsValidationError(
+    "Invalid CertOps key mode",
+    CERTOPS_KEY_MODE_INVALID,
+  );
 }
 
 function publicMetadataFor(certificate, options, chainIndex) {
@@ -180,6 +217,10 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
 
 async function importPublicCertificates(options) {
   const certificates = parsePublicCertificateMaterial(options.certificatePem);
+  const normalizedOptions = {
+    ...options,
+    keyMode: normalizeKeyMode(options.keyMode),
+  };
   const client = await pool.connect();
 
   try {
@@ -187,7 +228,12 @@ async function importPublicCertificates(options) {
     const items = [];
     for (let index = 0; index < certificates.length; index += 1) {
       items.push(
-        await upsertManagedCertificate(client, certificates[index], options, index),
+        await upsertManagedCertificate(
+          client,
+          certificates[index],
+          normalizedOptions,
+          index,
+        ),
       );
     }
     await client.query("COMMIT");
@@ -237,10 +283,12 @@ async function getManagedCertificate({ workspaceId, certId }) {
 module.exports = {
   CERTOPS_CERTIFICATE_NOT_FOUND,
   CERTOPS_CERTIFICATE_PARSE_FAILED,
+  CERTOPS_KEY_MODE_INVALID,
   PRIVATE_KEY_MATERIAL_REJECTED,
   getManagedCertificate,
   importPublicCertificates,
   listManagedCertificates,
+  normalizeKeyMode,
   normalizeLimit,
   normalizeOffset,
   toInventoryRecord,

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -1,0 +1,247 @@
+"use strict";
+
+const { pool } = require("../../db/database");
+const {
+  CERTOPS_CERTIFICATE_PARSE_FAILED,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  parsePublicCertificateMaterial,
+} = require("./parser");
+
+const CERTOPS_CERTIFICATE_NOT_FOUND = "CERTOPS_CERTIFICATE_NOT_FOUND";
+
+function dateToIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([_key, item]) => item !== undefined),
+  );
+}
+
+function chooseCertificateName(certificate, fallbackName) {
+  const trimmedFallback =
+    typeof fallbackName === "string" ? fallbackName.trim() : "";
+  if (trimmedFallback) return trimmedFallback;
+  return (
+    certificate.commonName ||
+    certificate.subjectAltNames?.[0] ||
+    certificate.subject ||
+    null
+  );
+}
+
+function toInventoryRecord(row) {
+  if (!row) return null;
+
+  return {
+    schemaVersion: 1,
+    id: row.id,
+    workspaceId: row.workspace_id,
+    tokenId: row.token_id,
+    profileId: row.profile_id,
+    status: row.status,
+    source: row.source,
+    sourceRef: row.source_ref,
+    commonName: row.common_name,
+    subjectAltNames: Array.isArray(row.subject_alt_names)
+      ? row.subject_alt_names
+      : [],
+    issuer: row.issuer,
+    serialNumber: row.serial_number,
+    fingerprintSha256: row.fingerprint_sha256,
+    spkiFingerprintSha256: row.spki_fingerprint_sha256,
+    certificatePem: row.certificate_pem,
+    publicKeyAlgorithm: row.public_key_algorithm,
+    publicKeySize: row.public_key_size,
+    signatureAlgorithm: row.signature_algorithm,
+    notBefore: dateToIso(row.not_before),
+    notAfter: dateToIso(row.not_after),
+    keyMode: row.key_mode,
+    keyReference: row.key_reference,
+    createdAt: dateToIso(row.created_at),
+    updatedAt: dateToIso(row.updated_at),
+  };
+}
+
+function normalizeLimit(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 50;
+  return Math.max(1, Math.min(100, parsed));
+}
+
+function normalizeOffset(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, parsed);
+}
+
+function publicMetadataFor(certificate, options, chainIndex) {
+  return compactObject({
+    parser: "certops-public-certificate-parser",
+    chainIndex,
+    subject: certificate.subject || null,
+    subjectAltName: certificate.subjectAltName || null,
+    fingerprint512: certificate.fingerprint512 || null,
+    publicKeyMetadata: certificate.publicKeyMetadata || null,
+    signatureAlgorithmOid: certificate.signatureAlgorithmOid || null,
+    requestSource: options.source || null,
+  });
+}
+
+async function upsertManagedCertificate(client, certificate, options, chainIndex) {
+  const params = [
+    options.workspaceId,
+    options.status || "discovered",
+    options.source || "import",
+    options.sourceRef || null,
+    chooseCertificateName(certificate, options.name),
+    certificate.commonName || null,
+    certificate.subjectAltNames || [],
+    certificate.issuer || null,
+    certificate.subject || null,
+    certificate.serialNumber || null,
+    certificate.certificatePem || null,
+    certificate.fingerprintSha256 || certificate.fingerprint256 || null,
+    certificate.spkiFingerprintSha256 || null,
+    certificate.publicKeyAlgorithm || null,
+    certificate.publicKeySize || null,
+    certificate.signatureAlgorithm || null,
+    certificate.notBefore || certificate.validFrom || null,
+    certificate.notAfter || certificate.validTo || null,
+    options.keyMode || null,
+    options.keyReference || null,
+    JSON.stringify(publicMetadataFor(certificate, options, chainIndex)),
+    options.createdBy || null,
+  ];
+
+  const result = await client.query(
+    `INSERT INTO managed_certificates (
+       workspace_id,
+       status,
+       source,
+       source_ref,
+       name,
+       common_name,
+       subject_alt_names,
+       issuer,
+       subject,
+       serial_number,
+       certificate_pem,
+       fingerprint_sha256,
+       spki_fingerprint_sha256,
+       public_key_algorithm,
+       public_key_size,
+       signature_algorithm,
+       not_before,
+       not_after,
+       key_mode,
+       key_reference,
+       public_metadata,
+       created_by
+     )
+     VALUES (
+       $1, $2, $3, $4, $5, $6, $7::text[], $8, $9, $10, $11, $12,
+       $13, $14, $15, $16, $17, $18, $19, $20, $21::jsonb, $22
+     )
+     ON CONFLICT (workspace_id, fingerprint_sha256)
+       WHERE fingerprint_sha256 IS NOT NULL
+     DO UPDATE SET
+       status = EXCLUDED.status,
+       source = EXCLUDED.source,
+       source_ref = EXCLUDED.source_ref,
+       name = COALESCE(EXCLUDED.name, managed_certificates.name),
+       common_name = EXCLUDED.common_name,
+       subject_alt_names = EXCLUDED.subject_alt_names,
+       issuer = EXCLUDED.issuer,
+       subject = EXCLUDED.subject,
+       serial_number = EXCLUDED.serial_number,
+       certificate_pem = EXCLUDED.certificate_pem,
+       spki_fingerprint_sha256 = EXCLUDED.spki_fingerprint_sha256,
+       public_key_algorithm = EXCLUDED.public_key_algorithm,
+       public_key_size = EXCLUDED.public_key_size,
+       signature_algorithm = EXCLUDED.signature_algorithm,
+       not_before = EXCLUDED.not_before,
+       not_after = EXCLUDED.not_after,
+       key_mode = COALESCE(EXCLUDED.key_mode, managed_certificates.key_mode),
+       key_reference = COALESCE(EXCLUDED.key_reference, managed_certificates.key_reference),
+       public_metadata = EXCLUDED.public_metadata,
+       created_by = COALESCE(managed_certificates.created_by, EXCLUDED.created_by),
+       updated_at = NOW()
+     RETURNING *`,
+    params,
+  );
+
+  return toInventoryRecord(result.rows[0]);
+}
+
+async function importPublicCertificates(options) {
+  const certificates = parsePublicCertificateMaterial(options.certificatePem);
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    const items = [];
+    for (let index = 0; index < certificates.length; index += 1) {
+      items.push(
+        await upsertManagedCertificate(client, certificates[index], options, index),
+      );
+    }
+    await client.query("COMMIT");
+    return items;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function listManagedCertificates({ workspaceId, limit, offset }) {
+  const normalizedLimit = normalizeLimit(limit);
+  const normalizedOffset = normalizeOffset(offset);
+  const result = await pool.query(
+    `SELECT *
+       FROM managed_certificates
+      WHERE workspace_id = $1
+      ORDER BY not_after ASC NULLS LAST, created_at DESC, id ASC
+      LIMIT $2 OFFSET $3`,
+    [workspaceId, normalizedLimit, normalizedOffset],
+  );
+
+  return {
+    items: result.rows.map(toInventoryRecord),
+    pagination: {
+      limit: normalizedLimit,
+      offset: normalizedOffset,
+    },
+  };
+}
+
+async function getManagedCertificate({ workspaceId, certId }) {
+  const result = await pool.query(
+    `SELECT *
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND id = $2
+      LIMIT 1`,
+    [workspaceId, certId],
+  );
+
+  return toInventoryRecord(result.rows[0] || null);
+}
+
+module.exports = {
+  CERTOPS_CERTIFICATE_NOT_FOUND,
+  CERTOPS_CERTIFICATE_PARSE_FAILED,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  getManagedCertificate,
+  importPublicCertificates,
+  listManagedCertificates,
+  normalizeLimit,
+  normalizeOffset,
+  toInventoryRecord,
+};

--- a/apps/api/services/certops/settings.js
+++ b/apps/api/services/certops/settings.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const { pool } = require("../../db/database");
+
+const CERTOPS_DISABLED = "CERTOPS_DISABLED";
+
+function parseBoolean(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on", "enabled"].includes(normalized)) return true;
+  if (["0", "false", "no", "off", "disabled"].includes(normalized)) return false;
+  return null;
+}
+
+function envCertOpsEnabled(env = process.env) {
+  return parseBoolean(env.CERTOPS_ENABLED);
+}
+
+async function dbCertOpsEnabled(dbPool = pool) {
+  try {
+    const { rows } = await dbPool.query(
+      "SELECT certops_settings FROM system_settings WHERE id = 1",
+    );
+    const settings = rows[0]?.certops_settings;
+    if (!settings || typeof settings !== "object") return null;
+    return parseBoolean(settings.enabled);
+  } catch (err) {
+    if (err?.code === "42P01" || err?.code === "42703") return null;
+    throw err;
+  }
+}
+
+async function isCertOpsEnabled({ dbPool = pool, env = process.env } = {}) {
+  const envValue = envCertOpsEnabled(env);
+  if (envValue !== null) return envValue;
+
+  const dbValue = await dbCertOpsEnabled(dbPool);
+  if (dbValue !== null) return dbValue;
+
+  return false;
+}
+
+module.exports = {
+  CERTOPS_DISABLED,
+  dbCertOpsEnabled,
+  envCertOpsEnabled,
+  isCertOpsEnabled,
+  parseBoolean,
+};

--- a/deploy/compose/docker-compose.test.yml
+++ b/deploy/compose/docker-compose.test.yml
@@ -48,6 +48,8 @@ services:
       # URLs
       - APP_URL=http://localhost:5173
       - API_URL=http://localhost:4000
+      # CertOps route tests intentionally enable the dark-launch flag.
+      - CERTOPS_ENABLED=${CERTOPS_ENABLED:-true}
       # Auth
       - SESSION_SECRET=test-session-secret-key
       # SMTP (MailHog)

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -196,6 +196,43 @@ describe("CertOps inventory routes", function () {
     expectNoPrivateKeyFields(leafCertificate);
   });
 
+  it("accepts a valid external key mode", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({
+        certificatePem: PUBLIC_CA_CERT,
+        keyMode: " external-unknown ",
+      })
+      .expect(202);
+
+    expect(response.body.count).to.equal(1);
+    expect(response.body.items[0].keyMode).to.equal("external-unknown");
+    expectNoPrivateKeyFields(response.body.items[0]);
+  });
+
+  it("rejects invalid keyMode with a controlled validation error", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({
+        certificatePem: PUBLIC_LEAF_CERT,
+        keyMode: "invalid-mode",
+      });
+
+    expect(response.status).to.equal(400);
+    expect(response.body).to.deep.equal({
+      error: "Invalid CertOps key mode",
+      code: "CERTOPS_KEY_MODE_INVALID",
+    });
+    expect(Object.keys(response.body).sort()).to.deep.equal(["code", "error"]);
+    expect(response.text).to.not.include("violates check constraint");
+    expect(response.text).to.not.include("managed_certificates");
+    expect(response.text).to.not.include("key_mode");
+    expect(response.text).to.not.include("PUBLIC_LEAF_CERT");
+    expectNoPrivateKeyFields(response.body);
+  });
+
   it("deduplicates by workspace and SHA-256 fingerprint", async () => {
     const duplicate = await request(BASE)
       .post(`/api/v1/workspaces/${workspaceId}/certops/certificates`)

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -1,0 +1,306 @@
+const path = require("path");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, request, TestUtils } = require("./setup");
+const { runMigrations } = require(
+  path.resolve(__dirname, "../../apps/api/migrations/migrate.js"),
+);
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+const PUBLIC_LEAF_CERT = `
+-----BEGIN CERTIFICATE-----
+MIIDgjCCAmqgAwIBAgIUKJShixxx/7TH81hKwHE3UsvIFMkwDQYJKoZIhvcNAQEL
+BQAwNDEYMBYGA1UEAwwPY2VydG9wcy5leGFtcGxlMRgwFgYDVQQKDA9Ub2tlblRp
+bWVyIFRlc3QwHhcNMjYwNjI2MDA0MDU5WhcNMjcwNjI2MDA0MDU5WjA0MRgwFgYD
+VQQDDA9jZXJ0b3BzLmV4YW1wbGUxGDAWBgNVBAoMD1Rva2VuVGltZXIgVGVzdDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANoaAIgElNelqNg6TsY++HnK
+rFeOgn7csJYu9AbFfQRAoFO592aVI9QdyejoGesSy+tDN06vJl411Ntz6caB2+fd
++qkllZ+c39IZEbp++PDp7dD+4aEC68tGoZ9F/9dOGRaZ4xSFp0W0+5hd8E5q4E9U
+MSdc4cUjQKuZX+jwBQqy+SRxhhNh6GPVWg3Cr6W0F53yFxWlb8q+4cwOZg0AP7sK
+2u8UvordGO3o4eiPsVtmRh87YeRnUDRuzPb4Mi/Fo9Cr+1Fq3Q3xdWH9LhP0DSmD
+89Ho84nvn+DfM+Dbnb7PsmNgqOVictn/LxHMOrl1F04BkvY9rNuBkh7wHC7TOR8C
+AwEAAaOBizCBiDAdBgNVHQ4EFgQUoOXgW3/xFso+3GDIpFqimZ2K2TUwHwYDVR0j
+BBgwFoAUoOXgW3/xFso+3GDIpFqimZ2K2TUwDwYDVR0TAQH/BAUwAwEB/zA1BgNV
+HREELjAsgg9jZXJ0b3BzLmV4YW1wbGWCE2FwaS5jZXJ0b3BzLmV4YW1wbGWHBH8A
+AAEwDQYJKoZIhvcNAQELBQADggEBAGi4XAScskH5bdxNbXwtEqlep2eDyseUyulF
+g2yILrkiA22+WveOZrmReuxHx+umHVAO4O6JtHwD1figZyKgCrMzrREqmRwGj6pb
+jgaW6Eeck+zFh1cKTH6ZUYlN6yOHOhKR0nBnseSuoh/gEangQVLRug3SqCCi6GQI
+aOAUKMHYsxTyfjtE2k7URQYy7fbfLW/k+68l+xI/ktwFlS+MncmrS+Lx+dWwxVCn
+EucPyYnACaKyw2oY6kCVaW9OReglxzoFzLxZvqxyrA1LpWjzgJiR7nIpZCappsi9
+gB1JS6DPep8dhLORucnHS/Opy2xOB0lB3kmNoh5bierJUVeReSc=
+-----END CERTIFICATE-----
+`;
+
+const PUBLIC_CA_CERT = `
+-----BEGIN CERTIFICATE-----
+MIIDaDCCAlCgAwIBAgIUdCT2l9wFjDoFlfsF97QP3v7uq5IwDQYJKoZIhvcNAQEL
+BQAwNDEYMBYGA1UEAwwPQ2VydE9wcyBUZXN0IENBMRgwFgYDVQQKDA9Ub2tlblRp
+bWVyIFRlc3QwHhcNMjYwNjI2MDA0MTA3WhcNMjgwNjI1MDA0MTA3WjA0MRgwFgYD
+VQQDDA9DZXJ0T3BzIFRlc3QgQ0ExGDAWBgNVBAoMD1Rva2VuVGltZXIgVGVzdDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANupE0mTV+O2+WJOXL/nj/Cw
+JzVE6KVygV/W8MZWg3yN+FFzO/o+AcCxJlRgnDdkF9P8CWmhsDZ4GfVZtTfjuQeT
+lu2Y5LG3fDGN3cxJovrbGjA1TbIRIODE7C5jAPJMvwmXE9PJO0nJnuhE15xKU7IZ
+2zk6fO/TwG7FfCqS9NBccbtHKB9sV/4dBf2GZ1eT8VMWLeUPrKFbAitQ7tgFb6h2
+MLKfMjfqbW+IYchp53YSPS8k/alXJRi84Ev6tDASrZoaYTjRO0Ps1QFa9tVBAQLg
+fa/4IpcXZmItiTYZlVAHN90WhbxZOiY5GiirZWWLkcUv9pSOHv07awzDolek/MkC
+AwEAAaNyMHAwHQYDVR0OBBYEFMET4X2O2V7eGtpu6k8TjKLtf6AxMB8GA1UdIwQY
+MBaAFMET4X2O2V7eGtpu6k8TjKLtf6AxMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0R
+BBYwFIISY2EuY2VydG9wcy5leGFtcGxlMA0GCSqGSIb3DQEBCwUAA4IBAQBUjILj
+UB9s79qPbzSVE4uZ+zMatfiOxG4PnF46iNJg1iRJJ1w3FOcjlj1FxO19RsRlqyOf
+2rICSmyiSGundtu7u7cFVK0OFhNr8Da9ugm0tqiHh5ZtwGCfbDirLDIwPuL2nelR
+8bk/cUepTFC1NAmRRa8cX3HgaEzY8YFThZ/JR1ps0/iWOMxC1MWdSNPgSrgX2DQ1
+Wyd4gytVWmsBFmV4Xvc2wshwjy56jm60KaaNAWN/N6xSL5ay5+ImaBm1g2rapCMU
+WXYC1Jw/NQfgLOwRIlX/AmpCib6udusu0XruVpYvBu9E2RxbaRto34iLQdUtrNN/
+o9wtTp83p6p21Okl
+-----END CERTIFICATE-----
+`;
+
+const PRIVATE_KEY_PEM = `
+-----BEGIN RSA PRIVATE KEY-----
+RkFLRS1OT1QtQS1SRUFMLUtFWQ==
+-----END RSA PRIVATE KEY-----
+`;
+
+async function primaryWorkspaceId(session) {
+  const response = await request(BASE)
+    .get("/api/v1/workspaces?limit=50&offset=0")
+    .set("Cookie", session.cookie)
+    .expect(200);
+  return response.body.items[0].id;
+}
+
+function walkKeys(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkKeys(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    visit(key);
+    walkKeys(item, visit);
+  }
+}
+
+function expectNoPrivateKeyFields(value) {
+  const forbiddenFragments = [
+    "private",
+    "pkcs12",
+    "pfx",
+    "key_material",
+    "key_pem",
+    "key_der",
+    "raw_key",
+    "backup",
+    "secret",
+    "credential",
+    "password",
+  ];
+
+  walkKeys(value, (key) => {
+    for (const fragment of forbiddenFragments) {
+      expect(
+        key.toLowerCase().includes(fragment),
+        `${key} looks like private-key custody`,
+      ).to.equal(false);
+    }
+  });
+  expect(JSON.stringify(value)).to.not.include("PRIVATE KEY");
+}
+
+describe("CertOps inventory routes", function () {
+  this.timeout(90000);
+
+  let ownerUser;
+  let ownerSession;
+  let managerUser;
+  let managerSession;
+  let viewerUser;
+  let viewerSession;
+  let outsiderUser;
+  let outsiderSession;
+  let workspaceId;
+  let outsiderWorkspaceId;
+  let leafCertificate;
+
+  before(async () => {
+    await runMigrations();
+
+    ownerUser = await TestUtils.createVerifiedTestUser();
+    ownerSession = await TestUtils.loginTestUser(
+      ownerUser.email,
+      "SecureTest123!@#",
+    );
+    workspaceId = await primaryWorkspaceId(ownerSession);
+
+    managerUser = await TestUtils.createVerifiedTestUser();
+    managerSession = await TestUtils.loginTestUser(
+      managerUser.email,
+      "SecureTest123!@#",
+    );
+    viewerUser = await TestUtils.createVerifiedTestUser();
+    viewerSession = await TestUtils.loginTestUser(
+      viewerUser.email,
+      "SecureTest123!@#",
+    );
+    outsiderUser = await TestUtils.createVerifiedTestUser();
+    outsiderSession = await TestUtils.loginTestUser(
+      outsiderUser.email,
+      "SecureTest123!@#",
+    );
+    outsiderWorkspaceId = await primaryWorkspaceId(outsiderSession);
+
+    await TestUtils.execQuery(
+      `INSERT INTO workspace_memberships (user_id, workspace_id, role, invited_by)
+       VALUES ($1, $2, 'workspace_manager', $3), ($4, $2, 'viewer', $3)
+       ON CONFLICT (user_id, workspace_id) DO UPDATE SET role = EXCLUDED.role`,
+      [managerUser.id, workspaceId, ownerUser.id, viewerUser.id],
+    );
+  });
+
+  after(async () => {
+    for (const [user, session] of [
+      [ownerUser, ownerSession],
+      [managerUser, managerSession],
+      [viewerUser, viewerSession],
+      [outsiderUser, outsiderSession],
+    ]) {
+      if (user?.email && session?.cookie) {
+        await TestUtils.cleanupTestUser(user.email, session.cookie);
+      }
+    }
+  });
+
+  it("imports a public certificate and returns normalized inventory data", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: `\n\n${PUBLIC_LEAF_CERT}\n` })
+      .expect(202);
+
+    expect(response.body.count).to.equal(1);
+    leafCertificate = response.body.items[0];
+    expect(leafCertificate.schemaVersion).to.equal(1);
+    expect(leafCertificate.workspaceId).to.equal(workspaceId);
+    expect(leafCertificate.source).to.equal("import");
+    expect(leafCertificate.commonName).to.equal("certops.example");
+    expect(leafCertificate.subjectAltNames).to.include("api.certops.example");
+    expect(leafCertificate.fingerprintSha256).to.match(/^[a-f0-9]{64}$/);
+    expect(leafCertificate.spkiFingerprintSha256).to.match(/^[a-f0-9]{64}$/);
+    expect(leafCertificate.notBefore).to.match(/^\d{4}-\d{2}-\d{2}T/);
+    expect(leafCertificate.notAfter).to.match(/^\d{4}-\d{2}-\d{2}T/);
+    expect(leafCertificate.certificatePem).to.include("BEGIN CERTIFICATE");
+    expectNoPrivateKeyFields(leafCertificate);
+  });
+
+  it("deduplicates by workspace and SHA-256 fingerprint", async () => {
+    const duplicate = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/certificates`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_LEAF_CERT })
+      .expect(201);
+
+    expect(duplicate.body.count).to.equal(1);
+    expect(duplicate.body.items[0].id).to.equal(leafCertificate.id);
+
+    const list = await request(BASE)
+      .get(`/api/v1/workspaces/${workspaceId}/certops/certificates`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+    const matching = list.body.items.filter(
+      (item) => item.fingerprintSha256 === leafCertificate.fingerprintSha256,
+    );
+    expect(matching).to.have.length(1);
+  });
+
+  it("allows a workspace manager to import a public certificate chain", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", managerSession.cookie)
+      .send({ certificatePem: `${PUBLIC_LEAF_CERT}\n${PUBLIC_CA_CERT}` })
+      .expect(202);
+
+    expect(response.body.count).to.equal(2);
+    expect(response.body.items.map((item) => item.commonName)).to.include(
+      "CertOps Test CA",
+    );
+  });
+
+  it("allows viewers to list and fetch certificates in their workspace", async () => {
+    const list = await request(BASE)
+      .get(`/api/v1/workspaces/${workspaceId}/certops/certificates`)
+      .set("Cookie", viewerSession.cookie)
+      .expect(200);
+
+    expect(list.body.items.map((item) => item.id)).to.include(
+      leafCertificate.id,
+    );
+
+    const detail = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${leafCertificate.id}`,
+      )
+      .set("Cookie", viewerSession.cookie)
+      .expect(200);
+
+    expect(detail.body.certificate.id).to.equal(leafCertificate.id);
+    expect(detail.body.certificate.workspaceId).to.equal(workspaceId);
+    expectNoPrivateKeyFields(detail.body.certificate);
+  });
+
+  it("denies viewer writes", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", viewerSession.cookie)
+      .send({ certificatePem: PUBLIC_CA_CERT });
+
+    expect(response.status).to.equal(403);
+    expect(response.body.code).to.equal("INSUFFICIENT_ROLE");
+  });
+
+  it("keeps certificate detail and list access isolated by workspace", async () => {
+    const crossWorkspaceDetail = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${outsiderWorkspaceId}/certops/certificates/${leafCertificate.id}`,
+      )
+      .set("Cookie", outsiderSession.cookie);
+
+    expect(crossWorkspaceDetail.status).to.equal(404);
+    expect(crossWorkspaceDetail.body.code).to.equal(
+      "CERTOPS_CERTIFICATE_NOT_FOUND",
+    );
+
+    const outsiderList = await request(BASE)
+      .get(`/api/v1/workspaces/${outsiderWorkspaceId}/certops/certificates`)
+      .set("Cookie", outsiderSession.cookie)
+      .expect(200);
+    expect(outsiderList.body.items).to.deep.equal([]);
+  });
+
+  it("rejects private key material without echoing raw input", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: `${PUBLIC_LEAF_CERT}\n${PRIVATE_KEY_PEM}` });
+
+    expect(response.status).to.equal(422);
+    expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expect(response.text).to.not.include("RSA PRIVATE KEY");
+    expect(response.text).to.not.include("RkFLRS1OT1QtQS1SRUFMLUtFWQ");
+  });
+
+  it("rejects malformed certificate input with a stable code", async () => {
+    const malformed = "not a public certificate";
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: malformed });
+
+    expect(response.status).to.equal(400);
+    expect(response.body.code).to.equal("CERTOPS_CERTIFICATE_PARSE_FAILED");
+    expect(response.text).to.not.include(malformed);
+  });
+});

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -87,6 +87,7 @@ tests/integration/audit-system-admin-org-scope.test.js
 # Schema and utilities
 tests/integration/database-schema.test.js
 tests/integration/certops-migration.test.js
+tests/integration/certops-inventory.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js
 tests/integration/vault.parsing.unit.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -85,6 +85,7 @@ tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
 tests/integration/certops-migration.test.js
+tests/integration/certops-inventory.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-settings.test.js
+++ b/tests/unit/certops-settings.test.js
@@ -1,0 +1,142 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  dbCertOpsEnabled,
+  envCertOpsEnabled,
+  isCertOpsEnabled,
+  parseBoolean,
+} = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/settings.js"),
+);
+const {
+  NOT_FOUND_RESPONSE,
+  createRequireCertOpsEnabled,
+} = require(
+  path.resolve(__dirname, "../../apps/api/middleware/require-certops-enabled.js"),
+);
+
+function poolReturning(settings) {
+  return {
+    async query() {
+      return { rows: [{ certops_settings: settings }] };
+    },
+  };
+}
+
+function poolThrowing(code) {
+  return {
+    async query() {
+      const error = new Error("database error");
+      error.code = code;
+      throw error;
+    },
+  };
+}
+
+function responseRecorder() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+describe("CertOps rollout settings", () => {
+  it("parses common boolean forms", () => {
+    assert.equal(parseBoolean(true), true);
+    assert.equal(parseBoolean(false), false);
+    assert.equal(parseBoolean("true"), true);
+    assert.equal(parseBoolean("1"), true);
+    assert.equal(parseBoolean("enabled"), true);
+    assert.equal(parseBoolean("false"), false);
+    assert.equal(parseBoolean("0"), false);
+    assert.equal(parseBoolean("disabled"), false);
+    assert.equal(parseBoolean("maybe"), null);
+    assert.equal(parseBoolean(undefined), null);
+  });
+
+  it("uses CERTOPS_ENABLED from the environment", () => {
+    assert.equal(envCertOpsEnabled({ CERTOPS_ENABLED: "true" }), true);
+    assert.equal(envCertOpsEnabled({ CERTOPS_ENABLED: "false" }), false);
+    assert.equal(envCertOpsEnabled({}), null);
+  });
+
+  it("reads certops_settings.enabled when the DB column exists", async () => {
+    assert.equal(await dbCertOpsEnabled(poolReturning({ enabled: true })), true);
+    assert.equal(await dbCertOpsEnabled(poolReturning({ enabled: false })), false);
+    assert.equal(await dbCertOpsEnabled(poolReturning({})), null);
+  });
+
+  it("treats a missing certops_settings column as unset", async () => {
+    assert.equal(await dbCertOpsEnabled(poolThrowing("42703")), null);
+    assert.equal(await dbCertOpsEnabled(poolThrowing("42P01")), null);
+  });
+
+  it("defaults to false and gives env precedence over DB", async () => {
+    assert.equal(
+      await isCertOpsEnabled({
+        env: {},
+        dbPool: poolReturning({ enabled: true }),
+      }),
+      true,
+    );
+    assert.equal(
+      await isCertOpsEnabled({
+        env: { CERTOPS_ENABLED: "false" },
+        dbPool: poolReturning({ enabled: true }),
+      }),
+      false,
+    );
+    assert.equal(
+      await isCertOpsEnabled({
+        env: {},
+        dbPool: poolReturning({}),
+      }),
+      false,
+    );
+  });
+});
+
+describe("requireCertOpsEnabled middleware", () => {
+  it("passes through when enabled", async () => {
+    const middleware = createRequireCertOpsEnabled({
+      flagResolver: async () => true,
+    });
+    const res = responseRecorder();
+    let nextCalled = false;
+
+    await middleware({}, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.statusCode, null);
+  });
+
+  it("returns the standard not-found response when disabled", async () => {
+    const middleware = createRequireCertOpsEnabled({
+      flagResolver: async () => false,
+    });
+    const res = responseRecorder();
+    let nextCalled = false;
+
+    await middleware({}, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(res.body, NOT_FOUND_RESPONSE);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the M1-A4 CertOps inventory API routes behind the `certops.enabled` gate.

* Adds workspace-scoped CertOps inventory routes:

  * `GET /api/v1/workspaces/:id/certops/certificates`
  * `POST /api/v1/workspaces/:id/certops/certificates`
  * `GET /api/v1/workspaces/:id/certops/certificates/:certId`
  * `POST /api/v1/workspaces/:id/certops/imports`
* Adds the CertOps inventory service layer.
* Adds `requireCertOpsEnabled` middleware.
* Adds CertOps settings resolution with `CERTOPS_ENABLED` env > optional `system_settings.certops_settings.enabled` > default `false`.
* Returns standard `404 { code: "NOT_FOUND" }` when CertOps routes are disabled.
* Keeps M1-A3 private-key rejection active on write routes before the feature gate, so key material still receives `422 PRIVATE_KEY_MATERIAL_REJECTED`.
* Supports public PEM certificate import/register using the M1-A2 parser.
* Deduplicates certificates by `workspace_id` + `fingerprint_sha256`.
* Enforces workspace isolation with safe 404 behavior for cross-workspace certificate IDs.
* Allows viewer read access and manager/admin write access.
* Records synchronous audit events for successful import/register using public IDs, fingerprints, and counts only.

## Verification

* `node --check apps/api/index.js`: ok
* `node --check apps/api/routes/certops.js`: ok
* `node --check apps/api/services/certops/inventory.js`: ok
* `node --check apps/api/services/certops/settings.js`: ok
* `node --check apps/api/middleware/require-certops-enabled.js`: ok
* `node --check tests/integration/certops-inventory.test.js`: ok
* `git diff --check`: ok
* `pnpm run test:unit`: ok
* `pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 60000 --exit`: ok with `CERTOPS_ENABLED=true`
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on M1-A3: `feature/certops-m1-a3-key-rejection`.
* No contract/OpenAPI changes were needed because the frozen M1 route paths already existed.
* `certops.enabled` now defaults to disabled unless enabled through environment/test configuration or a future DB-backed settings overlay.
* Full DB-managed CertOps settings persistence is not added in this slice.
* No endpoint-monitor bridge, dashboard/Cloud overlay, executor, agent, ACME, cert-manager, Helm, RBAC, api_tokens, jobs, or evidence work is included.
* Invalid `keyMode` now returns HTTP 400 `CERTOPS_KEY_MODE_INVALID` before hitting the DB constraint.
* `certops-inventory.test.js` is now classified in both core and core-compatible suites.
* M1 Core keeps `CERTOPS_ENABLED` as the authoritative rollout control; DB-backed `certops_settings` persistence is deferred.

## Test plan

* [ ] Review `apps/api/routes/certops.js`
* [ ] Review `apps/api/services/certops/inventory.js`
* [ ] Review `apps/api/services/certops/settings.js`
* [ ] Review `apps/api/middleware/require-certops-enabled.js`
* [ ] Review `tests/integration/certops-inventory.test.js`
* [ ] Run `pnpm run test:unit`
* [ ] Run `pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 60000 --exit`
* [ ] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
