### PR TITLE
feat(certops): add scoped api token service m2-a2

### DIFF
--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -823,6 +823,94 @@ const migrations = [
         WHERE cert_lifecycle_status IS NOT NULL;
     `,
   },
+  {
+    version: 12,
+    name: "certops_api_tokens_schema",
+    sql: `
+      -- CertOps API tokens store lookup metadata only. The raw plaintext token
+      -- is returned once by the service and is never persisted.
+      CREATE TABLE IF NOT EXISTS api_tokens (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL CHECK (char_length(btrim(name)) BETWEEN 1 AND 128),
+        token_prefix TEXT NOT NULL,
+        token_hash TEXT NOT NULL CHECK (token_hash ~ '^[a-f0-9]{64}$'),
+        scopes TEXT[] NOT NULL DEFAULT '{}'
+          CHECK (
+            COALESCE(array_length(scopes, 1), 0) BETWEEN 1 AND 8 AND
+            scopes <@ ARRAY[
+              'certops:executor:events',
+              'certops:jobs:read',
+              'certops:jobs:write',
+              'certops:evidence:write'
+            ]::text[]
+          ),
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'revoked')),
+        expires_at TIMESTAMPTZ NULL,
+        last_used_at TIMESTAMPTZ NULL,
+        revoked_at TIMESTAMPTZ NULL,
+        revoked_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_api_tokens_workspace_id UNIQUE (workspace_id, id)
+      );
+
+      DO $$
+      DECLARE
+        old_constraint_name TEXT;
+      BEGIN
+        FOR old_constraint_name IN
+          SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+           WHERE c.contype = 'c'
+             AND t.relname = 'api_tokens'
+             AND n.nspname = current_schema()
+             AND (
+               pg_get_constraintdef(c.oid) LIKE '%left(token_prefix, 5)%' OR
+               pg_get_constraintdef(c.oid) LIKE '%"left"(token_prefix, 5)%'
+             )
+        LOOP
+          EXECUTE format('ALTER TABLE api_tokens DROP CONSTRAINT %I', old_constraint_name);
+        END LOOP;
+
+        IF NOT EXISTS (
+          SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+           WHERE c.conname = 'api_tokens_token_prefix_check'
+             AND t.relname = 'api_tokens'
+             AND n.nspname = current_schema()
+        ) THEN
+          ALTER TABLE api_tokens
+            ADD CONSTRAINT api_tokens_token_prefix_check
+            CHECK (
+              token_prefix ~ '^ttx_[A-Za-z0-9]+$' AND
+              token_prefix <> 'ttx__'
+            ) NOT VALID;
+        END IF;
+      END $$;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_api_tokens_token_prefix
+        ON api_tokens(token_prefix);
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_api_tokens_token_hash
+        ON api_tokens(token_hash);
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_workspace
+        ON api_tokens(workspace_id);
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_workspace_status
+        ON api_tokens(workspace_id, status);
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_status_expires
+        ON api_tokens(status, expires_at)
+        WHERE status = 'active';
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_created_by
+        ON api_tokens(workspace_id, created_by)
+        WHERE created_by IS NOT NULL;
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -835,16 +835,16 @@ const migrations = [
         name TEXT NOT NULL CHECK (char_length(btrim(name)) BETWEEN 1 AND 128),
         token_prefix TEXT NOT NULL,
         token_hash TEXT NOT NULL CHECK (token_hash ~ '^[a-f0-9]{64}$'),
-        scopes TEXT[] NOT NULL DEFAULT '{}'
-          CHECK (
+        scopes TEXT[] NOT NULL DEFAULT '{}',
+        CONSTRAINT api_tokens_scopes_check CHECK (
             COALESCE(array_length(scopes, 1), 0) BETWEEN 1 AND 8 AND
             scopes <@ ARRAY[
-              'certops:executor:events',
+              'certops:read',
+              'certops:events:write',
               'certops:jobs:read',
-              'certops:jobs:write',
               'certops:evidence:write'
             ]::text[]
-          ),
+        ),
         status TEXT NOT NULL DEFAULT 'active'
           CHECK (status IN ('active', 'revoked')),
         expires_at TIMESTAMPTZ NULL,
@@ -876,6 +876,40 @@ const migrations = [
         LOOP
           EXECUTE format('ALTER TABLE api_tokens DROP CONSTRAINT %I', old_constraint_name);
         END LOOP;
+
+        FOR old_constraint_name IN
+          SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+           WHERE c.contype = 'c'
+             AND t.relname = 'api_tokens'
+             AND n.nspname = current_schema()
+             AND c.conname = 'api_tokens_scopes_check'
+        LOOP
+          EXECUTE format('ALTER TABLE api_tokens DROP CONSTRAINT %I', old_constraint_name);
+        END LOOP;
+
+        IF NOT EXISTS (
+          SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+           WHERE c.conname = 'api_tokens_scopes_check'
+             AND t.relname = 'api_tokens'
+             AND n.nspname = current_schema()
+        ) THEN
+          ALTER TABLE api_tokens
+            ADD CONSTRAINT api_tokens_scopes_check CHECK (
+              COALESCE(array_length(scopes, 1), 0) BETWEEN 1 AND 8 AND
+              scopes <@ ARRAY[
+                'certops:read',
+                'certops:events:write',
+                'certops:jobs:read',
+                'certops:evidence:write'
+              ]::text[]
+            ) NOT VALID;
+        END IF;
 
         IF NOT EXISTS (
           SELECT 1

--- a/apps/api/services/certops/apiTokens.js
+++ b/apps/api/services/certops/apiTokens.js
@@ -1,0 +1,432 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const { pool } = require("../../db/database");
+const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
+
+const CERTOPS_API_TOKEN_INVALID = "CERTOPS_API_TOKEN_INVALID";
+const CERTOPS_API_TOKEN_MALFORMED = "CERTOPS_API_TOKEN_MALFORMED";
+const CERTOPS_API_TOKEN_NAME_INVALID = "CERTOPS_API_TOKEN_NAME_INVALID";
+const CERTOPS_API_TOKEN_SCOPE_DENIED = "CERTOPS_API_TOKEN_SCOPE_DENIED";
+const CERTOPS_API_TOKEN_SCOPE_INVALID = "CERTOPS_API_TOKEN_SCOPE_INVALID";
+const CERTOPS_API_TOKEN_WORKSPACE_REQUIRED =
+  "CERTOPS_API_TOKEN_WORKSPACE_REQUIRED";
+const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
+
+const TOKEN_PREFIX = "ttx_";
+const TOKEN_ID_BYTES = 8;
+const TOKEN_RANDOM_BYTES = 32;
+const MAX_TOKEN_CREATE_ATTEMPTS = 3;
+const RAW_TOKEN_PATTERN = /^ttx_([A-Za-z0-9]+)_([A-Za-z0-9]+)$/;
+
+const ALLOWED_SCOPES = Object.freeze([
+  "certops:executor:events",
+  "certops:jobs:read",
+  "certops:jobs:write",
+  "certops:evidence:write",
+]);
+const ALLOWED_SCOPE_SET = new Set(ALLOWED_SCOPES);
+
+const SAFE_SELECT_FIELDS = `
+  id,
+  workspace_id,
+  name,
+  token_prefix,
+  scopes,
+  status,
+  expires_at,
+  last_used_at,
+  revoked_at,
+  revoked_by,
+  created_by,
+  created_at,
+  updated_at
+`;
+
+function serviceError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function dateToIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeName(value) {
+  if (typeof value !== "string") {
+    throw serviceError("API token name is required", CERTOPS_API_TOKEN_NAME_INVALID);
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 128) {
+    throw serviceError("API token name is invalid", CERTOPS_API_TOKEN_NAME_INVALID);
+  }
+  if (containsPrivateKeyMaterial(trimmed)) {
+    throw serviceError(
+      "Private key material is not accepted in CertOps API token metadata",
+      PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  }
+  return trimmed;
+}
+
+function normalizeScopes(scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0 || scopes.length > 8) {
+    throw serviceError(
+      "CertOps API token scopes are invalid",
+      CERTOPS_API_TOKEN_SCOPE_INVALID,
+    );
+  }
+
+  const normalized = [];
+  for (const scope of scopes) {
+    if (typeof scope !== "string") {
+      throw serviceError(
+        "CertOps API token scopes are invalid",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+    const trimmed = scope.trim();
+    if (!ALLOWED_SCOPE_SET.has(trimmed)) {
+      throw serviceError(
+        "CertOps API token scope is not allowed",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+    if (!normalized.includes(trimmed)) normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function normalizeRequiredScopes(requiredScopes) {
+  if (requiredScopes === undefined || requiredScopes === null) return [];
+  const scopes = Array.isArray(requiredScopes) ? requiredScopes : [requiredScopes];
+  if (scopes.length === 0) return [];
+
+  const normalized = [];
+  for (const scope of scopes) {
+    if (typeof scope !== "string") {
+      throw serviceError(
+        "CertOps API token scopes are invalid",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+    const trimmed = scope.trim();
+    if (!ALLOWED_SCOPE_SET.has(trimmed)) {
+      throw serviceError(
+        "CertOps API token scope is not allowed",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+    if (!normalized.includes(trimmed)) normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function normalizeExpiresAt(value) {
+  if (value === undefined || value === null || value === "") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw serviceError("API token expiry is invalid", CERTOPS_API_TOKEN_INVALID);
+  }
+  return date;
+}
+
+function normalizeWorkspaceId(value) {
+  const workspaceId = typeof value === "string" ? value.trim() : "";
+  if (!workspaceId) {
+    throw serviceError(
+      "Workspace is required for API token validation",
+      CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+    );
+  }
+  return workspaceId;
+}
+
+function generateRawToken() {
+  const tokenId = crypto.randomBytes(TOKEN_ID_BYTES).toString("hex");
+  const randomPart = crypto.randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
+  return `${TOKEN_PREFIX}${tokenId}_${randomPart}`;
+}
+
+function parseRawToken(rawToken) {
+  const token = typeof rawToken === "string" ? rawToken.trim() : "";
+  const match = RAW_TOKEN_PATTERN.exec(token);
+  if (!match) return null;
+
+  return {
+    rawToken: token,
+    tokenId: match[1],
+    tokenPrefix: `${TOKEN_PREFIX}${match[1]}`,
+  };
+}
+
+function tokenPrefixFor(rawToken) {
+  return parseRawToken(rawToken)?.tokenPrefix || null;
+}
+
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function safeCompareSha256Hex(candidateHash, storedHash) {
+  const candidate = /^[a-f0-9]{64}$/.test(candidateHash)
+    ? Buffer.from(candidateHash, "hex")
+    : Buffer.alloc(32);
+  const stored = /^[a-f0-9]{64}$/.test(String(storedHash || ""))
+    ? Buffer.from(storedHash, "hex")
+    : Buffer.alloc(32);
+  return crypto.timingSafeEqual(candidate, stored) && storedHash === candidateHash;
+}
+
+function scopesFromRow(row) {
+  if (Array.isArray(row?.scopes)) return row.scopes;
+  if (typeof row?.scopes === "string") {
+    try {
+      const parsed = JSON.parse(row.scopes);
+      if (Array.isArray(parsed)) return parsed;
+    } catch (_error) {
+      return [];
+    }
+  }
+  return [];
+}
+
+function hasRequiredScopes(grantedScopes, requiredScopes) {
+  const granted = new Set(grantedScopes);
+  return requiredScopes.every((scope) => granted.has(scope));
+}
+
+function tokenMetadataFromRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    name: row.name,
+    tokenPrefix: row.token_prefix,
+    scopes: scopesFromRow(row),
+    status: row.status,
+    expiresAt: dateToIso(row.expires_at),
+    lastUsedAt: dateToIso(row.last_used_at),
+    revokedAt: dateToIso(row.revoked_at),
+    revokedBy: row.revoked_by,
+    createdBy: row.created_by,
+    createdAt: dateToIso(row.created_at),
+    updatedAt: dateToIso(row.updated_at),
+  };
+}
+
+function invalidValidation(code = CERTOPS_API_TOKEN_INVALID) {
+  return { valid: false, code };
+}
+
+async function createApiToken(options) {
+  const db = options.client || pool;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const name = normalizeName(options.name);
+  const scopes = normalizeScopes(options.scopes);
+  const expiresAt = normalizeExpiresAt(options.expiresAt);
+
+  for (let attempt = 1; attempt <= MAX_TOKEN_CREATE_ATTEMPTS; attempt += 1) {
+    const plaintextToken = generateRawToken();
+    const tokenPrefix = tokenPrefixFor(plaintextToken);
+    const tokenHash = sha256Hex(plaintextToken);
+
+    try {
+      const result = await db.query(
+        `INSERT INTO api_tokens (
+           workspace_id,
+           name,
+           token_prefix,
+           token_hash,
+           scopes,
+           status,
+           expires_at,
+           created_by
+         )
+         VALUES ($1, $2, $3, $4, $5::text[], 'active', $6, $7)
+         RETURNING ${SAFE_SELECT_FIELDS}`,
+        [
+          workspaceId,
+          name,
+          tokenPrefix,
+          tokenHash,
+          scopes,
+          expiresAt,
+          options.createdBy || null,
+        ],
+      );
+
+      return {
+        token: tokenMetadataFromRow(result.rows[0]),
+        plaintextToken,
+      };
+    } catch (error) {
+      if (
+        error?.code === "23505" &&
+        attempt < MAX_TOKEN_CREATE_ATTEMPTS &&
+        /api_tokens_token_(?:prefix|hash)/.test(String(error.constraint || ""))
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw serviceError("Unable to create API token", CERTOPS_API_TOKEN_INVALID);
+}
+
+async function listApiTokens(options) {
+  const result = await (options.client || pool).query(
+    `SELECT ${SAFE_SELECT_FIELDS}
+       FROM api_tokens
+      WHERE workspace_id = $1
+      ORDER BY created_at DESC, id ASC`,
+    [normalizeWorkspaceId(options.workspaceId)],
+  );
+  return result.rows.map(tokenMetadataFromRow);
+}
+
+async function getApiTokenById(options) {
+  const result = await (options.client || pool).query(
+    `SELECT ${SAFE_SELECT_FIELDS}
+       FROM api_tokens
+      WHERE workspace_id = $1
+        AND id = $2
+      LIMIT 1`,
+    [normalizeWorkspaceId(options.workspaceId), options.tokenId],
+  );
+  return tokenMetadataFromRow(result.rows[0] || null);
+}
+
+async function revokeApiToken(options) {
+  const result = await (options.client || pool).query(
+    `UPDATE api_tokens
+        SET status = 'revoked',
+            revoked_at = COALESCE(revoked_at, NOW()),
+            revoked_by = COALESCE(revoked_by, $3),
+            updated_at = NOW()
+      WHERE workspace_id = $1
+        AND id = $2
+      RETURNING ${SAFE_SELECT_FIELDS}`,
+    [
+      normalizeWorkspaceId(options.workspaceId),
+      options.tokenId,
+      options.revokedBy || null,
+    ],
+  );
+  return tokenMetadataFromRow(result.rows[0] || null);
+}
+
+async function markApiTokenUsed(options) {
+  const result = await (options.client || pool).query(
+    `UPDATE api_tokens
+        SET last_used_at = NOW(),
+            updated_at = NOW()
+      WHERE id = $1
+      RETURNING ${SAFE_SELECT_FIELDS}`,
+    [options.tokenId],
+  );
+  return tokenMetadataFromRow(result.rows[0] || null);
+}
+
+async function validateApiToken(options) {
+  let workspaceId;
+  let requiredScopes;
+  try {
+    workspaceId = normalizeWorkspaceId(options.workspaceId);
+    requiredScopes = normalizeRequiredScopes(options.requiredScopes);
+  } catch (error) {
+    if (error.code === CERTOPS_API_TOKEN_WORKSPACE_REQUIRED) {
+      return invalidValidation(error.code);
+    }
+    throw error;
+  }
+
+  const parsedToken = parseRawToken(options.rawToken);
+  if (!parsedToken) {
+    return invalidValidation(CERTOPS_API_TOKEN_MALFORMED);
+  }
+
+  const rawToken = parsedToken.rawToken;
+  const candidateHash = sha256Hex(rawToken);
+  const result = await (options.client || pool).query(
+    `SELECT id,
+            workspace_id,
+            name,
+            token_prefix,
+            token_hash,
+            scopes,
+            status,
+            expires_at,
+            last_used_at,
+            revoked_at,
+            revoked_by,
+            created_by,
+            created_at,
+            updated_at
+       FROM api_tokens
+      WHERE token_prefix = $1
+      LIMIT 1`,
+    [parsedToken.tokenPrefix],
+  );
+
+  const row = result.rows[0];
+  if (!row) return invalidValidation();
+  if (!safeCompareSha256Hex(candidateHash, row.token_hash)) {
+    return invalidValidation();
+  }
+  if (String(row.workspace_id) !== workspaceId) {
+    return invalidValidation();
+  }
+  if (row.status !== "active") {
+    return invalidValidation();
+  }
+
+  const expiresAt = row.expires_at ? new Date(row.expires_at) : null;
+  if (expiresAt && expiresAt.getTime() <= Date.now()) {
+    return invalidValidation();
+  }
+
+  if (!hasRequiredScopes(scopesFromRow(row), requiredScopes)) {
+    return invalidValidation(CERTOPS_API_TOKEN_SCOPE_DENIED);
+  }
+
+  const token = await markApiTokenUsed({
+    client: options.client,
+    tokenId: row.id,
+  });
+  return { valid: true, token: token || tokenMetadataFromRow(row) };
+}
+
+module.exports = {
+  ALLOWED_SCOPES,
+  CERTOPS_API_TOKEN_INVALID,
+  CERTOPS_API_TOKEN_MALFORMED,
+  CERTOPS_API_TOKEN_NAME_INVALID,
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  TOKEN_PREFIX,
+  createApiToken,
+  getApiTokenById,
+  listApiTokens,
+  markApiTokenUsed,
+  revokeApiToken,
+  validateApiToken,
+  _test: {
+    hasRequiredScopes,
+    safeCompareSha256Hex,
+    scopesFromRow,
+    sha256Hex,
+    parseRawToken,
+    tokenMetadataFromRow,
+    tokenPrefixFor,
+  },
+};

--- a/apps/api/services/certops/apiTokens.js
+++ b/apps/api/services/certops/apiTokens.js
@@ -18,12 +18,14 @@ const TOKEN_PREFIX = "ttx_";
 const TOKEN_ID_BYTES = 8;
 const TOKEN_RANDOM_BYTES = 32;
 const MAX_TOKEN_CREATE_ATTEMPTS = 3;
+const MAX_RAW_TOKEN_LENGTH = 256;
+const LAST_USED_UPDATE_INTERVAL = "5 minutes";
 const RAW_TOKEN_PATTERN = /^ttx_([A-Za-z0-9]+)_([A-Za-z0-9]+)$/;
 
 const ALLOWED_SCOPES = Object.freeze([
-  "certops:executor:events",
+  "certops:read",
+  "certops:events:write",
   "certops:jobs:read",
-  "certops:jobs:write",
   "certops:evidence:write",
 ]);
 const ALLOWED_SCOPE_SET = new Set(ALLOWED_SCOPES);
@@ -155,12 +157,18 @@ function generateRawToken() {
 }
 
 function parseRawToken(rawToken) {
-  const token = typeof rawToken === "string" ? rawToken.trim() : "";
-  const match = RAW_TOKEN_PATTERN.exec(token);
+  if (
+    typeof rawToken !== "string" ||
+    rawToken.length === 0 ||
+    rawToken.length > MAX_RAW_TOKEN_LENGTH
+  ) {
+    return null;
+  }
+  const match = RAW_TOKEN_PATTERN.exec(rawToken);
   if (!match) return null;
 
   return {
-    rawToken: token,
+    rawToken,
     tokenId: match[1],
     tokenPrefix: `${TOKEN_PREFIX}${match[1]}`,
   };
@@ -175,13 +183,16 @@ function sha256Hex(value) {
 }
 
 function safeCompareSha256Hex(candidateHash, storedHash) {
-  const candidate = /^[a-f0-9]{64}$/.test(candidateHash)
+  const candidateIsSha256 = /^[a-f0-9]{64}$/.test(candidateHash);
+  const storedIsSha256 = /^[a-f0-9]{64}$/.test(String(storedHash || ""));
+  const candidate = candidateIsSha256
     ? Buffer.from(candidateHash, "hex")
     : Buffer.alloc(32);
-  const stored = /^[a-f0-9]{64}$/.test(String(storedHash || ""))
+  const stored = storedIsSha256
     ? Buffer.from(storedHash, "hex")
     : Buffer.alloc(32);
-  return crypto.timingSafeEqual(candidate, stored) && storedHash === candidateHash;
+  const matches = crypto.timingSafeEqual(candidate, stored);
+  return candidateIsSha256 && storedIsSha256 && matches;
 }
 
 function scopesFromRow(row) {
@@ -199,7 +210,19 @@ function scopesFromRow(row) {
 
 function hasRequiredScopes(grantedScopes, requiredScopes) {
   const granted = new Set(grantedScopes);
+  if (granted.has("certops:read")) {
+    granted.add("certops:jobs:read");
+  }
   return requiredScopes.every((scope) => granted.has(scope));
+}
+
+function tokenStatusFromRow(row) {
+  if (row?.status !== "active") return row?.status || null;
+  const expiresAt = row.expires_at ? new Date(row.expires_at) : null;
+  if (expiresAt && !Number.isNaN(expiresAt.getTime()) && expiresAt <= new Date()) {
+    return "expired";
+  }
+  return "active";
 }
 
 function tokenMetadataFromRow(row) {
@@ -210,7 +233,7 @@ function tokenMetadataFromRow(row) {
     name: row.name,
     tokenPrefix: row.token_prefix,
     scopes: scopesFromRow(row),
-    status: row.status,
+    status: tokenStatusFromRow(row),
     expiresAt: dateToIso(row.expires_at),
     lastUsedAt: dateToIso(row.last_used_at),
     revokedAt: dateToIso(row.revoked_at),
@@ -324,13 +347,30 @@ async function revokeApiToken(options) {
 }
 
 async function markApiTokenUsed(options) {
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const tokenHash = String(options.tokenHash || "");
+  if (!/^[a-f0-9]{64}$/.test(tokenHash)) return null;
+  const requiredScopes = normalizeRequiredScopes(options.requiredScopes);
   const result = await (options.client || pool).query(
     `UPDATE api_tokens
-        SET last_used_at = NOW(),
-            updated_at = NOW()
+        SET last_used_at = CASE
+              WHEN last_used_at IS NULL OR last_used_at <= NOW() - INTERVAL '${LAST_USED_UPDATE_INTERVAL}'
+                THEN NOW()
+              ELSE last_used_at
+            END,
+            updated_at = CASE
+              WHEN last_used_at IS NULL OR last_used_at <= NOW() - INTERVAL '${LAST_USED_UPDATE_INTERVAL}'
+                THEN NOW()
+              ELSE updated_at
+            END
       WHERE id = $1
+        AND workspace_id = $2
+        AND token_hash = $3
+        AND status = 'active'
+        AND (expires_at IS NULL OR expires_at > NOW())
+        AND scopes @> $4::text[]
       RETURNING ${SAFE_SELECT_FIELDS}`,
-    [options.tokenId],
+    [options.tokenId, workspaceId, tokenHash, requiredScopes],
   );
   return tokenMetadataFromRow(result.rows[0] || null);
 }
@@ -400,8 +440,12 @@ async function validateApiToken(options) {
   const token = await markApiTokenUsed({
     client: options.client,
     tokenId: row.id,
+    workspaceId,
+    tokenHash: candidateHash,
+    requiredScopes,
   });
-  return { valid: true, token: token || tokenMetadataFromRow(row) };
+  if (!token) return invalidValidation();
+  return { valid: true, token };
 }
 
 module.exports = {
@@ -426,6 +470,7 @@ module.exports = {
     scopesFromRow,
     sha256Hex,
     parseRawToken,
+    tokenStatusFromRow,
     tokenMetadataFromRow,
     tokenPrefixFor,
   },

--- a/apps/api/services/certops/apiTokens.js
+++ b/apps/api/services/certops/apiTokens.js
@@ -15,12 +15,14 @@ const CERTOPS_API_TOKEN_WORKSPACE_REQUIRED =
 const PRIVATE_KEY_MATERIAL_REJECTED = "PRIVATE_KEY_MATERIAL_REJECTED";
 
 const TOKEN_PREFIX = "ttx_";
-const TOKEN_ID_BYTES = 8;
-const TOKEN_RANDOM_BYTES = 32;
+const TOKEN_ID_HEX_LENGTH = 16;
+const TOKEN_SECRET_HEX_LENGTH = 64;
+const RAW_TOKEN_LENGTH = 85;
+const TOKEN_ID_BYTES = TOKEN_ID_HEX_LENGTH / 2;
+const TOKEN_RANDOM_BYTES = TOKEN_SECRET_HEX_LENGTH / 2;
 const MAX_TOKEN_CREATE_ATTEMPTS = 3;
-const MAX_RAW_TOKEN_LENGTH = 256;
 const LAST_USED_UPDATE_INTERVAL = "5 minutes";
-const RAW_TOKEN_PATTERN = /^ttx_([A-Za-z0-9]+)_([A-Za-z0-9]+)$/;
+const RAW_TOKEN_PATTERN = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/;
 
 const ALLOWED_SCOPES = Object.freeze([
   "certops:read",
@@ -29,6 +31,9 @@ const ALLOWED_SCOPES = Object.freeze([
   "certops:evidence:write",
 ]);
 const ALLOWED_SCOPE_SET = new Set(ALLOWED_SCOPES);
+const IMPLIED_SCOPE_GRANTS = Object.freeze({
+  "certops:read": Object.freeze(["certops:jobs:read"]),
+});
 
 const SAFE_SELECT_FIELDS = `
   id,
@@ -157,11 +162,7 @@ function generateRawToken() {
 }
 
 function parseRawToken(rawToken) {
-  if (
-    typeof rawToken !== "string" ||
-    rawToken.length === 0 ||
-    rawToken.length > MAX_RAW_TOKEN_LENGTH
-  ) {
+  if (typeof rawToken !== "string" || rawToken.length !== RAW_TOKEN_LENGTH) {
     return null;
   }
   const match = RAW_TOKEN_PATTERN.exec(rawToken);
@@ -210,10 +211,42 @@ function scopesFromRow(row) {
 
 function hasRequiredScopes(grantedScopes, requiredScopes) {
   const granted = new Set(grantedScopes);
-  if (granted.has("certops:read")) {
-    granted.add("certops:jobs:read");
+  for (const [scope, impliedScopes] of Object.entries(IMPLIED_SCOPE_GRANTS)) {
+    if (!granted.has(scope)) continue;
+    for (const impliedScope of impliedScopes) {
+      granted.add(impliedScope);
+    }
   }
   return requiredScopes.every((scope) => granted.has(scope));
+}
+
+function grantingScopesFor(requiredScope) {
+  const grantingScopes = [requiredScope];
+  for (const [scope, impliedScopes] of Object.entries(IMPLIED_SCOPE_GRANTS)) {
+    if (impliedScopes.includes(requiredScope)) grantingScopes.push(scope);
+  }
+  return grantingScopes;
+}
+
+function scopePredicateFor(requiredScopes, firstParameterIndex = 4) {
+  let parameterIndex = firstParameterIndex;
+  const values = [];
+  const clauses = requiredScopes.map((requiredScope) => {
+    const alternatives = grantingScopesFor(requiredScope).map((scope) => {
+      const placeholder = `$${parameterIndex}::text[]`;
+      parameterIndex += 1;
+      values.push([scope]);
+      return `scopes @> ${placeholder}`;
+    });
+    return alternatives.length === 1
+      ? alternatives[0]
+      : `(${alternatives.join(" OR ")})`;
+  });
+
+  return {
+    sql: clauses.length > 0 ? clauses.join("\n        AND ") : "TRUE",
+    values,
+  };
 }
 
 function tokenStatusFromRow(row) {
@@ -351,6 +384,7 @@ async function markApiTokenUsed(options) {
   const tokenHash = String(options.tokenHash || "");
   if (!/^[a-f0-9]{64}$/.test(tokenHash)) return null;
   const requiredScopes = normalizeRequiredScopes(options.requiredScopes);
+  const scopePredicate = scopePredicateFor(requiredScopes);
   const result = await (options.client || pool).query(
     `UPDATE api_tokens
         SET last_used_at = CASE
@@ -368,9 +402,9 @@ async function markApiTokenUsed(options) {
         AND token_hash = $3
         AND status = 'active'
         AND (expires_at IS NULL OR expires_at > NOW())
-        AND scopes @> $4::text[]
+        AND ${scopePredicate.sql}
       RETURNING ${SAFE_SELECT_FIELDS}`,
-    [options.tokenId, workspaceId, tokenHash, requiredScopes],
+    [options.tokenId, workspaceId, tokenHash, ...scopePredicate.values],
   );
   return tokenMetadataFromRow(result.rows[0] || null);
 }
@@ -465,11 +499,15 @@ module.exports = {
   revokeApiToken,
   validateApiToken,
   _test: {
+    RAW_TOKEN_LENGTH,
+    TOKEN_ID_HEX_LENGTH,
+    TOKEN_SECRET_HEX_LENGTH,
     hasRequiredScopes,
     safeCompareSha256Hex,
     scopesFromRow,
     sha256Hex,
     parseRawToken,
+    scopePredicateFor,
     tokenStatusFromRow,
     tokenMetadataFromRow,
     tokenPrefixFor,

--- a/tests/integration/certops-api-tokens.test.js
+++ b/tests/integration/certops-api-tokens.test.js
@@ -9,6 +9,7 @@ const { requireMigrateModule } = require("./variant-paths");
 const { runMigrations, migrations } = requireMigrateModule();
 const {
   CERTOPS_API_TOKEN_SCOPE_INVALID,
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
   createApiToken,
   getApiTokenById,
   listApiTokens,
@@ -65,7 +66,7 @@ function assertNoPlaintext(value, plaintextToken) {
 }
 
 function parseTokenShape(rawToken) {
-  const match = /^ttx_([^_]+)_([^_]+)$/.exec(rawToken);
+  const match = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/.exec(rawToken);
   expect(match, `expected ttx_<id>_<secret> token, got ${rawToken}`).to.not.equal(
     null,
   );
@@ -152,6 +153,7 @@ describe("CertOps API tokens", function () {
       });
 
       const { idPart, secretPart } = parseTokenShape(created.plaintextToken);
+      expect(created.plaintextToken.length).to.equal(_test.RAW_TOKEN_LENGTH);
       expect(idPart).to.not.equal("");
       expect(secretPart).to.not.equal("");
       expect(created.plaintextToken).to.not.match(/^ttx__/);
@@ -168,6 +170,9 @@ describe("CertOps API tokens", function () {
       expect(persisted.rows[0].token_prefix).to.not.equal("ttx__");
       expect(persisted.rows[0].token_hash).to.equal(
         _test.sha256Hex(created.plaintextToken),
+      );
+      expect(persisted.rows[0].token_hash).to.not.equal(
+        _test.sha256Hex(secretPart),
       );
       expect(JSON.stringify(persisted.rows[0])).to.not.include(
         created.plaintextToken,
@@ -276,6 +281,43 @@ describe("CertOps API tokens", function () {
       expect(JSON.stringify(persisted.rows[0])).to.not.include(
         created.plaintextToken,
       );
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("allows certops:read for job reads but not write scopes", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-read-scope",
+    );
+
+    try {
+      const created = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Read-only observer",
+        scopes: ["certops:read"],
+        createdBy: ownerId,
+      });
+
+      const jobsRead = await validateApiToken({
+        workspaceId: workspaceA,
+        rawToken: created.plaintextToken,
+        requiredScopes: ["certops:jobs:read"],
+      });
+      expect(jobsRead.valid).to.equal(true);
+
+      for (const requiredScope of [
+        "certops:events:write",
+        "certops:evidence:write",
+      ]) {
+        const result = await validateApiToken({
+          workspaceId: workspaceA,
+          rawToken: created.plaintextToken,
+          requiredScopes: [requiredScope],
+        });
+        expect(result.valid).to.equal(false);
+        expect(result.code).to.equal(CERTOPS_API_TOKEN_SCOPE_DENIED);
+      }
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
     }

--- a/tests/integration/certops-api-tokens.test.js
+++ b/tests/integration/certops-api-tokens.test.js
@@ -146,7 +146,7 @@ describe("CertOps API tokens", function () {
       const created = await createApiToken({
         workspaceId: workspaceA,
         name: "Executor",
-        scopes: ["certops:executor:events", "certops:jobs:read"],
+        scopes: ["certops:events:write", "certops:jobs:read"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
@@ -188,7 +188,7 @@ describe("CertOps API tokens", function () {
       const valid = await validateApiToken({
         workspaceId: workspaceA,
         rawToken: created.plaintextToken,
-        requiredScopes: ["certops:executor:events"],
+        requiredScopes: ["certops:events:write"],
       });
       expect(valid.valid).to.equal(true);
       expect(valid.token.id).to.equal(created.token.id);
@@ -197,7 +197,7 @@ describe("CertOps API tokens", function () {
       const wrongWorkspace = await validateApiToken({
         workspaceId: workspaceB,
         rawToken: created.plaintextToken,
-        requiredScopes: ["certops:executor:events"],
+        requiredScopes: ["certops:events:write"],
       });
       expect(wrongWorkspace.valid).to.equal(false);
 
@@ -212,7 +212,7 @@ describe("CertOps API tokens", function () {
       const afterRevoke = await validateApiToken({
         workspaceId: workspaceA,
         rawToken: created.plaintextToken,
-        requiredScopes: ["certops:executor:events"],
+        requiredScopes: ["certops:events:write"],
       });
       expect(afterRevoke.valid).to.equal(false);
     } finally {
@@ -244,7 +244,7 @@ describe("CertOps API tokens", function () {
       const created = await createApiToken({
         workspaceId: workspaceA,
         name: "Expired",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() - 60 * 1000),
         createdBy: ownerId,
       });
@@ -252,9 +252,16 @@ describe("CertOps API tokens", function () {
       const expired = await validateApiToken({
         workspaceId: workspaceA,
         rawToken: created.plaintextToken,
-        requiredScopes: ["certops:executor:events"],
+        requiredScopes: ["certops:events:write"],
       });
       expect(expired.valid).to.equal(false);
+      expect(created.token.status).to.equal("expired");
+
+      const expiredMetadata = await getApiTokenById({
+        workspaceId: workspaceA,
+        tokenId: created.token.id,
+      });
+      expect(expiredMetadata.status).to.equal("expired");
 
       const persisted = await TestUtils.execQuery(
         `SELECT token_hash, last_used_at

--- a/tests/integration/certops-api-tokens.test.js
+++ b/tests/integration/certops-api-tokens.test.js
@@ -1,0 +1,276 @@
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations, migrations } = requireMigrateModule();
+const {
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  createApiToken,
+  getApiTokenById,
+  listApiTokens,
+  revokeApiToken,
+  validateApiToken,
+  _test,
+} = require("../../apps/api/services/certops/apiTokens");
+
+const API_TOKENS_MIGRATION = migrations.find(
+  (migration) => migration.name === "certops_api_tokens_schema",
+);
+
+async function createWorkspacePair(label) {
+  const ownerEmail = `${label}-${Date.now()}-${crypto.randomUUID()}@example.com`;
+  const owner = await TestUtils.execQuery(
+    `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+     VALUES ($1, $2, $3, $4, 'local', TRUE)
+     RETURNING id`,
+    [
+      ownerEmail.toLowerCase(),
+      ownerEmail,
+      label,
+      "not-used-in-api-token-test",
+    ],
+  );
+  const ownerId = owner.rows[0].id;
+  const workspaceA = crypto.randomUUID();
+  const workspaceB = crypto.randomUUID();
+
+  await TestUtils.execQuery(
+    `INSERT INTO workspaces (id, name, created_by, plan)
+     VALUES ($1, $2, $3, 'oss'), ($4, $5, $3, 'oss')`,
+    [
+      workspaceA,
+      `${label} A`,
+      ownerId,
+      workspaceB,
+      `${label} B`,
+    ],
+  );
+
+  return { ownerId, workspaceA, workspaceB };
+}
+
+async function cleanupWorkspacePair(ownerId, workspaceIds) {
+  await TestUtils.execQuery("DELETE FROM workspaces WHERE id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+}
+
+function assertNoPlaintext(value, plaintextToken) {
+  expect(JSON.stringify(value)).to.not.include(plaintextToken);
+}
+
+function parseTokenShape(rawToken) {
+  const match = /^ttx_([^_]+)_([^_]+)$/.exec(rawToken);
+  expect(match, `expected ttx_<id>_<secret> token, got ${rawToken}`).to.not.equal(
+    null,
+  );
+  return { idPart: match[1], secretPart: match[2] };
+}
+
+describe("CertOps API tokens", function () {
+  this.timeout(60000);
+
+  before(async () => {
+    await runMigrations();
+    await TestUtils.execQuery(API_TOKENS_MIGRATION.sql);
+  });
+
+  it("creates the api_tokens table with safe lookup columns and indexes", async () => {
+    const columns = await TestUtils.execQuery(
+      `SELECT column_name
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'api_tokens'
+        ORDER BY ordinal_position`,
+    );
+
+    expect(columns.rows.map((row) => row.column_name)).to.include.members([
+      "id",
+      "workspace_id",
+      "name",
+      "token_prefix",
+      "token_hash",
+      "scopes",
+      "status",
+      "expires_at",
+      "last_used_at",
+      "revoked_at",
+      "revoked_by",
+      "created_by",
+      "created_at",
+      "updated_at",
+    ]);
+
+    const forbiddenFragments = [
+      "private",
+      "key_material",
+      "pfx",
+      "jks",
+      "password",
+      "credential",
+      "secret",
+    ];
+    for (const row of columns.rows) {
+      const hit = forbiddenFragments.find((fragment) =>
+        row.column_name.includes(fragment),
+      );
+      expect(hit, `${row.column_name} looks like custody`).to.equal(undefined);
+    }
+
+    const indexes = await TestUtils.execQuery(
+      `SELECT indexname
+         FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'api_tokens'`,
+    );
+    expect(indexes.rows.map((row) => row.indexname)).to.include.members([
+      "uq_api_tokens_token_prefix",
+      "uq_api_tokens_token_hash",
+      "idx_api_tokens_workspace",
+      "idx_api_tokens_workspace_status",
+      "idx_api_tokens_status_expires",
+    ]);
+  });
+
+  it("supports create, list, validate, and revoke without persisting raw tokens", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-flow",
+    );
+
+    try {
+      const created = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Executor",
+        scopes: ["certops:executor:events", "certops:jobs:read"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+
+      const { idPart, secretPart } = parseTokenShape(created.plaintextToken);
+      expect(idPart).to.not.equal("");
+      expect(secretPart).to.not.equal("");
+      expect(created.plaintextToken).to.not.match(/^ttx__/);
+      expect(created.token.workspaceId).to.equal(workspaceA);
+      expect(created.token.tokenHash).to.equal(undefined);
+
+      const persisted = await TestUtils.execQuery(
+        `SELECT token_prefix, token_hash
+           FROM api_tokens
+          WHERE id = $1`,
+        [created.token.id],
+      );
+      expect(persisted.rows[0].token_prefix).to.equal(`ttx_${idPart}`);
+      expect(persisted.rows[0].token_prefix).to.not.equal("ttx__");
+      expect(persisted.rows[0].token_hash).to.equal(
+        _test.sha256Hex(created.plaintextToken),
+      );
+      expect(JSON.stringify(persisted.rows[0])).to.not.include(
+        created.plaintextToken,
+      );
+
+      const listA = await listApiTokens({ workspaceId: workspaceA });
+      const listB = await listApiTokens({ workspaceId: workspaceB });
+      expect(listA.map((token) => token.id)).to.include(created.token.id);
+      expect(listB.map((token) => token.id)).to.not.include(created.token.id);
+      assertNoPlaintext(listA, created.plaintextToken);
+
+      const getWrongWorkspace = await getApiTokenById({
+        workspaceId: workspaceB,
+        tokenId: created.token.id,
+      });
+      expect(getWrongWorkspace).to.equal(null);
+
+      const valid = await validateApiToken({
+        workspaceId: workspaceA,
+        rawToken: created.plaintextToken,
+        requiredScopes: ["certops:executor:events"],
+      });
+      expect(valid.valid).to.equal(true);
+      expect(valid.token.id).to.equal(created.token.id);
+      expect(valid.token.lastUsedAt).to.be.a("string");
+
+      const wrongWorkspace = await validateApiToken({
+        workspaceId: workspaceB,
+        rawToken: created.plaintextToken,
+        requiredScopes: ["certops:executor:events"],
+      });
+      expect(wrongWorkspace.valid).to.equal(false);
+
+      const revoked = await revokeApiToken({
+        workspaceId: workspaceA,
+        tokenId: created.token.id,
+        revokedBy: ownerId,
+      });
+      expect(revoked.status).to.equal("revoked");
+      assertNoPlaintext(revoked, created.plaintextToken);
+
+      const afterRevoke = await validateApiToken({
+        workspaceId: workspaceA,
+        rawToken: created.plaintextToken,
+        requiredScopes: ["certops:executor:events"],
+      });
+      expect(afterRevoke.valid).to.equal(false);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects expired tokens and invalid scopes", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-expiry",
+    );
+
+    try {
+      let invalidScopeError;
+      try {
+        await createApiToken({
+          workspaceId: workspaceA,
+          name: "Invalid",
+          scopes: ["certops:everything"],
+          createdBy: ownerId,
+        });
+      } catch (error) {
+        invalidScopeError = error;
+      }
+      expect(invalidScopeError?.code).to.equal(
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+
+      const created = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Expired",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() - 60 * 1000),
+        createdBy: ownerId,
+      });
+
+      const expired = await validateApiToken({
+        workspaceId: workspaceA,
+        rawToken: created.plaintextToken,
+        requiredScopes: ["certops:executor:events"],
+      });
+      expect(expired.valid).to.equal(false);
+
+      const persisted = await TestUtils.execQuery(
+        `SELECT token_hash, last_used_at
+           FROM api_tokens
+          WHERE id = $1`,
+        [created.token.id],
+      );
+      expect(persisted.rows[0].token_hash).to.equal(
+        _test.sha256Hex(created.plaintextToken),
+      );
+      expect(persisted.rows[0].last_used_at).to.equal(null);
+      expect(JSON.stringify(persisted.rows[0])).to.not.include(
+        created.plaintextToken,
+      );
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+});

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -73,6 +73,7 @@ tests/integration/domain-checker.integration.test.js
 tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
+tests/integration/certops-api-tokens.test.js
 
 # Integrations
 tests/integration/github.integration.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -87,6 +87,7 @@ tests/integration/audit-system-admin-org-scope.test.js
 tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
+tests/integration/certops-api-tokens.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-api-tokens.test.js
+++ b/tests/unit/certops-api-tokens.test.js
@@ -108,13 +108,17 @@ function createMemoryClient() {
       if (normalizedSql.includes("SET last_used_at = CASE")) {
         const row = rows.find((item) => item.id === params[0]);
         client.beforeValidatedTouch?.(row, params);
-        const effectiveScopes = new Set(row?.scopes || []);
-        if (effectiveScopes.has("certops:read")) {
-          effectiveScopes.add("certops:jobs:read");
-        }
-        const hasRequiredScopes = (params[3] || []).every((scope) =>
-          effectiveScopes.has(scope),
+        const containsScopeSet = (scopeSet) =>
+          scopeSet.every((scope) => row?.scopes?.includes(scope));
+        const hasJobReadFallback = normalizedSql.includes(
+          "(scopes @> $4::text[] OR scopes @> $5::text[])",
         );
+        const hasRequiredScopes = hasJobReadFallback
+          ?
+              (containsScopeSet(params[3]) || containsScopeSet(params[4])) &&
+              params.slice(5).every(containsScopeSet)
+          : params.slice(3).every(containsScopeSet);
+        client.lastValidatedTouch = { sql: normalizedSql, params };
         const isExpired =
           row?.expires_at && new Date(row.expires_at).getTime() <= Date.now();
         if (
@@ -150,7 +154,7 @@ function assertNoPlaintextToken(value, plaintextToken) {
 }
 
 function parseTokenShape(rawToken) {
-  const match = /^ttx_([^_]+)_([^_]+)$/.exec(rawToken);
+  const match = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/.exec(rawToken);
   assert.ok(match, `expected ttx_<id>_<secret> token, got ${rawToken}`);
   return { idPart: match[1], secretPart: match[2] };
 }
@@ -213,6 +217,7 @@ describe("CertOps API token service", () => {
     const { idPart, secretPart } = parseTokenShape(created.plaintextToken);
 
     assert.equal(TOKEN_PREFIX, "ttx_");
+    assert.equal(created.plaintextToken.length, _test.RAW_TOKEN_LENGTH);
     assert.notEqual(idPart, "");
     assert.notEqual(secretPart, "");
     assert.equal(created.plaintextToken.startsWith("ttx__"), false);
@@ -223,6 +228,7 @@ describe("CertOps API token service", () => {
       client.rows[0].token_hash,
       _test.sha256Hex(created.plaintextToken),
     );
+    assert.notEqual(client.rows[0].token_hash, _test.sha256Hex(secretPart));
     assert.notEqual(client.rows[0].token_hash, created.plaintextToken);
     assert.equal(JSON.stringify(client.rows[0]).includes(created.plaintextToken), false);
     assert.equal(created.token.tokenHash, undefined);
@@ -259,6 +265,14 @@ describe("CertOps API token service", () => {
       requiredScopes: ["certops:jobs:read"],
     });
     assert.equal(jobsRead.valid, true);
+    assert.match(
+      client.lastValidatedTouch.sql,
+      /\(scopes @> \$4::text\[\] OR scopes @> \$5::text\[\]\)/,
+    );
+    assert.deepEqual(client.lastValidatedTouch.params.slice(3), [
+      ["certops:jobs:read"],
+      ["certops:read"],
+    ]);
 
     for (const requiredScope of [
       "certops:events:write",
@@ -379,12 +393,16 @@ describe("CertOps API token service", () => {
       name: "Exact token",
       scopes: ["certops:events:write"],
     });
+    const { idPart, secretPart } = parseTokenShape(created.plaintextToken);
     const queriesBeforeMalformedInput = client.queries.length;
 
     for (const rawToken of [
       `${created.plaintextToken} `,
       ` ${created.plaintextToken}`,
-      `ttx_id_${"a".repeat(257)}`,
+      `ttx_${idPart.toUpperCase()}_${secretPart}`,
+      `ttx_${idPart}a_${secretPart}`,
+      `ttx_${idPart}_${secretPart}a`,
+      created.plaintextToken.slice(0, -1),
     ]) {
       const result = await validateApiToken({
         client,

--- a/tests/unit/certops-api-tokens.test.js
+++ b/tests/unit/certops-api-tokens.test.js
@@ -1,0 +1,392 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  CERTOPS_API_TOKEN_MALFORMED,
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  TOKEN_PREFIX,
+  createApiToken,
+  getApiTokenById,
+  listApiTokens,
+  revokeApiToken,
+  validateApiToken,
+  _test,
+} = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/apiTokens.js"),
+);
+
+const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
+
+function date(offsetMs) {
+  return new Date(Date.now() + offsetMs);
+}
+
+function createMemoryClient() {
+  const rows = [];
+  let nextId = 1;
+
+  return {
+    rows,
+    async query(sql, params = []) {
+      const normalizedSql = sql.replace(/\s+/g, " ");
+
+      if (normalizedSql.includes("INSERT INTO api_tokens")) {
+        const row = {
+          id: `api-token-${nextId++}`,
+          workspace_id: params[0],
+          name: params[1],
+          token_prefix: params[2],
+          token_hash: params[3],
+          scopes: params[4],
+          status: "active",
+          expires_at: params[5],
+          last_used_at: null,
+          revoked_at: null,
+          revoked_by: null,
+          created_by: params[6],
+          created_at: new Date("2026-06-30T00:00:00.000Z"),
+          updated_at: new Date("2026-06-30T00:00:00.000Z"),
+        };
+        rows.push(row);
+        return { rows: [row] };
+      }
+
+      if (normalizedSql.includes("WHERE token_prefix = $1")) {
+        return { rows: rows.filter((row) => row.token_prefix === params[0]) };
+      }
+
+      if (
+        normalizedSql.includes("WHERE workspace_id = $1") &&
+        normalizedSql.includes("AND id = $2") &&
+        normalizedSql.includes("SELECT")
+      ) {
+        return {
+          rows: rows.filter(
+            (row) => row.workspace_id === params[0] && row.id === params[1],
+          ),
+        };
+      }
+
+      if (
+        normalizedSql.includes("WHERE workspace_id = $1") &&
+        normalizedSql.includes("ORDER BY created_at DESC")
+      ) {
+        return {
+          rows: rows.filter((row) => row.workspace_id === params[0]),
+        };
+      }
+
+      if (normalizedSql.includes("SET status = 'revoked'")) {
+        const row = rows.find(
+          (item) => item.workspace_id === params[0] && item.id === params[1],
+        );
+        if (!row) return { rows: [] };
+        row.status = "revoked";
+        row.revoked_at = row.revoked_at || new Date("2026-06-30T00:01:00.000Z");
+        row.revoked_by = row.revoked_by || params[2] || null;
+        row.updated_at = new Date("2026-06-30T00:01:00.000Z");
+        return { rows: [row] };
+      }
+
+      if (normalizedSql.includes("SET last_used_at = NOW()")) {
+        const row = rows.find((item) => item.id === params[0]);
+        if (!row) return { rows: [] };
+        row.last_used_at = new Date("2026-06-30T00:02:00.000Z");
+        row.updated_at = new Date("2026-06-30T00:02:00.000Z");
+        return { rows: [row] };
+      }
+
+      throw new Error(`Unexpected query: ${normalizedSql}`);
+    },
+  };
+}
+
+function assertNoPlaintextToken(value, plaintextToken) {
+  assert.equal(
+    JSON.stringify(value).includes(plaintextToken),
+    false,
+    "service output must not include plaintext token",
+  );
+}
+
+function parseTokenShape(rawToken) {
+  const match = /^ttx_([^_]+)_([^_]+)$/.exec(rawToken);
+  assert.ok(match, `expected ttx_<id>_<secret> token, got ${rawToken}`);
+  return { idPart: match[1], secretPart: match[2] };
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, keys);
+    return keys;
+  }
+  if (!value || typeof value !== "object") return keys;
+  for (const [key, item] of Object.entries(value)) {
+    keys.push(key);
+    collectKeys(item, keys);
+  }
+  return keys;
+}
+
+function assertNoCustodyKeys(value) {
+  const forbidden = [
+    "privatekey",
+    "privatekeypem",
+    "encryptedprivatekey",
+    "keymaterial",
+    "pfxblob",
+    "jksblob",
+    "tlskey",
+    "caprivatekey",
+    "keystorepassword",
+    "privatekeypassword",
+    "keypassword",
+    "password",
+    "secret",
+    "credential",
+    "tokensecret",
+    "apisecret",
+    "rawsecret",
+    "rawprivatekey",
+    "rawkey",
+    "pemprivatekey",
+  ];
+
+  for (const key of collectKeys(value)) {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const hit = forbidden.find((fragment) => normalized.includes(fragment));
+    assert.equal(hit, undefined, `${key} looks like a custody field`);
+  }
+}
+
+describe("CertOps API token service", () => {
+  it("creates ttx_<id>_<secret> tokens and stores only prefix plus sha256 hash", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Executor",
+      scopes: ["certops:executor:events"],
+      expiresAt: date(60_000),
+      createdBy: 123,
+    });
+    const { idPart, secretPart } = parseTokenShape(created.plaintextToken);
+
+    assert.equal(TOKEN_PREFIX, "ttx_");
+    assert.notEqual(idPart, "");
+    assert.notEqual(secretPart, "");
+    assert.equal(created.plaintextToken.startsWith("ttx__"), false);
+    assert.equal(created.token.tokenPrefix, client.rows[0].token_prefix);
+    assert.equal(client.rows[0].token_prefix, `ttx_${idPart}`);
+    assert.notEqual(client.rows[0].token_prefix, "ttx__");
+    assert.equal(
+      client.rows[0].token_hash,
+      _test.sha256Hex(created.plaintextToken),
+    );
+    assert.notEqual(client.rows[0].token_hash, created.plaintextToken);
+    assert.equal(JSON.stringify(client.rows[0]).includes(created.plaintextToken), false);
+    assert.equal(created.token.tokenHash, undefined);
+  });
+
+  it("rejects invalid scopes at creation time", async () => {
+    await assert.rejects(
+      () =>
+        createApiToken({
+          client: createMemoryClient(),
+          workspaceId: WORKSPACE_A,
+          name: "Bad scope",
+          scopes: ["certops:admin"],
+        }),
+      (error) => error?.code === CERTOPS_API_TOKEN_SCOPE_INVALID,
+    );
+  });
+
+  it("rejects private key material in persisted token metadata", async () => {
+    await assert.rejects(
+      () =>
+        createApiToken({
+          client: createMemoryClient(),
+          workspaceId: WORKSPACE_A,
+          name: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+          scopes: ["certops:executor:events"],
+        }),
+      (error) => error?.code === PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  });
+
+  it("validates required scopes and updates last_used_at only on success", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Executor",
+      scopes: ["certops:executor:events", "certops:jobs:read"],
+    });
+
+    const failed = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:evidence:write"],
+    });
+    assert.equal(failed.valid, false);
+    assert.equal(failed.code, CERTOPS_API_TOKEN_SCOPE_DENIED);
+    assert.equal(client.rows[0].last_used_at, null);
+
+    const validated = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    assert.equal(validated.valid, true);
+    assert.equal(validated.token.id, created.token.id);
+    assert.match(validated.token.lastUsedAt, /^2026-06-30T00:02:00/);
+  });
+
+  it("rejects malformed tokens and wrong prefixes", async () => {
+    const client = createMemoryClient();
+
+    for (const rawToken of [
+      "",
+      "not-a-token",
+      "abc__12345678901234567890",
+      "ttx__secret",
+      "ttx_id_",
+      "ttx__",
+      "ttx_secret",
+      "ttx_id",
+    ]) {
+      const result = await validateApiToken({
+        client,
+        workspaceId: WORKSPACE_A,
+        rawToken,
+        requiredScopes: [],
+      });
+      assert.equal(result.valid, false);
+      assert.equal(result.code, CERTOPS_API_TOKEN_MALFORMED);
+    }
+  });
+
+  it("rejects revoked tokens", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Executor",
+      scopes: ["certops:executor:events"],
+    });
+
+    await revokeApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+      revokedBy: 321,
+    });
+
+    const result = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    assert.equal(result.valid, false);
+  });
+
+  it("rejects expired tokens", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Expired",
+      scopes: ["certops:executor:events"],
+      expiresAt: date(-60_000),
+    });
+
+    const result = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    assert.equal(result.valid, false);
+    assert.equal(client.rows[0].last_used_at, null);
+  });
+
+  it("enforces workspace binding", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Workspace A",
+      scopes: ["certops:executor:events"],
+    });
+
+    const result = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_B,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    assert.equal(result.valid, false);
+    assert.equal(client.rows[0].last_used_at, null);
+  });
+
+  it("does not return plaintext tokens from list, get, or revoke", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Executor",
+      scopes: ["certops:executor:events"],
+    });
+
+    const list = await listApiTokens({ client, workspaceId: WORKSPACE_A });
+    const got = await getApiTokenById({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+    });
+    const revoked = await revokeApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+      revokedBy: 1,
+    });
+
+    assertNoPlaintextToken(list, created.plaintextToken);
+    assertNoPlaintextToken(got, created.plaintextToken);
+    assertNoPlaintextToken(revoked, created.plaintextToken);
+    assert.equal(list[0].tokenHash, undefined);
+    assert.equal(got.tokenHash, undefined);
+    assert.equal(revoked.tokenHash, undefined);
+  });
+
+  it("does not expose private-key-looking fields", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Safe metadata",
+      scopes: ["certops:executor:events"],
+    });
+    const listed = await listApiTokens({ client, workspaceId: WORKSPACE_A });
+
+    assertNoCustodyKeys(created.token);
+    assertNoCustodyKeys(listed);
+  });
+
+  it("uses constant-time sha256 hash comparison helpers", () => {
+    const hash = _test.sha256Hex("token-value");
+
+    assert.equal(_test.safeCompareSha256Hex(hash, hash), true);
+    assert.equal(_test.safeCompareSha256Hex(hash, _test.sha256Hex("other")), false);
+    assert.equal(_test.safeCompareSha256Hex(hash, "not-a-sha256"), false);
+  });
+});

--- a/tests/unit/certops-api-tokens.test.js
+++ b/tests/unit/certops-api-tokens.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 
 const {
+  ALLOWED_SCOPES,
   CERTOPS_API_TOKEN_MALFORMED,
   CERTOPS_API_TOKEN_SCOPE_DENIED,
   CERTOPS_API_TOKEN_SCOPE_INVALID,
@@ -22,6 +23,12 @@ const {
 
 const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
 const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
+const CANONICAL_M2_SCOPES = [
+  "certops:read",
+  "certops:events:write",
+  "certops:jobs:read",
+  "certops:evidence:write",
+];
 
 function date(offsetMs) {
   return new Date(Date.now() + offsetMs);
@@ -31,10 +38,14 @@ function createMemoryClient() {
   const rows = [];
   let nextId = 1;
 
-  return {
+  const client = {
     rows,
+    queries: [],
+    usageUpdateCount: 0,
+    beforeValidatedTouch: null,
     async query(sql, params = []) {
       const normalizedSql = sql.replace(/\s+/g, " ");
+      client.queries.push(normalizedSql);
 
       if (normalizedSql.includes("INSERT INTO api_tokens")) {
         const row = {
@@ -94,17 +105,40 @@ function createMemoryClient() {
         return { rows: [row] };
       }
 
-      if (normalizedSql.includes("SET last_used_at = NOW()")) {
+      if (normalizedSql.includes("SET last_used_at = CASE")) {
         const row = rows.find((item) => item.id === params[0]);
-        if (!row) return { rows: [] };
-        row.last_used_at = new Date("2026-06-30T00:02:00.000Z");
-        row.updated_at = new Date("2026-06-30T00:02:00.000Z");
+        client.beforeValidatedTouch?.(row, params);
+        const effectiveScopes = new Set(row?.scopes || []);
+        if (effectiveScopes.has("certops:read")) {
+          effectiveScopes.add("certops:jobs:read");
+        }
+        const hasRequiredScopes = (params[3] || []).every((scope) =>
+          effectiveScopes.has(scope),
+        );
+        const isExpired =
+          row?.expires_at && new Date(row.expires_at).getTime() <= Date.now();
+        if (
+          !row ||
+          row.workspace_id !== params[1] ||
+          row.token_hash !== params[2] ||
+          row.status !== "active" ||
+          isExpired ||
+          !hasRequiredScopes
+        ) {
+          return { rows: [] };
+        }
+        if (!row.last_used_at) {
+          row.last_used_at = new Date("2026-06-30T00:02:00.000Z");
+          row.updated_at = new Date("2026-06-30T00:02:00.000Z");
+          client.usageUpdateCount += 1;
+        }
         return { rows: [row] };
       }
 
       throw new Error(`Unexpected query: ${normalizedSql}`);
     },
   };
+  return client;
 }
 
 function assertNoPlaintextToken(value, plaintextToken) {
@@ -172,7 +206,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Executor",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       expiresAt: date(60_000),
       createdBy: 123,
     });
@@ -207,6 +241,57 @@ describe("CertOps API token service", () => {
     );
   });
 
+  it("uses canonical M2 scopes and keeps jobs claim deferred to M4", async () => {
+    assert.deepEqual(ALLOWED_SCOPES, CANONICAL_M2_SCOPES);
+
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Read-only observer",
+      scopes: ["certops:read"],
+    });
+
+    const jobsRead = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:jobs:read"],
+    });
+    assert.equal(jobsRead.valid, true);
+
+    for (const requiredScope of [
+      "certops:events:write",
+      "certops:evidence:write",
+    ]) {
+      const result = await validateApiToken({
+        client,
+        workspaceId: WORKSPACE_A,
+        rawToken: created.plaintextToken,
+        requiredScopes: [requiredScope],
+      });
+      assert.equal(result.valid, false);
+      assert.equal(result.code, CERTOPS_API_TOKEN_SCOPE_DENIED);
+    }
+
+    for (const deferredOrLegacyScope of [
+      "certops:executor:events",
+      "certops:jobs:write",
+      "certops:jobs:claim",
+    ]) {
+      await assert.rejects(
+        () =>
+          createApiToken({
+            client: createMemoryClient(),
+            workspaceId: WORKSPACE_A,
+            name: "Unsupported scope",
+            scopes: [deferredOrLegacyScope],
+          }),
+        (error) => error?.code === CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+  });
+
   it("rejects private key material in persisted token metadata", async () => {
     await assert.rejects(
       () =>
@@ -214,7 +299,7 @@ describe("CertOps API token service", () => {
           client: createMemoryClient(),
           workspaceId: WORKSPACE_A,
           name: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
-          scopes: ["certops:executor:events"],
+          scopes: ["certops:events:write"],
         }),
       (error) => error?.code === PRIVATE_KEY_MATERIAL_REJECTED,
     );
@@ -226,7 +311,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Executor",
-      scopes: ["certops:executor:events", "certops:jobs:read"],
+      scopes: ["certops:events:write", "certops:jobs:read"],
     });
 
     const failed = await validateApiToken({
@@ -243,11 +328,23 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     assert.equal(validated.valid, true);
     assert.equal(validated.token.id, created.token.id);
     assert.match(validated.token.lastUsedAt, /^2026-06-30T00:02:00/);
+
+    const firstLastUsedAt = client.rows[0].last_used_at;
+    const firstUsageUpdateCount = client.usageUpdateCount;
+    const validatedAgain = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:events:write"],
+    });
+    assert.equal(validatedAgain.valid, true);
+    assert.equal(client.rows[0].last_used_at, firstLastUsedAt);
+    assert.equal(client.usageUpdateCount, firstUsageUpdateCount);
   });
 
   it("rejects malformed tokens and wrong prefixes", async () => {
@@ -274,13 +371,70 @@ describe("CertOps API token service", () => {
     }
   });
 
+  it("hashes the full raw token and rejects oversized input before lookup", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Exact token",
+      scopes: ["certops:events:write"],
+    });
+    const queriesBeforeMalformedInput = client.queries.length;
+
+    for (const rawToken of [
+      `${created.plaintextToken} `,
+      ` ${created.plaintextToken}`,
+      `ttx_id_${"a".repeat(257)}`,
+    ]) {
+      const result = await validateApiToken({
+        client,
+        workspaceId: WORKSPACE_A,
+        rawToken,
+        requiredScopes: [],
+      });
+      assert.equal(result.valid, false);
+      assert.equal(result.code, CERTOPS_API_TOKEN_MALFORMED);
+    }
+    assert.equal(client.queries.length, queriesBeforeMalformedInput);
+
+    const exactToken = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:events:write"],
+    });
+    assert.equal(exactToken.valid, true);
+  });
+
+  it("atomically rejects a token revoked after lookup and before use", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Race-safe token",
+      scopes: ["certops:events:write"],
+    });
+    client.beforeValidatedTouch = (row) => {
+      row.status = "revoked";
+    };
+
+    const result = await validateApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:events:write"],
+    });
+    assert.equal(result.valid, false);
+    assert.equal(client.rows[0].last_used_at, null);
+  });
+
   it("rejects revoked tokens", async () => {
     const client = createMemoryClient();
     const created = await createApiToken({
       client,
       workspaceId: WORKSPACE_A,
       name: "Executor",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
     });
 
     await revokeApiToken({
@@ -294,7 +448,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     assert.equal(result.valid, false);
   });
@@ -305,7 +459,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Expired",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       expiresAt: date(-60_000),
     });
 
@@ -313,10 +467,19 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     assert.equal(result.valid, false);
     assert.equal(client.rows[0].last_used_at, null);
+    assert.equal(created.token.status, "expired");
+    const listed = await listApiTokens({ client, workspaceId: WORKSPACE_A });
+    const fetched = await getApiTokenById({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+    });
+    assert.equal(listed[0].status, "expired");
+    assert.equal(fetched.status, "expired");
   });
 
   it("enforces workspace binding", async () => {
@@ -325,14 +488,14 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Workspace A",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
     });
 
     const result = await validateApiToken({
       client,
       workspaceId: WORKSPACE_B,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     assert.equal(result.valid, false);
     assert.equal(client.rows[0].last_used_at, null);
@@ -344,7 +507,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Executor",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
     });
 
     const list = await listApiTokens({ client, workspaceId: WORKSPACE_A });
@@ -374,7 +537,7 @@ describe("CertOps API token service", () => {
       client,
       workspaceId: WORKSPACE_A,
       name: "Safe metadata",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
     });
     const listed = await listApiTokens({ client, workspaceId: WORKSPACE_A });
 

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -386,6 +386,30 @@ function prChangedFiles() {
   );
 }
 
+function changedAppFiles() {
+  const diffFiles = execFileSync("git", ["diff", "--name-only", "--", "apps"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  const statusFiles = execFileSync(
+    "git",
+    ["status", "--short", "--untracked-files=all", "--", "apps"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  )
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => line.slice(3).trim());
+
+  return [...new Set([...diffFiles, ...statusFiles])].sort();
+}
+
 describe("CertOps M2 contract skeletons", () => {
   it("includes the M2 job, executor event, and evidence schemas in the manifest", () => {
     const paths = manifestPaths();
@@ -712,20 +736,30 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("does not change apps runtime files or wire executor job/evidence behavior", () => {
+  it("keeps the committed M2-A1/M2-A2 diff within the stacked contract and token-service scope", () => {
     const { ref, files } = prChangedFiles();
-    const allowed = files.filter(
+    const allowedM2A2Files = new Set([
+      "apps/api/migrations/migrate.js",
+      "apps/api/services/certops/apiTokens.js",
+      "tests/integration/certops-api-tokens.test.js",
+      "tests/integration/suites/core-compatible.txt",
+      "tests/integration/suites/core.txt",
+      "tests/unit/certops-api-tokens.test.js",
+      "tests/unit/certops-migration.test.js",
+    ]);
+    const unexpectedFiles = files.filter(
       (file) =>
         file === "contracts.manifest.json" ||
         file.startsWith("packages/contracts/") ||
         file === "tests/unit/certops-m2-contracts.test.js" ||
-        file === "tests/unit/certops-routes-hardening.test.js",
+        file === "tests/unit/certops-routes-hardening.test.js" ||
+        allowedM2A2Files.has(file),
     );
 
     assert.deepEqual(
-      files.filter((file) => !allowed.includes(file)),
+      files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `M2-A1 diff against ${ref} must stay contract/test-only`,
+      `stacked M2-A1/M2-A2 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -734,5 +768,17 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("certificate_jobs"), false);
     assert.equal(certOpsRoutesSource.includes("certificate_evidence"), false);
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
+  });
+
+  it("keeps local app changes within the M2-A2 token-service scope", () => {
+    const allowedStackedM2A2Files = new Set([
+      "apps/api/migrations/migrate.js",
+      "apps/api/services/certops/apiTokens.js",
+    ]);
+    const unexpectedAppFiles = changedAppFiles().filter(
+      (file) => !allowedStackedM2A2Files.has(file),
+    );
+
+    assert.deepEqual(unexpectedAppFiles, []);
   });
 });

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -124,6 +124,9 @@ const certOpsMigration = migrations.find(
 const certOpsTokenLifecycleMigration = migrations.find(
   (migration) => migration.name === "certops_token_lifecycle_status",
 );
+const certOpsApiTokensMigration = migrations.find(
+  (migration) => migration.name === "certops_api_tokens_schema",
+);
 
 function getTableBlock(tableName) {
   const marker = `CREATE TABLE IF NOT EXISTS ${tableName} (`;
@@ -179,7 +182,7 @@ describe("CertOps inventory migration", () => {
     assert.equal(certOpsTokenLifecycleMigration.version, 11);
     assert.deepEqual(
       migrations.slice(-3).map((migration) => migration.version),
-      [9, 10, 11],
+      [10, 11, 12],
     );
     assert.match(
       certOpsTokenLifecycleMigration.sql,
@@ -200,6 +203,40 @@ describe("CertOps inventory migration", () => {
     assert.match(
       certOpsTokenLifecycleMigration.sql,
       /CREATE INDEX IF NOT EXISTS idx_tokens_workspace_cert_lifecycle_status/,
+    );
+  });
+
+  it("defines the CertOps API token migration after M1 schema migrations", () => {
+    assert.ok(
+      certOpsApiTokensMigration,
+      "expected certops_api_tokens_schema migration",
+    );
+    assert.equal(certOpsApiTokensMigration.version, 12);
+    assert.match(
+      certOpsApiTokensMigration.sql,
+      /CREATE TABLE IF NOT EXISTS api_tokens \(/,
+    );
+    assert.match(certOpsApiTokensMigration.sql, /workspace_id UUID NOT NULL/);
+    assert.match(certOpsApiTokensMigration.sql, /token_prefix TEXT NOT NULL/);
+    assert.match(certOpsApiTokensMigration.sql, /token_hash TEXT NOT NULL/);
+    assert.match(certOpsApiTokensMigration.sql, /scopes TEXT\[\] NOT NULL/);
+    assert.match(
+      certOpsApiTokensMigration.sql,
+      /api_tokens_token_prefix_check/,
+    );
+    assert.match(
+      certOpsApiTokensMigration.sql,
+      /token_prefix ~ '\^ttx_\[A-Za-z0-9\]\+\$'/,
+    );
+    assert.doesNotMatch(
+      certOpsApiTokensMigration.sql,
+      /left\(token_prefix,\s*5\)\s*=\s*'ttx__'/,
+    );
+    assert.match(certOpsApiTokensMigration.sql, /uq_api_tokens_token_prefix/);
+    assert.match(certOpsApiTokensMigration.sql, /uq_api_tokens_token_hash/);
+    assert.doesNotMatch(
+      certOpsApiTokensMigration.sql,
+      /private_key|privateKey|key_material|pfx|jks|password|credential|secret/i,
     );
   });
 

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -232,6 +232,24 @@ describe("CertOps inventory migration", () => {
       certOpsApiTokensMigration.sql,
       /left\(token_prefix,\s*5\)\s*=\s*'ttx__'/,
     );
+    for (const scope of [
+      "certops:read",
+      "certops:events:write",
+      "certops:jobs:read",
+      "certops:evidence:write",
+    ]) {
+      assert.match(certOpsApiTokensMigration.sql, new RegExp(`'${scope}'`));
+    }
+    for (const staleOrDeferredScope of [
+      "certops:executor:events",
+      "certops:jobs:write",
+      "certops:jobs:claim",
+    ]) {
+      assert.doesNotMatch(
+        certOpsApiTokensMigration.sql,
+        new RegExp(`'${staleOrDeferredScope}'`),
+      );
+    }
     assert.match(certOpsApiTokensMigration.sql, /uq_api_tokens_token_prefix/);
     assert.match(certOpsApiTokensMigration.sql, /uq_api_tokens_token_hash/);
     assert.doesNotMatch(


### PR DESCRIPTION
## Summary

This PR adds the M2-A2 CertOps scoped API-token storage and service foundation.

It prepares the future machine-token authentication layer without wiring runtime auth, executor routes, jobs, evidence persistence, dashboard UI, Cloud overlay, or agent behavior.

This PR adds:

* `api_tokens` migration
* scoped API-token backend service
* strict `ttx_<id>_<secret>` token format
* exact generated token shape:

  * `ttx_`
  * 16 lowercase hex characters for the token id
  * `_`
  * 64 lowercase hex characters for the secret
  * total length: 85 characters
* public `token_prefix = ttx_<id>` lookup
* SHA-256 hash storage for the full raw token
* workspace-bound validation
* explicit scope enforcement
* canonical M2 API-token scopes:

  * `certops:read`
  * `certops:events:write`
  * `certops:jobs:read`
  * `certops:evidence:write`
* M2 read-scope widening:

  * `certops:read` satisfies `certops:jobs:read`
  * `certops:read` does not satisfy write scopes
* explicit M4 deferral for `certops:jobs:claim`
* expiry and revocation handling
* computed effective token status for metadata responses
* atomic validate/touch behavior to avoid revoke/expiry TOCTOU
* throttled `last_used_at` updates
* unit and integration coverage

This PR also confirms API-token storage remains secret-safe:

* raw tokens are never persisted
* token secrets are never stored separately
* plaintext tokens are returned only once during creation
* list/get/revoke/validate never return plaintext tokens
* token hashes are not returned by public service methods
* validation uses constant-time SHA-256 hash comparison
* revoked, expired, malformed, wrong-workspace, and missing-scope tokens are rejected
* malformed legacy shapes such as `ttx__secret` are rejected
* oversized or non-exact token shapes are rejected before hashing or database lookup
* secret-only hashing is explicitly not used
* private-key material is rejected from token metadata

This PR aligns M2-A2 with `TOKENTIMER_CERTOPS_PLAN` v1.7 and `CERTOPS_EXECUTION_PLAN_2DEV`:

* the stored hash is `sha256(rawToken)` over the full `ttx_<id>_<secret>` token
* the service uses only canonical M2 scopes
* `certops:executor:events`, `certops:jobs:write`, and `certops:jobs:claim` are rejected
* `certops:jobs:claim` remains deferred to M4
* expired tokens are rejected and surfaced as `status: "expired"` in metadata
* token validation remains workspace-bound and scope-bound
* token validation/touch remains atomic against concurrent revoke/expiry
* high-volume validation avoids unnecessary `last_used_at` writes

This PR does not add new runtime product features.

## Security model

This PR preserves the M2 zero-private-key-custody invariant.

Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A2 API-token service.

The API-token service stores only lookup metadata:

* `token_prefix`
* `token_hash`
* public metadata
* scopes
* status
* timestamps
* workspace and actor references

It does not store:

* plaintext token
* token secret
* Authorization header
* private key
* private key PEM
* encrypted private key
* key material
* PFX/JKS blobs
* TLS key
* CA private key
* password/credential/secret-shaped metadata

## Review fixes

This PR fixes the M2-A2 review findings.

### 1. Hash material vs plan section 7.1

The implementation intentionally stores:

```txt
sha256(rawToken)
```

where `rawToken` is the full token string:

```txt
ttx_<id>_<secret>
```

This follows the updated `TOKENTIMER_CERTOPS_PLAN` v1.7 reconciliation.

Secret-only hashing is not used.

Tests verify that the persisted hash equals `sha256(full raw token)` and does not equal `sha256(secret segment)`.

### 2. Expired tokens no longer report active

Token metadata now exposes an effective status.

If the persisted row is active but `expires_at <= now`, service metadata reports:

```txt
expired
```

This applies to create/list/get/revoke/validate metadata paths.

### 3. Validate/touch TOCTOU fixed

Validation now performs the final touch/update through an atomic conditional SQL update.

The update requires:

* matching token id
* matching workspace id
* matching full-token hash
* `status = 'active'`
* `expires_at IS NULL OR expires_at > NOW()`
* required scope predicate

If a token is revoked or expires between lookup and touch, validation returns invalid.

### 4. Raw-token length and shape are bounded before hash/lookup

Tokens must match the exact generated shape before hash or DB lookup:

```txt
ttx_<16 lowercase hex>_<64 lowercase hex>
```

Invalid length, uppercase parts, whitespace, oversized token parts, and malformed prefixes are rejected as malformed before hashing and before database lookup.

### 5. `last_used_at` write amplification reduced

Successful validation no longer updates `last_used_at` on every call.

`last_used_at` is updated only when:

* it is `NULL`, or
* it is older than the configured update interval

The current interval is:

```txt
5 minutes
```

### 6. Migration 12 scope allowlist corrected

Migration 12 now allows only canonical M2 scopes:

* `certops:read`
* `certops:events:write`
* `certops:jobs:read`
* `certops:evidence:write`

The old scopes are not allowed:

* `certops:executor:events`
* `certops:jobs:write`
* `certops:jobs:claim`

### 7. `certops:jobs:claim` deferred to M4

`certops:jobs:claim` is intentionally not part of M2.

M2 uses:

```txt
certops:jobs:read
```

Job claiming remains deferred to the M4 agent job-claim protocol.

### 8. `certops:read` implication fixed in atomic SQL

`certops:read` now satisfies `certops:jobs:read` consistently in both:

* JavaScript scope checks
* atomic SQL validate/touch checks

`certops:read` does not satisfy:

* `certops:events:write`
* `certops:evidence:write`

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* `node --check apps/api/services/certops/apiTokens.js`: ok
* `node --check tests/unit/certops-api-tokens.test.js`: ok
* `node --check tests/integration/certops-api-tokens.test.js`: ok
* `node --check tests/unit/certops-migration.test.js`: ok
* `node --test tests/unit/certops-api-tokens.test.js`: ok
* `node --test tests/unit/certops-m2-contracts.test.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `node --test tests/unit/certops-migration.test.js`: ok
* `pnpm exec mocha tests/integration/certops-api-tokens.test.js --timeout 60000 --exit`: ok
* `pnpm run test:unit`: ok, 205 passing
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a1-contracts`.
* PR #50 / M2-A1 should merge before this PR is retargeted to `feature/certops`.
* This is an M2-A2 storage/service PR, not an auth middleware PR.
* Dev A owns this work because it touches DB migration, backend service, and security boundary behavior.
* Dev B dashboard UI, Cloud overlay, fake executor, fake agent, and timeline work remain split out.
* No machine-token auth middleware is included.
* No CSRF exemption logic is included.
* No machine-token rate limiter is included.
* No executor route implementation is included.
* No `certificate_jobs`, `certificate_job_log`, or `certificate_evidence` persistence is included.
* No dashboard UI, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, or connector work is included.
* No worker or deploy files are changed.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A2 service.

## Test plan

* [x] Review API-token migration
* [x] Review API-token service behavior
* [x] Verify strict `ttx_<id>_<secret>` token format
* [x] Verify generated tokens are exactly 85 characters
* [x] Verify malformed `ttx__...` tokens are rejected
* [x] Verify uppercase token parts are rejected
* [x] Verify wrong-length token ids are rejected
* [x] Verify wrong-length token secrets are rejected
* [x] Verify malformed and oversized tokens are rejected before hash/lookup
* [x] Verify raw token is never persisted
* [x] Verify token secret is never stored separately
* [x] Verify token hash uses SHA-256 over the full raw token
* [x] Verify secret-only hash is not used
* [x] Verify validation uses constant-time hash comparison
* [x] Verify revoked tokens are rejected
* [x] Verify expired tokens are rejected
* [x] Verify expired token metadata reports `status: "expired"`
* [x] Verify malformed tokens are rejected
* [x] Verify wrong-workspace tokens are rejected
* [x] Verify required scope enforcement
* [x] Verify canonical M2 scopes are accepted
* [x] Verify old/non-canonical scopes are rejected
* [x] Verify `certops:jobs:claim` is rejected and deferred to M4
* [x] Verify `certops:read` satisfies `certops:jobs:read`
* [x] Verify `certops:read` does not satisfy write scopes
* [x] Verify atomic validate/touch SQL matches the M2 scope implication rule
* [x] Verify concurrent revoke/expiry cannot return `valid: true`
* [x] Verify `last_used_at` updates only after successful validation
* [x] Verify `last_used_at` updates are throttled
* [x] Verify list/get/revoke/validate do not return plaintext tokens
* [x] Verify token hashes are not exposed in public metadata
* [x] Verify private-key material is rejected in API-token metadata
* [x] Verify migration 12 uses only canonical M2 scopes
* [x] Verify migration tests cover the API-token schema
* [x] Verify no auth middleware, rate limiter, executor route, jobs/evidence runtime, dashboard, Cloud, agent, worker, or deploy work is included
* [x] Run `node --test tests/unit/certops-api-tokens.test.js`
* [x] Run `node --test tests/unit/certops-m2-contracts.test.js`
* [x] Run `node --test tests/unit/certops-routes-hardening.test.js`
* [x] Run `node --test tests/unit/certops-migration.test.js`
* [x] Run `pnpm exec mocha tests/integration/certops-api-tokens.test.js --timeout 60000 --exit`
* [x] Run `pnpm run test:unit`
* [x] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
