### PR TITLE
feat(certops): bridge endpoint monitor observations to inventory m1-a5

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,14 +67,19 @@ Core rollout control for M1. The optional
 the JSONB column and admin settings persistence are deferred. The resolver must
 continue to fall back safely when that column is absent.
 
-## M1 follow-ups
+## M1 monitor bridge and instance history
 
-- Certificate instance history needs a public, workspace-scoped read endpoint
-  after the monitor bridge writes `certificate_instances`, preferably in #46 or
-  a focused follow-up. It should return public observation fields only, such as
-  `observedAt`, `status`, `deploymentReference`, `observedSubject`,
-  `observedIssuer`, `observedSerialNumber`, `observedFingerprintSha256`, and
-  `source`; it must never expose private key material or secret fields.
+- Existing endpoint/domain monitors populate CertOps inventory on their next
+  public certificate observation/check cycle. M1 does not add a historical
+  backfill job or admin UI; existing monitor recheck flows, where present, use
+  the same bridge path.
+- Certificate instance history is available at
+  `GET /api/v1/workspaces/:id/certops/certificates/:certId/instances`. It is
+  workspace-scoped, gated by `certops.enabled`, and returns public observation
+  fields only, such as `observedAt`, `status`, `deploymentReference`,
+  `observedSubject`, `observedIssuer`, `observedSerialNumber`,
+  `observedFingerprintSha256`, and `source`. It must never expose private key
+  material, evidence, or secret fields.
 
 ## Editions
 

--- a/apps/api/routes/admin.js
+++ b/apps/api/routes/admin.js
@@ -25,6 +25,13 @@ const {
   fetchHostnameCertificate,
   liveCertificateImportSkipDetail,
 } = require("../services/domainChecker");
+const {
+  bridgeEndpointCertificateObservation,
+} = require("../services/certops/monitorBridge");
+const { containsPrivateKeyMaterial } = require("../utils/secretMaterial");
+const {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+} = require("../middleware/reject-key-material");
 
 const DNS_LIVE_CERT_SKIP_DETAILS = new Set([
   "live_certificate_dns_unresolved",
@@ -73,6 +80,22 @@ function normalizeTokenSectionInput(value) {
   }
   const uniq = [...new Set(flat)];
   return uniq.length ? uniq : null;
+}
+
+async function recordCertOpsMonitorObservation(options) {
+  try {
+    await bridgeEndpointCertificateObservation({
+      dbPool: pool,
+      ...options,
+    });
+  } catch (err) {
+    logger.warn("CertOps monitor bridge failed", {
+      workspaceId: options.workspaceId,
+      domainMonitorId: options.domainMonitorId,
+      code: err.code || null,
+      error: err.message,
+    });
+  }
 }
 
 // ============================================================
@@ -805,6 +828,12 @@ router.post(
           code: "NO_CERTIFICATES_SELECTED",
         });
       }
+      if (containsPrivateKeyMaterial(certificates)) {
+        return res.status(422).json({
+          error: "Private key material is not accepted in certificate imports",
+          code: PRIVATE_KEY_MATERIAL_REJECTED,
+        });
+      }
       const importMax = getDomainCheckerImportMaxCertificates("oss");
       if (certificates.length > importMax) {
         return res.status(400).json({
@@ -1028,13 +1057,31 @@ router.post(
           for (const certDomain of certDomains) {
             const monitorUrl = `https://${certDomain}`;
             const existingMonitor = await pool.query(
-              `SELECT id FROM domain_monitors
+              `SELECT id, token_id FROM domain_monitors
                WHERE workspace_id = $1 AND url = $2
                LIMIT 1`,
               [req.workspace.id, monitorUrl],
             );
             if (existingMonitor.rows[0]?.id) {
               monitorsExisting += 1;
+              await recordCertOpsMonitorObservation({
+                workspaceId: req.workspace.id,
+                createdBy: req.user.id,
+                domainMonitorId: existingMonitor.rows[0].id,
+                tokenId:
+                  existingMonitor.rows[0].token_id || tokenResult.rows[0].id,
+                url: monitorUrl,
+                hostname: certDomain,
+                source: "domain_checker",
+                sourceRef: sourceCertId || certificate.id || certDomain,
+                certificate: {
+                  issuer,
+                  subject,
+                  serialNumber,
+                  fingerprintSha256: tlsFingerprint,
+                  notAfter: expiration,
+                },
+              });
               continue;
             }
             let monitorSslValidTo = null;
@@ -1049,12 +1096,13 @@ router.post(
             } catch (_) {}
             const monitorValidated = Boolean(monitorSslValidTo);
             const monitorValidatedAt = monitorValidated ? new Date() : null;
-            await pool.query(
+            const monitorResult = await pool.query(
               `INSERT INTO domain_monitors
                  (workspace_id, url, validated, validated_at,
                   ssl_issuer, ssl_subject, ssl_valid_from, ssl_valid_to, ssl_serial, ssl_fingerprint,
                   token_id, health_check_enabled, check_interval, alert_after_failures, created_by)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+               RETURNING id, token_id`,
               [
                 req.workspace.id,
                 monitorUrl,
@@ -1073,6 +1121,23 @@ router.post(
                 req.user.id,
               ],
             );
+            await recordCertOpsMonitorObservation({
+              workspaceId: req.workspace.id,
+              createdBy: req.user.id,
+              domainMonitorId: monitorResult.rows[0].id,
+              tokenId: tokenResult.rows[0].id,
+              url: monitorUrl,
+              hostname: certDomain,
+              source: "domain_checker",
+              sourceRef: sourceCertId || certificate.id || certDomain,
+              certificate: {
+                issuer,
+                subject,
+                serialNumber,
+                fingerprintSha256: tlsFingerprint,
+                notAfter: monitorSslValidTo || expiration,
+              },
+            });
             monitorsCreated += 1;
           }
         }
@@ -1248,6 +1313,8 @@ router.post(
               ssl_valid_to: cert.valid_to ? new Date(cert.valid_to) : null,
               ssl_serial: x509.serialNumber || cert.serialNumber || null,
               ssl_fingerprint: cert.fingerprint256 || cert.fingerprint || null,
+              public_certificate_pem:
+                typeof x509.toString === "function" ? x509.toString() : null,
             };
           }
         }
@@ -1345,6 +1412,28 @@ router.post(
             error: tokenErr.message,
           });
         }
+      }
+
+      if (sslData.ssl_valid_to) {
+        await recordCertOpsMonitorObservation({
+          workspaceId: req.workspace.id,
+          createdBy: req.user.id,
+          domainMonitorId: domainRow.id,
+          tokenId: domainRow.token_id || null,
+          url: normalizedUrl,
+          hostname: parsedUrl.hostname,
+          source: "endpoint_monitor",
+          sourceRef: domainRow.id,
+          certificate: {
+            issuer: sslData.ssl_issuer,
+            subject: sslData.ssl_subject,
+            serialNumber: sslData.ssl_serial,
+            fingerprintSha256: sslData.ssl_fingerprint,
+            notBefore: sslData.ssl_valid_from,
+            notAfter: sslData.ssl_valid_to,
+            certificatePem: sslData.public_certificate_pem,
+          },
+        });
       }
 
       try {

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -16,6 +16,7 @@ const {
   CERTOPS_KEY_MODE_INVALID,
   getManagedCertificate,
   importPublicCertificates,
+  listCertificateInstances,
   listManagedCertificates,
 } = require("../services/certops/inventory");
 const { writeAudit } = require("../services/audit");
@@ -190,6 +191,50 @@ router.post(
   requireCertOpsEnabled,
   requireCertOpsWriteRole,
   (req, res) => importCertificatesHandler(req, res, "api", 201),
+);
+
+router.get(
+  "/api/v1/workspaces/:id/certops/certificates/:certId/instances",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    if (!UUID_PATTERN.test(String(req.params.certId || ""))) {
+      return res.status(404).json({
+        error: "Certificate not found",
+        code: "CERTOPS_CERTIFICATE_NOT_FOUND",
+      });
+    }
+
+    try {
+      const result = await listCertificateInstances({
+        workspaceId: req.workspace.id,
+        certId: req.params.certId,
+        limit: req.query.limit,
+        offset: req.query.offset,
+      });
+
+      if (!result) {
+        return res.status(404).json({
+          error: "Certificate not found",
+          code: "CERTOPS_CERTIFICATE_NOT_FOUND",
+        });
+      }
+
+      return res.json(result);
+    } catch (err) {
+      logger.error("CertOps certificate instances list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        certId: req.params?.certId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list certificate instances",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
 );
 
 router.get(

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -79,6 +79,32 @@ function toInventoryRecord(row) {
   };
 }
 
+function toInstanceRecord(row) {
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    managedCertificateId: row.managed_certificate_id,
+    targetId: row.target_id,
+    domainMonitorId: row.domain_monitor_id,
+    tokenId: row.token_id,
+    status: row.status,
+    source: row.source,
+    sourceRef: row.source_ref,
+    observedFingerprintSha256: row.observed_fingerprint_sha256,
+    observedSerialNumber: row.observed_serial_number,
+    observedSubject: row.observed_subject,
+    observedIssuer: row.observed_issuer,
+    observedNotBefore: dateToIso(row.observed_not_before),
+    observedNotAfter: dateToIso(row.observed_not_after),
+    deploymentReference: row.deployment_reference,
+    observedAt: dateToIso(row.observed_at),
+    createdAt: dateToIso(row.created_at),
+    updatedAt: dateToIso(row.updated_at),
+  };
+}
+
 function normalizeLimit(value) {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed)) return 50;
@@ -280,6 +306,34 @@ async function getManagedCertificate({ workspaceId, certId }) {
   return toInventoryRecord(result.rows[0] || null);
 }
 
+async function listCertificateInstances({ workspaceId, certId, limit, offset }) {
+  const certificate = await getManagedCertificate({ workspaceId, certId });
+  if (!certificate) return null;
+
+  const normalizedLimit = normalizeLimit(limit);
+  const normalizedOffset = normalizeOffset(offset);
+  const result = await pool.query(
+    `SELECT *
+       FROM certificate_instances
+      WHERE workspace_id = $1
+        AND managed_certificate_id = $2
+      ORDER BY observed_at DESC NULLS LAST,
+               updated_at DESC,
+               created_at DESC,
+               id ASC
+      LIMIT $3 OFFSET $4`,
+    [workspaceId, certId, normalizedLimit, normalizedOffset],
+  );
+
+  return {
+    items: result.rows.map(toInstanceRecord),
+    pagination: {
+      limit: normalizedLimit,
+      offset: normalizedOffset,
+    },
+  };
+}
+
 module.exports = {
   CERTOPS_CERTIFICATE_NOT_FOUND,
   CERTOPS_CERTIFICATE_PARSE_FAILED,
@@ -287,10 +341,12 @@ module.exports = {
   PRIVATE_KEY_MATERIAL_REJECTED,
   getManagedCertificate,
   importPublicCertificates,
+  listCertificateInstances,
   listManagedCertificates,
   normalizeKeyMode,
   normalizeLimit,
   normalizeOffset,
+  toInstanceRecord,
   toInventoryRecord,
   upsertManagedCertificate,
 };

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -292,4 +292,5 @@ module.exports = {
   normalizeLimit,
   normalizeOffset,
   toInventoryRecord,
+  upsertManagedCertificate,
 };

--- a/apps/api/services/certops/monitorBridge.js
+++ b/apps/api/services/certops/monitorBridge.js
@@ -1,0 +1,492 @@
+"use strict";
+
+const {
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  toInventoryRecord,
+  upsertManagedCertificate,
+} = require("./inventory");
+const { isCertOpsEnabled } = require("./settings");
+const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
+
+const CERTOPS_MONITOR_BRIDGE_SKIPPED = "CERTOPS_MONITOR_BRIDGE_SKIPPED";
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([_key, item]) => item !== undefined),
+  );
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function normalizeFingerprintSha256(value) {
+  const text = normalizeText(value);
+  if (!text) return null;
+  const compact = text.replace(/[:\s-]/g, "").toLowerCase();
+  if (/^[a-f0-9]{32,}$/.test(compact)) return compact;
+  return text.toLowerCase();
+}
+
+function commonNameFromSubject(subject) {
+  const text = normalizeText(subject);
+  if (!text) return null;
+  const match = text.match(/(?:^|\n|,\s*)CN\s*=\s*([^,\n]+)/i);
+  return match?.[1]?.trim() || null;
+}
+
+function rejectPrivateMaterial(value) {
+  if (!containsPrivateKeyMaterial(value)) return;
+  const error = new Error("Private key material is not accepted by CertOps");
+  error.code = PRIVATE_KEY_MATERIAL_REJECTED;
+  error.status = 422;
+  throw error;
+}
+
+function certificateFromObservation(options) {
+  const input = options.certificate || {};
+  rejectPrivateMaterial(input);
+
+  const subject = normalizeText(
+    input.subject || input.ssl_subject || input.commonName,
+  );
+  const issuer = normalizeText(input.issuer || input.ssl_issuer);
+  const serialNumber = normalizeText(
+    input.serialNumber || input.serial_number || input.ssl_serial,
+  );
+  const fingerprintSha256 = normalizeFingerprintSha256(
+    input.fingerprintSha256 ||
+      input.fingerprint256 ||
+      input.fingerprint ||
+      input.ssl_fingerprint,
+  );
+  const notBefore = normalizeDate(
+    input.notBefore || input.validFrom || input.ssl_valid_from,
+  );
+  const notAfter = normalizeDate(
+    input.notAfter ||
+      input.validTo ||
+      input.expiration ||
+      input.ssl_valid_to,
+  );
+  const certificatePem = normalizeText(
+    input.certificatePem || input.publicCertificatePem,
+  );
+
+  return {
+    commonName:
+      normalizeText(input.commonName) ||
+      commonNameFromSubject(subject) ||
+      normalizeText(options.hostname),
+    subjectAltNames: Array.isArray(input.subjectAltNames)
+      ? input.subjectAltNames.filter(Boolean)
+      : [],
+    issuer,
+    subject,
+    serialNumber,
+    certificatePem,
+    fingerprintSha256,
+    notBefore,
+    notAfter,
+  };
+}
+
+function hasPublicObservation(certificate) {
+  return Boolean(
+    certificate.fingerprintSha256 ||
+      certificate.serialNumber ||
+      certificate.subject ||
+      certificate.issuer ||
+      certificate.notAfter ||
+      certificate.certificatePem,
+  );
+}
+
+async function withBridgeClient(options, fn) {
+  if (options.client) return fn(options.client);
+  if (!options.dbPool || typeof options.dbPool.connect !== "function") {
+    throw new Error("CertOps monitor bridge requires a client or dbPool");
+  }
+
+  const client = await options.dbPool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+function bridgeSource(options) {
+  return normalizeText(options.source) || "endpoint_monitor";
+}
+
+function bridgeSourceRef(options) {
+  return normalizeText(options.sourceRef || options.domainMonitorId);
+}
+
+async function updateManagedCertificateToken(client, managedCertificate, tokenId) {
+  if (!tokenId || !managedCertificate?.id) return managedCertificate;
+  const result = await client.query(
+    `UPDATE managed_certificates
+        SET token_id = $1,
+            updated_at = NOW()
+      WHERE workspace_id = $2
+        AND id = $3
+      RETURNING *`,
+    [tokenId, managedCertificate.workspaceId, managedCertificate.id],
+  );
+  return toInventoryRecord(result.rows[0]);
+}
+
+async function existingManagedCertificate(client, options) {
+  const sourceRef = bridgeSourceRef(options);
+  if (!sourceRef) return null;
+
+  const result = await client.query(
+    `SELECT *
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND source = $2
+        AND source_ref = $3
+      ORDER BY updated_at DESC, created_at DESC
+      LIMIT 1`,
+    [options.workspaceId, bridgeSource(options), sourceRef],
+  );
+  return result.rows[0] ? toInventoryRecord(result.rows[0]) : null;
+}
+
+async function updateManagedCertificateFromObservation(
+  client,
+  managedCertificate,
+  certificate,
+  options,
+) {
+  const metadata = compactObject({
+    bridge: "certops-monitor-observation",
+    source: bridgeSource(options),
+    sourceRef: bridgeSourceRef(options),
+    domainMonitorId: normalizeText(options.domainMonitorId),
+    hostname: normalizeText(options.hostname),
+    url: normalizeText(options.url),
+  });
+  const result = await client.query(
+    `UPDATE managed_certificates
+        SET status = $3,
+            token_id = COALESCE($4, token_id),
+            name = COALESCE($5, name),
+            common_name = COALESCE($6, common_name),
+            issuer = COALESCE($7, issuer),
+            subject = COALESCE($8, subject),
+            serial_number = COALESCE($9, serial_number),
+            certificate_pem = COALESCE($10, certificate_pem),
+            not_before = COALESCE($11, not_before),
+            not_after = COALESCE($12, not_after),
+            public_metadata = public_metadata || $13::jsonb,
+            updated_at = NOW()
+      WHERE workspace_id = $1
+        AND id = $2
+      RETURNING *`,
+    [
+      options.workspaceId,
+      managedCertificate.id,
+      options.status || "discovered",
+      options.tokenId || null,
+      normalizeText(options.name || options.hostname),
+      certificate.commonName,
+      certificate.issuer,
+      certificate.subject,
+      certificate.serialNumber,
+      certificate.certificatePem,
+      certificate.notBefore,
+      certificate.notAfter,
+      JSON.stringify(metadata),
+    ],
+  );
+  return toInventoryRecord(result.rows[0]);
+}
+
+async function upsertObservedManagedCertificate(client, certificate, options) {
+  let managedCertificate = null;
+
+  if (!certificate.fingerprintSha256) {
+    managedCertificate = await existingManagedCertificate(client, options);
+    if (managedCertificate) {
+      return updateManagedCertificateFromObservation(
+        client,
+        managedCertificate,
+        certificate,
+        options,
+      );
+    }
+  }
+
+  managedCertificate = await upsertManagedCertificate(
+    client,
+    certificate,
+    {
+      workspaceId: options.workspaceId,
+      status: options.status || "discovered",
+      source: bridgeSource(options),
+      sourceRef: bridgeSourceRef(options),
+      name: options.name || options.hostname,
+      createdBy: options.createdBy || null,
+    },
+    0,
+  );
+
+  return updateManagedCertificateToken(client, managedCertificate, options.tokenId);
+}
+
+async function upsertCertificateTarget(client, options) {
+  const source = bridgeSource(options);
+  const sourceRef = bridgeSourceRef(options);
+  const hostname = normalizeText(options.hostname);
+  const url = normalizeText(options.url);
+  const name = normalizeText(options.targetName || hostname || url) || "endpoint";
+  const metadata = compactObject({
+    bridge: "certops-monitor-observation",
+    source,
+    sourceRef,
+    hostname,
+    url,
+  });
+
+  const existing = await client.query(
+    `SELECT *
+       FROM certificate_targets
+      WHERE workspace_id = $1
+        AND domain_monitor_id = $2
+      ORDER BY updated_at DESC, created_at DESC
+      LIMIT 1`,
+    [options.workspaceId, options.domainMonitorId],
+  );
+
+  if (existing.rows[0]) {
+    const result = await client.query(
+      `UPDATE certificate_targets
+          SET token_id = COALESCE($3, token_id),
+              name = COALESCE($4, name),
+              target_type = $5,
+              status = 'active',
+              source = $6,
+              source_ref = COALESCE($7, source_ref),
+              hostname = COALESCE($8, hostname),
+              url = COALESCE($9, url),
+              deployment_reference = COALESCE($10, deployment_reference),
+              public_metadata = public_metadata || $11::jsonb,
+              updated_at = NOW()
+        WHERE workspace_id = $1
+          AND id = $2
+        RETURNING *`,
+      [
+        options.workspaceId,
+        existing.rows[0].id,
+        options.tokenId || null,
+        name,
+        options.targetType || "endpoint",
+        source,
+        sourceRef,
+        hostname,
+        url,
+        url || hostname,
+        JSON.stringify(metadata),
+      ],
+    );
+    return result.rows[0];
+  }
+
+  const result = await client.query(
+    `INSERT INTO certificate_targets (
+       workspace_id,
+       domain_monitor_id,
+       token_id,
+       name,
+       target_type,
+       status,
+       source,
+       source_ref,
+       hostname,
+       url,
+       deployment_reference,
+       public_metadata,
+       created_by
+     )
+     VALUES ($1, $2, $3, $4, $5, 'active', $6, $7, $8, $9, $10, $11::jsonb, $12)
+     RETURNING *`,
+    [
+      options.workspaceId,
+      options.domainMonitorId,
+      options.tokenId || null,
+      name,
+      options.targetType || "endpoint",
+      source,
+      sourceRef,
+      hostname,
+      url,
+      url || hostname,
+      JSON.stringify(metadata),
+      options.createdBy || null,
+    ],
+  );
+  return result.rows[0];
+}
+
+async function upsertCertificateInstance(
+  client,
+  certificate,
+  managedCertificate,
+  target,
+  options,
+) {
+  const source = bridgeSource(options);
+  const sourceRef = bridgeSourceRef(options);
+  const metadata = compactObject({
+    bridge: "certops-monitor-observation",
+    source,
+    sourceRef,
+    domainMonitorId: normalizeText(options.domainMonitorId),
+    hostname: normalizeText(options.hostname),
+    url: normalizeText(options.url),
+    tokenLinked: Boolean(options.tokenId),
+  });
+  const observedAt = normalizeDate(options.observedAt) || new Date();
+
+  const result = await client.query(
+    `INSERT INTO certificate_instances (
+       workspace_id,
+       managed_certificate_id,
+       target_id,
+       domain_monitor_id,
+       token_id,
+       status,
+       source,
+       source_ref,
+       observed_fingerprint_sha256,
+       observed_serial_number,
+       observed_subject,
+       observed_issuer,
+       observed_not_before,
+       observed_not_after,
+       deployment_reference,
+       observed_at,
+       public_metadata,
+       created_by
+     )
+     VALUES (
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+       $11, $12, $13, $14, $15, $16, $17::jsonb, $18
+     )
+     ON CONFLICT (workspace_id, target_id, managed_certificate_id)
+     DO UPDATE SET
+       domain_monitor_id = EXCLUDED.domain_monitor_id,
+       token_id = COALESCE(EXCLUDED.token_id, certificate_instances.token_id),
+       status = EXCLUDED.status,
+       source = EXCLUDED.source,
+       source_ref = COALESCE(EXCLUDED.source_ref, certificate_instances.source_ref),
+       observed_fingerprint_sha256 = EXCLUDED.observed_fingerprint_sha256,
+       observed_serial_number = EXCLUDED.observed_serial_number,
+       observed_subject = EXCLUDED.observed_subject,
+       observed_issuer = EXCLUDED.observed_issuer,
+       observed_not_before = EXCLUDED.observed_not_before,
+       observed_not_after = EXCLUDED.observed_not_after,
+       deployment_reference = EXCLUDED.deployment_reference,
+       observed_at = EXCLUDED.observed_at,
+       public_metadata = EXCLUDED.public_metadata,
+       updated_at = NOW()
+     RETURNING *`,
+    [
+      options.workspaceId,
+      managedCertificate.id,
+      target.id,
+      options.domainMonitorId,
+      options.tokenId || null,
+      options.instanceStatus || "active",
+      source,
+      sourceRef,
+      certificate.fingerprintSha256,
+      certificate.serialNumber,
+      certificate.subject,
+      certificate.issuer,
+      certificate.notBefore,
+      certificate.notAfter,
+      normalizeText(options.deploymentReference || options.url),
+      observedAt,
+      JSON.stringify(metadata),
+      options.createdBy || null,
+    ],
+  );
+
+  return result.rows[0];
+}
+
+async function bridgeEndpointCertificateObservation(options = {}) {
+  if (!options.workspaceId || !options.domainMonitorId) {
+    throw new Error("workspaceId and domainMonitorId are required");
+  }
+
+  const db = options.client || options.dbPool;
+  const enabled = await isCertOpsEnabled({
+    dbPool: db,
+    env: options.env || process.env,
+  });
+  if (!enabled) {
+    return {
+      skipped: true,
+      code: CERTOPS_MONITOR_BRIDGE_SKIPPED,
+      reason: "certops_disabled",
+    };
+  }
+
+  const certificate = certificateFromObservation(options);
+  if (!hasPublicObservation(certificate)) {
+    return {
+      skipped: true,
+      code: CERTOPS_MONITOR_BRIDGE_SKIPPED,
+      reason: "no_public_certificate_observation",
+    };
+  }
+
+  return withBridgeClient(options, async (client) => {
+    const managedCertificate = await upsertObservedManagedCertificate(
+      client,
+      certificate,
+      options,
+    );
+    const target = await upsertCertificateTarget(client, options);
+    const instance = await upsertCertificateInstance(
+      client,
+      certificate,
+      managedCertificate,
+      target,
+      options,
+    );
+
+    return {
+      skipped: false,
+      managedCertificate,
+      target,
+      instance,
+    };
+  });
+}
+
+module.exports = {
+  CERTOPS_MONITOR_BRIDGE_SKIPPED,
+  bridgeEndpointCertificateObservation,
+  normalizeFingerprintSha256,
+};

--- a/apps/api/services/certops/monitorBridge.js
+++ b/apps/api/services/certops/monitorBridge.js
@@ -33,8 +33,16 @@ function normalizeFingerprintSha256(value) {
   const text = normalizeText(value);
   if (!text) return null;
   const compact = text.replace(/[:\s-]/g, "").toLowerCase();
-  if (/^[a-f0-9]{32,}$/.test(compact)) return compact;
-  return text.toLowerCase();
+  if (/^[a-f0-9]{64}$/.test(compact)) return compact;
+  return null;
+}
+
+function firstSha256Fingerprint(...values) {
+  for (const value of values) {
+    const normalized = normalizeFingerprintSha256(value);
+    if (normalized) return normalized;
+  }
+  return null;
 }
 
 function commonNameFromSubject(subject) {
@@ -63,11 +71,12 @@ function certificateFromObservation(options) {
   const serialNumber = normalizeText(
     input.serialNumber || input.serial_number || input.ssl_serial,
   );
-  const fingerprintSha256 = normalizeFingerprintSha256(
-    input.fingerprintSha256 ||
-      input.fingerprint256 ||
-      input.fingerprint ||
-      input.ssl_fingerprint,
+  const fingerprintSha256 = firstSha256Fingerprint(
+    input.fingerprintSha256,
+    input.fingerprint_sha256,
+    input.fingerprint256,
+    input.fingerprint,
+    input.ssl_fingerprint,
   );
   const notBefore = normalizeDate(
     input.notBefore || input.validFrom || input.ssl_valid_from,

--- a/apps/api/services/certops/settings.js
+++ b/apps/api/services/certops/settings.js
@@ -1,8 +1,10 @@
 "use strict";
 
-const { pool } = require("../../db/database");
-
 const CERTOPS_DISABLED = "CERTOPS_DISABLED";
+
+function defaultPool() {
+  return require("../../db/database").pool;
+}
 
 function parseBoolean(value) {
   if (typeof value === "boolean") return value;
@@ -17,7 +19,7 @@ function envCertOpsEnabled(env = process.env) {
   return parseBoolean(env.CERTOPS_ENABLED);
 }
 
-async function dbCertOpsEnabled(dbPool = pool) {
+async function dbCertOpsEnabled(dbPool = defaultPool()) {
   try {
     const { rows } = await dbPool.query(
       "SELECT certops_settings FROM system_settings WHERE id = 1",
@@ -31,7 +33,7 @@ async function dbCertOpsEnabled(dbPool = pool) {
   }
 }
 
-async function isCertOpsEnabled({ dbPool = pool, env = process.env } = {}) {
+async function isCertOpsEnabled({ dbPool = defaultPool(), env = process.env } = {}) {
   const envValue = envCertOpsEnabled(env);
   if (envValue !== null) return envValue;
 

--- a/apps/worker/src/endpoint-check-worker.js
+++ b/apps/worker/src/endpoint-check-worker.js
@@ -14,6 +14,7 @@ import tls from "tls";
 import https from "https";
 import http from "http";
 import { X509Certificate } from "crypto";
+import { createRequire } from "module";
 import {
   resolveContactGroup,
   hasEmailContacts,
@@ -21,6 +22,11 @@ import {
   hasWebhookNames,
   getWebhookNames,
 } from "./shared/contactGroups.js";
+
+const require = createRequire(import.meta.url);
+const { bridgeEndpointCertificateObservation } = require(
+  "../../api/services/certops/monitorBridge.js",
+);
 
 function formatDateYmd(date) {
   if (!date) return null;
@@ -302,6 +308,7 @@ async function runEndpointChecks() {
         workspace_id,
         consecutive_failures,
       } = domain;
+      let currentTokenId = token_id;
       logger.info(`Checking endpoint: ${url}`);
 
       try {
@@ -315,6 +322,8 @@ async function runEndpointChecks() {
 
             if (cert && cert.raw) {
               const x509 = new X509Certificate(cert.raw);
+              const publicCertificatePem =
+                typeof x509.toString === "function" ? x509.toString() : null;
               const sslData = {
                 ssl_issuer: x509.issuer || null,
                 ssl_subject: x509.subject || null,
@@ -325,6 +334,7 @@ async function runEndpointChecks() {
                 ssl_serial: x509.serialNumber || null,
                 ssl_fingerprint:
                   cert.fingerprint256 || cert.fingerprint || null,
+                public_certificate_pem: publicCertificatePem,
               };
 
               // Update endpoint monitor with cert data
@@ -347,7 +357,7 @@ async function runEndpointChecks() {
               );
 
               // Update linked token expiration if cert changed
-              if (token_id && sslData.ssl_valid_to) {
+              if (currentTokenId && sslData.ssl_valid_to) {
                 const newExpiry = formatDateYmd(sslData.ssl_valid_to);
                 if (newExpiry) {
                   await client.query(
@@ -359,14 +369,14 @@ async function runEndpointChecks() {
                       sslData.ssl_issuer,
                       sslData.ssl_serial,
                       sslData.ssl_subject,
-                      token_id,
+                      currentTokenId,
                     ],
                   );
                 }
               }
 
               // Auto-create token if we got cert data but no token is linked yet
-              if (!token_id && sslData.ssl_valid_to) {
+              if (!currentTokenId && sslData.ssl_valid_to) {
                 try {
                   // Resolve workspace default contact group for the new token
                   let defaultCgId = null;
@@ -405,12 +415,42 @@ async function runEndpointChecks() {
                     "UPDATE domain_monitors SET token_id = $1 WHERE id = $2",
                     [tokenRes.rows[0].id, id],
                   );
+                  currentTokenId = tokenRes.rows[0].id;
                 } catch (tokenErr) {
                   logger.warn("Failed to auto-create token for endpoint", {
                     url,
                     error: tokenErr.message,
                   });
                 }
+              }
+
+              try {
+                await bridgeEndpointCertificateObservation({
+                  client,
+                  workspaceId: workspace_id,
+                  domainMonitorId: id,
+                  tokenId: currentTokenId,
+                  url,
+                  hostname: parsedUrl.hostname,
+                  source: "endpoint_monitor",
+                  sourceRef: id,
+                  certificate: {
+                    issuer: sslData.ssl_issuer,
+                    subject: sslData.ssl_subject,
+                    serialNumber: sslData.ssl_serial,
+                    fingerprintSha256: sslData.ssl_fingerprint,
+                    notBefore: sslData.ssl_valid_from,
+                    notAfter: sslData.ssl_valid_to,
+                    certificatePem: sslData.public_certificate_pem,
+                  },
+                });
+              } catch (bridgeErr) {
+                logger.warn("CertOps monitor bridge failed", {
+                  workspaceId: workspace_id,
+                  domainMonitorId: id,
+                  code: bridgeErr.code || null,
+                  error: bridgeErr.message,
+                });
               }
             }
           } catch (sslErr) {

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -45,6 +45,7 @@
       { "path": "/api/v1/workspaces/{id}/certops/certificates", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/certificates", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}/instances", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/imports", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "GET" },

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3010,6 +3010,125 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/certificates/{certId}/instances:
+    get:
+      tags: [CertOps]
+      summary: List managed certificate instances
+      operationId: listCertOpsCertificateInstances
+      description: Returns public, workspace-scoped certificate observation history for one managed certificate. Private key material, evidence, raw output, and secret fields are never returned.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: certId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Managed certificate identifier.
+        - $ref: "#/components/parameters/limitParam"
+        - $ref: "#/components/parameters/offsetParam"
+      responses:
+        "200":
+          description: Managed certificate instance history
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [items, pagination]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: false
+                      required:
+                        - id
+                        - workspaceId
+                        - managedCertificateId
+                        - targetId
+                        - status
+                        - source
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        workspaceId:
+                          type: string
+                          format: uuid
+                        managedCertificateId:
+                          type: string
+                          format: uuid
+                        targetId:
+                          type: string
+                          format: uuid
+                        domainMonitorId:
+                          type: string
+                          format: uuid
+                          nullable: true
+                        tokenId:
+                          type: integer
+                          nullable: true
+                        status:
+                          type: string
+                        source:
+                          type: string
+                        sourceRef:
+                          type: string
+                          nullable: true
+                        observedFingerprintSha256:
+                          type: string
+                          pattern: "^[a-f0-9]{64}$"
+                          nullable: true
+                        observedSerialNumber:
+                          type: string
+                          nullable: true
+                        observedSubject:
+                          type: string
+                          nullable: true
+                        observedIssuer:
+                          type: string
+                          nullable: true
+                        observedNotBefore:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        observedNotAfter:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        deploymentReference:
+                          type: string
+                          nullable: true
+                        observedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        updatedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Managed certificate not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Certificate not found
+                code: CERTOPS_CERTIFICATE_NOT_FOUND
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/imports:
     post:
       tags: [CertOps]

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -111,6 +111,28 @@ function expectNoPrivateKeyFields(value) {
   expect(JSON.stringify(value)).to.not.include("PRIVATE KEY");
 }
 
+const CERTIFICATE_INSTANCE_FIELDS = [
+  "createdAt",
+  "deploymentReference",
+  "domainMonitorId",
+  "id",
+  "managedCertificateId",
+  "observedAt",
+  "observedFingerprintSha256",
+  "observedIssuer",
+  "observedNotAfter",
+  "observedNotBefore",
+  "observedSerialNumber",
+  "observedSubject",
+  "source",
+  "sourceRef",
+  "status",
+  "targetId",
+  "tokenId",
+  "updatedAt",
+  "workspaceId",
+].sort();
+
 describe("CertOps inventory routes", function () {
   this.timeout(90000);
 
@@ -288,6 +310,107 @@ describe("CertOps inventory routes", function () {
     expectNoPrivateKeyFields(detail.body.certificate);
   });
 
+  it("allows viewers to list public certificate instance history", async () => {
+    const sourceRef = `certops-inventory-route-${Date.now()}`;
+    const target = await TestUtils.execQuery(
+      `INSERT INTO certificate_targets (
+         workspace_id,
+         name,
+         target_type,
+         status,
+         source,
+         source_ref,
+         hostname,
+         url,
+         deployment_reference
+       )
+       VALUES ($1, $2, 'endpoint', 'active', 'endpoint_monitor', $3, $4, $5, $5)
+       RETURNING id`,
+      [
+        workspaceId,
+        "certops.example endpoint",
+        sourceRef,
+        "certops.example",
+        "https://certops.example",
+      ],
+    );
+    const targetId = target.rows[0].id;
+
+    const instance = await TestUtils.execQuery(
+      `INSERT INTO certificate_instances (
+         workspace_id,
+         managed_certificate_id,
+         target_id,
+         status,
+         source,
+         source_ref,
+         observed_fingerprint_sha256,
+         observed_serial_number,
+         observed_subject,
+         observed_issuer,
+         observed_not_before,
+         observed_not_after,
+         deployment_reference,
+         observed_at
+       )
+       VALUES (
+         $1, $2, $3, 'active', 'endpoint_monitor', $4, $5, $6, $7, $8,
+         $9, $10, $11, $12
+       )
+       RETURNING id`,
+      [
+        workspaceId,
+        leafCertificate.id,
+        targetId,
+        sourceRef,
+        leafCertificate.fingerprintSha256,
+        leafCertificate.serialNumber,
+        leafCertificate.commonName,
+        leafCertificate.issuer,
+        leafCertificate.notBefore,
+        leafCertificate.notAfter,
+        "https://certops.example",
+        "2026-06-27T12:00:00.000Z",
+      ],
+    );
+
+    const response = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${leafCertificate.id}/instances?limit=10&offset=0`,
+      )
+      .set("Cookie", viewerSession.cookie)
+      .expect(200);
+
+    const item = response.body.items.find(
+      (entry) => entry.id === instance.rows[0].id,
+    );
+    expect(item).to.exist;
+    expect(Object.keys(item).sort()).to.deep.equal(CERTIFICATE_INSTANCE_FIELDS);
+    expect(item.workspaceId).to.equal(workspaceId);
+    expect(item.managedCertificateId).to.equal(leafCertificate.id);
+    expect(item.targetId).to.equal(targetId);
+    expect(item.domainMonitorId).to.equal(null);
+    expect(item.tokenId).to.equal(null);
+    expect(item.status).to.equal("active");
+    expect(item.source).to.equal("endpoint_monitor");
+    expect(item.sourceRef).to.equal(sourceRef);
+    expect(item.observedFingerprintSha256).to.equal(
+      leafCertificate.fingerprintSha256,
+    );
+    expect(item.observedSerialNumber).to.equal(leafCertificate.serialNumber);
+    expect(item.observedSubject).to.equal(leafCertificate.commonName);
+    expect(item.observedIssuer).to.equal(leafCertificate.issuer);
+    expect(item.observedNotBefore).to.equal(leafCertificate.notBefore);
+    expect(item.observedNotAfter).to.equal(leafCertificate.notAfter);
+    expect(item.deploymentReference).to.equal("https://certops.example");
+    expect(item.observedAt).to.equal("2026-06-27T12:00:00.000Z");
+    expect(response.body.pagination).to.deep.equal({ limit: 10, offset: 0 });
+    expectNoPrivateKeyFields(response.body);
+    expect(JSON.stringify(response.body)).to.not.include("public_metadata");
+    expect(JSON.stringify(response.body)).to.not.include("publicMetadata");
+    expect(JSON.stringify(response.body)).to.not.include("evidence");
+  });
+
   it("denies viewer writes", async () => {
     const response = await request(BASE)
       .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
@@ -315,6 +438,28 @@ describe("CertOps inventory routes", function () {
       .set("Cookie", outsiderSession.cookie)
       .expect(200);
     expect(outsiderList.body.items).to.deep.equal([]);
+  });
+
+  it("keeps certificate instance history isolated by workspace", async () => {
+    const response = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${outsiderWorkspaceId}/certops/certificates/${leafCertificate.id}/instances`,
+      )
+      .set("Cookie", outsiderSession.cookie);
+
+    expect(response.status).to.equal(404);
+    expect(response.body.code).to.equal("CERTOPS_CERTIFICATE_NOT_FOUND");
+  });
+
+  it("returns safe 404 for malformed certificate ids on instance history", async () => {
+    const response = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/not-a-uuid/instances`,
+      )
+      .set("Cookie", ownerSession.cookie);
+
+    expect(response.status).to.equal(404);
+    expect(response.body.code).to.equal("CERTOPS_CERTIFICATE_NOT_FOUND");
   });
 
   it("rejects private key material without echoing raw input", async () => {

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -54,6 +54,7 @@ const { lookupDomain, normalizeRootDomain, parseDiscoveryLines } =
   ]);
 const {
   bridgeEndpointCertificateObservation,
+  normalizeFingerprintSha256,
 } = requireFirstExisting(["apps/api/services/certops/monitorBridge"]);
 const { pool } = requireFirstExisting(["apps/api/db/database"]);
 
@@ -63,6 +64,7 @@ const API_FINGERPRINT = "b".repeat(64);
 const API_FINGERPRINT_COLON = API_FINGERPRINT.match(/../g)
   .join(":")
   .toUpperCase();
+const SHA1_FINGERPRINT = "d".repeat(40);
 
 function walkKeys(value, visit) {
   if (Array.isArray(value)) {
@@ -251,6 +253,14 @@ describe("Domain checker discovery service integration", function () {
     expect(source).to.include("DOMAIN_CHECKER_LOOKUP_RATE_LIMIT_MAX");
     expect(source).to.include("DOMAIN_CHECKER_RATE_LIMITED");
   });
+
+  it("normalizes only SHA-256 fingerprints for the CertOps bridge", () => {
+    expect(normalizeFingerprintSha256(API_FINGERPRINT_COLON)).to.equal(
+      API_FINGERPRINT,
+    );
+    expect(normalizeFingerprintSha256(SHA1_FINGERPRINT)).to.equal(null);
+    expect(normalizeFingerprintSha256("not-a-fingerprint")).to.equal(null);
+  });
 });
 
 describe("Domain checker API import integration", function () {
@@ -380,6 +390,17 @@ describe("Domain checker API import integration", function () {
         sources: ["subfinder"],
       },
       {
+        id: "disc-sha1",
+        name: "sha1.example.com",
+        domains: ["sha1.example.com"],
+        expiration: "2099-02-06",
+        issuer: "Integration Test CA 3",
+        subject: "CN=sha1.example.com",
+        serialNumber: "serial-sha1",
+        fingerprint: SHA1_FINGERPRINT,
+        sources: ["subfinder"],
+      },
+      {
         id: "disc-outside",
         name: "outside.invalid",
         domains: ["outside.invalid"],
@@ -409,13 +430,13 @@ describe("Domain checker API import integration", function () {
       })
       .expect(201);
 
-    expect(response.body.imported).to.have.length(2);
+    expect(response.body.imported).to.have.length(3);
     expect(response.body.skipped).to.have.length(2);
     expect(response.body.skippedCounts).to.deep.equal({
       duplicate: 0,
       invalid: 2,
     });
-    expect(response.body.monitors).to.deep.equal({ created: 2, existing: 0 });
+    expect(response.body.monitors).to.deep.equal({ created: 3, existing: 0 });
     expect(
       response.body.skipped.map((entry) => entry.detail).sort(),
     ).to.deep.equal([
@@ -431,7 +452,7 @@ describe("Domain checker API import integration", function () {
         ORDER BY name`,
       [tokenIds],
     );
-    expect(tokenRows.rows).to.have.length(2);
+    expect(tokenRows.rows).to.have.length(3);
     expect(tokenRows.rows.every((row) => row.type === "ssl_cert")).to.equal(
       true,
     );
@@ -452,11 +473,19 @@ describe("Domain checker API import integration", function () {
          FROM domain_monitors
         WHERE workspace_id = $1 AND url = ANY($2::text[])
         ORDER BY url`,
-      [workspaceId, ["https://api.example.com", "https://www.example.com"]],
+      [
+        workspaceId,
+        [
+          "https://api.example.com",
+          "https://sha1.example.com",
+          "https://www.example.com",
+        ],
+      ],
     );
-    expect(monitors.rows).to.have.length(2);
+    expect(monitors.rows).to.have.length(3);
     expect(monitors.rows.map((row) => row.url)).to.deep.equal([
       "https://api.example.com",
+      "https://sha1.example.com",
       "https://www.example.com",
     ]);
     expect(
@@ -503,9 +532,16 @@ describe("Domain checker API import integration", function () {
         WHERE ci.workspace_id = $1
           AND ct.url = ANY($2::text[])
         ORDER BY ct.url`,
-      [workspaceId, ["https://api.example.com", "https://www.example.com"]],
+      [
+        workspaceId,
+        [
+          "https://api.example.com",
+          "https://sha1.example.com",
+          "https://www.example.com",
+        ],
+      ],
     );
-    expect(certopsRows.rows).to.have.length(2);
+    expect(certopsRows.rows).to.have.length(3);
 
     const importedTokenByName = Object.fromEntries(
       response.body.imported.map((entry) => [entry.name, entry.tokenId]),
@@ -519,8 +555,17 @@ describe("Domain checker API import integration", function () {
     expect(certopsByUrl["https://www.example.com"].fingerprint_sha256).to.equal(
       WWW_FINGERPRINT,
     );
+    expect(certopsByUrl["https://sha1.example.com"].fingerprint_sha256).to.equal(
+      null,
+    );
+    expect(
+      certopsByUrl["https://sha1.example.com"].observed_fingerprint_sha256,
+    ).to.equal(null);
     expect(certopsByUrl["https://api.example.com"].token_id).to.equal(
       importedTokenByName["api.example.com"],
+    );
+    expect(certopsByUrl["https://sha1.example.com"].token_id).to.equal(
+      importedTokenByName["sha1.example.com"],
     );
     expect(certopsByUrl["https://www.example.com"].token_id).to.equal(
       importedTokenByName["www.example.com"],
@@ -609,15 +654,15 @@ describe("Domain checker API import integration", function () {
     const metadata = normalizeMetadata(audit.rows[0].metadata);
     expect(metadata.domain).to.equal("example.com");
     expect(metadata.source).to.equal("subfinder");
-    expect(metadata.submitted).to.equal(4);
-    expect(metadata.imported).to.equal(2);
+    expect(metadata.submitted).to.equal(5);
+    expect(metadata.imported).to.equal(3);
     expect(metadata.skipped).to.equal(2);
     expect(metadata.skipped_invalid).to.equal(2);
     expect(metadata.skipped_duplicate).to.equal(0);
     expect(metadata.skipped_unreachable).to.equal(0);
     expect(metadata.skipped_other_invalid).to.equal(2);
     expect(metadata.create_monitors).to.equal(true);
-    expect(metadata.monitors_created).to.equal(2);
+    expect(metadata.monitors_created).to.equal(3);
     expect(metadata.monitor_health_check_enabled).to.equal(false);
     expect(metadata.monitor_check_interval).to.equal("daily");
     expect(metadata.monitor_alert_after_failures).to.equal(3);

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -52,8 +52,55 @@ const { lookupDomain, normalizeRootDomain, parseDiscoveryLines } =
     "apps/api/services/domainChecker",
     "apps/saas/services/domainChecker",
   ]);
+const {
+  bridgeEndpointCertificateObservation,
+} = requireFirstExisting(["apps/api/services/certops/monitorBridge"]);
+const { pool } = requireFirstExisting(["apps/api/db/database"]);
 
 const paidPlanForDomainChecker = "pro";
+const WWW_FINGERPRINT = "a".repeat(64);
+const API_FINGERPRINT = "b".repeat(64);
+const API_FINGERPRINT_COLON = API_FINGERPRINT.match(/../g)
+  .join(":")
+  .toUpperCase();
+
+function walkKeys(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkKeys(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    visit(key);
+    walkKeys(item, visit);
+  }
+}
+
+function expectNoPrivateKeyFields(value) {
+  const forbiddenFragments = [
+    "private",
+    "pkcs12",
+    "pfx",
+    "key_material",
+    "key_pem",
+    "key_der",
+    "raw_key",
+    "backup",
+    "secret",
+    "credential",
+    "password",
+  ];
+
+  walkKeys(value, (key) => {
+    for (const fragment of forbiddenFragments) {
+      expect(
+        key.toLowerCase().includes(fragment),
+        `${key} looks like private-key custody`,
+      ).to.equal(false);
+    }
+  });
+  expect(JSON.stringify(value)).to.not.include("PRIVATE KEY");
+}
 
 describe("Domain checker discovery service integration", function () {
   this.timeout(60000);
@@ -232,6 +279,18 @@ describe("Domain checker API import integration", function () {
         [workspaceId],
       );
       await TestUtils.execQuery(
+        "DELETE FROM certificate_instances WHERE workspace_id = $1",
+        [workspaceId],
+      );
+      await TestUtils.execQuery(
+        "DELETE FROM certificate_targets WHERE workspace_id = $1 AND source IN ('domain_checker', 'endpoint_monitor')",
+        [workspaceId],
+      );
+      await TestUtils.execQuery(
+        "DELETE FROM managed_certificates WHERE workspace_id = $1 AND source IN ('domain_checker', 'endpoint_monitor')",
+        [workspaceId],
+      );
+      await TestUtils.execQuery(
         "DELETE FROM domain_monitors WHERE workspace_id = $1 AND url LIKE 'https://%.example.com'",
         [workspaceId],
       );
@@ -274,6 +333,26 @@ describe("Domain checker API import integration", function () {
       })
       .expect(400);
     expect(tooMany.body.code).to.equal("TOO_MANY_CERTIFICATES");
+
+    const privateKey = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/domain-checker/import`)
+      .set("Cookie", session.cookie)
+      .send({
+        domain: "example.com",
+        certificates: [
+          {
+            id: "private-key-rejected",
+            name: "www.example.com",
+            domains: ["www.example.com"],
+            expiration: "2099-12-31",
+            certificatePem:
+              "-----BEGIN PRIVATE KEY-----\nRkFLRS1LRVk=\n-----END PRIVATE KEY-----",
+          },
+        ],
+      })
+      .expect(422);
+    expect(privateKey.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expect(JSON.stringify(privateKey.body)).to.not.include("RkFLRS1LRVk");
   });
 
   it("imports discovered SSL tokens, creates monitors, reports skipped reasons, and writes audit metadata", async () => {
@@ -286,7 +365,7 @@ describe("Domain checker API import integration", function () {
         issuer: "Integration Test CA",
         subject: "CN=www.example.com",
         serialNumber: "serial-www",
-        fingerprint: "fp-www",
+        fingerprint: WWW_FINGERPRINT,
         sources: ["subfinder"],
       },
       {
@@ -297,6 +376,7 @@ describe("Domain checker API import integration", function () {
         issuerName: "Integration Test CA 2",
         commonName: "api.example.com",
         sourceCertId: "source-api",
+        fingerprint: API_FINGERPRINT_COLON,
         sources: ["subfinder"],
       },
       {
@@ -368,7 +448,7 @@ describe("Domain checker API import integration", function () {
     ).to.equal(true);
 
     const monitors = await TestUtils.execQuery(
-      `SELECT url, health_check_enabled, check_interval, alert_after_failures
+      `SELECT id, url, token_id, health_check_enabled, check_interval, alert_after_failures
          FROM domain_monitors
         WHERE workspace_id = $1 AND url = ANY($2::text[])
         ORDER BY url`,
@@ -388,6 +468,134 @@ describe("Domain checker API import integration", function () {
     expect(
       monitors.rows.every((row) => Number(row.alert_after_failures) === 3),
     ).to.equal(true);
+    expect(monitors.rows.every((row) => tokenIds.includes(row.token_id))).to.equal(
+      true,
+    );
+
+    const certopsRows = await TestUtils.execQuery(
+      `SELECT
+          ci.id,
+          ci.workspace_id,
+          ci.domain_monitor_id,
+          ci.token_id,
+          ci.target_id,
+          ci.managed_certificate_id,
+          ci.observed_fingerprint_sha256,
+          ci.observed_subject,
+          ci.observed_issuer,
+          ci.observed_not_after,
+          ci.public_metadata AS instance_metadata,
+          ct.url,
+          ct.workspace_id AS target_workspace_id,
+          ct.token_id AS target_token_id,
+          ct.public_metadata AS target_metadata,
+          mc.workspace_id AS certificate_workspace_id,
+          mc.token_id AS managed_token_id,
+          mc.fingerprint_sha256,
+          mc.certificate_pem,
+          mc.public_metadata AS certificate_metadata
+         FROM certificate_instances ci
+         JOIN certificate_targets ct
+           ON ct.workspace_id = ci.workspace_id AND ct.id = ci.target_id
+         JOIN managed_certificates mc
+           ON mc.workspace_id = ci.workspace_id
+          AND mc.id = ci.managed_certificate_id
+        WHERE ci.workspace_id = $1
+          AND ct.url = ANY($2::text[])
+        ORDER BY ct.url`,
+      [workspaceId, ["https://api.example.com", "https://www.example.com"]],
+    );
+    expect(certopsRows.rows).to.have.length(2);
+
+    const importedTokenByName = Object.fromEntries(
+      response.body.imported.map((entry) => [entry.name, entry.tokenId]),
+    );
+    const certopsByUrl = Object.fromEntries(
+      certopsRows.rows.map((row) => [row.url, row]),
+    );
+    expect(certopsByUrl["https://api.example.com"].fingerprint_sha256).to.equal(
+      API_FINGERPRINT,
+    );
+    expect(certopsByUrl["https://www.example.com"].fingerprint_sha256).to.equal(
+      WWW_FINGERPRINT,
+    );
+    expect(certopsByUrl["https://api.example.com"].token_id).to.equal(
+      importedTokenByName["api.example.com"],
+    );
+    expect(certopsByUrl["https://www.example.com"].token_id).to.equal(
+      importedTokenByName["www.example.com"],
+    );
+    for (const row of certopsRows.rows) {
+      expect(row.workspace_id).to.equal(workspaceId);
+      expect(row.target_workspace_id).to.equal(workspaceId);
+      expect(row.certificate_workspace_id).to.equal(workspaceId);
+      expect(row.target_token_id).to.equal(row.token_id);
+      expect(row.managed_token_id).to.equal(row.token_id);
+      expect(row.certificate_pem).to.equal(null);
+      expect(row.observed_not_after).to.not.equal(null);
+      expectNoPrivateKeyFields(normalizeMetadata(row.instance_metadata));
+      expectNoPrivateKeyFields(normalizeMetadata(row.target_metadata));
+      expectNoPrivateKeyFields(normalizeMetadata(row.certificate_metadata));
+    }
+
+    const wwwRow = certopsByUrl["https://www.example.com"];
+    const repeatedObservation = await bridgeEndpointCertificateObservation({
+      dbPool: pool,
+      env: { CERTOPS_ENABLED: "true" },
+      workspaceId,
+      domainMonitorId: wwwRow.domain_monitor_id,
+      tokenId: wwwRow.token_id,
+      url: wwwRow.url,
+      hostname: "www.example.com",
+      source: "domain_checker",
+      sourceRef: "disc-www",
+      certificate: {
+        issuer: "Integration Test CA",
+        subject: "CN=www.example.com",
+        serialNumber: "serial-www",
+        fingerprintSha256: WWW_FINGERPRINT,
+        notAfter: "2099-02-03",
+      },
+    });
+    expect(repeatedObservation.instance.id).to.equal(wwwRow.id);
+    const repeatedCount = await TestUtils.execQuery(
+      `SELECT COUNT(*)::int AS count
+         FROM certificate_instances
+        WHERE workspace_id = $1
+          AND target_id = $2
+          AND managed_certificate_id = $3`,
+      [workspaceId, wwwRow.target_id, wwwRow.managed_certificate_id],
+    );
+    expect(repeatedCount.rows[0].count).to.equal(1);
+
+    const disabledFingerprint = "c".repeat(64);
+    const disabledObservation = await bridgeEndpointCertificateObservation({
+      dbPool: pool,
+      env: { CERTOPS_ENABLED: "false" },
+      workspaceId,
+      domainMonitorId: wwwRow.domain_monitor_id,
+      tokenId: wwwRow.token_id,
+      url: wwwRow.url,
+      hostname: "www.example.com",
+      source: "domain_checker",
+      sourceRef: "disabled-observation",
+      certificate: {
+        issuer: "Integration Test CA",
+        subject: "CN=www.example.com",
+        fingerprintSha256: disabledFingerprint,
+        notAfter: "2099-02-03",
+      },
+    });
+    expect(disabledObservation.skipped).to.equal(true);
+    expect(disabledObservation.reason).to.equal("certops_disabled");
+    const disabledRows = await TestUtils.execQuery(
+      `SELECT id
+         FROM managed_certificates
+        WHERE workspace_id = $1
+          AND fingerprint_sha256 = $2`,
+      [workspaceId, disabledFingerprint],
+    );
+    expect(disabledRows.rows).to.have.length(0);
 
     const audit = await TestUtils.execQuery(
       `SELECT metadata

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -365,7 +365,7 @@ describe("Domain checker API import integration", function () {
     expect(JSON.stringify(privateKey.body)).to.not.include("RkFLRS1LRVk");
   });
 
-  it("imports discovered SSL tokens, creates monitors, reports skipped reasons, and writes audit metadata", async () => {
+  it("imports discovered SSL tokens and populates CertOps on monitor observations", async () => {
     const certificates = [
       {
         id: "disc-www",
@@ -584,6 +584,8 @@ describe("Domain checker API import integration", function () {
     }
 
     const wwwRow = certopsByUrl["https://www.example.com"];
+    // Existing monitor rechecks enter the same bridge; repeated observations
+    // update the existing instance instead of creating backfill duplicates.
     const repeatedObservation = await bridgeEndpointCertificateObservation({
       dbPool: pool,
       env: { CERTOPS_ENABLED: "true" },


### PR DESCRIPTION
## Summary

This PR adds the M1-A5 CertOps endpoint/domain monitor bridge.

* Adds `monitorBridge.js` to create/update CertOps inventory records from existing endpoint/domain monitor certificate observations.
* Creates or updates:

  * `certificate_targets`
  * `managed_certificates`
  * `certificate_instances`
* Links managed certificates by SHA-256 fingerprint where available.
* Keeps bridge behavior idempotent by monitor target + managed certificate.
* No-ops when `certops.enabled` is false.
* Preserves existing linked token behavior by recording the resulting token ID on CertOps target/instance rows after existing monitor token creation/update.
* Does not relink existing domain-checker monitors.
* Stores public/non-secret certificate observation metadata only.
* Rejects private-key material in domain-checker certificate imports with `PRIVATE_KEY_MATERIAL_REJECTED`.
* Requires true SHA-256 fingerprints before writing `fingerprint_sha256` / `observed_fingerprint_sha256`; SHA-1 or unknown generic fingerprints are left null instead of being stored as SHA-256.
* Adds `GET /api/v1/workspaces/:id/certops/certificates/:certId/instances` for public instance history.
* Documents that existing monitors populate CertOps on the next public certificate observation/check cycle.
* Updates CertOps route compatibility and OpenAPI route skeleton for the instance history read endpoint.

## Verification

* `node --check apps/api/services/certops/monitorBridge.js`: ok
* `node --check tests/integration/domain-checker.integration.test.js`: ok
* `node --check` on changed JS files: ok
* `git diff --check`: ok
* `pnpm run migrate`: ok
* `pnpm run test:unit`: ok
* `pnpm exec mocha tests/integration/domain-checker.integration.test.js --timeout 120000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 120000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-migration.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/endpoint-check-worker.integration.test.js --timeout 120000 --exit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on M1-A4: `feature/certops-m1-a4-inventory-routes`.
* The bridge is intentionally disabled when `certops.enabled` is false, so existing monitor behavior continues unchanged.
* Existing monitor token creation/update remains the source of truth; CertOps only records the resulting linked token ID.
* Fingerprint handling is strict: `fingerprintSha256`, `fingerprint_sha256`, and `fingerprint256` populate SHA-256 fields only when they normalize to exactly 64 hex characters. Generic `fingerprint` / `ssl_fingerprint` values are accepted only if they are real SHA-256 length.
* If only a SHA-1 or unknown generic fingerprint is available, `fingerprint_sha256` / `observed_fingerprint_sha256` remain null.
* No dashboard/Cloud overlay, executor, agent, ACME, cert-manager, Helm/RBAC, api_tokens, jobs, or evidence backend work is included.
* No M2 work is included.

## Test plan

* [ ] Review `apps/api/services/certops/monitorBridge.js`
* [ ] Review `apps/worker/src/endpoint-check-worker.js`
* [ ] Review `apps/api/routes/admin.js`
* [ ] Review `tests/integration/domain-checker.integration.test.js`
* [ ] Run `pnpm run test:unit`
* [ ] Run `pnpm exec mocha tests/integration/domain-checker.integration.test.js --timeout 120000 --exit`
* [ ] Run `pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 120000 --exit`
* [ ] Run `pnpm exec mocha tests/integration/endpoint-check-worker.integration.test.js --timeout 120000 --exit`
* [ ] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
