### PR TITLE
feat(certops): add machine token auth middleware m2-a3

### DIFF
--- a/apps/api/middleware/api-token-auth.js
+++ b/apps/api/middleware/api-token-auth.js
@@ -8,8 +8,13 @@ const {
 } = require("../services/certops/apiTokens");
 
 const CERTOPS_API_TOKEN_UNAUTHORIZED = "CERTOPS_API_TOKEN_UNAUTHORIZED";
+const CERTOPS_API_TOKEN_SCOPE_REQUIRED = "CERTOPS_API_TOKEN_SCOPE_REQUIRED";
 const CERTOPS_API_TOKEN_WORKSPACE_REQUIRED =
   "CERTOPS_API_TOKEN_WORKSPACE_REQUIRED";
+const CERTOPS_API_TOKEN_WORKSPACE_MISMATCH =
+  "CERTOPS_API_TOKEN_WORKSPACE_MISMATCH";
+const CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN =
+  "CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN";
 
 const UNAUTHORIZED_RESPONSE = Object.freeze({
   error: "CertOps API token authentication required",
@@ -28,12 +33,25 @@ function authError(message, code) {
 }
 
 function responseForUnauthorized(code = CERTOPS_API_TOKEN_UNAUTHORIZED) {
-  return code === CERTOPS_API_TOKEN_WORKSPACE_REQUIRED
-    ? {
+  if (code === CERTOPS_API_TOKEN_WORKSPACE_REQUIRED) {
+    return {
         error: "Workspace context is required for CertOps API token authentication",
         code,
-      }
-    : UNAUTHORIZED_RESPONSE;
+    };
+  }
+  if (code === CERTOPS_API_TOKEN_WORKSPACE_MISMATCH) {
+    return {
+      error: "CertOps API token workspace context did not match",
+      code,
+    };
+  }
+  if (code === CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN) {
+    return {
+      error: "Session identity is not allowed for CertOps API token authentication",
+      code,
+    };
+  }
+  return UNAUTHORIZED_RESPONSE;
 }
 
 function bearerTokenFromRequest(req) {
@@ -59,6 +77,13 @@ function normalizeRequiredScopes(scopes) {
   const normalized = [];
   const allowed = new Set(ALLOWED_SCOPES);
 
+  if (list.length === 0) {
+    throw authError(
+      "At least one CertOps API token scope is required",
+      CERTOPS_API_TOKEN_SCOPE_REQUIRED,
+    );
+  }
+
   for (const scope of list) {
     if (typeof scope !== "string") {
       throw authError(
@@ -68,6 +93,12 @@ function normalizeRequiredScopes(scopes) {
     }
 
     const trimmed = scope.trim();
+    if (!trimmed) {
+      throw authError(
+        "At least one CertOps API token scope is required",
+        CERTOPS_API_TOKEN_SCOPE_REQUIRED,
+      );
+    }
     if (!allowed.has(trimmed)) {
       throw authError(
         "CertOps API token scope is not allowed",
@@ -78,6 +109,12 @@ function normalizeRequiredScopes(scopes) {
     if (!normalized.includes(trimmed)) normalized.push(trimmed);
   }
 
+  if (normalized.length === 0) {
+    throw authError(
+      "At least one CertOps API token scope is required",
+      CERTOPS_API_TOKEN_SCOPE_REQUIRED,
+    );
+  }
   return normalized;
 }
 
@@ -88,26 +125,60 @@ function firstNonEmptyString(values) {
   return null;
 }
 
-function workspaceIdFromRequest(req, options = {}) {
-  if (typeof options.resolveWorkspaceId === "function") {
-    const resolved = options.resolveWorkspaceId(req);
-    if (typeof resolved === "string" && resolved.trim()) return resolved.trim();
+function workspaceIdFromRouteParams(req, options = {}) {
+  const paramName = options.workspaceIdParam || "workspaceId";
+  return firstNonEmptyString([req.params?.[paramName]]);
+}
+
+function workspaceResolutionFromRequest(req, options = {}) {
+  const routeWorkspaceId = workspaceIdFromRouteParams(req, options);
+  const bodyWorkspaceId = firstNonEmptyString([req.body?.workspaceId]);
+  const resolvedWorkspaceId =
+    typeof options.resolveWorkspaceId === "function"
+      ? firstNonEmptyString([options.resolveWorkspaceId(req)])
+      : null;
+
+  if (routeWorkspaceId) {
+    if (bodyWorkspaceId && bodyWorkspaceId !== routeWorkspaceId) {
+      return { workspaceId: null, code: CERTOPS_API_TOKEN_WORKSPACE_MISMATCH };
+    }
+    if (resolvedWorkspaceId && resolvedWorkspaceId !== routeWorkspaceId) {
+      return { workspaceId: null, code: CERTOPS_API_TOKEN_WORKSPACE_MISMATCH };
+    }
+    return { workspaceId: routeWorkspaceId, code: null };
   }
 
-  const paramNames = [
-    options.workspaceIdParam,
-    "workspaceId",
-    "id",
-  ].filter(Boolean);
-  const paramValues = paramNames.map((name) => req.params?.[name]);
-  const workspaceId = firstNonEmptyString(paramValues);
-  if (workspaceId) return workspaceId;
+  if (
+    resolvedWorkspaceId &&
+    options.allowBodyWorkspaceId === true &&
+    bodyWorkspaceId &&
+    bodyWorkspaceId !== resolvedWorkspaceId
+  ) {
+    return { workspaceId: null, code: CERTOPS_API_TOKEN_WORKSPACE_MISMATCH };
+  }
+  if (resolvedWorkspaceId) {
+    return { workspaceId: resolvedWorkspaceId, code: null };
+  }
 
   if (options.allowBodyWorkspaceId === true) {
-    return firstNonEmptyString([req.body?.workspaceId]);
+    return { workspaceId: bodyWorkspaceId, code: null };
   }
 
-  return null;
+  return { workspaceId: null, code: CERTOPS_API_TOKEN_WORKSPACE_REQUIRED };
+}
+
+function workspaceIdFromRequest(req, options = {}) {
+  return workspaceResolutionFromRequest(req, options).workspaceId;
+}
+
+function hasSessionIdentity(req) {
+  return Boolean(
+    req.user ||
+      req.session ||
+      req.isAdmin === true ||
+      req.authenticated === true ||
+      (typeof req.isAuthenticated === "function" && req.isAuthenticated() === true),
+  );
 }
 
 function safeApiTokenIdentity(token) {
@@ -131,16 +202,27 @@ function createCertOpsApiTokenAuth(options = {}) {
   const validateToken = options.validateApiToken || validateApiToken;
 
   return async function certOpsApiTokenAuth(req, res, next) {
+    if (hasSessionIdentity(req)) {
+      return res
+        .status(401)
+        .json(responseForUnauthorized(CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN));
+    }
+
     const bearer = bearerTokenFromRequest(req);
     if (!bearer.ok) {
       return res.status(401).json(UNAUTHORIZED_RESPONSE);
     }
 
-    const workspaceId = workspaceIdFromRequest(req, options);
+    const workspaceResolution = workspaceResolutionFromRequest(req, options);
+    const workspaceId = workspaceResolution.workspaceId;
     if (!workspaceId) {
       return res
         .status(401)
-        .json(responseForUnauthorized(CERTOPS_API_TOKEN_WORKSPACE_REQUIRED));
+        .json(
+          responseForUnauthorized(
+            workspaceResolution.code || CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+          ),
+        );
     }
 
     let validation;
@@ -172,7 +254,10 @@ function createCertOpsApiTokenAuth(options = {}) {
 
 module.exports = {
   CERTOPS_API_TOKEN_UNAUTHORIZED,
+  CERTOPS_API_TOKEN_SCOPE_REQUIRED,
   CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+  CERTOPS_API_TOKEN_WORKSPACE_MISMATCH,
+  CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN,
   bearerTokenFromRequest,
   createCertOpsApiTokenAuth,
   requireCertOpsApiToken: createCertOpsApiTokenAuth,
@@ -180,6 +265,8 @@ module.exports = {
   workspaceIdFromRequest,
   _test: {
     normalizeRequiredScopes,
+    hasSessionIdentity,
     responseForUnauthorized,
+    workspaceResolutionFromRequest,
   },
 };

--- a/apps/api/middleware/api-token-auth.js
+++ b/apps/api/middleware/api-token-auth.js
@@ -1,0 +1,185 @@
+"use strict";
+
+const {
+  ALLOWED_SCOPES,
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  validateApiToken,
+} = require("../services/certops/apiTokens");
+
+const CERTOPS_API_TOKEN_UNAUTHORIZED = "CERTOPS_API_TOKEN_UNAUTHORIZED";
+const CERTOPS_API_TOKEN_WORKSPACE_REQUIRED =
+  "CERTOPS_API_TOKEN_WORKSPACE_REQUIRED";
+
+const UNAUTHORIZED_RESPONSE = Object.freeze({
+  error: "CertOps API token authentication required",
+  code: CERTOPS_API_TOKEN_UNAUTHORIZED,
+});
+
+const SCOPE_DENIED_RESPONSE = Object.freeze({
+  error: "CertOps API token scope denied",
+  code: CERTOPS_API_TOKEN_SCOPE_DENIED,
+});
+
+function authError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function responseForUnauthorized(code = CERTOPS_API_TOKEN_UNAUTHORIZED) {
+  return code === CERTOPS_API_TOKEN_WORKSPACE_REQUIRED
+    ? {
+        error: "Workspace context is required for CertOps API token authentication",
+        code,
+      }
+    : UNAUTHORIZED_RESPONSE;
+}
+
+function bearerTokenFromRequest(req) {
+  const header =
+    typeof req.get === "function"
+      ? req.get("Authorization")
+      : req.headers?.authorization;
+  if (typeof header !== "string" || !header.trim()) {
+    return { ok: false };
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match || !match[1].trim()) {
+    return { ok: false };
+  }
+
+  return { ok: true, rawToken: match[1].trim() };
+}
+
+function normalizeRequiredScopes(scopes) {
+  const values = scopes === undefined || scopes === null ? [] : scopes;
+  const list = Array.isArray(values) ? values : [values];
+  const normalized = [];
+  const allowed = new Set(ALLOWED_SCOPES);
+
+  for (const scope of list) {
+    if (typeof scope !== "string") {
+      throw authError(
+        "CertOps API token scope is invalid",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+
+    const trimmed = scope.trim();
+    if (!allowed.has(trimmed)) {
+      throw authError(
+        "CertOps API token scope is not allowed",
+        CERTOPS_API_TOKEN_SCOPE_INVALID,
+      );
+    }
+
+    if (!normalized.includes(trimmed)) normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function firstNonEmptyString(values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function workspaceIdFromRequest(req, options = {}) {
+  if (typeof options.resolveWorkspaceId === "function") {
+    const resolved = options.resolveWorkspaceId(req);
+    if (typeof resolved === "string" && resolved.trim()) return resolved.trim();
+  }
+
+  const paramNames = [
+    options.workspaceIdParam,
+    "workspaceId",
+    "id",
+  ].filter(Boolean);
+  const paramValues = paramNames.map((name) => req.params?.[name]);
+  const workspaceId = firstNonEmptyString(paramValues);
+  if (workspaceId) return workspaceId;
+
+  if (options.allowBodyWorkspaceId === true) {
+    return firstNonEmptyString([req.body?.workspaceId]);
+  }
+
+  return null;
+}
+
+function safeApiTokenIdentity(token) {
+  if (!token) return null;
+
+  return {
+    id: token.id,
+    workspaceId: token.workspaceId,
+    tokenPrefix: token.tokenPrefix,
+    scopes: Array.isArray(token.scopes) ? [...token.scopes] : [],
+    name: token.name,
+    createdBy: token.createdBy ?? null,
+    lastUsedAt: token.lastUsedAt || null,
+  };
+}
+
+function createCertOpsApiTokenAuth(options = {}) {
+  const requiredScopes = normalizeRequiredScopes(
+    options.scopes ?? options.requiredScopes,
+  );
+  const validateToken = options.validateApiToken || validateApiToken;
+
+  return async function certOpsApiTokenAuth(req, res, next) {
+    const bearer = bearerTokenFromRequest(req);
+    if (!bearer.ok) {
+      return res.status(401).json(UNAUTHORIZED_RESPONSE);
+    }
+
+    const workspaceId = workspaceIdFromRequest(req, options);
+    if (!workspaceId) {
+      return res
+        .status(401)
+        .json(responseForUnauthorized(CERTOPS_API_TOKEN_WORKSPACE_REQUIRED));
+    }
+
+    let validation;
+    try {
+      validation = await validateToken({
+        client: options.client,
+        rawToken: bearer.rawToken,
+        workspaceId,
+        requiredScopes,
+      });
+    } catch (error) {
+      if (error?.code === CERTOPS_API_TOKEN_SCOPE_INVALID) {
+        return res.status(403).json(SCOPE_DENIED_RESPONSE);
+      }
+      return next(error);
+    }
+
+    if (!validation?.valid) {
+      if (validation?.code === CERTOPS_API_TOKEN_SCOPE_DENIED) {
+        return res.status(403).json(SCOPE_DENIED_RESPONSE);
+      }
+      return res.status(401).json(UNAUTHORIZED_RESPONSE);
+    }
+
+    req.apiToken = safeApiTokenIdentity(validation.token);
+    return next();
+  };
+}
+
+module.exports = {
+  CERTOPS_API_TOKEN_UNAUTHORIZED,
+  CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+  bearerTokenFromRequest,
+  createCertOpsApiTokenAuth,
+  requireCertOpsApiToken: createCertOpsApiTokenAuth,
+  safeApiTokenIdentity,
+  workspaceIdFromRequest,
+  _test: {
+    normalizeRequiredScopes,
+    responseForUnauthorized,
+  },
+};

--- a/apps/api/middleware/csrf-exempt.js
+++ b/apps/api/middleware/csrf-exempt.js
@@ -1,7 +1,16 @@
 const { isInternalWorkerRequest } = require("./internal-worker-auth");
 
+function isCertOpsMachineTokenCsrfExemptPath(requestPath) {
+  return (
+    requestPath === "/v1/certops/executor/events" ||
+    requestPath.startsWith("/v1/certops/executor/") ||
+    requestPath === "/api/v1/certops/executor/events" ||
+    requestPath.startsWith("/api/v1/certops/executor/")
+  );
+}
+
 function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
-  const allowPath = options.allowPath || (() => false);
+  const allowPath = options.allowPath || isCertOpsMachineTokenCsrfExemptPath;
 
   return (req, res, next) => {
     if (
@@ -15,7 +24,7 @@ function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
     const requestPath = req.path || "";
     if (requestPath === "/logout") return next();
     if (isInternalWorkerRequest(req)) return next();
-    if (allowPath(requestPath)) return next();
+    if (allowPath(requestPath, req)) return next();
 
     return doubleCsrfProtection(req, res, next);
   };
@@ -23,4 +32,5 @@ function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
 
 module.exports = {
   createCsrfExemptMiddleware,
+  isCertOpsMachineTokenCsrfExemptPath,
 };

--- a/apps/api/middleware/csrf-exempt.js
+++ b/apps/api/middleware/csrf-exempt.js
@@ -1,16 +1,18 @@
 const { isInternalWorkerRequest } = require("./internal-worker-auth");
 
+// Add a route here only when its machine-token middleware is explicitly mounted.
+const CERTOPS_MACHINE_TOKEN_CSRF_EXEMPT_PATHS = new Set([
+  "/v1/certops/executor/events",
+  "/api/v1/certops/executor/events",
+]);
+
 function isCertOpsMachineTokenCsrfExemptPath(requestPath) {
-  return (
-    requestPath === "/v1/certops/executor/events" ||
-    requestPath.startsWith("/v1/certops/executor/") ||
-    requestPath === "/api/v1/certops/executor/events" ||
-    requestPath.startsWith("/api/v1/certops/executor/")
-  );
+  return CERTOPS_MACHINE_TOKEN_CSRF_EXEMPT_PATHS.has(requestPath);
 }
 
 function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
-  const allowPath = options.allowPath || isCertOpsMachineTokenCsrfExemptPath;
+  const allowPath =
+    typeof options.allowPath === "function" ? options.allowPath : () => false;
 
   return (req, res, next) => {
     if (
@@ -31,6 +33,7 @@ function createCsrfExemptMiddleware(doubleCsrfProtection, options = {}) {
 }
 
 module.exports = {
+  CERTOPS_MACHINE_TOKEN_CSRF_EXEMPT_PATHS,
   createCsrfExemptMiddleware,
   isCertOpsMachineTokenCsrfExemptPath,
 };

--- a/tests/integration/certops-api-token-auth.test.js
+++ b/tests/integration/certops-api-token-auth.test.js
@@ -64,7 +64,7 @@ async function cleanupWorkspacePair(ownerId, workspaceIds) {
   await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
 }
 
-function buildAuthHarness(requiredScopes = ["certops:executor:events"]) {
+function buildAuthHarness(requiredScopes = ["certops:events:write"]) {
   const app = express();
   app.use(express.json());
 
@@ -112,7 +112,7 @@ describe("CertOps API token auth middleware", function () {
       const created = await createApiToken({
         workspaceId: workspaceA,
         name: "Executor",
-        scopes: ["certops:executor:events", "certops:jobs:read"],
+        scopes: ["certops:events:write", "certops:jobs:read"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
@@ -131,7 +131,7 @@ describe("CertOps API token auth middleware", function () {
         createdBy: ownerId,
       });
       expect(response.body.apiToken.scopes).to.include(
-        "certops:executor:events",
+        "certops:events:write",
       );
       expect(response.body.apiToken.token_hash).to.equal(undefined);
       expect(response.body.apiToken.plaintextToken).to.equal(undefined);
@@ -179,7 +179,7 @@ describe("CertOps API token auth middleware", function () {
       const validForA = await createApiToken({
         workspaceId: workspaceA,
         name: "Workspace A",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
@@ -205,7 +205,7 @@ describe("CertOps API token auth middleware", function () {
       const expired = await createApiToken({
         workspaceId: workspaceA,
         name: "Expired",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() - 60 * 1000),
         createdBy: ownerId,
       });

--- a/tests/integration/certops-api-token-auth.test.js
+++ b/tests/integration/certops-api-token-auth.test.js
@@ -70,7 +70,10 @@ function buildAuthHarness(requiredScopes = ["certops:events:write"]) {
 
   app.post(
     "/api/v1/workspaces/:id/certops/machine-auth-test",
-    createCertOpsApiTokenAuth({ scopes: requiredScopes }),
+    createCertOpsApiTokenAuth({
+      scopes: requiredScopes,
+      workspaceIdParam: "id",
+    }),
     (req, res) =>
       res.status(200).json({
         apiToken: req.apiToken,
@@ -120,7 +123,7 @@ describe("CertOps API token auth middleware", function () {
       const response = await supertest(buildAuthHarness())
         .post(`/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`)
         .set("Authorization", `Bearer ${created.plaintextToken}`)
-        .send({ workspaceId: workspaceB });
+        .send({});
 
       expect(response.status).to.equal(200);
       expect(response.body.apiToken).to.include({

--- a/tests/integration/certops-api-token-auth.test.js
+++ b/tests/integration/certops-api-token-auth.test.js
@@ -1,0 +1,236 @@
+const crypto = require("crypto");
+const { createRequire } = require("module");
+const supertest = require("supertest");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+const {
+  createApiToken,
+  revokeApiToken,
+} = require("../../apps/api/services/certops/apiTokens");
+const {
+  createCertOpsApiTokenAuth,
+} = require("../../apps/api/middleware/api-token-auth");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
+
+async function createWorkspacePair(label) {
+  const ownerEmail = `${label}-${Date.now()}-${crypto.randomUUID()}@example.com`;
+  const owner = await TestUtils.execQuery(
+    `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+     VALUES ($1, $2, $3, $4, 'local', TRUE)
+     RETURNING id`,
+    [
+      ownerEmail.toLowerCase(),
+      ownerEmail,
+      label,
+      "not-used-in-api-token-auth-test",
+    ],
+  );
+  const ownerId = owner.rows[0].id;
+  const workspaceA = crypto.randomUUID();
+  const workspaceB = crypto.randomUUID();
+
+  await TestUtils.execQuery(
+    `INSERT INTO workspaces (id, name, created_by, plan)
+     VALUES ($1, $2, $3, 'oss'), ($4, $5, $3, 'oss')`,
+    [
+      workspaceA,
+      `${label} A`,
+      ownerId,
+      workspaceB,
+      `${label} B`,
+    ],
+  );
+
+  return { ownerId, workspaceA, workspaceB };
+}
+
+async function cleanupWorkspacePair(ownerId, workspaceIds) {
+  await TestUtils.execQuery("DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM workspaces WHERE id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+}
+
+function buildAuthHarness(requiredScopes = ["certops:executor:events"]) {
+  const app = express();
+  app.use(express.json());
+
+  app.post(
+    "/api/v1/workspaces/:id/certops/machine-auth-test",
+    createCertOpsApiTokenAuth({ scopes: requiredScopes }),
+    (req, res) =>
+      res.status(200).json({
+        apiToken: req.apiToken,
+        hasUser: !!req.user,
+        isAdmin: req.isAdmin === true,
+        authenticated: req.authenticated === true,
+      }),
+  );
+
+  app.use((err, req, res, next) => {
+    if (res.headersSent) return next(err);
+    return res.status(500).json({
+      error: "Internal test harness error",
+      code: err?.code || "INTERNAL_ERROR",
+    });
+  });
+
+  return app;
+}
+
+function expectNoRawToken(responseBody, rawToken) {
+  expect(JSON.stringify(responseBody)).to.not.include(rawToken);
+  expect(JSON.stringify(responseBody)).to.not.include(`Bearer ${rawToken}`);
+}
+
+describe("CertOps API token auth middleware", function () {
+  this.timeout(60000);
+
+  before(async () => {
+    await runMigrations();
+  });
+
+  it("authenticates a valid scoped token without attaching session/admin identity", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-auth-success",
+    );
+
+    try {
+      const created = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Executor",
+        scopes: ["certops:executor:events", "certops:jobs:read"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+
+      const response = await supertest(buildAuthHarness())
+        .post(`/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`)
+        .set("Authorization", `Bearer ${created.plaintextToken}`)
+        .send({ workspaceId: workspaceB });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.apiToken).to.include({
+        id: created.token.id,
+        workspaceId: workspaceA,
+        tokenPrefix: created.token.tokenPrefix,
+        name: "Executor",
+        createdBy: ownerId,
+      });
+      expect(response.body.apiToken.scopes).to.include(
+        "certops:executor:events",
+      );
+      expect(response.body.apiToken.token_hash).to.equal(undefined);
+      expect(response.body.apiToken.plaintextToken).to.equal(undefined);
+      expect(response.body.hasUser).to.equal(false);
+      expect(response.body.isAdmin).to.equal(false);
+      expect(response.body.authenticated).to.equal(false);
+      expectNoRawToken(response.body, created.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects missing, non-Bearer, and malformed tokens with generic 401", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-auth-invalid",
+    );
+
+    try {
+      for (const authorization of [
+        null,
+        "Basic abc123",
+        "Bearer ttx__bad",
+      ]) {
+        const request = supertest(buildAuthHarness()).post(
+          `/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`,
+        );
+        if (authorization) request.set("Authorization", authorization);
+
+        const response = await request.send({});
+        expect(response.status).to.equal(401);
+        expect(response.body.code).to.equal("CERTOPS_API_TOKEN_UNAUTHORIZED");
+        expect(JSON.stringify(response.body)).to.not.include("ttx__bad");
+      }
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects wrong-workspace, revoked, expired, and missing-scope tokens", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-api-token-auth-failures",
+    );
+
+    try {
+      const validForA = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Workspace A",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+
+      const wrongWorkspace = await supertest(buildAuthHarness())
+        .post(`/api/v1/workspaces/${workspaceB}/certops/machine-auth-test`)
+        .set("Authorization", `Bearer ${validForA.plaintextToken}`)
+        .send({});
+      expect(wrongWorkspace.status).to.equal(401);
+      expectNoRawToken(wrongWorkspace.body, validForA.plaintextToken);
+
+      await revokeApiToken({
+        workspaceId: workspaceA,
+        tokenId: validForA.token.id,
+        revokedBy: ownerId,
+      });
+      const revoked = await supertest(buildAuthHarness())
+        .post(`/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`)
+        .set("Authorization", `Bearer ${validForA.plaintextToken}`)
+        .send({});
+      expect(revoked.status).to.equal(401);
+
+      const expired = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Expired",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() - 60 * 1000),
+        createdBy: ownerId,
+      });
+      const expiredResponse = await supertest(buildAuthHarness())
+        .post(`/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`)
+        .set("Authorization", `Bearer ${expired.plaintextToken}`)
+        .send({});
+      expect(expiredResponse.status).to.equal(401);
+
+      const jobsOnly = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Jobs only",
+        scopes: ["certops:jobs:read"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+      const missingScope = await supertest(buildAuthHarness())
+        .post(`/api/v1/workspaces/${workspaceA}/certops/machine-auth-test`)
+        .set("Authorization", `Bearer ${jobsOnly.plaintextToken}`)
+        .send({});
+      expect(missingScope.status).to.equal(403);
+      expect(missingScope.body.code).to.equal("CERTOPS_API_TOKEN_SCOPE_DENIED");
+      expectNoRawToken(missingScope.body, jobsOnly.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+});

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -74,6 +74,7 @@ tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
+tests/integration/certops-api-token-auth.test.js
 
 # Integrations
 tests/integration/github.integration.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -88,6 +88,7 @@ tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
+tests/integration/certops-api-token-auth.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-api-token-auth.test.js
+++ b/tests/unit/certops-api-token-auth.test.js
@@ -12,7 +12,10 @@ const {
   path.resolve(__dirname, "../../apps/api/services/certops/apiTokens.js"),
 );
 const {
+  CERTOPS_API_TOKEN_SCOPE_REQUIRED,
+  CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN,
   CERTOPS_API_TOKEN_UNAUTHORIZED,
+  CERTOPS_API_TOKEN_WORKSPACE_MISMATCH,
   bearerTokenFromRequest,
   createCertOpsApiTokenAuth,
   safeApiTokenIdentity,
@@ -34,7 +37,7 @@ const RAW_TOKEN =
 
 function createRequest({
   authorization,
-  params = { id: WORKSPACE_A },
+  params = { workspaceId: WORKSPACE_A },
   body,
   method = "POST",
   path: requestPath = "/v1/workspaces/111/certops/test",
@@ -161,7 +164,7 @@ describe("CertOps API token auth middleware", () => {
 
     const req = createRequest({
       authorization: `Bearer ${RAW_TOKEN}`,
-      params: { id: WORKSPACE_A },
+      params: { workspaceId: WORKSPACE_A },
     });
     const result = await runMiddleware(middleware, req);
 
@@ -187,12 +190,12 @@ describe("CertOps API token auth middleware", () => {
     assert.equal(req.authenticated, undefined);
   });
 
-  it("prefers URL workspace params over body workspaceId", async () => {
-    let workspaceId;
+  it("fails closed when route and body workspace IDs differ", async () => {
+    let validationCalled = false;
     const middleware = createCertOpsApiTokenAuth({
       scopes: ["certops:events:write"],
-      validateApiToken: async (options) => {
-        workspaceId = options.workspaceId;
+      validateApiToken: async () => {
+        validationCalled = true;
         return successfulValidation();
       },
     });
@@ -202,28 +205,108 @@ describe("CertOps API token auth middleware", () => {
       params: { workspaceId: WORKSPACE_A },
       body: { workspaceId: WORKSPACE_B },
     });
-    await runMiddleware(middleware, req);
+    const result = await runMiddleware(middleware, req);
 
-    assert.equal(workspaceId, WORKSPACE_A);
+    assert.equal(result.res.statusCode, 401);
+    assert.equal(result.res.body.code, CERTOPS_API_TOKEN_WORKSPACE_MISMATCH);
+    assert.equal(validationCalled, false);
+    assert.equal(req.apiToken, undefined);
   });
 
-  it("can use an explicit workspace resolver for future machine routes", async () => {
+  it("uses only explicit workspace sources and rejects resolver mismatches", async () => {
+    const defaultMiddleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      validateApiToken: async () => successfulValidation(),
+    });
+    const defaultIdResult = await runMiddleware(
+      defaultMiddleware,
+      createRequest({
+        authorization: `Bearer ${RAW_TOKEN}`,
+        params: { id: WORKSPACE_A },
+      }),
+    );
+    assert.equal(defaultIdResult.res.statusCode, 401);
+    assert.equal(
+      defaultIdResult.res.body.code,
+      CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+    );
+
+    const explicitIdMiddleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      workspaceIdParam: "id",
+      validateApiToken: async (options) =>
+        successfulValidation({ workspaceId: options.workspaceId }),
+    });
+    const explicitIdResult = await runMiddleware(
+      explicitIdMiddleware,
+      createRequest({
+        authorization: `Bearer ${RAW_TOKEN}`,
+        params: { id: WORKSPACE_A },
+      }),
+    );
+    assert.equal(explicitIdResult.nextCalled, true);
+    assert.equal(explicitIdResult.req.apiToken.workspaceId, WORKSPACE_A);
+
+    const bodyDisabledResult = await runMiddleware(
+      defaultMiddleware,
+      createRequest({
+        authorization: `Bearer ${RAW_TOKEN}`,
+        params: {},
+        body: { workspaceId: WORKSPACE_A },
+      }),
+    );
+    assert.equal(bodyDisabledResult.res.statusCode, 401);
+    assert.equal(
+      bodyDisabledResult.res.body.code,
+      CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+    );
+
+    const bodyEnabledMiddleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      allowBodyWorkspaceId: true,
+      validateApiToken: async (options) =>
+        successfulValidation({ workspaceId: options.workspaceId }),
+    });
+    const bodyEnabledResult = await runMiddleware(
+      bodyEnabledMiddleware,
+      createRequest({
+        authorization: `Bearer ${RAW_TOKEN}`,
+        params: {},
+        body: { workspaceId: WORKSPACE_A },
+      }),
+    );
+    assert.equal(bodyEnabledResult.nextCalled, true);
+    assert.equal(bodyEnabledResult.req.apiToken.workspaceId, WORKSPACE_A);
+
     const middleware = createCertOpsApiTokenAuth({
       scopes: ["certops:events:write"],
-      resolveWorkspaceId: (req) => req.body.workspaceId,
+      resolveWorkspaceId: () => WORKSPACE_B,
       validateApiToken: async (options) =>
         successfulValidation({ workspaceId: options.workspaceId }),
     });
 
     const req = createRequest({
       authorization: `Bearer ${RAW_TOKEN}`,
-      params: {},
-      body: { workspaceId: WORKSPACE_A },
+      params: { workspaceId: WORKSPACE_A },
     });
     const result = await runMiddleware(middleware, req);
 
-    assert.equal(result.nextCalled, true);
-    assert.equal(req.apiToken.workspaceId, WORKSPACE_A);
+    assert.equal(result.res.statusCode, 401);
+    assert.equal(result.res.body.code, CERTOPS_API_TOKEN_WORKSPACE_MISMATCH);
+    assert.equal(req.apiToken, undefined);
+
+    const matchingResolverMiddleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      resolveWorkspaceId: () => WORKSPACE_A,
+      validateApiToken: async (options) =>
+        successfulValidation({ workspaceId: options.workspaceId }),
+    });
+    const matchingResolverResult = await runMiddleware(
+      matchingResolverMiddleware,
+      req,
+    );
+    assert.equal(matchingResolverResult.nextCalled, true);
+    assert.equal(matchingResolverResult.req.apiToken.workspaceId, WORKSPACE_A);
   });
 
   it("rejects missing, non-Bearer, and empty Authorization headers with 401", async () => {
@@ -311,6 +394,51 @@ describe("CertOps API token auth middleware", () => {
     );
   });
 
+  it("requires at least one configured machine-token scope", () => {
+    for (const scopes of [undefined, null, [], "", " ", [" "]]) {
+      assert.throws(
+        () => createCertOpsApiTokenAuth({ scopes }),
+        (error) => error.code === CERTOPS_API_TOKEN_SCOPE_REQUIRED,
+      );
+    }
+
+    assert.doesNotThrow(() =>
+      createCertOpsApiTokenAuth({ scopes: ["certops:events:write"] }),
+    );
+  });
+
+  it("rejects mixed session and machine-token identities before validation", async () => {
+    for (const sessionIdentity of [
+      { user: { id: 1 } },
+      { session: { userId: 1 } },
+      { isAdmin: true },
+      { authenticated: true },
+      { isAuthenticated: () => true },
+    ]) {
+      let validationCalled = false;
+      const middleware = createCertOpsApiTokenAuth({
+        scopes: ["certops:events:write"],
+        validateApiToken: async () => {
+          validationCalled = true;
+          return successfulValidation();
+        },
+      });
+      const req = Object.assign(
+        createRequest({ authorization: `Bearer ${RAW_TOKEN}` }),
+        sessionIdentity,
+      );
+      const result = await runMiddleware(middleware, req);
+
+      assert.equal(result.res.statusCode, 401);
+      assert.equal(
+        result.res.body.code,
+        CERTOPS_API_TOKEN_SESSION_IDENTITY_FORBIDDEN,
+      );
+      assert.equal(validationCalled, false);
+      assert.equal(req.apiToken, undefined);
+    }
+  });
+
   it("does not expose custody-looking fields in req.apiToken or responses", async () => {
     const middleware = createCertOpsApiTokenAuth({
       scopes: ["certops:events:write"],
@@ -331,7 +459,7 @@ describe("CertOps API token auth middleware", () => {
   it("exports safe request parsing helpers", () => {
     const req = createRequest({
       authorization: `Bearer ${RAW_TOKEN}`,
-      params: { id: WORKSPACE_A },
+      params: { workspaceId: WORKSPACE_A },
     });
 
     assert.deepEqual(bearerTokenFromRequest(req), {
@@ -355,48 +483,38 @@ describe("CertOps API token auth middleware", () => {
 });
 
 describe("CertOps machine-token CSRF exemption", () => {
-  it("exempts only the future executor machine-token namespace", () => {
-    assert.equal(
-      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/executor/events"),
-      true,
-    );
-    assert.equal(
-      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/executor/jobs/1/events"),
-      true,
-    );
-    assert.equal(
-      isCertOpsMachineTokenCsrfExemptPath(
-        "/v1/workspaces/111/certops/certificates",
-      ),
-      false,
-    );
-    assert.equal(
-      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/agent/register"),
-      false,
-    );
-    assert.equal(isCertOpsMachineTokenCsrfExemptPath("/v1/tokens"), false);
+  it("allows only exact planned machine-token paths when explicitly requested", () => {
+    for (const requestPath of [
+      "/v1/certops/executor/events",
+      "/api/v1/certops/executor/events",
+    ]) {
+      assert.equal(isCertOpsMachineTokenCsrfExemptPath(requestPath), true);
+    }
+    for (const requestPath of [
+      "/api/v1/certops/executor/events/extra",
+      "/api/v1/certops/executor/jobs",
+      "/api/v1/certops/executor/anything",
+      "/v1/certops/executor/jobs",
+      "/v1/workspaces/111/certops/certificates",
+      "/v1/certops/agent/register",
+    ]) {
+      assert.equal(isCertOpsMachineTokenCsrfExemptPath(requestPath), false);
+    }
   });
 
-  it("keeps unrelated state-changing API routes behind CSRF protection", async () => {
+  it("defaults fail-closed and permits exact paths only with an explicit allowlist", async () => {
     let protectedCalls = 0;
     let nextCalls = 0;
-    const middleware = createCsrfExemptMiddleware((_req, res) => {
+    const csrfProtection = (_req, res) => {
       protectedCalls += 1;
       return res.status(403).json({ code: "EBADCSRFTOKEN" });
+    };
+    const defaultMiddleware = createCsrfExemptMiddleware(csrfProtection);
+    const explicitMiddleware = createCsrfExemptMiddleware(csrfProtection, {
+      allowPath: isCertOpsMachineTokenCsrfExemptPath,
     });
 
-    await middleware(
-      createRequest({
-        path: "/v1/workspaces/111/certops/certificates",
-        method: "POST",
-      }),
-      createResponse(),
-      () => {
-        nextCalls += 1;
-      },
-    );
-
-    await middleware(
+    await defaultMiddleware(
       createRequest({
         path: "/v1/certops/executor/events",
         method: "POST",
@@ -407,7 +525,44 @@ describe("CertOps machine-token CSRF exemption", () => {
       },
     );
 
-    assert.equal(protectedCalls, 1);
-    assert.equal(nextCalls, 1);
+    await explicitMiddleware(
+      createRequest({
+        path: "/v1/certops/executor/events",
+        method: "POST",
+      }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+
+    await explicitMiddleware(
+      createRequest({
+        path: "/v1/certops/executor/events/extra",
+        method: "POST",
+      }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+
+    await defaultMiddleware(
+      createRequest({ path: "/logout", method: "POST" }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+    await defaultMiddleware(
+      createRequest({ path: "/v1/tokens", method: "GET" }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+
+    assert.equal(protectedCalls, 2);
+    assert.equal(nextCalls, 3);
   });
 });

--- a/tests/unit/certops-api-token-auth.test.js
+++ b/tests/unit/certops-api-token-auth.test.js
@@ -1,0 +1,412 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  CERTOPS_API_TOKEN_WORKSPACE_REQUIRED,
+} = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/apiTokens.js"),
+);
+const {
+  CERTOPS_API_TOKEN_UNAUTHORIZED,
+  bearerTokenFromRequest,
+  createCertOpsApiTokenAuth,
+  safeApiTokenIdentity,
+  workspaceIdFromRequest,
+} = require(
+  path.resolve(__dirname, "../../apps/api/middleware/api-token-auth.js"),
+);
+const {
+  createCsrfExemptMiddleware,
+  isCertOpsMachineTokenCsrfExemptPath,
+} = require(
+  path.resolve(__dirname, "../../apps/api/middleware/csrf-exempt.js"),
+);
+
+const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
+const RAW_TOKEN = "ttx_abc123_secret456";
+
+function createRequest({
+  authorization,
+  params = { id: WORKSPACE_A },
+  body,
+  method = "POST",
+  path: requestPath = "/v1/workspaces/111/certops/test",
+} = {}) {
+  const headers = {};
+  if (authorization !== undefined) headers.authorization = authorization;
+
+  return {
+    method,
+    path: requestPath,
+    params,
+    body,
+    headers,
+    get(name) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+async function runMiddleware(middleware, req) {
+  const res = createResponse();
+  const result = {
+    req,
+    res,
+    nextCalled: false,
+    nextError: null,
+  };
+
+  await middleware(req, res, (error) => {
+    result.nextCalled = !error;
+    result.nextError = error || null;
+  });
+
+  return result;
+}
+
+function successfulValidation(overrides = {}) {
+  return {
+    valid: true,
+    token: {
+      id: "token-1",
+      workspaceId: WORKSPACE_A,
+      tokenPrefix: "ttx_abc123",
+      scopes: ["certops:executor:events", "certops:jobs:read"],
+      name: "Executor",
+      createdBy: 42,
+      lastUsedAt: "2026-07-02T00:00:00.000Z",
+      token_hash: "must-not-attach",
+      plaintextToken: "must-not-attach",
+      ...overrides,
+    },
+  };
+}
+
+function collectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, keys);
+    return keys;
+  }
+  if (!value || typeof value !== "object") return keys;
+  for (const [key, child] of Object.entries(value)) {
+    keys.push(key);
+    collectKeys(child, keys);
+  }
+  return keys;
+}
+
+function assertNoCustodyKeys(value) {
+  const forbidden = [
+    "privatekey",
+    "privatekeypem",
+    "encryptedprivatekey",
+    "keymaterial",
+    "pfxblob",
+    "jksblob",
+    "tlskey",
+    "caprivatekey",
+    "keystorepassword",
+    "privatekeypassword",
+    "keypassword",
+    "password",
+    "secret",
+    "credential",
+    "tokensecret",
+    "apisecret",
+    "rawsecret",
+    "rawprivatekey",
+    "rawkey",
+    "pemprivatekey",
+  ];
+
+  for (const key of collectKeys(value)) {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const hit = forbidden.find((fragment) => normalized.includes(fragment));
+    assert.equal(hit, undefined, `${key} looks like a custody field`);
+  }
+}
+
+describe("CertOps API token auth middleware", () => {
+  it("authenticates valid Bearer tokens and attaches safe machine identity", async () => {
+    const calls = [];
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async (options) => {
+        calls.push(options);
+        return successfulValidation();
+      },
+    });
+
+    const req = createRequest({
+      authorization: `Bearer ${RAW_TOKEN}`,
+      params: { id: WORKSPACE_A },
+    });
+    const result = await runMiddleware(middleware, req);
+
+    assert.equal(result.nextCalled, true);
+    assert.equal(result.res.statusCode, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].rawToken, RAW_TOKEN);
+    assert.equal(calls[0].workspaceId, WORKSPACE_A);
+    assert.deepEqual(calls[0].requiredScopes, ["certops:executor:events"]);
+    assert.deepEqual(req.apiToken, {
+      id: "token-1",
+      workspaceId: WORKSPACE_A,
+      tokenPrefix: "ttx_abc123",
+      scopes: ["certops:executor:events", "certops:jobs:read"],
+      name: "Executor",
+      createdBy: 42,
+      lastUsedAt: "2026-07-02T00:00:00.000Z",
+    });
+    assert.equal(req.apiToken.token_hash, undefined);
+    assert.equal(req.apiToken.plaintextToken, undefined);
+    assert.equal(req.user, undefined);
+    assert.equal(req.isAdmin, undefined);
+    assert.equal(req.authenticated, undefined);
+  });
+
+  it("prefers URL workspace params over body workspaceId", async () => {
+    let workspaceId;
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async (options) => {
+        workspaceId = options.workspaceId;
+        return successfulValidation();
+      },
+    });
+
+    const req = createRequest({
+      authorization: `Bearer ${RAW_TOKEN}`,
+      params: { workspaceId: WORKSPACE_A },
+      body: { workspaceId: WORKSPACE_B },
+    });
+    await runMiddleware(middleware, req);
+
+    assert.equal(workspaceId, WORKSPACE_A);
+  });
+
+  it("can use an explicit workspace resolver for future machine routes", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      resolveWorkspaceId: (req) => req.body.workspaceId,
+      validateApiToken: async (options) =>
+        successfulValidation({ workspaceId: options.workspaceId }),
+    });
+
+    const req = createRequest({
+      authorization: `Bearer ${RAW_TOKEN}`,
+      params: {},
+      body: { workspaceId: WORKSPACE_A },
+    });
+    const result = await runMiddleware(middleware, req);
+
+    assert.equal(result.nextCalled, true);
+    assert.equal(req.apiToken.workspaceId, WORKSPACE_A);
+  });
+
+  it("rejects missing, non-Bearer, and empty Authorization headers with 401", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async () => {
+        throw new Error("validator must not be called");
+      },
+    });
+
+    for (const authorization of [undefined, "", "Basic abc", "Bearer"]) {
+      const result = await runMiddleware(
+        middleware,
+        createRequest({ authorization }),
+      );
+
+      assert.equal(result.nextCalled, false);
+      assert.equal(result.res.statusCode, 401);
+      assert.equal(result.res.body.code, CERTOPS_API_TOKEN_UNAUTHORIZED);
+    }
+  });
+
+  it("rejects malformed, revoked, expired, and wrong-workspace tokens with generic 401", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async () => ({ valid: false, code: "ANY_REASON" }),
+    });
+    const result = await runMiddleware(
+      middleware,
+      createRequest({ authorization: `Bearer ${RAW_TOKEN}` }),
+    );
+
+    assert.equal(result.res.statusCode, 401);
+    assert.deepEqual(result.res.body, {
+      error: "CertOps API token authentication required",
+      code: CERTOPS_API_TOKEN_UNAUTHORIZED,
+    });
+    assert.equal(JSON.stringify(result.res.body).includes(RAW_TOKEN), false);
+    assert.equal(
+      JSON.stringify(result.res.body).includes(`Bearer ${RAW_TOKEN}`),
+      false,
+    );
+  });
+
+  it("rejects valid tokens missing a required scope with 403", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:evidence:write"],
+      validateApiToken: async () => ({
+        valid: false,
+        code: CERTOPS_API_TOKEN_SCOPE_DENIED,
+      }),
+    });
+    const result = await runMiddleware(
+      middleware,
+      createRequest({ authorization: `Bearer ${RAW_TOKEN}` }),
+    );
+
+    assert.equal(result.res.statusCode, 403);
+    assert.equal(result.res.body.code, CERTOPS_API_TOKEN_SCOPE_DENIED);
+  });
+
+  it("fails safely when workspace context is missing", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async () => {
+        throw new Error("validator must not be called without workspace");
+      },
+    });
+    const result = await runMiddleware(
+      middleware,
+      createRequest({ authorization: `Bearer ${RAW_TOKEN}`, params: {} }),
+    );
+
+    assert.equal(result.res.statusCode, 401);
+    assert.equal(result.res.body.code, CERTOPS_API_TOKEN_WORKSPACE_REQUIRED);
+  });
+
+  it("rejects unknown configured required scopes at setup time", () => {
+    assert.throws(
+      () =>
+        createCertOpsApiTokenAuth({
+          scopes: ["certops:admin"],
+        }),
+      (error) => error.code === CERTOPS_API_TOKEN_SCOPE_INVALID,
+    );
+  });
+
+  it("does not expose custody-looking fields in req.apiToken or responses", async () => {
+    const middleware = createCertOpsApiTokenAuth({
+      scopes: ["certops:executor:events"],
+      validateApiToken: async () => successfulValidation(),
+    });
+    const result = await runMiddleware(
+      middleware,
+      createRequest({ authorization: `Bearer ${RAW_TOKEN}` }),
+    );
+
+    assertNoCustodyKeys(result.req.apiToken);
+    assertNoCustodyKeys({
+      error: "CertOps API token authentication required",
+      code: CERTOPS_API_TOKEN_UNAUTHORIZED,
+    });
+  });
+
+  it("exports safe request parsing helpers", () => {
+    const req = createRequest({
+      authorization: `Bearer ${RAW_TOKEN}`,
+      params: { id: WORKSPACE_A },
+    });
+
+    assert.deepEqual(bearerTokenFromRequest(req), {
+      ok: true,
+      rawToken: RAW_TOKEN,
+    });
+    assert.equal(workspaceIdFromRequest(req), WORKSPACE_A);
+    assert.deepEqual(
+      safeApiTokenIdentity(successfulValidation().token),
+      {
+        id: "token-1",
+        workspaceId: WORKSPACE_A,
+        tokenPrefix: "ttx_abc123",
+        scopes: ["certops:executor:events", "certops:jobs:read"],
+        name: "Executor",
+        createdBy: 42,
+        lastUsedAt: "2026-07-02T00:00:00.000Z",
+      },
+    );
+  });
+});
+
+describe("CertOps machine-token CSRF exemption", () => {
+  it("exempts only the future executor machine-token namespace", () => {
+    assert.equal(
+      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/executor/events"),
+      true,
+    );
+    assert.equal(
+      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/executor/jobs/1/events"),
+      true,
+    );
+    assert.equal(
+      isCertOpsMachineTokenCsrfExemptPath(
+        "/v1/workspaces/111/certops/certificates",
+      ),
+      false,
+    );
+    assert.equal(
+      isCertOpsMachineTokenCsrfExemptPath("/v1/certops/agent/register"),
+      false,
+    );
+    assert.equal(isCertOpsMachineTokenCsrfExemptPath("/v1/tokens"), false);
+  });
+
+  it("keeps unrelated state-changing API routes behind CSRF protection", async () => {
+    let protectedCalls = 0;
+    let nextCalls = 0;
+    const middleware = createCsrfExemptMiddleware((_req, res) => {
+      protectedCalls += 1;
+      return res.status(403).json({ code: "EBADCSRFTOKEN" });
+    });
+
+    await middleware(
+      createRequest({
+        path: "/v1/workspaces/111/certops/certificates",
+        method: "POST",
+      }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+
+    await middleware(
+      createRequest({
+        path: "/v1/certops/executor/events",
+        method: "POST",
+      }),
+      createResponse(),
+      () => {
+        nextCalls += 1;
+      },
+    );
+
+    assert.equal(protectedCalls, 1);
+    assert.equal(nextCalls, 1);
+  });
+});

--- a/tests/unit/certops-api-token-auth.test.js
+++ b/tests/unit/certops-api-token-auth.test.js
@@ -29,7 +29,8 @@ const {
 
 const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
 const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
-const RAW_TOKEN = "ttx_abc123_secret456";
+const RAW_TOKEN =
+  "ttx_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 function createRequest({
   authorization,
@@ -92,7 +93,7 @@ function successfulValidation(overrides = {}) {
       id: "token-1",
       workspaceId: WORKSPACE_A,
       tokenPrefix: "ttx_abc123",
-      scopes: ["certops:executor:events", "certops:jobs:read"],
+      scopes: ["certops:events:write", "certops:jobs:read"],
       name: "Executor",
       createdBy: 42,
       lastUsedAt: "2026-07-02T00:00:00.000Z",
@@ -151,7 +152,7 @@ describe("CertOps API token auth middleware", () => {
   it("authenticates valid Bearer tokens and attaches safe machine identity", async () => {
     const calls = [];
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async (options) => {
         calls.push(options);
         return successfulValidation();
@@ -169,12 +170,12 @@ describe("CertOps API token auth middleware", () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0].rawToken, RAW_TOKEN);
     assert.equal(calls[0].workspaceId, WORKSPACE_A);
-    assert.deepEqual(calls[0].requiredScopes, ["certops:executor:events"]);
+    assert.deepEqual(calls[0].requiredScopes, ["certops:events:write"]);
     assert.deepEqual(req.apiToken, {
       id: "token-1",
       workspaceId: WORKSPACE_A,
       tokenPrefix: "ttx_abc123",
-      scopes: ["certops:executor:events", "certops:jobs:read"],
+      scopes: ["certops:events:write", "certops:jobs:read"],
       name: "Executor",
       createdBy: 42,
       lastUsedAt: "2026-07-02T00:00:00.000Z",
@@ -189,7 +190,7 @@ describe("CertOps API token auth middleware", () => {
   it("prefers URL workspace params over body workspaceId", async () => {
     let workspaceId;
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async (options) => {
         workspaceId = options.workspaceId;
         return successfulValidation();
@@ -208,7 +209,7 @@ describe("CertOps API token auth middleware", () => {
 
   it("can use an explicit workspace resolver for future machine routes", async () => {
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       resolveWorkspaceId: (req) => req.body.workspaceId,
       validateApiToken: async (options) =>
         successfulValidation({ workspaceId: options.workspaceId }),
@@ -227,7 +228,7 @@ describe("CertOps API token auth middleware", () => {
 
   it("rejects missing, non-Bearer, and empty Authorization headers with 401", async () => {
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async () => {
         throw new Error("validator must not be called");
       },
@@ -247,7 +248,7 @@ describe("CertOps API token auth middleware", () => {
 
   it("rejects malformed, revoked, expired, and wrong-workspace tokens with generic 401", async () => {
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async () => ({ valid: false, code: "ANY_REASON" }),
     });
     const result = await runMiddleware(
@@ -286,7 +287,7 @@ describe("CertOps API token auth middleware", () => {
 
   it("fails safely when workspace context is missing", async () => {
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async () => {
         throw new Error("validator must not be called without workspace");
       },
@@ -312,7 +313,7 @@ describe("CertOps API token auth middleware", () => {
 
   it("does not expose custody-looking fields in req.apiToken or responses", async () => {
     const middleware = createCertOpsApiTokenAuth({
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       validateApiToken: async () => successfulValidation(),
     });
     const result = await runMiddleware(
@@ -344,7 +345,7 @@ describe("CertOps API token auth middleware", () => {
         id: "token-1",
         workspaceId: WORKSPACE_A,
         tokenPrefix: "ttx_abc123",
-        scopes: ["certops:executor:events", "certops:jobs:read"],
+        scopes: ["certops:events:write", "certops:jobs:read"],
         name: "Executor",
         createdBy: 42,
         lastUsedAt: "2026-07-02T00:00:00.000Z",

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -736,14 +736,18 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("keeps the committed M2-A1/M2-A2 diff within the stacked contract and token-service scope", () => {
+  it("keeps the committed M2-A1/M2-A2/M2-A3 diff within the stacked scope", () => {
     const { ref, files } = prChangedFiles();
-    const allowedM2A2Files = new Set([
+    const allowedM2Files = new Set([
       "apps/api/migrations/migrate.js",
+      "apps/api/middleware/api-token-auth.js",
+      "apps/api/middleware/csrf-exempt.js",
       "apps/api/services/certops/apiTokens.js",
+      "tests/integration/certops-api-token-auth.test.js",
       "tests/integration/certops-api-tokens.test.js",
       "tests/integration/suites/core-compatible.txt",
       "tests/integration/suites/core.txt",
+      "tests/unit/certops-api-token-auth.test.js",
       "tests/unit/certops-api-tokens.test.js",
       "tests/unit/certops-migration.test.js",
     ]);
@@ -753,13 +757,13 @@ describe("CertOps M2 contract skeletons", () => {
         file.startsWith("packages/contracts/") ||
         file === "tests/unit/certops-m2-contracts.test.js" ||
         file === "tests/unit/certops-routes-hardening.test.js" ||
-        allowedM2A2Files.has(file),
+        allowedM2Files.has(file),
     );
 
     assert.deepEqual(
       files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `stacked M2-A1/M2-A2 diff against ${ref} must stay within the allowed scope`,
+      `stacked M2-A1/M2-A2/M2-A3 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -770,13 +774,15 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
   });
 
-  it("keeps local app changes within the M2-A2 token-service scope", () => {
-    const allowedStackedM2A2Files = new Set([
+  it("keeps local app changes within the M2-A2/M2-A3 token and auth scope", () => {
+    const allowedStackedM2Files = new Set([
       "apps/api/migrations/migrate.js",
+      "apps/api/middleware/api-token-auth.js",
+      "apps/api/middleware/csrf-exempt.js",
       "apps/api/services/certops/apiTokens.js",
     ]);
     const unexpectedAppFiles = changedAppFiles().filter(
-      (file) => !allowedStackedM2A2Files.has(file),
+      (file) => !allowedStackedM2Files.has(file),
     );
 
     assert.deepEqual(unexpectedAppFiles, []);


### PR DESCRIPTION
## Summary

This PR adds the M2-A3 CertOps machine-token authentication middleware.

It wires the scoped API-token foundation from M2-A2 into a reusable backend middleware without adding executor runtime behavior, jobs/evidence persistence, rate limiting, dashboard UI, Cloud overlay, or agent behavior.

This PR adds:

* CertOps machine-token auth middleware
* `Authorization: Bearer ttx_<id>_<secret>` validation
* workspace-bound token validation
* required-scope enforcement
* sanitized `req.apiToken` machine identity attachment
* narrow CSRF exemption support for future CertOps executor token-auth routes
* unit and integration coverage

The middleware validates machine tokens through the M2-A2 `apiTokens` service and attaches only safe metadata to the request:

* token ID
* workspace ID
* token prefix
* scopes
* name
* creator metadata
* last-used metadata

This PR also confirms the machine-token auth layer remains secret-safe:

* raw tokens are never attached to `req.apiToken`
* raw tokens are never returned in responses
* Authorization headers are not echoed
* token hashes are not exposed
* invalid, malformed, expired, revoked, wrong-workspace, and missing-scope tokens are rejected
* machine tokens do not create blanket admin/session behavior

This PR does not add new runtime product features.

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* `node --check apps/api/middleware/api-token-auth.js`: ok
* `node --check tests/unit/certops-api-token-auth.test.js`: ok
* `node --check tests/integration/certops-api-token-auth.test.js`: ok
* `node --test tests/unit/certops-api-token-auth.test.js`: ok
* `node --test tests/unit/certops-api-tokens.test.js`: ok
* `node --test tests/unit/certops-m2-contracts.test.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `pnpm exec mocha tests/integration/certops-api-token-auth.test.js --timeout 60000 --exit`: ok
* `pnpm run test:unit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a2-api-tokens`.
* PR #50 / M2-A1 should merge first.
* PR #51 / M2-A2 should merge before this PR is retargeted.
* This is an M2-A3 middleware PR, not a rate-limiter PR.
* Dev A owns this work because it touches backend security middleware and machine-auth boundaries.
* Dev B dashboard UI, Cloud overlay, fake executor, fake agent, and timeline work remain split out.
* No machine-token rate limiter is included.
* No executor route implementation is included.
* No executor event handler is included.
* No `certificate_jobs`, `certificate_job_log`, or `certificate_evidence` persistence is included.
* No dashboard UI, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, or connector work is included.
* CSRF exemption is narrowly limited to future CertOps executor token-auth route namespaces.
* Machine-token auth does not set `req.user`, `req.isAdmin`, or blanket admin/session-authenticated flags.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A3 middleware.

## Test plan

* [x] Review machine-token auth middleware
* [x] Review CSRF exemption scope
* [x] Verify valid Bearer token authentication
* [x] Verify `req.apiToken` is attached on success
* [x] Verify `req.apiToken` contains only sanitized metadata
* [x] Verify raw token is not attached to the request identity
* [x] Verify token hash is not exposed
* [x] Verify missing Authorization header is rejected
* [x] Verify non-Bearer Authorization header is rejected
* [x] Verify empty Bearer token is rejected
* [x] Verify malformed token is rejected
* [x] Verify expired token is rejected
* [x] Verify revoked token is rejected
* [x] Verify wrong-workspace token is rejected
* [x] Verify missing required scope is rejected
* [x] Verify missing workspace context fails safely
* [x] Verify unknown required scope fails safely
* [x] Verify no blanket admin/session behavior is created
* [x] Verify no rate limiter, executor handler, jobs/evidence persistence, dashboard, Cloud, or agent work is included
* [x] Run `node --test tests/unit/certops-api-token-auth.test.js`
* [x] Run `node --test tests/unit/certops-api-tokens.test.js`
* [x] Run `node --test tests/unit/certops-m2-contracts.test.js`
* [x] Run `node --test tests/unit/certops-routes-hardening.test.js`
* [x] Run `pnpm exec mocha tests/integration/certops-api-token-auth.test.js --timeout 60000 --exit`
* [x] Run `pnpm run test:unit`
* [x] Run `pnpm run check:contracts && pnpm run check:contracts:integrity`
