### PR TITLE
test(certops): harden M1 route acceptance checks m1-a6

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,10 @@ policy toggle. It is enforced in depth:
 - schema design (no inventory field is meant to hold key material),
 - the API rejection boundary (HTTP 422 `PRIVATE_KEY_MATERIAL_REJECTED`).
 
+Field-name redaction and explicit sanitized logging are wired for the current
+M1 boundary paths. A broader logger content-scrub layer for arbitrary log
+message content is a follow-up, not something M1 assumes globally.
+
 The one private key the platform does hold is the platform operational signing
 key (Ed25519) used to sign jobs. It is never used for certificate issuance and
 never holds customer key material. See ADR-0003.

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -773,6 +773,46 @@ const migrations = [
         ON certificate_instances(workspace_id, target_id, managed_certificate_id);
     `,
   },
+  {
+    version: 11,
+    name: "certops_token_lifecycle_status",
+    sql: `
+      ALTER TABLE tokens
+        ADD COLUMN IF NOT EXISTS cert_lifecycle_status TEXT NULL;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+           WHERE c.conname = 'tokens_cert_lifecycle_status_check'
+             AND t.relname = 'tokens'
+             AND n.nspname = current_schema()
+        ) THEN
+          ALTER TABLE tokens
+            ADD CONSTRAINT tokens_cert_lifecycle_status_check
+            CHECK (
+              cert_lifecycle_status IS NULL OR
+              cert_lifecycle_status IN (
+                'discovered',
+                'active',
+                'renewing',
+                'expiring',
+                'expired',
+                'revoked',
+                'decommissioned'
+              )
+            );
+        END IF;
+      END $$;
+
+      CREATE INDEX IF NOT EXISTS idx_tokens_workspace_cert_lifecycle_status
+        ON tokens(workspace_id, cert_lifecycle_status)
+        WHERE cert_lifecycle_status IS NOT NULL;
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -12,13 +12,17 @@ const {
 } = require("../middleware/require-certops-enabled");
 const { hasAtLeastRole } = require("../services/rbac");
 const {
+  CERTOPS_CERTIFICATE_NOT_FOUND,
   CERTOPS_CERTIFICATE_PARSE_FAILED,
+  CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID,
+  CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID,
   CERTOPS_KEY_MODE_INVALID,
   CERTOPS_KEY_REFERENCE_INVALID,
   getManagedCertificate,
   importPublicCertificates,
   listCertificateInstances,
   listManagedCertificates,
+  retireManagedCertificate,
 } = require("../services/certops/inventory");
 const { writeAudit } = require("../services/audit");
 const { logger } = require("../utils/logger");
@@ -92,6 +96,27 @@ function handleCertOpsError(res, err) {
     });
   }
 
+  if (err?.code === CERTOPS_CERTIFICATE_NOT_FOUND) {
+    return res.status(404).json({
+      error: "Certificate not found",
+      code: CERTOPS_CERTIFICATE_NOT_FOUND,
+    });
+  }
+
+  if (err?.code === CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID) {
+    return res.status(400).json({
+      error: "Invalid certificate retire status",
+      code: CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID,
+    });
+  }
+
+  if (err?.code === CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID) {
+    return res.status(400).json({
+      error: "Invalid certificate retire reason",
+      code: CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID,
+    });
+  }
+
   if (err?.code === CERTOPS_KEY_MODE_INVALID) {
     return res.status(400).json({
       error: "Invalid CertOps key mode",
@@ -130,6 +155,43 @@ async function recordInventoryAudit(req, source, certificates) {
       ),
     },
   });
+}
+
+async function retireCertificateHandler(req, res) {
+  if (!UUID_PATTERN.test(String(req.params.certId || ""))) {
+    return res.status(404).json({
+      error: "Certificate not found",
+      code: CERTOPS_CERTIFICATE_NOT_FOUND,
+    });
+  }
+
+  try {
+    const certificate = await retireManagedCertificate({
+      workspaceId: req.workspace.id,
+      certificateId: req.params.certId,
+      status: req.body?.status,
+      reason: req.body?.reason,
+      actorUserId: req.user?.id || null,
+      createdBy: req.user?.id || null,
+    });
+
+    return res.json({ certificate });
+  } catch (err) {
+    const handled = handleCertOpsError(res, err);
+    if (handled) return handled;
+
+    logger.error("CertOps certificate retire failed", {
+      error: err.message,
+      code: err.code || null,
+      workspaceId: req.workspace?.id,
+      certId: req.params?.certId,
+      userId: req.user?.id,
+    });
+    return res.status(500).json({
+      error: "Failed to retire certificate",
+      code: "INTERNAL_ERROR",
+    });
+  }
 }
 
 async function importCertificatesHandler(req, res, source, statusCode) {
@@ -243,6 +305,15 @@ router.get(
       });
     }
   },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/certificates/:certId/retire",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  retireCertificateHandler,
 );
 
 router.get(

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -14,6 +14,7 @@ const { hasAtLeastRole } = require("../services/rbac");
 const {
   CERTOPS_CERTIFICATE_PARSE_FAILED,
   CERTOPS_KEY_MODE_INVALID,
+  CERTOPS_KEY_REFERENCE_INVALID,
   getManagedCertificate,
   importPublicCertificates,
   listCertificateInstances,
@@ -98,6 +99,13 @@ function handleCertOpsError(res, err) {
     });
   }
 
+  if (err?.code === CERTOPS_KEY_REFERENCE_INVALID) {
+    return res.status(400).json({
+      error: "keyReference must be a non-secret reference",
+      code: CERTOPS_KEY_REFERENCE_INVALID,
+    });
+  }
+
   return null;
 }
 
@@ -125,15 +133,15 @@ async function recordInventoryAudit(req, source, certificates) {
 }
 
 async function importCertificatesHandler(req, res, source, statusCode) {
-  const options = writeOptionsFromRequest(req, source);
-  if (!options.certificatePem) {
-    return res.status(400).json({
-      error: "certificatePem is required",
-      code: "CERTOPS_CERTIFICATE_PEM_REQUIRED",
-    });
-  }
-
   try {
+    const options = writeOptionsFromRequest(req, source);
+    if (!options.certificatePem) {
+      return res.status(400).json({
+        error: "certificatePem is required",
+        code: "CERTOPS_CERTIFICATE_PEM_REQUIRED",
+      });
+    }
+
     const certificates = await importPublicCertificates(options);
     await recordInventoryAudit(req, source, certificates);
     return res.status(statusCode).json({

--- a/apps/api/routes/tokens.js
+++ b/apps/api/routes/tokens.js
@@ -14,6 +14,14 @@ const { sanitizeForLogging } = require("../utils/sanitize");
 const router = require("express").Router();
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:$|[T\s])/;
+const CERTOPS_MANAGED_CERTIFICATE_RETIRE_REQUIRED =
+  "CERTOPS_MANAGED_CERTIFICATE_RETIRE_REQUIRED";
+const CERTIFICATE_TOKEN_TYPES = new Set([
+  "ssl_cert",
+  "tls_cert",
+  "code_signing",
+  "client_cert",
+]);
 
 const padDatePart = (value) => String(value).padStart(2, "0");
 
@@ -53,6 +61,26 @@ const normalizeDateOnlyInput = (value) => {
   if (Number.isNaN(date.getTime())) return null;
   return formatUtcDateOnly(date);
 };
+
+function isCertificateToken(token) {
+  const category = String(token?.category || "").toLowerCase();
+  const type = String(token?.type || "").toLowerCase();
+  return category === "cert" || CERTIFICATE_TOKEN_TYPES.has(type);
+}
+
+async function isManagedBackedCertificateToken(token) {
+  if (!token?.workspace_id || !isCertificateToken(token)) return false;
+
+  const result = await pool.query(
+    `SELECT 1
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND token_id = $2
+      LIMIT 1`,
+    [token.workspace_id, token.id],
+  );
+  return result.rowCount > 0;
+}
 
 // --- TOKEN MANAGEMENT ROUTES ---
 
@@ -1311,7 +1339,7 @@ router.delete(
 
       // 1. Fetch all requested tokens to check ownership/workspace permissions in one go
       const tokensRes = await pool.query(
-        "SELECT id, name, workspace_id, user_id FROM tokens WHERE id = ANY($1::int[])",
+        "SELECT id, name, workspace_id, user_id, type, category FROM tokens WHERE id = ANY($1::int[])",
         [ids],
       );
       const existingTokens = tokensRes.rows;
@@ -1330,7 +1358,7 @@ router.delete(
       }
 
       // 2. Filter tokens by permission
-      const authorizedTokens = [];
+      let authorizedTokens = [];
       const workspaceIds = [
         ...new Set(
           existingTokens
@@ -1362,6 +1390,33 @@ router.delete(
           authorizedTokens.push(token);
         } else {
           results.failed.push({ id: token.id, reason: "Forbidden" });
+        }
+      }
+
+      const authorizedCertTokenIds = authorizedTokens
+        .filter((token) => token.workspace_id && isCertificateToken(token))
+        .map((token) => token.id);
+      if (authorizedCertTokenIds.length > 0) {
+        const managedBacked = await pool.query(
+          `SELECT DISTINCT token_id
+             FROM managed_certificates
+            WHERE token_id = ANY($1::int[])`,
+          [authorizedCertTokenIds],
+        );
+        const blockedTokenIds = new Set(
+          managedBacked.rows.map((row) => row.token_id),
+        );
+
+        if (blockedTokenIds.size > 0) {
+          authorizedTokens = authorizedTokens.filter((token) => {
+            if (!blockedTokenIds.has(token.id)) return true;
+            results.failed.push({
+              id: token.id,
+              reason: "Managed certificate retire required",
+              code: CERTOPS_MANAGED_CERTIFICATE_RETIRE_REQUIRED,
+            });
+            return false;
+          });
         }
       }
 
@@ -1450,6 +1505,14 @@ router.delete(
         : existing.user_id === req.user.id;
       if (!canDelete)
         return res.status(403).json({ error: "Forbidden", code: "FORBIDDEN" });
+
+      if (await isManagedBackedCertificateToken(existing)) {
+        return res.status(409).json({
+          error: "Managed certificates must be retired before removal",
+          code: CERTOPS_MANAGED_CERTIFICATE_RETIRE_REQUIRED,
+        });
+      }
+
       await pool.query("DELETE FROM alert_queue WHERE token_id = $1", [
         parseInt(id, 10),
       ]);

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -187,6 +187,7 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
   const keyReference = normalizeKeyReference(options.keyReference);
   const params = [
     options.workspaceId,
+    options.tokenId || null,
     options.status || "discovered",
     options.source || "import",
     options.sourceRef || null,
@@ -213,6 +214,7 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
   const result = await client.query(
     `INSERT INTO managed_certificates (
        workspace_id,
+       token_id,
        status,
        source,
        source_ref,
@@ -236,12 +238,13 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
        created_by
      )
      VALUES (
-       $1, $2, $3, $4, $5, $6, $7::text[], $8, $9, $10, $11, $12,
-       $13, $14, $15, $16, $17, $18, $19, $20, $21::jsonb, $22
+       $1, $2, $3, $4, $5, $6, $7, $8::text[], $9, $10, $11, $12,
+       $13, $14, $15, $16, $17, $18, $19, $20, $21, $22::jsonb, $23
      )
      ON CONFLICT (workspace_id, fingerprint_sha256)
        WHERE fingerprint_sha256 IS NOT NULL
      DO UPDATE SET
+       token_id = COALESCE(EXCLUDED.token_id, managed_certificates.token_id),
        status = EXCLUDED.status,
        source = EXCLUDED.source,
        source_ref = EXCLUDED.source_ref,

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -6,6 +6,7 @@ const {
   PRIVATE_KEY_MATERIAL_REJECTED,
   parsePublicCertificateMaterial,
 } = require("./parser");
+const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
 
 const CERTOPS_CERTIFICATE_NOT_FOUND = "CERTOPS_CERTIFICATE_NOT_FOUND";
 const CERTOPS_KEY_MODE_INVALID = "CERTOPS_KEY_MODE_INVALID";
@@ -20,6 +21,12 @@ const ALLOWED_KEY_MODES = new Set([
   "os-store-managed",
   "external-unknown",
 ]);
+const CERTOPS_KEY_REFERENCE_INVALID = "CERTOPS_KEY_REFERENCE_INVALID";
+const KEY_REFERENCE_MAX_LENGTH = 256;
+const PEM_MARKER_PATTERN = /-----\s*(?:BEGIN|END)\b/i;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:password|secret|token|credential|private_key|privatekey|key_material)\s*=/i;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 
 function dateToIso(value) {
   if (!value) return null;
@@ -44,6 +51,27 @@ function chooseCertificateName(certificate, fallbackName) {
     certificate.subject ||
     null
   );
+}
+
+function keyReferenceError() {
+  const err = new Error("CertOps keyReference must be a non-secret reference");
+  err.code = CERTOPS_KEY_REFERENCE_INVALID;
+  return err;
+}
+
+function normalizeKeyReference(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw keyReferenceError();
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > KEY_REFERENCE_MAX_LENGTH) throw keyReferenceError();
+  if (containsPrivateKeyMaterial(trimmed)) throw keyReferenceError();
+  if (PEM_MARKER_PATTERN.test(trimmed)) throw keyReferenceError();
+  if (SECRET_ASSIGNMENT_PATTERN.test(trimmed)) throw keyReferenceError();
+  if (CONTROL_CHARACTER_PATTERN.test(trimmed)) throw keyReferenceError();
+
+  return trimmed;
 }
 
 function toInventoryRecord(row) {
@@ -156,6 +184,7 @@ function publicMetadataFor(certificate, options, chainIndex) {
 }
 
 async function upsertManagedCertificate(client, certificate, options, chainIndex) {
+  const keyReference = normalizeKeyReference(options.keyReference);
   const params = [
     options.workspaceId,
     options.status || "discovered",
@@ -176,7 +205,7 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
     certificate.notBefore || certificate.validFrom || null,
     certificate.notAfter || certificate.validTo || null,
     options.keyMode || null,
-    options.keyReference || null,
+    keyReference,
     JSON.stringify(publicMetadataFor(certificate, options, chainIndex)),
     options.createdBy || null,
   ];
@@ -338,12 +367,14 @@ module.exports = {
   CERTOPS_CERTIFICATE_NOT_FOUND,
   CERTOPS_CERTIFICATE_PARSE_FAILED,
   CERTOPS_KEY_MODE_INVALID,
+  CERTOPS_KEY_REFERENCE_INVALID,
   PRIVATE_KEY_MATERIAL_REJECTED,
   getManagedCertificate,
   importPublicCertificates,
   listCertificateInstances,
   listManagedCertificates,
   normalizeKeyMode,
+  normalizeKeyReference,
   normalizeLimit,
   normalizeOffset,
   toInstanceRecord,

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -53,6 +53,42 @@ function chooseCertificateName(certificate, fallbackName) {
   );
 }
 
+function formatDateYmd(value) {
+  const iso = dateToIso(value);
+  return iso ? iso.slice(0, 10) : null;
+}
+
+function tokenNameFor(certificate, fallbackName) {
+  const name = String(chooseCertificateName(certificate, fallbackName) || "Certificate")
+    .trim()
+    .slice(0, 100);
+  return name.length >= 3 ? name : "Certificate";
+}
+
+function certificateDomainsFor(certificate) {
+  const domains = [];
+  if (Array.isArray(certificate.subjectAltNames)) {
+    for (const value of certificate.subjectAltNames) {
+      const domain = typeof value === "string" ? value.trim() : "";
+      if (domain) domains.push(domain);
+    }
+  }
+  const commonName =
+    typeof certificate.commonName === "string" ? certificate.commonName.trim() : "";
+  if (commonName) domains.push(commonName);
+  return Array.from(new Set(domains));
+}
+
+function fingerprintSha256For(certificate) {
+  return certificate.fingerprintSha256 || certificate.fingerprint256 || null;
+}
+
+function certOpsTokenNotes(certificate, domains) {
+  const fingerprint = fingerprintSha256For(certificate) || "unknown";
+  const domainText = domains.length ? ` Domains: ${domains.join(", ")}.` : "";
+  return `Imported by CertOps public PEM import. Fingerprint: ${fingerprint}.${domainText}`;
+}
+
 function keyReferenceError() {
   const err = new Error("CertOps keyReference must be a non-secret reference");
   err.code = CERTOPS_KEY_REFERENCE_INVALID;
@@ -183,6 +219,110 @@ function publicMetadataFor(certificate, options, chainIndex) {
   });
 }
 
+async function existingManagedCertificateForToken(client, certificate, options) {
+  const fingerprintSha256 = fingerprintSha256For(certificate);
+  if (!fingerprintSha256) return null;
+  const result = await client.query(
+    `SELECT id, token_id
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND fingerprint_sha256 = $2
+      LIMIT 1`,
+    [options.workspaceId, fingerprintSha256],
+  );
+  return result.rows[0] || null;
+}
+
+async function existingCertOpsToken(client, certificate, options, domains) {
+  const fingerprintSha256 = fingerprintSha256For(certificate);
+  if (fingerprintSha256) {
+    const byFingerprint = await client.query(
+      `SELECT id
+         FROM tokens
+        WHERE workspace_id = $1
+          AND type = 'ssl_cert'
+          AND notes ILIKE $2
+        ORDER BY imported_at DESC NULLS LAST, created_at DESC, id DESC
+        LIMIT 1`,
+      [
+        options.workspaceId,
+        `%Imported by CertOps public PEM import. Fingerprint: ${fingerprintSha256}.%`,
+      ],
+    );
+    if (byFingerprint.rows[0]) return byFingerprint.rows[0];
+  }
+
+  const expiration = formatDateYmd(certificate.notAfter || certificate.validTo);
+  if (!expiration || domains.length === 0) return null;
+  const byShape = await client.query(
+    `SELECT id
+       FROM tokens
+      WHERE workspace_id = $1
+        AND type = 'ssl_cert'
+        AND expiration = $2
+        AND COALESCE(issuer, '') = COALESCE($3, '')
+        AND domains && $4::text[]
+      ORDER BY imported_at DESC NULLS LAST, created_at DESC, id DESC
+      LIMIT 1`,
+    [options.workspaceId, expiration, certificate.issuer || null, domains],
+  );
+  return byShape.rows[0] || null;
+}
+
+async function ensureManagedCertificateToken(
+  client,
+  certificate,
+  options,
+  existingManagedCertificate = null,
+) {
+  if (options.tokenId) return options.tokenId;
+
+  const existing =
+    existingManagedCertificate ||
+    (await existingManagedCertificateForToken(client, certificate, options));
+  if (existing?.token_id) return existing.token_id;
+
+  const domains = certificateDomainsFor(certificate);
+  const existingToken = await existingCertOpsToken(
+    client,
+    certificate,
+    options,
+    domains,
+  );
+  if (existingToken?.id) return existingToken.id;
+
+  const expiration = formatDateYmd(certificate.notAfter || certificate.validTo);
+  if (!expiration) {
+    throw certOpsValidationError(
+      "Certificate expiration is required",
+      CERTOPS_CERTIFICATE_PARSE_FAILED,
+    );
+  }
+
+  const token = await client.query(
+    `INSERT INTO tokens
+       (user_id, workspace_id, created_by, name, expiration, type, category,
+        issuer, serial_number, subject, domains, location, notes, imported_at)
+     VALUES ($1, $2, $3, $4, $5, 'ssl_cert', 'cert',
+             $6, $7, $8, $9::text[], $10, $11, NOW())
+     RETURNING id`,
+    [
+      options.createdBy || null,
+      options.workspaceId,
+      options.createdBy || null,
+      tokenNameFor(certificate, options.name),
+      expiration,
+      certificate.issuer || null,
+      certificate.serialNumber || null,
+      certificate.subject || null,
+      domains,
+      domains[0] || null,
+      certOpsTokenNotes(certificate, domains),
+    ],
+  );
+  return token.rows[0].id;
+}
+
 async function upsertManagedCertificate(client, certificate, options, chainIndex) {
   const keyReference = normalizeKeyReference(options.keyReference);
   const params = [
@@ -285,11 +425,23 @@ async function importPublicCertificates(options) {
     await client.query("BEGIN");
     const items = [];
     for (let index = 0; index < certificates.length; index += 1) {
+      const certificate = certificates[index];
+      const existingManagedCertificate = await existingManagedCertificateForToken(
+        client,
+        certificate,
+        normalizedOptions,
+      );
+      const tokenId = await ensureManagedCertificateToken(
+        client,
+        certificate,
+        normalizedOptions,
+        existingManagedCertificate,
+      );
       items.push(
         await upsertManagedCertificate(
           client,
-          certificates[index],
-          normalizedOptions,
+          certificate,
+          { ...normalizedOptions, tokenId },
           index,
         ),
       );

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -9,6 +9,10 @@ const {
 const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
 
 const CERTOPS_CERTIFICATE_NOT_FOUND = "CERTOPS_CERTIFICATE_NOT_FOUND";
+const CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID =
+  "CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID";
+const CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID =
+  "CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID";
 const CERTOPS_KEY_MODE_INVALID = "CERTOPS_KEY_MODE_INVALID";
 
 const ALLOWED_KEY_MODES = new Set([
@@ -23,10 +27,12 @@ const ALLOWED_KEY_MODES = new Set([
 ]);
 const CERTOPS_KEY_REFERENCE_INVALID = "CERTOPS_KEY_REFERENCE_INVALID";
 const KEY_REFERENCE_MAX_LENGTH = 256;
+const RETIRE_REASON_MAX_LENGTH = 512;
 const PEM_MARKER_PATTERN = /-----\s*(?:BEGIN|END)\b/i;
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(?:password|secret|token|credential|private_key|privatekey|key_material)\s*=/i;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const RETIRE_STATUSES = new Set(["revoked", "decommissioned"]);
 
 function dateToIso(value) {
   if (!value) return null;
@@ -185,6 +191,52 @@ function certOpsValidationError(message, code) {
   const error = new Error(message);
   error.code = code;
   return error;
+}
+
+function privateKeyMaterialError() {
+  return certOpsValidationError(
+    "Private key material is not accepted in CertOps requests",
+    PRIVATE_KEY_MATERIAL_REJECTED,
+  );
+}
+
+function normalizeRetireStatus(value) {
+  if (typeof value !== "string") {
+    throw certOpsValidationError(
+      "Invalid certificate retire status",
+      CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (RETIRE_STATUSES.has(trimmed)) return trimmed;
+
+  throw certOpsValidationError(
+    "Invalid certificate retire status",
+    CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID,
+  );
+}
+
+function retireReasonError() {
+  return certOpsValidationError(
+    "Invalid certificate retire reason",
+    CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID,
+  );
+}
+
+function normalizeRetireReason(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw retireReasonError();
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > RETIRE_REASON_MAX_LENGTH) throw retireReasonError();
+  if (containsPrivateKeyMaterial(trimmed)) throw privateKeyMaterialError();
+  if (PEM_MARKER_PATTERN.test(trimmed)) throw retireReasonError();
+  if (SECRET_ASSIGNMENT_PATTERN.test(trimmed)) throw retireReasonError();
+  if (CONTROL_CHARACTER_PATTERN.test(trimmed)) throw retireReasonError();
+
+  return trimmed;
 }
 
 function normalizeKeyMode(value) {
@@ -518,9 +570,129 @@ async function listCertificateInstances({ workspaceId, certId, limit, offset }) 
   };
 }
 
+function resolveRetireArgs(clientOrPool, options) {
+  if (options === undefined) {
+    return { db: pool, options: clientOrPool || {} };
+  }
+  return { db: clientOrPool || pool, options: options || {} };
+}
+
+async function writeRetireAudit(client, options, certificate, status, reason) {
+  await client.query(
+    `INSERT INTO audit_events (
+       actor_user_id,
+       subject_user_id,
+       action,
+       target_type,
+       target_id,
+       channel,
+       metadata,
+       workspace_id
+     )
+     VALUES ($1, $2, 'CERTOPS_CERTIFICATE_RETIRED', 'managed_certificate',
+             NULL, NULL, $3::jsonb, $4)`,
+    [
+      options.actorUserId || options.createdBy || null,
+      options.actorUserId || options.createdBy || null,
+      JSON.stringify(
+        compactObject({
+          managedCertificateId: certificate.id,
+          tokenId: certificate.token_id,
+          status,
+          reason,
+          fingerprintSha256: certificate.fingerprint_sha256,
+        }),
+      ),
+      options.workspaceId,
+    ],
+  );
+}
+
+async function retireManagedCertificate(clientOrPool, options) {
+  const resolved = resolveRetireArgs(clientOrPool, options);
+  const normalizedStatus = normalizeRetireStatus(resolved.options.status);
+  const normalizedReason = normalizeRetireReason(resolved.options.reason);
+  const db = resolved.db;
+  const client =
+    db && typeof db.connect === "function" ? await db.connect() : db;
+  const shouldRelease = db && typeof db.connect === "function";
+
+  if (!client || typeof client.query !== "function") {
+    throw new Error("retireManagedCertificate requires a pg client or pool");
+  }
+
+  try {
+    await client.query("BEGIN");
+
+    const existing = await client.query(
+      `SELECT *
+         FROM managed_certificates
+        WHERE workspace_id = $1
+          AND id = $2
+        FOR UPDATE`,
+      [resolved.options.workspaceId, resolved.options.certificateId],
+    );
+
+    const certificate = existing.rows[0];
+    if (!certificate) {
+      throw certOpsValidationError(
+        "Certificate not found",
+        CERTOPS_CERTIFICATE_NOT_FOUND,
+      );
+    }
+
+    const updated = await client.query(
+      `UPDATE managed_certificates
+          SET status = $1,
+              updated_at = NOW()
+        WHERE workspace_id = $2
+          AND id = $3
+        RETURNING *`,
+      [
+        normalizedStatus,
+        resolved.options.workspaceId,
+        resolved.options.certificateId,
+      ],
+    );
+
+    if (certificate.token_id) {
+      await client.query(
+        `UPDATE tokens
+            SET cert_lifecycle_status = $1,
+                updated_at = NOW()
+          WHERE workspace_id = $2
+            AND id = $3`,
+        [normalizedStatus, resolved.options.workspaceId, certificate.token_id],
+      );
+    }
+
+    await writeRetireAudit(
+      client,
+      resolved.options,
+      updated.rows[0],
+      normalizedStatus,
+      normalizedReason,
+    );
+
+    await client.query("COMMIT");
+    return toInventoryRecord(updated.rows[0]);
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackError) {
+      /* Preserve the original error. */
+    }
+    throw err;
+  } finally {
+    if (shouldRelease) client.release();
+  }
+}
+
 module.exports = {
   CERTOPS_CERTIFICATE_NOT_FOUND,
   CERTOPS_CERTIFICATE_PARSE_FAILED,
+  CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID,
+  CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID,
   CERTOPS_KEY_MODE_INVALID,
   CERTOPS_KEY_REFERENCE_INVALID,
   PRIVATE_KEY_MATERIAL_REJECTED,
@@ -532,6 +704,7 @@ module.exports = {
   normalizeKeyReference,
   normalizeLimit,
   normalizeOffset,
+  retireManagedCertificate,
   toInstanceRecord,
   toInventoryRecord,
   upsertManagedCertificate,

--- a/apps/api/services/certops/monitorBridge.js
+++ b/apps/api/services/certops/monitorBridge.js
@@ -253,6 +253,7 @@ async function upsertObservedManagedCertificate(client, certificate, options) {
       source: bridgeSource(options),
       sourceRef: bridgeSourceRef(options),
       name: options.name || options.hostname,
+      tokenId: options.tokenId || null,
       createdBy: options.createdBy || null,
     },
     0,

--- a/apps/api/utils/secretMaterial.js
+++ b/apps/api/utils/secretMaterial.js
@@ -29,11 +29,17 @@ const GENERIC_SECRET_REDACTION_PLACEHOLDER = "[REDACTED]";
 // PKCS#1 (BEGIN RSA PRIVATE KEY), SEC1 (BEGIN EC PRIVATE KEY), DSA, OpenSSH,
 // and encrypted variants (BEGIN ENCRYPTED PRIVATE KEY / BEGIN RSA ENCRYPTED ...).
 // It must NOT match PUBLIC KEY, CERTIFICATE, or CERTIFICATE REQUEST blocks.
-const PRIVATE_KEY_PEM_PATTERN = /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----/;
+const PRIVATE_KEY_PEM_LABEL_PATTERN = String.raw`(?:[A-Z0-9]+\s+)*PRIVATE\s+KEY`;
+const PRIVATE_KEY_PEM_PATTERN = new RegExp(
+  String.raw`-----\s*BEGIN\s+${PRIVATE_KEY_PEM_LABEL_PATTERN}\s*-----`,
+  "i",
+);
 
 // Whole private-key PEM block (header to footer), used for redaction.
-const PRIVATE_KEY_PEM_BLOCK_PATTERN =
-  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g;
+const PRIVATE_KEY_PEM_BLOCK_PATTERN = new RegExp(
+  String.raw`-----\s*BEGIN\s+${PRIVATE_KEY_PEM_LABEL_PATTERN}\s*-----[\s\S]*?-----\s*END\s+${PRIVATE_KEY_PEM_LABEL_PATTERN}\s*-----`,
+  "gi",
+);
 
 // Conservative Authorization-header / bearer-token redaction for generic
 // secret scrubbing (extended in M2 evidence redaction work).
@@ -132,7 +138,7 @@ function stringContainsPrivateKey(value) {
  */
 function containsPrivateKeyMaterial(value, depth = 0) {
   if (value === null || value === undefined) return false;
-  if (depth > MAX_SCAN_DEPTH) return false;
+  if (depth > MAX_SCAN_DEPTH) return true;
 
   if (typeof value === "string") return stringContainsPrivateKey(value);
 

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -46,6 +46,7 @@
       { "path": "/api/v1/workspaces/{id}/certops/certificates", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}/instances", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}/retire", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/imports", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "GET" },

--- a/packages/contracts/db/baseline-minimum.schema.json
+++ b/packages/contracts/db/baseline-minimum.schema.json
@@ -14,6 +14,7 @@
         "users",
         "workspaces",
         "workspace_memberships",
+        "tokens",
         "certificate_profiles",
         "managed_certificates",
         "certificate_targets",
@@ -28,6 +29,9 @@
         },
         "workspace_memberships": {
           "$ref": "#/definitions/tableMemberships"
+        },
+        "tokens": {
+          "$ref": "#/definitions/tableTokens"
         },
         "certificate_profiles": {
           "$ref": "#/definitions/tableCertificateProfiles"
@@ -105,6 +109,27 @@
             "secret",
             "credential",
             "password"
+          ]
+        }
+      }
+    },
+    "tableTokens": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredColumns"],
+      "properties": {
+        "requiredColumns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "not": { "$ref": "#/definitions/certOpsSafeRequiredColumns/not" },
+          "minItems": 5,
+          "allOf": [
+            { "contains": { "const": "id" } },
+            { "contains": { "const": "workspace_id" } },
+            { "contains": { "const": "type" } },
+            { "contains": { "const": "category" } },
+            { "contains": { "const": "cert_lifecycle_status" } }
           ]
         }
       }

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3197,6 +3197,86 @@ paths:
                 code: CERTOPS_CERTIFICATE_NOT_FOUND
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/certificates/{certId}/retire:
+    post:
+      tags: [CertOps]
+      summary: Retire a managed certificate
+      operationId: retireCertOpsCertificate
+      description: Soft-retires a managed certificate by moving public lifecycle status to revoked or decommissioned. The managed certificate, linked token, and instance history are preserved; request bodies containing private key material are rejected before feature gating.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: certId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Managed certificate identifier.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertOpsCertificateRetireRequest"
+      responses:
+        "200":
+          description: Managed certificate retired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsManagedCertificateDetailResponse"
+        "400":
+          description: Invalid retire request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                invalidStatus:
+                  value:
+                    error: Invalid certificate retire status
+                    code: CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID
+                invalidReason:
+                  value:
+                    error: Invalid certificate retire reason
+                    code: CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Authenticated user lacks the workspace manager/admin role required for CertOps writes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Forbidden: insufficient role"
+                code: INSUFFICIENT_ROLE
+        "404":
+          description: CertOps is disabled or the certificate was not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                certopsDisabled:
+                  value:
+                    error: Endpoint not found
+                    code: NOT_FOUND
+                certificateNotFound:
+                  value:
+                    error: Certificate not found
+                    code: CERTOPS_CERTIFICATE_NOT_FOUND
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/imports:
     post:
       tags: [CertOps]
@@ -3800,6 +3880,22 @@ components:
       properties:
         certificate:
           $ref: "#/components/schemas/CertOpsManagedCertificate"
+    CertOpsCertificateRetireRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum:
+            - revoked
+            - decommissioned
+          description: Soft-retire lifecycle status to apply to the managed certificate and linked token.
+        reason:
+          type: string
+          nullable: true
+          maxLength: 512
+          description: Optional non-secret retirement reason. Private-key material, PEM markers, and secret-looking assignments are rejected.
     CertOpsCertificateWriteResponse:
       type: object
       additionalProperties: false

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -2746,6 +2746,21 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
+                      required: [tokenId]
+                      properties:
+                        certificateId:
+                          type: string
+                          nullable: true
+                          description: Source certificate identifier from the domain checker payload when available.
+                        tokenId:
+                          type: integer
+                          minimum: 1
+                          description: Actual non-secret tokens.id value created or linked for the imported certificate.
+                        name:
+                          type: string
+                        expiration:
+                          type: string
+                          format: date
                   skipped:
                     type: array
                     description: |-

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -2915,18 +2915,16 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
   # ----------------------------------------------------------------------------
-  # CertOps route skeletons (Phase 0 freeze).
-  # Documented-but-not-yet-implemented. Frozen to keep M1/M2 unblocked.
-  # Request/response schemas are filled in during M1 (inventory) and M2 (jobs,
-  # tokens, executor). No CertOps runtime routes exist yet, so these do not
-  # affect openapi runtime-coverage (runtime -> spec direction only).
+  # CertOps routes. M1 inventory routes are implemented with precise public-only
+  # schemas below. M2/M4 machine, token, job, and agent namespaces remain frozen
+  # skeletons so downstream overlays can build without route churn.
   # ----------------------------------------------------------------------------
   /api/v1/workspaces/{id}/certops/certificates:
     get:
       tags: [CertOps]
       summary: List managed certificates
       operationId: listCertOpsCertificates
-      description: Returns the workspace's managed certificate inventory (public material only). Skeleton; response schema lands in M1.
+      description: Returns the workspace's managed certificate inventory. Response objects contain public certificate material and public metadata only.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - $ref: "#/components/parameters/limitParam"
@@ -2937,10 +2935,18 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/CertOpsManagedCertificateListResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: CertOps is disabled for this deployment or workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Endpoint not found
+                code: NOT_FOUND
         "403":
           $ref: "#/components/responses/Forbidden"
         "500":
@@ -2949,7 +2955,7 @@ paths:
       tags: [CertOps]
       summary: Create or register a managed certificate
       operationId: createCertOpsCertificate
-      description: Registers a managed certificate from public material. Bodies containing private key material are rejected (422). Skeleton; request schema lands in M1.
+      description: Registers a managed certificate from public certificate material. Request bodies containing private key material are rejected before feature gating.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
       requestBody:
@@ -2957,29 +2963,62 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties: true
+              $ref: "#/components/schemas/CertOpsCertificateWriteRequest"
       responses:
         "201":
           description: Managed certificate registered
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/CertOpsCertificateWriteResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          description: Missing certificate material, malformed public certificate input, or invalid key reference
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingCertificate:
+                  value:
+                    error: certificatePem is required
+                    code: CERTOPS_CERTIFICATE_PEM_REQUIRED
+                parseFailed:
+                  value:
+                    error: Certificate input could not be parsed
+                    code: CERTOPS_CERTIFICATE_PARSE_FAILED
+                invalidKeyReference:
+                  value:
+                    error: keyReference must be a non-secret reference
+                    code: CERTOPS_KEY_REFERENCE_INVALID
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Authenticated user lacks the workspace manager/admin role required for CertOps writes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Forbidden: insufficient role"
+                code: INSUFFICIENT_ROLE
+        "404":
+          description: CertOps is disabled for this deployment or workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Endpoint not found
+                code: NOT_FOUND
         "422":
           description: Request rejected because it contained private key material
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/certificates/{certId}:
@@ -2987,7 +3026,7 @@ paths:
       tags: [CertOps]
       summary: Get a managed certificate
       operationId: getCertOpsCertificate
-      description: Returns a single managed certificate (public material only). Skeleton; response schema lands in M1.
+      description: Returns a single managed certificate. Response objects contain public certificate material and public metadata only.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - in: path
@@ -3002,12 +3041,26 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/CertOpsManagedCertificateDetailResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          description: CertOps is disabled or the certificate was not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                certopsDisabled:
+                  value:
+                    error: Endpoint not found
+                    code: NOT_FOUND
+                certificateNotFound:
+                  value:
+                    error: Certificate not found
+                    code: CERTOPS_CERTIFICATE_NOT_FOUND
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/certificates/{certId}/instances:
@@ -3134,7 +3187,7 @@ paths:
       tags: [CertOps]
       summary: Import certificates from public material
       operationId: createCertOpsImport
-      description: Imports certificates from PEM/public material. Private key material is rejected (422). Skeleton; request schema lands in M1.
+      description: Imports certificates from PEM/public material. Private key material is rejected before feature gating.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
       requestBody:
@@ -3142,29 +3195,62 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties: true
+              $ref: "#/components/schemas/CertOpsCertificateWriteRequest"
       responses:
         "202":
           description: Import accepted
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/CertOpsCertificateWriteResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          description: Missing certificate material, malformed public certificate input, or invalid key reference
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingCertificate:
+                  value:
+                    error: certificatePem is required
+                    code: CERTOPS_CERTIFICATE_PEM_REQUIRED
+                parseFailed:
+                  value:
+                    error: Certificate input could not be parsed
+                    code: CERTOPS_CERTIFICATE_PARSE_FAILED
+                invalidKeyReference:
+                  value:
+                    error: keyReference must be a non-secret reference
+                    code: CERTOPS_KEY_REFERENCE_INVALID
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
-          $ref: "#/components/responses/Forbidden"
+          description: Authenticated user lacks the workspace manager/admin role required for CertOps writes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Forbidden: insufficient role"
+                code: INSUFFICIENT_ROLE
+        "404":
+          description: CertOps is disabled for this deployment or workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Endpoint not found
+                code: NOT_FOUND
         "422":
           description: Request rejected because it contained private key material
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/jobs:
@@ -3528,6 +3614,244 @@ components:
         code: VALIDATION_ERROR
         details:
           - email is required
+    CertOpsManagedCertificate:
+      type: object
+      additionalProperties: false
+      description: Public-only CertOps managed certificate inventory record. This schema intentionally excludes private-key custody fields; private key material is rejected at the API boundary.
+      required:
+        - schemaVersion
+        - id
+        - workspaceId
+        - tokenId
+        - profileId
+        - status
+        - source
+        - sourceRef
+        - commonName
+        - subjectAltNames
+        - issuer
+        - serialNumber
+        - fingerprintSha256
+        - spkiFingerprintSha256
+        - certificatePem
+        - publicKeyAlgorithm
+        - publicKeySize
+        - signatureAlgorithm
+        - notBefore
+        - notAfter
+        - keyMode
+        - keyReference
+        - createdAt
+        - updatedAt
+      properties:
+        schemaVersion:
+          type: integer
+          enum: [1]
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        tokenId:
+          type: integer
+          nullable: true
+        profileId:
+          type: string
+          format: uuid
+          nullable: true
+        status:
+          type: string
+          enum:
+            - discovered
+            - active
+            - renewing
+            - expiring
+            - expired
+            - revoked
+            - decommissioned
+        source:
+          type: string
+          nullable: true
+          enum:
+            - manual
+            - api
+            - import
+            - domain_checker
+            - endpoint_monitor
+            - integration
+            - auto_sync
+            - null
+        sourceRef:
+          type: string
+          nullable: true
+          description: Opaque non-secret source reference.
+        commonName:
+          type: string
+          nullable: true
+        subjectAltNames:
+          type: array
+          items:
+            type: string
+        issuer:
+          type: string
+          nullable: true
+        serialNumber:
+          type: string
+          nullable: true
+        fingerprintSha256:
+          type: string
+          nullable: true
+          pattern: "^[a-f0-9]{64}$"
+          description: Lowercase SHA-256 fingerprint of public certificate material.
+        spkiFingerprintSha256:
+          type: string
+          nullable: true
+          pattern: "^[a-f0-9]{64}$"
+          description: Lowercase SHA-256 fingerprint of the public SubjectPublicKeyInfo.
+        certificatePem:
+          type: string
+          nullable: true
+          description: Public certificate PEM only. Private-key PEM, PFX/PKCS#12, and key-bearing material are rejected.
+        publicKeyAlgorithm:
+          type: string
+          nullable: true
+        publicKeySize:
+          type: integer
+          minimum: 1
+          nullable: true
+        signatureAlgorithm:
+          type: string
+          nullable: true
+        notBefore:
+          type: string
+          format: date-time
+          nullable: true
+        notAfter:
+          type: string
+          format: date-time
+          nullable: true
+        keyMode:
+          type: string
+          nullable: true
+          enum:
+            - agent-local
+            - proxy-agent-local
+            - cert-manager-managed
+            - appliance-managed
+            - hsm-managed
+            - vault-managed
+            - os-store-managed
+            - external-unknown
+            - null
+          description: Non-secret mode describing where the private key lives outside the control plane.
+        keyReference:
+          type: string
+          nullable: true
+          maxLength: 256
+          description: Opaque non-secret external reference. Inline secrets, private-key material, PEM markers, and control characters are rejected.
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+    CertOpsManagedCertificateListResponse:
+      type: object
+      additionalProperties: false
+      required: [items, pagination]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsManagedCertificate"
+        pagination:
+          type: object
+          additionalProperties: false
+          required: [limit, offset]
+          properties:
+            limit:
+              type: integer
+              minimum: 1
+            offset:
+              type: integer
+              minimum: 0
+    CertOpsManagedCertificateDetailResponse:
+      type: object
+      additionalProperties: false
+      required: [certificate]
+      properties:
+        certificate:
+          $ref: "#/components/schemas/CertOpsManagedCertificate"
+    CertOpsCertificateWriteResponse:
+      type: object
+      additionalProperties: false
+      required: [items, count]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsManagedCertificate"
+        count:
+          type: integer
+          minimum: 0
+    CertOpsCertificateWriteRequest:
+      type: object
+      additionalProperties: true
+      description: Recognized fields for public certificate import/register operations. Unknown fields are ignored by the current runtime, but the entire request body is scanned and rejected if any field contains private key material.
+      anyOf:
+        - required: [certificatePem]
+        - required: [pem]
+        - required: [certificate]
+        - required: [chainPem]
+        - required: [certificates]
+      properties:
+        certificatePem:
+          type: string
+          description: Public certificate PEM or PEM chain. Private key material is rejected with PRIVATE_KEY_MATERIAL_REJECTED.
+        pem:
+          type: string
+          description: Public certificate PEM or PEM chain.
+        certificate:
+          type: string
+          description: Public certificate PEM or PEM chain.
+        chainPem:
+          type: string
+          description: Public certificate PEM chain.
+        certificates:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: Public certificate PEM blocks joined by the runtime into a chain.
+        sourceRef:
+          type: string
+          nullable: true
+          description: Opaque non-secret source reference.
+        name:
+          type: string
+          nullable: true
+        keyMode:
+          type: string
+          nullable: true
+          enum:
+            - agent-local
+            - proxy-agent-local
+            - cert-manager-managed
+            - appliance-managed
+            - hsm-managed
+            - vault-managed
+            - os-store-managed
+            - external-unknown
+            - null
+          description: Non-secret mode describing where the private key lives outside the control plane.
+        keyReference:
+          type: string
+          nullable: true
+          maxLength: 256
+          description: Opaque non-secret external reference. Invalid references return CERTOPS_KEY_REFERENCE_INVALID; private-key material returns PRIVATE_KEY_MATERIAL_REJECTED.
     SessionUser:
       type: object
       required: [id, email]

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -111,6 +111,84 @@ function expectNoPrivateKeyFields(value) {
   expect(JSON.stringify(value)).to.not.include("PRIVATE KEY");
 }
 
+function formatDateYmd(value) {
+  if (!value) return null;
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}/.test(value)) {
+    return value.slice(0, 10);
+  }
+  if (value instanceof Date) {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const day = String(value.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+async function expectLinkedSslToken(certificate, expectedWorkspaceId) {
+  expect(Number.isInteger(certificate.tokenId)).to.equal(true);
+  expect(certificate.tokenId).to.be.greaterThan(0);
+
+  const tokenRows = await TestUtils.execQuery(
+    `SELECT id,
+            workspace_id,
+            user_id,
+            created_by,
+            name,
+            expiration,
+            type,
+            category,
+            issuer,
+            serial_number,
+            subject,
+            domains,
+            notes,
+            imported_at
+       FROM tokens
+      WHERE id = $1`,
+    [certificate.tokenId],
+  );
+  expect(tokenRows.rows).to.have.length(1);
+  const token = tokenRows.rows[0];
+  expect(token.workspace_id).to.equal(expectedWorkspaceId);
+  expect(token.type).to.equal("ssl_cert");
+  expect(token.category).to.equal("cert");
+  expect(token.name).to.be.a("string");
+  expect(token.name.length).to.be.greaterThan(2);
+  expect(formatDateYmd(token.expiration)).to.equal(
+    formatDateYmd(certificate.notAfter),
+  );
+  expect(token.issuer).to.equal(certificate.issuer);
+  expect(token.serial_number).to.equal(certificate.serialNumber);
+  expect(token.subject).to.be.a("string");
+  expect(token.subject).to.include(certificate.commonName);
+  expect(token.domains).to.include(certificate.commonName);
+  for (const san of certificate.subjectAltNames || []) {
+    expect(token.domains).to.include(san);
+  }
+  expect(token.notes).to.include("Imported by CertOps public PEM import.");
+  expect(token.notes).to.include(
+    `Fingerprint: ${certificate.fingerprintSha256}.`,
+  );
+  expect(token.imported_at).to.not.equal(null);
+  expectNoPrivateKeyFields(token);
+
+  const managedRows = await TestUtils.execQuery(
+    `SELECT token_id
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND id = $2`,
+    [expectedWorkspaceId, certificate.id],
+  );
+  expect(managedRows.rows).to.have.length(1);
+  expect(managedRows.rows[0].token_id).to.equal(certificate.tokenId);
+  expect(managedRows.rows[0].token_id).to.not.equal(null);
+
+  return token;
+}
+
 const CERTIFICATE_INSTANCE_FIELDS = [
   "createdAt",
   "deploymentReference",
@@ -218,10 +296,33 @@ describe("CertOps inventory routes", function () {
     expect(leafCertificate.spkiFingerprintSha256).to.match(/^[a-f0-9]{64}$/);
     expect(leafCertificate.notBefore).to.match(/^\d{4}-\d{2}-\d{2}T/);
     expect(leafCertificate.notAfter).to.match(/^\d{4}-\d{2}-\d{2}T/);
+    await expectLinkedSslToken(leafCertificate, workspaceId);
     expect(leafCertificate.keyMode).to.equal("external-unknown");
     expect(leafCertificate.keyReference).to.equal("vault://pki/web/example");
     expect(leafCertificate.certificatePem).to.include("BEGIN CERTIFICATE");
     expectNoPrivateKeyFields(leafCertificate);
+  });
+
+  it("register endpoint creates and reuses the linked token", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/certificates`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_CA_CERT })
+      .expect(201);
+
+    expect(response.body.count).to.equal(1);
+    const registered = response.body.items[0];
+    expect(registered.tokenId).to.not.equal(null);
+    await expectLinkedSslToken(registered, workspaceId);
+
+    const duplicate = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/certificates`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_CA_CERT })
+      .expect(201);
+
+    expect(duplicate.body.items[0].id).to.equal(registered.id);
+    expect(duplicate.body.items[0].tokenId).to.equal(registered.tokenId);
   });
 
   it("accepts a valid external key mode", async () => {
@@ -281,6 +382,37 @@ describe("CertOps inventory routes", function () {
 
     expect(duplicate.body.count).to.equal(1);
     expect(duplicate.body.items[0].id).to.equal(leafCertificate.id);
+    expect(duplicate.body.items[0].tokenId).to.equal(leafCertificate.tokenId);
+    await expectLinkedSslToken(duplicate.body.items[0], workspaceId);
+
+    await TestUtils.execQuery(
+      `UPDATE managed_certificates
+          SET token_id = NULL
+        WHERE workspace_id = $1
+          AND id = $2`,
+      [workspaceId, leafCertificate.id],
+    );
+    const relink = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_LEAF_CERT })
+      .expect(202);
+    expect(relink.body.items[0].id).to.equal(leafCertificate.id);
+    expect(relink.body.items[0].tokenId).to.equal(leafCertificate.tokenId);
+    await expectLinkedSslToken(relink.body.items[0], workspaceId);
+
+    const linkedTokens = await TestUtils.execQuery(
+      `SELECT COUNT(*)::int AS count
+         FROM tokens
+        WHERE workspace_id = $1
+          AND type = 'ssl_cert'
+          AND notes ILIKE $2`,
+      [
+        workspaceId,
+        `%Imported by CertOps public PEM import. Fingerprint: ${leafCertificate.fingerprintSha256}.%`,
+      ],
+    );
+    expect(linkedTokens.rows[0].count).to.equal(1);
 
     const list = await request(BASE)
       .get(`/api/v1/workspaces/${workspaceId}/certops/certificates`)

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -200,7 +200,11 @@ describe("CertOps inventory routes", function () {
     const response = await request(BASE)
       .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
       .set("Cookie", ownerSession.cookie)
-      .send({ certificatePem: `\n\n${PUBLIC_LEAF_CERT}\n` })
+      .send({
+        certificatePem: `\n\n${PUBLIC_LEAF_CERT}\n`,
+        keyMode: "external-unknown",
+        keyReference: "  vault://pki/web/example  ",
+      })
       .expect(202);
 
     expect(response.body.count).to.equal(1);
@@ -214,6 +218,8 @@ describe("CertOps inventory routes", function () {
     expect(leafCertificate.spkiFingerprintSha256).to.match(/^[a-f0-9]{64}$/);
     expect(leafCertificate.notBefore).to.match(/^\d{4}-\d{2}-\d{2}T/);
     expect(leafCertificate.notAfter).to.match(/^\d{4}-\d{2}-\d{2}T/);
+    expect(leafCertificate.keyMode).to.equal("external-unknown");
+    expect(leafCertificate.keyReference).to.equal("vault://pki/web/example");
     expect(leafCertificate.certificatePem).to.include("BEGIN CERTIFICATE");
     expectNoPrivateKeyFields(leafCertificate);
   });
@@ -253,6 +259,17 @@ describe("CertOps inventory routes", function () {
     expect(response.text).to.not.include("key_mode");
     expect(response.text).to.not.include("PUBLIC_LEAF_CERT");
     expectNoPrivateKeyFields(response.body);
+  });
+
+  it("normalizes an empty key reference to null", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_CA_CERT, keyReference: "   " })
+      .expect(202);
+
+    expect(response.body.count).to.equal(1);
+    expect(response.body.items[0].keyReference).to.equal(null);
   });
 
   it("deduplicates by workspace and SHA-256 fingerprint", async () => {
@@ -472,6 +489,44 @@ describe("CertOps inventory routes", function () {
     expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
     expect(response.text).to.not.include("RSA PRIVATE KEY");
     expect(response.text).to.not.include("RkFLRS1OT1QtQS1SRUFMLUtFWQ");
+  });
+
+  it("rejects an overlong key reference without echoing it", async () => {
+    const keyReference = `hsm://${"a".repeat(260)}`;
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_LEAF_CERT, keyReference });
+
+    expect(response.status).to.equal(400);
+    expect(response.body.code).to.equal("CERTOPS_KEY_REFERENCE_INVALID");
+    expect(response.text).to.not.include(keyReference);
+  });
+
+  it("rejects obvious secret-like key references without echoing them", async () => {
+    const keyReference = "external-unknown://legacy-ref?password=swordfish";
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({ certificatePem: PUBLIC_LEAF_CERT, keyReference });
+
+    expect(response.status).to.equal(400);
+    expect(response.body.code).to.equal("CERTOPS_KEY_REFERENCE_INVALID");
+    expect(response.text).to.not.include(keyReference);
+  });
+
+  it("rejects private key material in keyReference at the request boundary", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/certops/imports`)
+      .set("Cookie", ownerSession.cookie)
+      .send({
+        certificatePem: PUBLIC_LEAF_CERT,
+        keyReference: PRIVATE_KEY_PEM,
+      });
+
+    expect(response.status).to.equal(422);
+    expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expect(response.text).to.not.include("RSA PRIVATE KEY");
   });
 
   it("rejects malformed certificate input with a stable code", async () => {

--- a/tests/integration/certops-inventory.test.js
+++ b/tests/integration/certops-inventory.test.js
@@ -189,6 +189,62 @@ async function expectLinkedSslToken(certificate, expectedWorkspaceId) {
   return token;
 }
 
+async function managedCertificateRow(workspaceId, certificateId) {
+  const rows = await TestUtils.execQuery(
+    `SELECT id, workspace_id, token_id, status, fingerprint_sha256
+       FROM managed_certificates
+      WHERE workspace_id = $1
+        AND id = $2`,
+    [workspaceId, certificateId],
+  );
+  expect(rows.rows).to.have.length(1);
+  return rows.rows[0];
+}
+
+async function tokenRow(tokenId) {
+  const rows = await TestUtils.execQuery(
+    `SELECT id, workspace_id, type, category, cert_lifecycle_status
+       FROM tokens
+      WHERE id = $1`,
+    [tokenId],
+  );
+  expect(rows.rows).to.have.length(1);
+  return rows.rows[0];
+}
+
+async function certificateInstanceCount(workspaceId, certificateId) {
+  const rows = await TestUtils.execQuery(
+    `SELECT COUNT(*)::int AS count
+       FROM certificate_instances
+      WHERE workspace_id = $1
+        AND managed_certificate_id = $2`,
+    [workspaceId, certificateId],
+  );
+  return rows.rows[0].count;
+}
+
+async function createWorkspaceToken(session, workspaceId, overrides = {}) {
+  const tokenName = `${overrides.name || "CertOps token"} ${Date.now()} ${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  const response = await request(BASE)
+    .post("/api/tokens")
+    .set("Cookie", session.cookie)
+    .send({
+      name: tokenName,
+      type: "api_key",
+      category: "key_secret",
+      expiresAt: "2099-12-31",
+      workspace_id: workspaceId,
+      location: `certops-test-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      ...overrides,
+    })
+    .expect(201);
+  return response.body;
+}
+
 const CERTIFICATE_INSTANCE_FIELDS = [
   "createdAt",
   "deploymentReference",
@@ -225,6 +281,7 @@ describe("CertOps inventory routes", function () {
   let workspaceId;
   let outsiderWorkspaceId;
   let leafCertificate;
+  let caCertificate;
 
   before(async () => {
     await runMigrations();
@@ -312,6 +369,7 @@ describe("CertOps inventory routes", function () {
 
     expect(response.body.count).to.equal(1);
     const registered = response.body.items[0];
+    caCertificate = registered;
     expect(registered.tokenId).to.not.equal(null);
     await expectLinkedSslToken(registered, workspaceId);
 
@@ -558,6 +616,206 @@ describe("CertOps inventory routes", function () {
     expect(JSON.stringify(response.body)).to.not.include("public_metadata");
     expect(JSON.stringify(response.body)).to.not.include("publicMetadata");
     expect(JSON.stringify(response.body)).to.not.include("evidence");
+  });
+
+  it("retires a managed certificate as decommissioned without deleting rows", async () => {
+    const instanceCountBefore = await certificateInstanceCount(
+      workspaceId,
+      leafCertificate.id,
+    );
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${leafCertificate.id}/retire`,
+      )
+      .set("Cookie", ownerSession.cookie)
+      .send({ status: "decommissioned", reason: "rotation completed" })
+      .expect(200);
+
+    expect(response.body.certificate.id).to.equal(leafCertificate.id);
+    expect(response.body.certificate.status).to.equal("decommissioned");
+    expect(response.body.certificate.tokenId).to.equal(leafCertificate.tokenId);
+    expectNoPrivateKeyFields(response.body);
+
+    const managed = await managedCertificateRow(workspaceId, leafCertificate.id);
+    expect(managed.status).to.equal("decommissioned");
+    expect(managed.token_id).to.equal(leafCertificate.tokenId);
+
+    const linkedToken = await tokenRow(leafCertificate.tokenId);
+    expect(linkedToken.cert_lifecycle_status).to.equal("decommissioned");
+
+    const instanceCountAfter = await certificateInstanceCount(
+      workspaceId,
+      leafCertificate.id,
+    );
+    expect(instanceCountAfter).to.equal(instanceCountBefore);
+
+    const audit = await TestUtils.execQuery(
+      `SELECT metadata
+         FROM audit_events
+        WHERE workspace_id = $1
+          AND action = 'CERTOPS_CERTIFICATE_RETIRED'
+          AND metadata->>'managedCertificateId' = $2
+        ORDER BY id DESC
+        LIMIT 1`,
+      [workspaceId, leafCertificate.id],
+    );
+    expect(audit.rows).to.have.length(1);
+    expect(audit.rows[0].metadata).to.include({
+      managedCertificateId: leafCertificate.id,
+      tokenId: leafCertificate.tokenId,
+      status: "decommissioned",
+      reason: "rotation completed",
+      fingerprintSha256: leafCertificate.fingerprintSha256,
+    });
+    expectNoPrivateKeyFields(audit.rows[0].metadata);
+  });
+
+  it("retires a managed certificate as revoked and mirrors token lifecycle", async () => {
+    expect(caCertificate).to.exist;
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${caCertificate.id}/retire`,
+      )
+      .set("Cookie", managerSession.cookie)
+      .send({ status: "revoked", reason: "issuer revoked certificate" })
+      .expect(200);
+
+    expect(response.body.certificate.id).to.equal(caCertificate.id);
+    expect(response.body.certificate.status).to.equal("revoked");
+    expectNoPrivateKeyFields(response.body);
+
+    const managed = await managedCertificateRow(workspaceId, caCertificate.id);
+    expect(managed.status).to.equal("revoked");
+    expect(managed.token_id).to.equal(caCertificate.tokenId);
+
+    const linkedToken = await tokenRow(caCertificate.tokenId);
+    expect(linkedToken.cert_lifecycle_status).to.equal("revoked");
+  });
+
+  it("rejects invalid retire status without changing database state", async () => {
+    const before = await managedCertificateRow(workspaceId, caCertificate.id);
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${caCertificate.id}/retire`,
+      )
+      .set("Cookie", ownerSession.cookie)
+      .send({ status: "deleted", reason: "operator requested deletion" });
+
+    expect(response.status).to.equal(400);
+    expect(response.body).to.deep.equal({
+      error: "Invalid certificate retire status",
+      code: "CERTOPS_CERTIFICATE_RETIRE_STATUS_INVALID",
+    });
+
+    const after = await managedCertificateRow(workspaceId, caCertificate.id);
+    expect(after.status).to.equal(before.status);
+    const linkedToken = await tokenRow(caCertificate.tokenId);
+    expect(linkedToken.cert_lifecycle_status).to.equal(before.status);
+  });
+
+  it("rejects private-key material in retire reason without echoing it", async () => {
+    const before = await managedCertificateRow(workspaceId, leafCertificate.id);
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${workspaceId}/certops/certificates/${leafCertificate.id}/retire`,
+      )
+      .set("Cookie", ownerSession.cookie)
+      .send({ status: "revoked", reason: PRIVATE_KEY_PEM });
+
+    expect(response.status).to.equal(422);
+    expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expect(response.text).to.not.include("RSA PRIVATE KEY");
+    expect(response.text).to.not.include("RkFLRS1OT1QtQS1SRUFMLUtFWQ");
+
+    const after = await managedCertificateRow(workspaceId, leafCertificate.id);
+    expect(after.status).to.equal(before.status);
+    const linkedToken = await tokenRow(leafCertificate.tokenId);
+    expect(linkedToken.cert_lifecycle_status).to.equal(before.status);
+  });
+
+  it("keeps retire operations isolated by workspace", async () => {
+    const before = await managedCertificateRow(workspaceId, leafCertificate.id);
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${outsiderWorkspaceId}/certops/certificates/${leafCertificate.id}/retire`,
+      )
+      .set("Cookie", outsiderSession.cookie)
+      .send({ status: "revoked", reason: "wrong workspace" });
+
+    expect(response.status).to.equal(404);
+    expect(response.body.code).to.equal("CERTOPS_CERTIFICATE_NOT_FOUND");
+
+    const after = await managedCertificateRow(workspaceId, leafCertificate.id);
+    expect(after.status).to.equal(before.status);
+  });
+
+  it("blocks hard delete of managed-backed certificate tokens", async () => {
+    const instanceCountBefore = await certificateInstanceCount(
+      workspaceId,
+      leafCertificate.id,
+    );
+
+    const response = await request(BASE)
+      .delete(`/api/tokens/${leafCertificate.tokenId}`)
+      .set("Cookie", ownerSession.cookie);
+
+    expect(response.status).to.equal(409);
+    expect(response.body).to.deep.equal({
+      error: "Managed certificates must be retired before removal",
+      code: "CERTOPS_MANAGED_CERTIFICATE_RETIRE_REQUIRED",
+    });
+
+    await tokenRow(leafCertificate.tokenId);
+    await managedCertificateRow(workspaceId, leafCertificate.id);
+    const instanceCountAfter = await certificateInstanceCount(
+      workspaceId,
+      leafCertificate.id,
+    );
+    expect(instanceCountAfter).to.equal(instanceCountBefore);
+  });
+
+  it("allows hard delete of manual cert tokens not backed by managed certificates", async () => {
+    const token = await createWorkspaceToken(ownerSession, workspaceId, {
+      name: "Manual Cert Token",
+      type: "tls_cert",
+      category: "cert",
+      domains: ["manual-delete.certops.example"],
+    });
+
+    const response = await request(BASE)
+      .delete(`/api/tokens/${token.id}`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+
+    expect(response.body.message).to.include("deleted");
+    const rows = await TestUtils.execQuery("SELECT 1 FROM tokens WHERE id = $1", [
+      token.id,
+    ]);
+    expect(rows.rows).to.have.length(0);
+  });
+
+  it("allows hard delete of non-cert tokens", async () => {
+    const token = await createWorkspaceToken(ownerSession, workspaceId, {
+      name: "Manual API Token",
+      type: "api_key",
+      category: "key_secret",
+    });
+
+    const response = await request(BASE)
+      .delete(`/api/tokens/${token.id}`)
+      .set("Cookie", ownerSession.cookie)
+      .expect(200);
+
+    expect(response.body.message).to.include("deleted");
+    const rows = await TestUtils.execQuery("SELECT 1 FROM tokens WHERE id = $1", [
+      token.id,
+    ]);
+    expect(rows.rows).to.have.length(0);
   });
 
   it("denies viewer writes", async () => {

--- a/tests/integration/certops-migration.test.js
+++ b/tests/integration/certops-migration.test.js
@@ -20,6 +20,9 @@ const CERTOPS_TABLES = [
 const CERTOPS_MIGRATION = migrations.find(
   (migration) => migration.name === "certops_inventory_schema",
 );
+const CERTOPS_TOKEN_LIFECYCLE_MIGRATION = migrations.find(
+  (migration) => migration.name === "certops_token_lifecycle_status",
+);
 
 function quoteIdentifier(identifier) {
   return `"${String(identifier).replace(/"/g, '""')}"`;
@@ -123,6 +126,41 @@ describe("CertOps inventory migration", function () {
       [CERTOPS_MIGRATION.version],
     );
     expect(res.rows[0].count).to.equal(1);
+  });
+
+  it("adds the nullable token certificate lifecycle status idempotently", async () => {
+    expect(CERTOPS_TOKEN_LIFECYCLE_MIGRATION).to.exist;
+    expect(CERTOPS_TOKEN_LIFECYCLE_MIGRATION.version).to.equal(11);
+
+    await TestUtils.execQuery(CERTOPS_TOKEN_LIFECYCLE_MIGRATION.sql);
+    await TestUtils.execQuery(CERTOPS_TOKEN_LIFECYCLE_MIGRATION.sql);
+
+    const column = await TestUtils.execQuery(
+      `SELECT is_nullable, data_type
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'tokens'
+          AND column_name = 'cert_lifecycle_status'`,
+    );
+    expect(column.rows).to.have.length(1);
+    expect(column.rows[0].is_nullable).to.equal("YES");
+    expect(column.rows[0].data_type).to.equal("text");
+
+    const constraint = await TestUtils.execQuery(
+      `SELECT COUNT(*)::int AS count
+         FROM pg_constraint
+        WHERE conname = 'tokens_cert_lifecycle_status_check'`,
+    );
+    expect(constraint.rows[0].count).to.equal(1);
+
+    const index = await TestUtils.execQuery(
+      `SELECT COUNT(*)::int AS count
+         FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'tokens'
+          AND indexname = 'idx_tokens_workspace_cert_lifecycle_status'`,
+    );
+    expect(index.rows[0].count).to.equal(1);
   });
 
   it("does not create private-key custody columns", async () => {

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -65,6 +65,8 @@ const API_FINGERPRINT_COLON = API_FINGERPRINT.match(/../g)
   .join(":")
   .toUpperCase();
 const SHA1_FINGERPRINT = "d".repeat(40);
+const NONCANONICAL_PRIVATE_KEY_BODY = "FAKE-TEST-BODY";
+const NONCANONICAL_PRIVATE_KEY_PEM = `-----begin rsa private key-----\n${NONCANONICAL_PRIVATE_KEY_BODY}\n-----end rsa private key-----`;
 
 function walkKeys(value, visit) {
   if (Array.isArray(value)) {
@@ -363,6 +365,58 @@ describe("Domain checker API import integration", function () {
       .expect(422);
     expect(privateKey.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
     expect(JSON.stringify(privateKey.body)).to.not.include("RkFLRS1LRVk");
+  });
+
+  it("rejects noncanonical private-key-like import payloads before persistence", async () => {
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${workspaceId}/domain-checker/import`)
+      .set("Cookie", session.cookie)
+      .send({
+        domain: "example.com",
+        certificates: [
+          {
+            id: "noncanonical-private-key-rejected",
+            name: "keyprobe.example.com",
+            domains: ["keyprobe.example.com"],
+            expiration: "2099-12-31",
+            issuer: "Probe CA",
+            subject: NONCANONICAL_PRIVATE_KEY_PEM,
+            certificatePem: NONCANONICAL_PRIVATE_KEY_PEM,
+            fingerprint: WWW_FINGERPRINT,
+            sources: ["subfinder", NONCANONICAL_PRIVATE_KEY_PEM],
+          },
+        ],
+        monitorOptions: { enabled: true },
+      })
+      .expect(422);
+
+    expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expect(JSON.stringify(response.body)).to.not.include(
+      NONCANONICAL_PRIVATE_KEY_BODY,
+    );
+
+    const tokenRows = await TestUtils.execQuery(
+      "SELECT id FROM tokens WHERE workspace_id = $1 AND name = $2",
+      [workspaceId, "keyprobe.example.com"],
+    );
+    expect(tokenRows.rows).to.have.length(0);
+
+    const monitorRows = await TestUtils.execQuery(
+      "SELECT id FROM domain_monitors WHERE workspace_id = $1 AND url = $2",
+      [workspaceId, "https://keyprobe.example.com"],
+    );
+    expect(monitorRows.rows).to.have.length(0);
+
+    const certopsRows = await TestUtils.execQuery(
+      `SELECT ci.id
+         FROM certificate_instances ci
+         JOIN certificate_targets ct
+           ON ct.workspace_id = ci.workspace_id AND ct.id = ci.target_id
+        WHERE ci.workspace_id = $1
+          AND ct.url = $2`,
+      [workspaceId, "https://keyprobe.example.com"],
+    );
+    expect(certopsRows.rows).to.have.length(0);
   });
 
   it("imports discovered SSL tokens and populates CertOps on monitor observations", async () => {

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -633,21 +633,22 @@ describe("Domain checker API import integration", function () {
     expect(
       certopsByUrl["https://sha1.example.com"].observed_fingerprint_sha256,
     ).to.equal(null);
-    expect(certopsByUrl["https://api.example.com"].token_id).to.equal(
-      importedTokenByName["api.example.com"],
-    );
-    expect(certopsByUrl["https://sha1.example.com"].token_id).to.equal(
-      importedTokenByName["sha1.example.com"],
-    );
-    expect(certopsByUrl["https://www.example.com"].token_id).to.equal(
-      importedTokenByName["www.example.com"],
-    );
+    const expectedTokenNameByUrl = {
+      "https://api.example.com": "api.example.com",
+      "https://sha1.example.com": "sha1.example.com",
+      "https://www.example.com": "www.example.com",
+    };
+    for (const [url, tokenName] of Object.entries(expectedTokenNameByUrl)) {
+      const expectedTokenId = importedTokenByName[tokenName];
+      expect(certopsByUrl[url].token_id).to.equal(expectedTokenId);
+      expect(certopsByUrl[url].target_token_id).to.equal(expectedTokenId);
+      expect(certopsByUrl[url].managed_token_id).to.equal(expectedTokenId);
+      expect(certopsByUrl[url].managed_token_id).to.not.equal(null);
+    }
     for (const row of certopsRows.rows) {
       expect(row.workspace_id).to.equal(workspaceId);
       expect(row.target_workspace_id).to.equal(workspaceId);
       expect(row.certificate_workspace_id).to.equal(workspaceId);
-      expect(row.target_token_id).to.equal(row.token_id);
-      expect(row.managed_token_id).to.equal(row.token_id);
       expect(row.certificate_pem).to.equal(null);
       expect(row.observed_not_after).to.not.equal(null);
       expectNoPrivateKeyFields(normalizeMetadata(row.instance_metadata));
@@ -686,6 +687,31 @@ describe("Domain checker API import integration", function () {
       [workspaceId, wwwRow.target_id, wwwRow.managed_certificate_id],
     );
     expect(repeatedCount.rows[0].count).to.equal(1);
+    const repeatedTokenLinks = await TestUtils.execQuery(
+      `SELECT ci.token_id,
+              ct.token_id AS target_token_id,
+              mc.token_id AS managed_token_id
+         FROM certificate_instances ci
+         JOIN certificate_targets ct
+           ON ct.workspace_id = ci.workspace_id AND ct.id = ci.target_id
+         JOIN managed_certificates mc
+           ON mc.workspace_id = ci.workspace_id
+          AND mc.id = ci.managed_certificate_id
+        WHERE ci.workspace_id = $1
+          AND ci.id = $2`,
+      [workspaceId, wwwRow.id],
+    );
+    expect(repeatedTokenLinks.rows).to.have.length(1);
+    expect(repeatedTokenLinks.rows[0].token_id).to.equal(
+      importedTokenByName["www.example.com"],
+    );
+    expect(repeatedTokenLinks.rows[0].target_token_id).to.equal(
+      importedTokenByName["www.example.com"],
+    );
+    expect(repeatedTokenLinks.rows[0].managed_token_id).to.equal(
+      importedTokenByName["www.example.com"],
+    );
+    expect(repeatedTokenLinks.rows[0].managed_token_id).to.not.equal(null);
 
     const disabledFingerprint = "c".repeat(64);
     const disabledObservation = await bridgeEndpointCertificateObservation({

--- a/tests/integration/domain-checker.integration.test.js
+++ b/tests/integration/domain-checker.integration.test.js
@@ -498,7 +498,16 @@ describe("Domain checker API import integration", function () {
       "no_matching_domains_and_missing_expiration",
     ]);
 
+    expect(
+      response.body.imported.every(
+        (entry) => Number.isInteger(entry.tokenId) && entry.tokenId > 0,
+      ),
+    ).to.equal(true);
     const tokenIds = response.body.imported.map((entry) => entry.tokenId);
+    expect(new Set(tokenIds).size).to.equal(tokenIds.length);
+    const importedTokenByName = Object.fromEntries(
+      response.body.imported.map((entry) => [entry.name, entry.tokenId]),
+    );
     const tokenRows = await TestUtils.execQuery(
       `SELECT id, name, type, category, issuer, subject, domains, notes
          FROM tokens
@@ -554,6 +563,18 @@ describe("Domain checker API import integration", function () {
     expect(monitors.rows.every((row) => tokenIds.includes(row.token_id))).to.equal(
       true,
     );
+    const monitorByUrl = Object.fromEntries(
+      monitors.rows.map((row) => [row.url, row]),
+    );
+    expect(monitorByUrl["https://api.example.com"].token_id).to.equal(
+      importedTokenByName["api.example.com"],
+    );
+    expect(monitorByUrl["https://sha1.example.com"].token_id).to.equal(
+      importedTokenByName["sha1.example.com"],
+    );
+    expect(monitorByUrl["https://www.example.com"].token_id).to.equal(
+      importedTokenByName["www.example.com"],
+    );
 
     const certopsRows = await TestUtils.execQuery(
       `SELECT
@@ -597,9 +618,6 @@ describe("Domain checker API import integration", function () {
     );
     expect(certopsRows.rows).to.have.length(3);
 
-    const importedTokenByName = Object.fromEntries(
-      response.body.imported.map((entry) => [entry.name, entry.tokenId]),
-    );
     const certopsByUrl = Object.fromEntries(
       certopsRows.rows.map((row) => [row.url, row]),
     );

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -69,6 +69,10 @@ tests/integration/endpoint-health-alerts.test.js
 tests/integration/endpoint-check-worker.integration.test.js
 tests/integration/domain-checker.integration.test.js
 
+# CertOps M1
+tests/integration/certops-migration.test.js
+tests/integration/certops-inventory.test.js
+
 # Integrations
 tests/integration/github.integration.test.js
 tests/integration/gitlab.integration.test.js
@@ -86,8 +90,6 @@ tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
 tests/integration/database-schema.test.js
-tests/integration/certops-migration.test.js
-tests/integration/certops-inventory.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js
 tests/integration/vault.parsing.unit.test.js

--- a/tests/integration/test-setup-guide.md
+++ b/tests/integration/test-setup-guide.md
@@ -94,6 +94,41 @@ pnpm run test:core
 3. **`token-categories.test.js`** - Tests for token category functionality
 4. **`tokens.test.js`** - General token management tests
 
+## CertOps and Domain Checker Local Validation
+
+When running focused integration tests directly from a Windows PowerShell host,
+load the same database/API environment that the repo wrappers expect. The Docker
+test stack exposes PostgreSQL on the host, so use `localhost` from PowerShell.
+Inside Docker, service-to-service traffic uses `DB_HOST=postgres`.
+
+```powershell
+$env:DB_HOST="localhost"
+$env:DB_PORT="5432"
+$env:DB_NAME="tokentimer"
+$env:DB_USER="tokentimer"
+$env:DB_PASSWORD="password"
+$env:TEST_API_URL="http://localhost:4000"
+$env:CERTOPS_ENABLED="true"
+```
+
+Prefer the repository env wrapper for focused Mocha commands; it loads `.env`
+or safe local defaults before invoking the test process:
+
+```powershell
+node scripts/run-with-env.js pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 120000 --exit
+node scripts/run-with-env.js pnpm exec mocha tests/integration/domain-checker.integration.test.js --timeout 120000 --exit
+node scripts/run-with-env.js pnpm exec mocha tests/integration/endpoint-check-worker.integration.test.js --timeout 120000 --exit
+```
+
+Use the Docker test stack helpers when the local database/API stack is not
+already running:
+
+```bash
+pnpm run test:up
+# run the focused commands above
+pnpm run test:down
+```
+
 ### Test Utilities
 
 - **`test-server.js`** - Server connection and utility functions

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -93,6 +93,14 @@ const BASELINE_CERTOPS_COLUMNS = {
   ],
 };
 
+const BASELINE_TOKEN_COLUMNS = [
+  "id",
+  "workspace_id",
+  "type",
+  "category",
+  "cert_lifecycle_status",
+];
+
 const FORBIDDEN_CUSTODY_COLUMNS = [
   "privateKey",
   "private_key",
@@ -112,6 +120,9 @@ const FORBIDDEN_CUSTODY_COLUMNS = [
 
 const certOpsMigration = migrations.find(
   (migration) => migration.name === "certops_inventory_schema",
+);
+const certOpsTokenLifecycleMigration = migrations.find(
+  (migration) => migration.name === "certops_token_lifecycle_status",
 );
 
 function getTableBlock(tableName) {
@@ -158,6 +169,38 @@ describe("CertOps inventory migration", () => {
   it("defines the M1 inventory migration", () => {
     assert.ok(certOpsMigration, "expected certops_inventory_schema migration");
     assert.equal(certOpsMigration.version, 10);
+  });
+
+  it("defines the token lifecycle migration after the inventory migration", () => {
+    assert.ok(
+      certOpsTokenLifecycleMigration,
+      "expected certops_token_lifecycle_status migration",
+    );
+    assert.equal(certOpsTokenLifecycleMigration.version, 11);
+    assert.deepEqual(
+      migrations.slice(-3).map((migration) => migration.version),
+      [9, 10, 11],
+    );
+    assert.match(
+      certOpsTokenLifecycleMigration.sql,
+      /ALTER TABLE tokens\s+ADD COLUMN IF NOT EXISTS cert_lifecycle_status TEXT NULL/,
+    );
+    assert.match(
+      certOpsTokenLifecycleMigration.sql,
+      /tokens_cert_lifecycle_status_check/,
+    );
+    assert.match(
+      certOpsTokenLifecycleMigration.sql,
+      /'revoked'/,
+    );
+    assert.match(
+      certOpsTokenLifecycleMigration.sql,
+      /'decommissioned'/,
+    );
+    assert.match(
+      certOpsTokenLifecycleMigration.sql,
+      /CREATE INDEX IF NOT EXISTS idx_tokens_workspace_cert_lifecycle_status/,
+    );
   });
 
   it("creates every CertOps table idempotently", () => {
@@ -257,6 +300,38 @@ describe("CertOps inventory migration", () => {
         `${tableName} baseline contract allows ${forbiddenHit}`,
       );
     }
+  });
+
+  it("requires the token certificate lifecycle column in the baseline DB contract", () => {
+    const tableSchema = baselineMinimumSchema.properties.tables.properties;
+    const requiredTables = baselineMinimumSchema.properties.tables.required;
+
+    assert.ok(
+      requiredTables.includes("tokens"),
+      "tokens must be required by the baseline contract",
+    );
+    assert.ok(tableSchema.tokens, "tokens schema is missing");
+
+    const resolvedTableSchema = resolveBaselineSchema(tableSchema.tokens);
+    const requiredColumns = resolvedTableSchema.properties.requiredColumns;
+    for (const columnName of BASELINE_TOKEN_COLUMNS) {
+      assert.match(
+        JSON.stringify(requiredColumns),
+        new RegExp(`"const":"${columnName}"`),
+        `tokens must require ${columnName}`,
+      );
+    }
+
+    const forbiddenHit = FORBIDDEN_CUSTODY_COLUMNS.find((columnName) =>
+      JSON.stringify(requiredColumns)
+        .toLowerCase()
+        .includes(`"${columnName.toLowerCase()}"`),
+    );
+    assert.equal(
+      forbiddenHit,
+      undefined,
+      `tokens baseline contract allows ${forbiddenHit}`,
+    );
   });
 
   it("links certificates to existing tokens without making tokens depend on CertOps", () => {

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -85,6 +85,7 @@ describe("CertOps M1 route hardening", () => {
       "GET /api/v1/workspaces/:id/certops/certificates/:certId",
       "GET /api/v1/workspaces/:id/certops/certificates/:certId/instances",
       "POST /api/v1/workspaces/:id/certops/certificates",
+      "POST /api/v1/workspaces/:id/certops/certificates/:certId/retire",
       "POST /api/v1/workspaces/:id/certops/imports",
     ].sort());
 
@@ -100,6 +101,10 @@ describe("CertOps M1 route hardening", () => {
         "get",
         "/api/v1/workspaces/:id/certops/certificates/:certId/instances",
       ],
+      [
+        "post",
+        "/api/v1/workspaces/:id/certops/certificates/:certId/retire",
+      ],
       ["get", "/api/v1/workspaces/:id/certops/certificates/:certId"],
       ["post", "/api/v1/workspaces/:id/certops/imports"],
     ]) {
@@ -107,25 +112,34 @@ describe("CertOps M1 route hardening", () => {
     }
   });
 
-  it("declares certificate instance history before generic certificate detail", () => {
+  it("declares specific certificate child routes before generic certificate detail", () => {
     const instancesIndex = routesSource.indexOf(
       '"/api/v1/workspaces/:id/certops/certificates/:certId/instances"',
+    );
+    const retireIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/certificates/:certId/retire"',
     );
     const detailIndex = routesSource.indexOf(
       '"/api/v1/workspaces/:id/certops/certificates/:certId"',
     );
 
     assert.notEqual(instancesIndex, -1);
+    assert.notEqual(retireIndex, -1);
     assert.notEqual(detailIndex, -1);
     assert.ok(
       instancesIndex < detailIndex,
       "instance history route must be declared before generic certificate detail",
+    );
+    assert.ok(
+      retireIndex < detailIndex,
+      "retire route must be declared before generic certificate detail",
     );
   });
 
   it("runs private-key rejection before feature gating on write routes", () => {
     for (const routePath of [
       "/api/v1/workspaces/:id/certops/certificates",
+      "/api/v1/workspaces/:id/certops/certificates/:certId/retire",
       "/api/v1/workspaces/:id/certops/imports",
     ]) {
       const block = routeBlock("post", routePath);
@@ -187,6 +201,10 @@ describe("CertOps M1 route hardening", () => {
     assertOpenApiRoute(
       "/api/v1/workspaces/{id}/certops/certificates/{certId}/instances",
       "GET",
+    );
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/certificates/{certId}/retire",
+      "POST",
     );
   });
 });

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -9,6 +9,53 @@ const routesSource = fs.readFileSync(
   path.resolve(__dirname, "../../apps/api/routes/certops.js"),
   "utf8",
 );
+const routeCompatContract = require("../../packages/contracts/api/certops-route-compat.contract.json");
+const openApiSource = fs.readFileSync(
+  path.resolve(__dirname, "../../packages/contracts/openapi/openapi.yaml"),
+  "utf8",
+);
+
+function parseOpenApiPathMethods(source) {
+  const paths = new Map();
+  let inPaths = false;
+  let currentPath = null;
+
+  for (const line of source.split(/\r?\n/)) {
+    if (line === "paths:") {
+      inPaths = true;
+      continue;
+    }
+
+    if (inPaths && /^[A-Za-z][^:]*:\s*$/.test(line)) break;
+
+    const pathMatch = line.match(/^  (\/[^:]+):\s*$/);
+    if (pathMatch) {
+      currentPath = pathMatch[1];
+      paths.set(currentPath, new Set());
+      continue;
+    }
+
+    const methodMatch = line.match(
+      /^    (get|post|put|patch|delete|options|head|trace):\s*$/,
+    );
+    if (currentPath && methodMatch) {
+      paths.get(currentPath).add(methodMatch[1].toUpperCase());
+    }
+  }
+
+  return paths;
+}
+
+const openApiPathMethods = parseOpenApiPathMethods(openApiSource);
+
+function assertOpenApiRoute(routePath, method) {
+  const methods = openApiPathMethods.get(routePath);
+  assert.ok(methods, `${routePath} missing from OpenAPI paths`);
+  assert.ok(
+    methods.has(method.toUpperCase()),
+    `${method.toUpperCase()} ${routePath} missing from OpenAPI paths`,
+  );
+}
 
 function routeBlock(method, routePath) {
   const start = routesSource.indexOf(`router.${method}(\n  "${routePath}"`);
@@ -93,5 +140,53 @@ describe("CertOps M1 route hardening", () => {
         `${routePath} must check the rollout gate before write authorization`,
       );
     }
+  });
+
+  it("keeps the route-compat contract and OpenAPI path skeletons aligned", () => {
+    const { namespacePolicy, routeAuth, guarantees } = routeCompatContract;
+    const stableRoutes = guarantees.stableRoutes;
+    const stableRouteByPath = new Map(
+      stableRoutes.map((route) => [route.path, route]),
+    );
+
+    for (const route of stableRoutes) {
+      assertOpenApiRoute(route.path, route.method);
+
+      if (route.path.startsWith("/api/v1/workspaces/")) {
+        assert.ok(
+          route.path.startsWith(namespacePolicy.workspaceScoped.prefix),
+          `${route.path} is outside the workspace CertOps namespace`,
+        );
+      }
+
+      if (route.path.startsWith("/api/v1/certops/executor")) {
+        assert.ok(
+          route.path.startsWith(namespacePolicy.executor.prefix),
+          `${route.path} is outside the executor CertOps namespace`,
+        );
+      }
+
+      if (route.path.startsWith("/api/v1/certops/agent")) {
+        assert.ok(
+          route.path.startsWith(namespacePolicy.agent.prefix),
+          `${route.path} is outside the agent CertOps namespace`,
+        );
+      }
+    }
+
+    for (const [routePath, authScheme] of Object.entries(routeAuth)) {
+      const route = stableRouteByPath.get(routePath);
+      assert.ok(route, `${routePath} routeAuth entry is not a stable route`);
+      assertOpenApiRoute(routePath, route.method);
+      assert.ok(
+        openApiSource.includes(`${authScheme}:`),
+        `${authScheme} missing from OpenAPI security schemes or route security`,
+      );
+    }
+
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/certificates/{certId}/instances",
+      "GET",
+    );
   });
 });

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const routesSource = fs.readFileSync(
+  path.resolve(__dirname, "../../apps/api/routes/certops.js"),
+  "utf8",
+);
+
+function routeBlock(method, routePath) {
+  const start = routesSource.indexOf(`router.${method}(\n  "${routePath}"`);
+  assert.notEqual(start, -1, `${method.toUpperCase()} ${routePath} not found`);
+
+  const nextRoute = routesSource.indexOf("\nrouter.", start + 1);
+  const end =
+    nextRoute === -1
+      ? routesSource.indexOf("\nmodule.exports", start)
+      : nextRoute;
+  assert.notEqual(
+    end,
+    -1,
+    `${method.toUpperCase()} ${routePath} block end not found`,
+  );
+  return routesSource.slice(start, end);
+}
+
+describe("CertOps M1 route hardening", () => {
+  it("implements only the frozen M1 workspace inventory routes", () => {
+    const routeMatches = Array.from(
+      routesSource.matchAll(/router\.(get|post)\(\n\s+"([^"]+)"/g),
+    ).map((match) => `${match[1].toUpperCase()} ${match[2]}`);
+
+    assert.deepEqual(routeMatches.sort(), [
+      "GET /api/v1/workspaces/:id/certops/certificates",
+      "GET /api/v1/workspaces/:id/certops/certificates/:certId",
+      "POST /api/v1/workspaces/:id/certops/certificates",
+      "POST /api/v1/workspaces/:id/certops/imports",
+    ].sort());
+
+    assert.equal(routesSource.includes("/api/v1/certops/executor"), false);
+    assert.equal(routesSource.includes("/api/v1/certops/agent"), false);
+  });
+
+  it("gates every inventory route with certops.enabled", () => {
+    for (const [method, routePath] of [
+      ["get", "/api/v1/workspaces/:id/certops/certificates"],
+      ["post", "/api/v1/workspaces/:id/certops/certificates"],
+      ["get", "/api/v1/workspaces/:id/certops/certificates/:certId"],
+      ["post", "/api/v1/workspaces/:id/certops/imports"],
+    ]) {
+      assert.match(routeBlock(method, routePath), /requireCertOpsEnabled/);
+    }
+  });
+
+  it("runs private-key rejection before feature gating on write routes", () => {
+    for (const routePath of [
+      "/api/v1/workspaces/:id/certops/certificates",
+      "/api/v1/workspaces/:id/certops/imports",
+    ]) {
+      const block = routeBlock("post", routePath);
+      assert.ok(
+        block.indexOf("rejectKeyMaterial") <
+          block.indexOf("requireCertOpsEnabled"),
+        `${routePath} must reject private key material before the rollout gate`,
+      );
+      assert.ok(
+        block.indexOf("requireCertOpsEnabled") <
+          block.indexOf("requireCertOpsWriteRole"),
+        `${routePath} must check the rollout gate before write authorization`,
+      );
+    }
+  });
+});

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -36,6 +36,7 @@ describe("CertOps M1 route hardening", () => {
     assert.deepEqual(routeMatches.sort(), [
       "GET /api/v1/workspaces/:id/certops/certificates",
       "GET /api/v1/workspaces/:id/certops/certificates/:certId",
+      "GET /api/v1/workspaces/:id/certops/certificates/:certId/instances",
       "POST /api/v1/workspaces/:id/certops/certificates",
       "POST /api/v1/workspaces/:id/certops/imports",
     ].sort());
@@ -48,11 +49,31 @@ describe("CertOps M1 route hardening", () => {
     for (const [method, routePath] of [
       ["get", "/api/v1/workspaces/:id/certops/certificates"],
       ["post", "/api/v1/workspaces/:id/certops/certificates"],
+      [
+        "get",
+        "/api/v1/workspaces/:id/certops/certificates/:certId/instances",
+      ],
       ["get", "/api/v1/workspaces/:id/certops/certificates/:certId"],
       ["post", "/api/v1/workspaces/:id/certops/imports"],
     ]) {
       assert.match(routeBlock(method, routePath), /requireCertOpsEnabled/);
     }
+  });
+
+  it("declares certificate instance history before generic certificate detail", () => {
+    const instancesIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/certificates/:certId/instances"',
+    );
+    const detailIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/certificates/:certId"',
+    );
+
+    assert.notEqual(instancesIndex, -1);
+    assert.notEqual(detailIndex, -1);
+    assert.ok(
+      instancesIndex < detailIndex,
+      "instance history route must be declared before generic certificate detail",
+    );
   });
 
   it("runs private-key rejection before feature gating on write routes", () => {

--- a/tests/unit/reject-key-material.test.js
+++ b/tests/unit/reject-key-material.test.js
@@ -20,6 +20,12 @@ const FAKE_PRIVATE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
 const fakePem = (label) =>
   `-----BEGIN ${label}-----\n${FAKE_PRIVATE_BODY}\n-----END ${label}-----`;
 
+const NONCANONICAL_PRIVATE_KEY_PEMS = [
+  `-----begin rsa private key-----\n${FAKE_PRIVATE_BODY}\n-----end rsa private key-----`,
+  `-----BEGIN  RSA   PRIVATE   KEY-----\n${FAKE_PRIVATE_BODY}\n-----END  RSA   PRIVATE   KEY-----`,
+  `-----BeGiN EnCrYpTeD PrIvAtE KeY-----\n${FAKE_PRIVATE_BODY}\n-----eNd EnCrYpTeD PrIvAtE KeY-----`,
+];
+
 const PUBLIC_CERTIFICATE_PEM = fakePem("CERTIFICATE");
 const PUBLIC_KEY_PEM = fakePem("PUBLIC KEY");
 
@@ -28,6 +34,14 @@ function fakePkcs12Buffer() {
     Buffer.from([0x30, 0x5c, 0x02, 0x01, 0x03]),
     Buffer.alloc(89, 0),
   ]);
+}
+
+function deeplyNested(value, depth = 14) {
+  let node = value;
+  for (let index = 0; index < depth; index += 1) {
+    node = { child: node };
+  }
+  return node;
 }
 
 const WORKSPACE_ID = "550e8400-e29b-41d4-a716-446655440000";
@@ -103,11 +117,24 @@ describe("rejectKeyMaterial middleware", () => {
     await assertRejected({ certificate: fakePem("RSA PRIVATE KEY") });
   });
 
+  it("rejects noncanonical private key PEM armor", async () => {
+    await assertRejected({ certificate: NONCANONICAL_PRIVATE_KEY_PEMS[0] });
+  });
+
   it("rejects nested private key material", async () => {
     await assertRejected({
       import: {
         notes: "nested payload",
         certificate: { pem: fakePem("EC PRIVATE KEY") },
+      },
+    });
+  });
+
+  it("rejects nested noncanonical private key material", async () => {
+    await assertRejected({
+      import: {
+        notes: "nested payload",
+        certificate: { pem: NONCANONICAL_PRIVATE_KEY_PEMS[1] },
       },
     });
   });
@@ -118,12 +145,30 @@ describe("rejectKeyMaterial middleware", () => {
     });
   });
 
+  it("rejects array-contained noncanonical private key material", async () => {
+    await assertRejected({
+      certificates: [PUBLIC_CERTIFICATE_PEM, NONCANONICAL_PRIVATE_KEY_PEMS[2]],
+    });
+  });
+
   it("rejects base64-wrapped private key PEM", async () => {
     const wrapped = Buffer.from(fakePem("ENCRYPTED PRIVATE KEY")).toString(
       "base64",
     );
 
     await assertRejected({ attachment: wrapped });
+  });
+
+  it("rejects base64-wrapped noncanonical private key PEM", async () => {
+    const wrapped = Buffer.from(NONCANONICAL_PRIVATE_KEY_PEMS[2]).toString(
+      "base64",
+    );
+
+    await assertRejected({ attachment: wrapped });
+  });
+
+  it("rejects buffer request bodies carrying noncanonical private key PEM", async () => {
+    await assertRejected(Buffer.from(NONCANONICAL_PRIVATE_KEY_PEMS[1]));
   });
 
   it("rejects PKCS#12/PFX-like binary request bodies", async () => {
@@ -146,6 +191,16 @@ describe("rejectKeyMaterial middleware", () => {
     await assertAllowed({
       certificatePem: "not a certificate and not private key material",
     });
+  });
+
+  it("rejects over-depth request bodies without echoing nested content", async () => {
+    const nestedPayload = "harmless but too deeply nested";
+    const result = await assertRejected(deeplyNested(nestedPayload));
+
+    assert.equal(
+      JSON.stringify(result.responseBody).includes(nestedPayload),
+      false,
+    );
   });
 
   it("records a synchronous audit event without alert_queue dependency", async () => {
@@ -228,6 +283,15 @@ describe("rejectKeyMaterial middleware", () => {
 
   it("does not echo private key material in the response", async () => {
     const privateKey = fakePem("RSA PRIVATE KEY");
+    const result = await assertRejected({ payload: privateKey });
+    const serialized = JSON.stringify(result.responseBody);
+
+    assert.equal(serialized.includes(privateKey), false);
+    assert.equal(serialized.includes(FAKE_PRIVATE_BODY), false);
+  });
+
+  it("does not echo noncanonical private key material in the response", async () => {
+    const privateKey = NONCANONICAL_PRIVATE_KEY_PEMS[0];
     const result = await assertRejected({ payload: privateKey });
     const serialized = JSON.stringify(result.responseBody);
 

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -27,6 +27,14 @@ function fakePkcs12Buffer() {
   ]);
 }
 
+function deeplyNested(value, depth = 14) {
+  let node = value;
+  for (let index = 0; index < depth; index += 1) {
+    node = { child: node };
+  }
+  return node;
+}
+
 const PRIVATE_KEY_LABELS = [
   "PRIVATE KEY", // PKCS#8
   "RSA PRIVATE KEY", // PKCS#1
@@ -35,6 +43,21 @@ const PRIVATE_KEY_LABELS = [
   "OPENSSH PRIVATE KEY",
   "ENCRYPTED PRIVATE KEY",
   "RSA ENCRYPTED PRIVATE KEY",
+];
+
+const NONCANONICAL_PRIVATE_KEY_PEMS = [
+  {
+    name: "lowercase PEM armor",
+    value: `-----begin rsa private key-----\n${FAKE_BODY}\n-----end rsa private key-----`,
+  },
+  {
+    name: "extra PEM armor whitespace",
+    value: `-----BEGIN  RSA   PRIVATE   KEY-----\n${FAKE_BODY}\n-----END  RSA   PRIVATE   KEY-----`,
+  },
+  {
+    name: "mixed-case PEM armor",
+    value: `-----BeGiN EnCrYpTeD PrIvAtE KeY-----\n${FAKE_BODY}\n-----eNd EnCrYpTeD PrIvAtE KeY-----`,
+  },
 ];
 
 const NON_KEY_VALUES = [
@@ -57,8 +80,35 @@ describe("secretMaterial.containsPrivateKeyMaterial", () => {
     });
   }
 
+  for (const fixture of NONCANONICAL_PRIVATE_KEY_PEMS) {
+    it(`detects ${fixture.name}`, () => {
+      assert.strictEqual(containsPrivateKeyMaterial(fixture.value), true);
+    });
+  }
+
+  it("detects noncanonical private key PEM in objects, arrays, and buffers", () => {
+    const privateKey = NONCANONICAL_PRIVATE_KEY_PEMS[1].value;
+
+    assert.strictEqual(
+      containsPrivateKeyMaterial({ certificate: { pem: privateKey } }),
+      true,
+    );
+    assert.strictEqual(
+      containsPrivateKeyMaterial(["public metadata", privateKey]),
+      true,
+    );
+    assert.strictEqual(containsPrivateKeyMaterial(Buffer.from(privateKey)), true);
+  });
+
   it("detects base64-wrapped private key PEM", () => {
     const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
+  });
+
+  it("detects base64-wrapped noncanonical private key PEM", () => {
+    const wrapped = Buffer.from(
+      NONCANONICAL_PRIVATE_KEY_PEMS[2].value,
+    ).toString("base64");
     assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
   });
 
@@ -105,10 +155,17 @@ describe("secretMaterial.containsPrivateKeyMaterial", () => {
     assert.strictEqual(containsPrivateKeyMaterial(payload), false);
   });
 
-  it("does not infinitely recurse on cyclic objects", () => {
+  it("fails closed for harmless values nested beyond the scan depth", () => {
+    assert.strictEqual(
+      containsPrivateKeyMaterial(deeplyNested("harmless public metadata")),
+      true,
+    );
+  });
+
+  it("does not infinitely recurse on cyclic objects and fails closed", () => {
     const a = {};
     a.self = a;
-    assert.strictEqual(containsPrivateKeyMaterial(a), false);
+    assert.strictEqual(containsPrivateKeyMaterial(a), true);
   });
 });
 
@@ -122,8 +179,30 @@ describe("secretMaterial.redactPrivateKeyMaterial", () => {
     assert.ok(out.endsWith("after"));
   });
 
+  for (const fixture of NONCANONICAL_PRIVATE_KEY_PEMS) {
+    it(`redacts ${fixture.name}`, () => {
+      const input = `before\n${fixture.value}\nafter`;
+      const out = redactPrivateKeyMaterial(input);
+
+      assert.ok(out.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+      assert.ok(!out.includes(FAKE_BODY));
+      assert.ok(!/private\s+key/i.test(out));
+      assert.ok(out.startsWith("before"));
+      assert.ok(out.endsWith("after"));
+    });
+  }
+
   it("redacts a base64-wrapped private key to the placeholder", () => {
     const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64");
+    const out = redactPrivateKeyMaterial(wrapped);
+    assert.strictEqual(out, PRIVATE_KEY_REDACTION_PLACEHOLDER);
+    assert.ok(!out.includes(wrapped));
+  });
+
+  it("redacts a base64-wrapped noncanonical private key to the placeholder", () => {
+    const wrapped = Buffer.from(
+      NONCANONICAL_PRIVATE_KEY_PEMS[0].value,
+    ).toString("base64");
     const out = redactPrivateKeyMaterial(wrapped);
     assert.strictEqual(out, PRIVATE_KEY_REDACTION_PLACEHOLDER);
     assert.ok(!out.includes(wrapped));


### PR DESCRIPTION
## Summary

This PR adds the M1-A6 CertOps final hardening and acceptance checkpoint.

It reviews and hardens the completed CertOps M1 backend slice:

* M1-A1 inventory schema
* M1-A2 public certificate parser
* M1-A3 private-key rejection and audit
* M1-A4 gated inventory API routes
* M1-A5 endpoint/domain monitor bridge

This PR also closes the remaining review follow-ups before calling M1 Core complete:

* Adds CertOps migration and inventory integration tests to the enterprise `core-compatible` suite.
* Adds a real `certops-route-compat.contract.json` ↔ OpenAPI conformance test for frozen CertOps routes.
* Protects the Dev B dashboard backend dependency:

  * `GET /api/v1/workspaces/:id/certops/certificates/:certId/instances`
  * route ordering before generic certificate detail
  * `certops.enabled` gating
  * OpenAPI/contract parity
* Ensures successful domain-checker import response items return a real non-null `tokenId`.
* Verifies the linked `tokenId` is consistent across imported response items, domain monitors, CertOps targets, instances, and managed certificate rows.
* Updates OpenAPI so successful imported items require non-null `tokenId`.
* Corrects `CONTEXT.md` to avoid overclaiming broad logger content-scrub; M1 documents field-name redaction/sanitized boundary logging, while broader arbitrary log content-scrub remains follow-up.
* Confirms private-key material is rejected before storage or processing.
* Confirms no private-key-looking fields are persisted or returned.
* Confirms workspace isolation and safe 404 behavior.
* Confirms monitor bridge idempotency and strict SHA-256 fingerprint handling.
* Does not add new runtime product features.
* Fixes the runtime token-link persistence bug: successful domain-checker imports now persist the real linked `tokens.id` into `managed_certificates.token_id`, not only into the import response, monitor, target, and instance rows.
* Fixes direct CertOps PEM imports/registers so they create or reuse a public `tokens` row, persist the real `tokens.id` into `managed_certificates.token_id`, and return non-null `items[].tokenId` for dashboard visibility.

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* `node --check tests/unit/certops-routes-hardening.test.js`: ok
* `node --check tests/integration/domain-checker.integration.test.js`: ok
* `node --check tests/integration/certops-inventory.test.js`: ok
* `node --check apps/api/routes/certops.js`: ok
* `node --check apps/api/services/certops/inventory.js`: ok
* `node --check apps/api/services/certops/monitorBridge.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `pnpm run test:unit`: ok
* `node scripts/run-with-env.js pnpm exec mocha tests/integration/certops-migration.test.js --timeout 60000 --exit`: ok
* `node scripts/run-with-env.js pnpm exec mocha tests/integration/certops-inventory.test.js --timeout 120000 --exit`: ok
* `node scripts/run-with-env.js pnpm exec mocha tests/integration/domain-checker.integration.test.js --timeout 120000 --exit`: ok
* `node scripts/run-with-env.js pnpm exec mocha tests/integration/endpoint-check-worker.integration.test.js --timeout 120000 --exit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on M1-A5: `feature/certops-m1-a5-endpoint-monitor-bridge`.
* This is a hardening/checkpoint PR, not a new feature slice.
* Dev B dashboard UI and Cloud overlay work remain split out; this PR only protects the backend/OpenAPI/contract surface they depend on.
* No dashboard UI, Cloud overlay, executor runtime, agent runtime, ACME runtime, cert-manager runtime, Helm/RBAC, `api_tokens` runtime, jobs, or evidence backend work is included.
* No M2 work is included.
* CertOps remains observe-only in M1.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by the M1 control plane.

## Test plan

* [x] Review M1 hardening changes
* [x] Review CertOps security assumptions
* [x] Verify route contract ↔ OpenAPI conformance
* [x] Verify CertOps migration/inventory tests are in `core-compatible`
* [x] Verify Dev B instance-history route remains stable
* [x] Verify successful import response items return non-null `tokenId`
* [x] Run `pnpm run test:unit`
* [x] Run CertOps migration integration test
* [x] Run CertOps inventory integration test
* [x] Run domain-checker integration test
* [x] Run endpoint-check-worker integration test
* [x] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
