### PR TITLE
feat(certops): add machine token rate limiter m2-a4

### DIFF
--- a/apps/api/middleware/machine-token-rate-limit.js
+++ b/apps/api/middleware/machine-token-rate-limit.js
@@ -1,0 +1,130 @@
+"use strict";
+
+const rateLimit = require("express-rate-limit");
+
+const { CERTOPS_API_TOKEN_UNAUTHORIZED } = require("./api-token-auth");
+const { logger, resolveClientIp } = require("../utils/logger");
+
+const CERTOPS_MACHINE_RATE_LIMITED = "CERTOPS_MACHINE_RATE_LIMITED";
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX = 120;
+
+const AUTH_REQUIRED_RESPONSE = Object.freeze({
+  error: "CertOps API token authentication required",
+  code: CERTOPS_API_TOKEN_UNAUTHORIZED,
+});
+
+const RATE_LIMIT_RESPONSE = Object.freeze({
+  error: "CertOps machine-token rate limit exceeded",
+  code: CERTOPS_MACHINE_RATE_LIMITED,
+});
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function safeRoutePattern(req) {
+  return req.route?.path || req.baseUrl || null;
+}
+
+function defaultMachineIdResolver(req) {
+  return (
+    req.apiToken?.agentId ||
+    req.apiToken?.executorId ||
+    req.params?.agentId ||
+    req.params?.executorId ||
+    null
+  );
+}
+
+function safeKeyFragment(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/[^A-Za-z0-9._:-]/g, "_").slice(0, 128);
+}
+
+function machineTokenRateLimitKey(req, options = {}) {
+  const identity = req.apiToken || {};
+  const workspaceId = safeKeyFragment(identity.workspaceId);
+  const tokenPrefix = safeKeyFragment(identity.tokenPrefix);
+
+  if (!workspaceId || !tokenPrefix) return null;
+
+  const resolveMachineId =
+    options.machineIdResolver ||
+    options.agentOrExecutorIdResolver ||
+    defaultMachineIdResolver;
+  const machineId = safeKeyFragment(resolveMachineId(req));
+
+  const baseKey = `certops-machine:${workspaceId}:${tokenPrefix}`;
+  return machineId ? `${baseKey}:${machineId}` : baseKey;
+}
+
+function retryAfterSeconds(req, windowMs) {
+  const resetTime = req.rateLimit?.resetTime;
+  if (resetTime instanceof Date) {
+    return Math.max(1, Math.ceil((resetTime.getTime() - Date.now()) / 1000));
+  }
+  return Math.max(1, Math.ceil(windowMs / 1000));
+}
+
+function createCertOpsMachineTokenRateLimit(options = {}) {
+  const windowMs = positiveInteger(options.windowMs, DEFAULT_WINDOW_MS);
+  const max = positiveInteger(options.max, DEFAULT_MAX);
+  const keyResolver = options.keyResolver || machineTokenRateLimitKey;
+
+  const limiter = rateLimit({
+    windowMs,
+    max,
+    standardHeaders: options.standardHeaders ?? true,
+    legacyHeaders: options.legacyHeaders ?? false,
+    skipSuccessfulRequests: options.skipSuccessfulRequests ?? false,
+    skipFailedRequests: options.skipFailedRequests ?? false,
+    keyGenerator: (req) => keyResolver(req, options),
+    handler: (req, res) => {
+      const retryAfter = retryAfterSeconds(req, windowMs);
+
+      logger.warn("RATE_LIMIT_EXCEEDED", {
+        type: "certops_machine_token",
+        workspaceId: req.apiToken?.workspaceId || null,
+        tokenPrefix: req.apiToken?.tokenPrefix || null,
+        route: safeRoutePattern(req),
+        ip: resolveClientIp(req),
+        retryAfterSeconds: retryAfter,
+      });
+
+      res.set("Retry-After", String(retryAfter));
+      return res.status(429).json({
+        ...RATE_LIMIT_RESPONSE,
+        retry_after_seconds: retryAfter,
+      });
+    },
+  });
+
+  return function certOpsMachineTokenRateLimit(req, res, next) {
+    const key = keyResolver(req, options);
+    if (!key) {
+      return res.status(401).json(AUTH_REQUIRED_RESPONSE);
+    }
+
+    return limiter(req, res, next);
+  };
+}
+
+module.exports = {
+  CERTOPS_MACHINE_RATE_LIMITED,
+  DEFAULT_MAX,
+  DEFAULT_WINDOW_MS,
+  createCertOpsMachineTokenRateLimit,
+  createMachineTokenRateLimit: createCertOpsMachineTokenRateLimit,
+  machineTokenRateLimitKey,
+  _test: {
+    defaultMachineIdResolver,
+    retryAfterSeconds,
+    safeKeyFragment,
+    safeRoutePattern,
+  },
+};

--- a/apps/api/middleware/machine-token-rate-limit.js
+++ b/apps/api/middleware/machine-token-rate-limit.js
@@ -33,8 +33,6 @@ function defaultMachineIdResolver(req) {
   return (
     req.apiToken?.agentId ||
     req.apiToken?.executorId ||
-    req.params?.agentId ||
-    req.params?.executorId ||
     null
   );
 }
@@ -83,6 +81,7 @@ function createCertOpsMachineTokenRateLimit(options = {}) {
     legacyHeaders: options.legacyHeaders ?? false,
     skipSuccessfulRequests: options.skipSuccessfulRequests ?? false,
     skipFailedRequests: options.skipFailedRequests ?? false,
+    ...(options.store ? { store: options.store } : {}),
     keyGenerator: (req) => keyResolver(req, options),
     handler: (req, res) => {
       const retryAfter = retryAfterSeconds(req, windowMs);

--- a/apps/api/middleware/machine-token-rate-limit.js
+++ b/apps/api/middleware/machine-token-rate-limit.js
@@ -6,9 +6,16 @@ const { CERTOPS_API_TOKEN_UNAUTHORIZED } = require("./api-token-auth");
 const { logger, resolveClientIp } = require("../utils/logger");
 
 const CERTOPS_MACHINE_RATE_LIMITED = "CERTOPS_MACHINE_RATE_LIMITED";
+const CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID =
+  "CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID";
+const CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED =
+  "CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED";
 
 const DEFAULT_WINDOW_MS = 60_000;
 const DEFAULT_MAX = 120;
+const RAW_TOKEN_PATTERN = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/;
+const UUID_SEGMENT_PATTERN =
+  /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i;
 
 const AUTH_REQUIRED_RESPONSE = Object.freeze({
   error: "CertOps API token authentication required",
@@ -20,34 +27,123 @@ const RATE_LIMIT_RESPONSE = Object.freeze({
   code: CERTOPS_MACHINE_RATE_LIMITED,
 });
 
-function positiveInteger(value, fallback) {
-  const parsed = Number.parseInt(String(value), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+function limiterError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
 }
 
-function safeRoutePattern(req) {
-  return req.route?.path || req.baseUrl || null;
-}
-
-function defaultMachineIdResolver(req) {
-  return (
-    req.apiToken?.agentId ||
-    req.apiToken?.executorId ||
-    null
+function hasConfiguredValue(value) {
+  return !(
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && !value.trim())
   );
 }
 
-function safeKeyFragment(value) {
-  if (typeof value !== "string") return null;
+function configuredInteger(value, fallback, { allowZero = false } = {}) {
+  if (!hasConfiguredValue(value)) return fallback;
+
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^\d+$/.test(value.trim())
+        ? Number(value.trim())
+        : Number.NaN;
+  if (
+    !Number.isFinite(parsed) ||
+    !Number.isInteger(parsed) ||
+    (allowZero ? parsed < 0 : parsed <= 0)
+  ) {
+    throw limiterError(
+      "CertOps machine-token rate limit configuration is invalid",
+      CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID,
+    );
+  }
+  return parsed;
+}
+
+function rateLimitOptions(options = {}) {
+  const configuredLimit = hasConfiguredValue(options.limit)
+    ? options.limit
+    : options.max;
+
+  return {
+    limit: configuredInteger(configuredLimit, DEFAULT_MAX, {
+      allowZero: true,
+    }),
+    windowMs: configuredInteger(options.windowMs, DEFAULT_WINDOW_MS),
+  };
+}
+
+function requireSharedStoreIfConfigured(options = {}) {
+  if (options.requireSharedStore === true && !options.store) {
+    throw limiterError(
+      "A shared store is required for CertOps machine-token rate limiting",
+      CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED,
+    );
+  }
+}
+
+function safeKeyFragment(value, fallback = null) {
+  if (typeof value !== "string") return fallback;
   const trimmed = value.trim();
-  if (!trimmed) return null;
-  return trimmed.replace(/[^A-Za-z0-9._:-]/g, "_").slice(0, 128);
+  if (!trimmed) return fallback;
+  return trimmed.replace(/[^A-Za-z0-9._:-]/g, "_").slice(0, 128) || fallback;
+}
+
+function isDynamicPathSegment(segment) {
+  return (
+    UUID_SEGMENT_PATTERN.test(segment) ||
+    /^[0-9]+$/.test(segment) ||
+    /^[a-f0-9]{16,}$/i.test(segment) ||
+    /^ttx_/i.test(segment) ||
+    segment.length > 64
+  );
+}
+
+function normalizeRouteFamily(value) {
+  if (typeof value !== "string") return "unknown";
+
+  const pathOnly = value.split(/[?#]/, 1)[0].trim();
+  if (!pathOnly) return "unknown";
+
+  const segments = pathOnly
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      const normalized = segment.replace(/[^A-Za-z0-9:_-]/g, "_").slice(0, 64);
+      if (!normalized || isDynamicPathSegment(normalized)) return "id";
+      return normalized.toLowerCase();
+    });
+
+  return safeKeyFragment(segments.join("_"), "unknown");
+}
+
+function defaultRouteFamilyResolver(req) {
+  const routePath = typeof req.route?.path === "string" ? req.route.path : null;
+  if (routePath) return `${req.baseUrl || ""}${routePath}`;
+  return req.path || req.originalUrl || req.url || "";
+}
+
+function routeFamilyFromRequest(req, options = {}) {
+  const resolver = options.routeFamilyResolver || defaultRouteFamilyResolver;
+  return normalizeRouteFamily(resolver(req));
+}
+
+function safeRoutePattern(req, options = {}) {
+  return routeFamilyFromRequest(req, options);
+}
+
+function defaultMachineIdResolver(req) {
+  return req.apiToken?.agentId || req.apiToken?.executorId || null;
 }
 
 function machineTokenRateLimitKey(req, options = {}) {
   const identity = req.apiToken || {};
   const workspaceId = safeKeyFragment(identity.workspaceId);
   const tokenPrefix = safeKeyFragment(identity.tokenPrefix);
+  const routeFamily = routeFamilyFromRequest(req, options);
 
   if (!workspaceId || !tokenPrefix) return null;
 
@@ -57,8 +153,42 @@ function machineTokenRateLimitKey(req, options = {}) {
     defaultMachineIdResolver;
   const machineId = safeKeyFragment(resolveMachineId(req));
 
-  const baseKey = `certops-machine:${workspaceId}:${tokenPrefix}`;
+  const baseKey = `certops-machine:${workspaceId}:${tokenPrefix}:${routeFamily}`;
   return machineId ? `${baseKey}:${machineId}` : baseKey;
+}
+
+function authorizationHeader(req) {
+  const value =
+    typeof req.get === "function"
+      ? req.get("Authorization")
+      : req.headers?.authorization;
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function tokenPrefixFromAuthorization(req) {
+  const match = /^Bearer\s+(ttx_[a-f0-9]{16}_[a-f0-9]{64})$/i.exec(
+    authorizationHeader(req),
+  );
+  if (!match || match[1] !== match[1].toLowerCase()) return null;
+
+  const tokenMatch = RAW_TOKEN_PATTERN.exec(match[1]);
+  return tokenMatch ? `ttx_${tokenMatch[1]}` : null;
+}
+
+function preAuthWorkspaceId(req, options = {}) {
+  const paramName = options.workspaceIdParam || "workspaceId";
+  return safeKeyFragment(req.params?.[paramName], "workspace-unknown");
+}
+
+function machineTokenPreAuthRateLimitKey(req, options = {}) {
+  const routeFamily = routeFamilyFromRequest(req, options);
+  const workspaceId = preAuthWorkspaceId(req, options);
+  const tokenPrefix = tokenPrefixFromAuthorization(req);
+  const identity = tokenPrefix
+    ? `prefix:${tokenPrefix}`
+    : `ip:${safeKeyFragment(resolveClientIp(req), "unknown")}`;
+
+  return `certops-machine-preauth:${routeFamily}:${workspaceId}:${identity}`;
 }
 
 function retryAfterSeconds(req, windowMs) {
@@ -69,60 +199,100 @@ function retryAfterSeconds(req, windowMs) {
   return Math.max(1, Math.ceil(windowMs / 1000));
 }
 
-function createCertOpsMachineTokenRateLimit(options = {}) {
-  const windowMs = positiveInteger(options.windowMs, DEFAULT_WINDOW_MS);
-  const max = positiveInteger(options.max, DEFAULT_MAX);
-  const keyResolver = options.keyResolver || machineTokenRateLimitKey;
+function createRateLimitHandler({ windowMs, preAuth, options }) {
+  return (req, res) => {
+    const retryAfter = retryAfterSeconds(req, windowMs);
+
+    logger.warn("RATE_LIMIT_EXCEEDED", {
+      type: "certops_machine_token",
+      phase: preAuth ? "pre_auth" : "post_auth",
+      workspaceId: preAuth
+        ? preAuthWorkspaceId(req, options)
+        : safeKeyFragment(req.apiToken?.workspaceId),
+      routeFamily: routeFamilyFromRequest(req, options),
+      ip: resolveClientIp(req),
+      retryAfterSeconds: retryAfter,
+    });
+
+    res.set("Retry-After", String(retryAfter));
+    return res.status(429).json({
+      ...RATE_LIMIT_RESPONSE,
+      retryAfterSeconds: retryAfter,
+    });
+  };
+}
+
+function createLimiter(options, { preAuth, keyResolver }) {
+  requireSharedStoreIfConfigured(options);
+  const { windowMs, limit } = rateLimitOptions(options);
+  const handler = createRateLimitHandler({ windowMs, preAuth, options });
+
+  if (limit === 0) {
+    return {
+      limiter: (req, res) => handler(req, res),
+      keyResolver,
+    };
+  }
 
   const limiter = rateLimit({
     windowMs,
-    max,
+    limit,
     standardHeaders: options.standardHeaders ?? true,
     legacyHeaders: options.legacyHeaders ?? false,
     skipSuccessfulRequests: options.skipSuccessfulRequests ?? false,
     skipFailedRequests: options.skipFailedRequests ?? false,
     ...(options.store ? { store: options.store } : {}),
     keyGenerator: (req) => keyResolver(req, options),
-    handler: (req, res) => {
-      const retryAfter = retryAfterSeconds(req, windowMs);
-
-      logger.warn("RATE_LIMIT_EXCEEDED", {
-        type: "certops_machine_token",
-        workspaceId: req.apiToken?.workspaceId || null,
-        tokenPrefix: req.apiToken?.tokenPrefix || null,
-        route: safeRoutePattern(req),
-        ip: resolveClientIp(req),
-        retryAfterSeconds: retryAfter,
-      });
-
-      res.set("Retry-After", String(retryAfter));
-      return res.status(429).json({
-        ...RATE_LIMIT_RESPONSE,
-        retry_after_seconds: retryAfter,
-      });
-    },
+    handler,
   });
 
+  return { limiter, keyResolver };
+}
+
+// Cloud overlays should pass a distributed store and set requireSharedStore.
+// Core intentionally uses express-rate-limit's in-memory store by default.
+function createCertOpsMachineTokenRateLimit(options = {}) {
+  const keyResolver = options.keyResolver || machineTokenRateLimitKey;
+  const { limiter } = createLimiter(options, { preAuth: false, keyResolver });
+
   return function certOpsMachineTokenRateLimit(req, res, next) {
-    const key = keyResolver(req, options);
-    if (!key) {
+    if (!keyResolver(req, options)) {
       return res.status(401).json(AUTH_REQUIRED_RESPONSE);
     }
+    return limiter(req, res, next);
+  };
+}
 
+function createCertOpsMachineTokenPreAuthRateLimit(options = {}) {
+  const keyResolver = options.keyResolver || machineTokenPreAuthRateLimitKey;
+  const { limiter } = createLimiter(options, { preAuth: true, keyResolver });
+
+  return function certOpsMachineTokenPreAuthRateLimit(req, res, next) {
     return limiter(req, res, next);
   };
 }
 
 module.exports = {
   CERTOPS_MACHINE_RATE_LIMITED,
+  CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID,
+  CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED,
   DEFAULT_MAX,
   DEFAULT_WINDOW_MS,
+  createCertOpsMachineTokenPreAuthRateLimit,
   createCertOpsMachineTokenRateLimit,
+  createMachineTokenPreAuthRateLimit: createCertOpsMachineTokenPreAuthRateLimit,
   createMachineTokenRateLimit: createCertOpsMachineTokenRateLimit,
+  machineTokenPreAuthRateLimitKey,
   machineTokenRateLimitKey,
+  tokenPrefixFromAuthorization,
   _test: {
+    configuredInteger,
     defaultMachineIdResolver,
+    defaultRouteFamilyResolver,
+    normalizeRouteFamily,
+    rateLimitOptions,
     retryAfterSeconds,
+    routeFamilyFromRequest,
     safeKeyFragment,
     safeRoutePattern,
   },

--- a/tests/integration/certops-machine-token-rate-limit.test.js
+++ b/tests/integration/certops-machine-token-rate-limit.test.js
@@ -14,6 +14,7 @@ const {
   createCertOpsApiTokenAuth,
 } = require("../../apps/api/middleware/api-token-auth");
 const {
+  createCertOpsMachineTokenPreAuthRateLimit,
   createCertOpsMachineTokenRateLimit,
 } = require("../../apps/api/middleware/machine-token-rate-limit");
 
@@ -97,10 +98,43 @@ function buildRateLimitHarness({ max = 2, windowMs = 60_000 } = {}) {
   return app;
 }
 
+function buildPreAuthOrderingHarness({ max = 0, onValidate } = {}) {
+  const app = express();
+  app.use(express.json());
+
+  app.post(
+    "/api/v1/workspaces/:workspaceId/certops/pre-auth-rate-limit-test",
+    createCertOpsMachineTokenPreAuthRateLimit({ max }),
+    createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      validateApiToken: async () => {
+        onValidate?.();
+        return {
+          valid: true,
+          token: {
+            id: "not-used",
+            workspaceId: "not-used",
+            tokenPrefix: "ttx_0123456789abcdef",
+            scopes: ["certops:events:write"],
+            name: "not-used",
+            createdBy: null,
+            lastUsedAt: null,
+          },
+        };
+      },
+    }),
+    (_req, res) => res.status(200).json({ ok: true }),
+  );
+
+  return app;
+}
+
 function expectNoRawToken(responseBody, rawToken) {
   expect(JSON.stringify(responseBody)).to.not.include(rawToken);
   expect(JSON.stringify(responseBody)).to.not.include(`Bearer ${rawToken}`);
   expect(JSON.stringify(responseBody)).to.not.include("token_hash");
+  expect(JSON.stringify(responseBody)).to.not.include("privateKey");
+  expect(JSON.stringify(responseBody)).to.not.include("credential");
 }
 
 describe("CertOps machine-token rate limiter", function () {
@@ -144,6 +178,8 @@ describe("CertOps machine-token rate limiter", function () {
       expect(third.status).to.equal(429);
       expect(third.body.code).to.equal("CERTOPS_MACHINE_RATE_LIMITED");
       expect(third.headers["retry-after"]).to.match(/^[1-9][0-9]*$/);
+      expect(third.body.retryAfterSeconds).to.be.a("number");
+      expect(third.body.retry_after_seconds).to.equal(undefined);
       expectNoRawToken(third.body, created.plaintextToken);
       expect(first.body.hasUser).to.equal(false);
       expect(first.body.isAdmin).to.equal(false);
@@ -209,5 +245,30 @@ describe("CertOps machine-token rate limiter", function () {
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
     }
+  });
+
+  it("blocks at pre-auth rate limiting before token validation", async () => {
+    let validationCalls = 0;
+    const rawToken = `ttx_0123456789abcdef_${"a".repeat(64)}`;
+    const response = await supertest(
+      buildPreAuthOrderingHarness({
+        max: 0,
+        onValidate: () => {
+          validationCalls += 1;
+        },
+      }),
+    )
+      .post(
+        "/api/v1/workspaces/11111111-1111-4111-8111-111111111111/certops/pre-auth-rate-limit-test",
+      )
+      .set("Authorization", `Bearer ${rawToken}`)
+      .send({});
+
+    expect(response.status).to.equal(429);
+    expect(response.body.code).to.equal("CERTOPS_MACHINE_RATE_LIMITED");
+    expect(response.body.retryAfterSeconds).to.be.a("number");
+    expect(response.body.retry_after_seconds).to.equal(undefined);
+    expect(validationCalls).to.equal(0);
+    expectNoRawToken(response.body, rawToken);
   });
 });

--- a/tests/integration/certops-machine-token-rate-limit.test.js
+++ b/tests/integration/certops-machine-token-rate-limit.test.js
@@ -1,0 +1,210 @@
+const crypto = require("crypto");
+const { createRequire } = require("module");
+const supertest = require("supertest");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+const { createApiToken } = require("../../apps/api/services/certops/apiTokens");
+const {
+  createCertOpsApiTokenAuth,
+} = require("../../apps/api/middleware/api-token-auth");
+const {
+  createCertOpsMachineTokenRateLimit,
+} = require("../../apps/api/middleware/machine-token-rate-limit");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
+
+async function createWorkspacePair(label) {
+  const ownerEmail = `${label}-${Date.now()}-${crypto.randomUUID()}@example.com`;
+  const owner = await TestUtils.execQuery(
+    `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+     VALUES ($1, $2, $3, $4, 'local', TRUE)
+     RETURNING id`,
+    [
+      ownerEmail.toLowerCase(),
+      ownerEmail,
+      label,
+      "not-used-in-machine-rate-limit-test",
+    ],
+  );
+  const ownerId = owner.rows[0].id;
+  const workspaceA = crypto.randomUUID();
+  const workspaceB = crypto.randomUUID();
+
+  await TestUtils.execQuery(
+    `INSERT INTO workspaces (id, name, created_by, plan)
+     VALUES ($1, $2, $3, 'oss'), ($4, $5, $3, 'oss')`,
+    [
+      workspaceA,
+      `${label} A`,
+      ownerId,
+      workspaceB,
+      `${label} B`,
+    ],
+  );
+
+  return { ownerId, workspaceA, workspaceB };
+}
+
+async function cleanupWorkspacePair(ownerId, workspaceIds) {
+  await TestUtils.execQuery(
+    "DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery("DELETE FROM workspaces WHERE id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+}
+
+function buildRateLimitHarness({ max = 2, windowMs = 60_000 } = {}) {
+  const app = express();
+  app.use(express.json());
+
+  app.post(
+    "/api/v1/workspaces/:id/certops/machine-rate-limit-test",
+    createCertOpsApiTokenAuth({ scopes: ["certops:executor:events"] }),
+    createCertOpsMachineTokenRateLimit({ max, windowMs }),
+    (req, res) =>
+      res.status(200).json({
+        ok: true,
+        apiToken: req.apiToken,
+        hasUser: !!req.user,
+        isAdmin: req.isAdmin === true,
+        authenticated: req.authenticated === true,
+      }),
+  );
+
+  app.use((err, req, res, next) => {
+    if (res.headersSent) return next(err);
+    return res.status(500).json({
+      error: "Internal test harness error",
+      code: err?.code || "INTERNAL_ERROR",
+    });
+  });
+
+  return app;
+}
+
+function expectNoRawToken(responseBody, rawToken) {
+  expect(JSON.stringify(responseBody)).to.not.include(rawToken);
+  expect(JSON.stringify(responseBody)).to.not.include(`Bearer ${rawToken}`);
+  expect(JSON.stringify(responseBody)).to.not.include("token_hash");
+}
+
+describe("CertOps machine-token rate limiter", function () {
+  this.timeout(60000);
+
+  before(async () => {
+    await runMigrations();
+  });
+
+  it("allows valid machine tokens under limit and blocks the same token over limit", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-machine-rate-limit-basic",
+    );
+
+    try {
+      const created = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Executor",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+      const app = buildRateLimitHarness({ max: 2 });
+      const route = `/api/v1/workspaces/${workspaceA}/certops/machine-rate-limit-test`;
+
+      const first = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${created.plaintextToken}`)
+        .send({});
+      const second = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${created.plaintextToken}`)
+        .send({});
+      const third = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${created.plaintextToken}`)
+        .send({});
+
+      expect(first.status).to.equal(200);
+      expect(second.status).to.equal(200);
+      expect(third.status).to.equal(429);
+      expect(third.body.code).to.equal("CERTOPS_MACHINE_RATE_LIMITED");
+      expect(third.headers["retry-after"]).to.match(/^[1-9][0-9]*$/);
+      expectNoRawToken(third.body, created.plaintextToken);
+      expect(first.body.hasUser).to.equal(false);
+      expect(first.body.isAdmin).to.equal(false);
+      expect(first.body.authenticated).to.equal(false);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("keeps different tokens and workspaces in separate limiter buckets", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-machine-rate-limit-isolation",
+    );
+
+    try {
+      const tokenA1 = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Executor A1",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+      const tokenA2 = await createApiToken({
+        workspaceId: workspaceA,
+        name: "Executor A2",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+      const tokenB = await createApiToken({
+        workspaceId: workspaceB,
+        name: "Executor B",
+        scopes: ["certops:executor:events"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdBy: ownerId,
+      });
+      const app = buildRateLimitHarness({ max: 1 });
+      const routeA = `/api/v1/workspaces/${workspaceA}/certops/machine-rate-limit-test`;
+      const routeB = `/api/v1/workspaces/${workspaceB}/certops/machine-rate-limit-test`;
+
+      const firstA1 = await supertest(app)
+        .post(routeA)
+        .set("Authorization", `Bearer ${tokenA1.plaintextToken}`)
+        .send({});
+      const firstA2 = await supertest(app)
+        .post(routeA)
+        .set("Authorization", `Bearer ${tokenA2.plaintextToken}`)
+        .send({});
+      const firstB = await supertest(app)
+        .post(routeB)
+        .set("Authorization", `Bearer ${tokenB.plaintextToken}`)
+        .send({});
+      const secondA1 = await supertest(app)
+        .post(routeA)
+        .set("Authorization", `Bearer ${tokenA1.plaintextToken}`)
+        .send({});
+
+      expect(firstA1.status).to.equal(200);
+      expect(firstA2.status).to.equal(200);
+      expect(firstB.status).to.equal(200);
+      expect(secondA1.status).to.equal(429);
+      expectNoRawToken(secondA1.body, tokenA1.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+});

--- a/tests/integration/certops-machine-token-rate-limit.test.js
+++ b/tests/integration/certops-machine-token-rate-limit.test.js
@@ -71,7 +71,10 @@ function buildRateLimitHarness({ max = 2, windowMs = 60_000 } = {}) {
 
   app.post(
     "/api/v1/workspaces/:id/certops/machine-rate-limit-test",
-    createCertOpsApiTokenAuth({ scopes: ["certops:executor:events"] }),
+    createCertOpsApiTokenAuth({
+      scopes: ["certops:events:write"],
+      workspaceIdParam: "id",
+    }),
     createCertOpsMachineTokenRateLimit({ max, windowMs }),
     (req, res) =>
       res.status(200).json({
@@ -116,7 +119,7 @@ describe("CertOps machine-token rate limiter", function () {
       const created = await createApiToken({
         workspaceId: workspaceA,
         name: "Executor",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
@@ -159,21 +162,21 @@ describe("CertOps machine-token rate limiter", function () {
       const tokenA1 = await createApiToken({
         workspaceId: workspaceA,
         name: "Executor A1",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
       const tokenA2 = await createApiToken({
         workspaceId: workspaceA,
         name: "Executor A2",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });
       const tokenB = await createApiToken({
         workspaceId: workspaceB,
         name: "Executor B",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         createdBy: ownerId,
       });

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -75,6 +75,7 @@ tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
 tests/integration/certops-api-token-auth.test.js
+tests/integration/certops-machine-token-rate-limit.test.js
 
 # Integrations
 tests/integration/github.integration.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -89,6 +89,7 @@ tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
 tests/integration/certops-api-token-auth.test.js
+tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -742,6 +742,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",
       "apps/api/middleware/csrf-exempt.js",
+      "apps/api/middleware/machine-token-rate-limit.js",
       "apps/api/services/certops/apiTokens.js",
       "tests/integration/certops-api-token-auth.test.js",
       "tests/integration/certops-api-tokens.test.js",

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -736,7 +736,7 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("keeps the committed M2-A1/M2-A2/M2-A3 diff within the stacked scope", () => {
+  it("keeps the committed M2-A1 through M2-A4 diff within the stacked scope", () => {
     const { ref, files } = prChangedFiles();
     const allowedM2Files = new Set([
       "apps/api/migrations/migrate.js",
@@ -746,10 +746,12 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/services/certops/apiTokens.js",
       "tests/integration/certops-api-token-auth.test.js",
       "tests/integration/certops-api-tokens.test.js",
+      "tests/integration/certops-machine-token-rate-limit.test.js",
       "tests/integration/suites/core-compatible.txt",
       "tests/integration/suites/core.txt",
       "tests/unit/certops-api-token-auth.test.js",
       "tests/unit/certops-api-tokens.test.js",
+      "tests/unit/certops-machine-token-rate-limit.test.js",
       "tests/unit/certops-migration.test.js",
     ]);
     const unexpectedFiles = files.filter(
@@ -764,7 +766,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.deepEqual(
       files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `stacked M2-A1/M2-A2/M2-A3 diff against ${ref} must stay within the allowed scope`,
+      `stacked M2-A1 through M2-A4 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -775,7 +777,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
   });
 
-  it("keeps local app changes within the M2-A2/M2-A3 token and auth scope", () => {
+  it("keeps local app changes within the M2-A2 through M2-A4 auth scope", () => {
     const allowedStackedM2Files = new Set([
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -779,6 +779,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",
       "apps/api/middleware/csrf-exempt.js",
+      "apps/api/middleware/machine-token-rate-limit.js",
       "apps/api/services/certops/apiTokens.js",
     ]);
     const unexpectedAppFiles = changedAppFiles().filter(

--- a/tests/unit/certops-machine-token-rate-limit.test.js
+++ b/tests/unit/certops-machine-token-rate-limit.test.js
@@ -27,6 +27,7 @@ function createRequest({
   tokenPrefix = "ttx_abc123",
   agentId,
   executorId,
+  params = {},
   user,
   authorization = `Bearer ${RAW_TOKEN}`,
 } = {}) {
@@ -37,7 +38,7 @@ function createRequest({
     method: "POST",
     path: "/v1/certops/executor/events",
     baseUrl: "/api",
-    params: {},
+    params,
     headers,
     user,
     apiToken:
@@ -46,7 +47,7 @@ function createRequest({
             id: "token-1",
             workspaceId,
             tokenPrefix,
-            scopes: ["certops:executor:events"],
+            scopes: ["certops:events:write"],
             name: "Executor",
             createdBy: 42,
             lastUsedAt: null,
@@ -131,12 +132,46 @@ describe("CertOps machine-token rate limiter", () => {
       `certops-machine:${WORKSPACE_A}:ttx_abc123:agent:one`,
     );
     assert.equal(
+      machineTokenRateLimitKey(
+        createRequest({ executorId: "executor:one" }),
+      ),
+      `certops-machine:${WORKSPACE_A}:ttx_abc123:executor:one`,
+    );
+    assert.equal(
       machineTokenRateLimitKey(createRequest({ workspaceId: null })),
       null,
     );
     assert.equal(
       machineTokenRateLimitKey(createRequest({ tokenPrefix: null })),
       null,
+    );
+  });
+
+  it("ignores route-param machine IDs by default", () => {
+    assert.equal(
+      machineTokenRateLimitKey(
+        createRequest({
+          params: {
+            agentId: "attacker-agent",
+            executorId: "attacker-executor",
+          },
+        }),
+      ),
+      `certops-machine:${WORKSPACE_A}:ttx_abc123`,
+    );
+  });
+
+  it("allows explicit opt-in route-param machine IDs through a custom resolver", () => {
+    assert.equal(
+      machineTokenRateLimitKey(
+        createRequest({
+          params: { agentId: "agent-from-route" },
+        }),
+        {
+          machineIdResolver: (req) => req.params.agentId,
+        },
+      ),
+      `certops-machine:${WORKSPACE_A}:ttx_abc123:agent-from-route`,
     );
   });
 
@@ -199,7 +234,7 @@ describe("CertOps machine-token rate limiter", () => {
     assert.equal(blocked.res.statusCode, 429);
   });
 
-  it("includes optional agent or executor ID in the key when available", async () => {
+  it("uses authenticated apiToken agent IDs for separate buckets", async () => {
     const middleware = createCertOpsMachineTokenRateLimit({
       windowMs: 60_000,
       max: 1,
@@ -220,6 +255,42 @@ describe("CertOps machine-token rate limiter", () => {
       createRequest({ agentId: "agent-a" }),
     );
     assert.equal(blocked.res.statusCode, 429);
+  });
+
+  it("ignores varying route params for bucket identity unless explicitly configured", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+
+    const first = await runMiddleware(
+      middleware,
+      createRequest({ params: { agentId: "agent-a" } }),
+    );
+    const second = await runMiddleware(
+      middleware,
+      createRequest({ params: { agentId: "agent-b" } }),
+    );
+
+    assert.equal(first.nextCalled, true);
+    assert.equal(second.res.statusCode, 429);
+
+    const optInMiddleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+      machineIdResolver: (req) => req.params.agentId,
+    });
+    const optInFirst = await runMiddleware(
+      optInMiddleware,
+      createRequest({ params: { agentId: "agent-a" } }),
+    );
+    const optInSecond = await runMiddleware(
+      optInMiddleware,
+      createRequest({ params: { agentId: "agent-b" } }),
+    );
+
+    assert.equal(optInFirst.nextCalled, true);
+    assert.equal(optInSecond.nextCalled, true);
   });
 
   it("fails closed when req.apiToken is missing", async () => {

--- a/tests/unit/certops-machine-token-rate-limit.test.js
+++ b/tests/unit/certops-machine-token-rate-limit.test.js
@@ -1,0 +1,258 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { CERTOPS_API_TOKEN_UNAUTHORIZED } = require(
+  path.resolve(__dirname, "../../apps/api/middleware/api-token-auth.js"),
+);
+const {
+  CERTOPS_MACHINE_RATE_LIMITED,
+  createCertOpsMachineTokenRateLimit,
+  machineTokenRateLimitKey,
+} = require(
+  path.resolve(
+    __dirname,
+    "../../apps/api/middleware/machine-token-rate-limit.js",
+  ),
+);
+
+const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
+const RAW_TOKEN = "ttx_abc123_secret456";
+
+function createRequest({
+  workspaceId = WORKSPACE_A,
+  tokenPrefix = "ttx_abc123",
+  agentId,
+  executorId,
+  user,
+  authorization = `Bearer ${RAW_TOKEN}`,
+} = {}) {
+  const headers = {};
+  if (authorization !== undefined) headers.authorization = authorization;
+
+  return {
+    method: "POST",
+    path: "/v1/certops/executor/events",
+    baseUrl: "/api",
+    params: {},
+    headers,
+    user,
+    apiToken:
+      workspaceId || tokenPrefix
+        ? {
+            id: "token-1",
+            workspaceId,
+            tokenPrefix,
+            scopes: ["certops:executor:events"],
+            name: "Executor",
+            createdBy: 42,
+            lastUsedAt: null,
+            agentId,
+            executorId,
+          }
+        : undefined,
+    get(name) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    getHeader(name) {
+      return this.headers[name];
+    },
+    end(payload) {
+      this.ended = true;
+      this.endPayload = payload;
+      return this;
+    },
+  };
+}
+
+async function runMiddleware(middleware, req) {
+  const res = createResponse();
+  const result = {
+    req,
+    res,
+    nextCalled: false,
+    nextError: null,
+  };
+
+  await middleware(req, res, (error) => {
+    result.nextCalled = !error;
+    result.nextError = error || null;
+  });
+
+  return result;
+}
+
+function assertNoSensitiveResponseData(body) {
+  const text = JSON.stringify(body);
+  assert.equal(text.includes(RAW_TOKEN), false);
+  assert.equal(text.includes(`Bearer ${RAW_TOKEN}`), false);
+  assert.equal(text.includes("token_hash"), false);
+  assert.equal(text.includes("privateKey"), false);
+  assert.equal(text.includes("credential"), false);
+  assert.equal(text.includes("apiSecret"), false);
+}
+
+describe("CertOps machine-token rate limiter", () => {
+  it("builds machine-specific workspace-bound keys", () => {
+    assert.equal(
+      machineTokenRateLimitKey(createRequest()),
+      `certops-machine:${WORKSPACE_A}:ttx_abc123`,
+    );
+    assert.equal(
+      machineTokenRateLimitKey(
+        createRequest({ agentId: "agent:one" }),
+      ),
+      `certops-machine:${WORKSPACE_A}:ttx_abc123:agent:one`,
+    );
+    assert.equal(
+      machineTokenRateLimitKey(createRequest({ workspaceId: null })),
+      null,
+    );
+    assert.equal(
+      machineTokenRateLimitKey(createRequest({ tokenPrefix: null })),
+      null,
+    );
+  });
+
+  it("allows requests under limit and rejects repeated requests over limit", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 2,
+    });
+
+    const first = await runMiddleware(middleware, createRequest());
+    const second = await runMiddleware(middleware, createRequest());
+    const third = await runMiddleware(middleware, createRequest());
+
+    assert.equal(first.nextCalled, true);
+    assert.equal(second.nextCalled, true);
+    assert.equal(third.nextCalled, false);
+    assert.equal(third.res.statusCode, 429);
+    assert.equal(third.res.body.code, CERTOPS_MACHINE_RATE_LIMITED);
+    assert.match(third.res.headers["Retry-After"], /^[1-9][0-9]*$/);
+    assertNoSensitiveResponseData(third.res.body);
+  });
+
+  it("keeps different token prefixes in separate buckets", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+
+    assert.equal((await runMiddleware(middleware, createRequest())).nextCalled, true);
+    assert.equal(
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ tokenPrefix: "ttx_def456" }),
+        )
+      ).nextCalled,
+      true,
+    );
+    const blocked = await runMiddleware(middleware, createRequest());
+    assert.equal(blocked.res.statusCode, 429);
+  });
+
+  it("keeps different workspaces in separate buckets", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+
+    assert.equal((await runMiddleware(middleware, createRequest())).nextCalled, true);
+    assert.equal(
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ workspaceId: WORKSPACE_B }),
+        )
+      ).nextCalled,
+      true,
+    );
+    const blocked = await runMiddleware(middleware, createRequest());
+    assert.equal(blocked.res.statusCode, 429);
+  });
+
+  it("includes optional agent or executor ID in the key when available", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+
+    assert.equal(
+      (await runMiddleware(middleware, createRequest({ agentId: "agent-a" })))
+        .nextCalled,
+      true,
+    );
+    assert.equal(
+      (await runMiddleware(middleware, createRequest({ agentId: "agent-b" })))
+        .nextCalled,
+      true,
+    );
+    const blocked = await runMiddleware(
+      middleware,
+      createRequest({ agentId: "agent-a" }),
+    );
+    assert.equal(blocked.res.statusCode, 429);
+  });
+
+  it("fails closed when req.apiToken is missing", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+    const result = await runMiddleware(
+      middleware,
+      createRequest({ workspaceId: null, tokenPrefix: null }),
+    );
+
+    assert.equal(result.nextCalled, false);
+    assert.equal(result.res.statusCode, 401);
+    assert.equal(result.res.body.code, CERTOPS_API_TOKEN_UNAUTHORIZED);
+  });
+
+  it("is independent from req.user and session state", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({
+      windowMs: 60_000,
+      max: 1,
+    });
+
+    const first = await runMiddleware(
+      middleware,
+      createRequest({ user: { id: 1, role: "admin" } }),
+    );
+    const second = await runMiddleware(
+      middleware,
+      createRequest({ user: { id: 2, role: "viewer" } }),
+    );
+
+    assert.equal(first.nextCalled, true);
+    assert.equal(second.res.statusCode, 429);
+  });
+});

--- a/tests/unit/certops-machine-token-rate-limit.test.js
+++ b/tests/unit/certops-machine-token-rate-limit.test.js
@@ -2,6 +2,7 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const { createRequire } = require("node:module");
 const path = require("node:path");
 
 const { CERTOPS_API_TOKEN_UNAUTHORIZED } = require(
@@ -9,8 +10,14 @@ const { CERTOPS_API_TOKEN_UNAUTHORIZED } = require(
 );
 const {
   CERTOPS_MACHINE_RATE_LIMITED,
+  CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID,
+  CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED,
+  createCertOpsMachineTokenPreAuthRateLimit,
   createCertOpsMachineTokenRateLimit,
+  machineTokenPreAuthRateLimitKey,
   machineTokenRateLimitKey,
+  tokenPrefixFromAuthorization,
+  _test,
 } = require(
   path.resolve(
     __dirname,
@@ -18,16 +25,29 @@ const {
   ),
 );
 
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const { MemoryStore } = apiRequire("express-rate-limit");
+
 const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
 const WORKSPACE_B = "22222222-2222-4222-8222-222222222222";
-const RAW_TOKEN = "ttx_abc123_secret456";
+const TOKEN_ID = "0123456789abcdef";
+const TOKEN_SECRET = "a".repeat(64);
+const RAW_TOKEN = `ttx_${TOKEN_ID}_${TOKEN_SECRET}`;
+const TOKEN_PREFIX = `ttx_${TOKEN_ID}`;
 
 function createRequest({
   workspaceId = WORKSPACE_A,
-  tokenPrefix = "ttx_abc123",
+  tokenPrefix = TOKEN_PREFIX,
   agentId,
   executorId,
   params = {},
+  route = { path: "/events" },
+  baseUrl = "/api/v1/certops/executor",
+  path: requestPath = "/api/v1/certops/executor/events",
+  originalUrl = requestPath,
+  ip = "203.0.113.7",
   user,
   authorization = `Bearer ${RAW_TOKEN}`,
 } = {}) {
@@ -36,8 +56,11 @@ function createRequest({
 
   return {
     method: "POST",
-    path: "/v1/certops/executor/events",
-    baseUrl: "/api",
+    path: requestPath,
+    originalUrl,
+    baseUrl,
+    route,
+    ip,
     params,
     headers,
     user,
@@ -119,23 +142,34 @@ function assertNoSensitiveResponseData(body) {
   assert.equal(text.includes("apiSecret"), false);
 }
 
+function assertRateLimited(result) {
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.res.statusCode, 429);
+  assert.equal(result.res.body.code, CERTOPS_MACHINE_RATE_LIMITED);
+  assert.match(result.res.headers["Retry-After"], /^[1-9][0-9]*$/);
+  assert.equal(typeof result.res.body.retryAfterSeconds, "number");
+  assert.equal(result.res.body.retry_after_seconds, undefined);
+  assertNoSensitiveResponseData(result.res.body);
+}
+
 describe("CertOps machine-token rate limiter", () => {
-  it("builds machine-specific workspace-bound keys", () => {
+  it("keys post-auth requests by workspace, public prefix, and route family", () => {
+    const key = machineTokenRateLimitKey(createRequest());
     assert.equal(
-      machineTokenRateLimitKey(createRequest()),
-      `certops-machine:${WORKSPACE_A}:ttx_abc123`,
+      key,
+      `certops-machine:${WORKSPACE_A}:${TOKEN_PREFIX}:api_v1_certops_executor_events`,
+    );
+    assert.equal(key.includes(RAW_TOKEN), false);
+    assert.equal(key.includes("Bearer"), false);
+    assert.equal(key.includes("token_hash"), false);
+
+    assert.equal(
+      machineTokenRateLimitKey(createRequest({ agentId: "agent:one" })),
+      `${key}:agent:one`,
     );
     assert.equal(
-      machineTokenRateLimitKey(
-        createRequest({ agentId: "agent:one" }),
-      ),
-      `certops-machine:${WORKSPACE_A}:ttx_abc123:agent:one`,
-    );
-    assert.equal(
-      machineTokenRateLimitKey(
-        createRequest({ executorId: "executor:one" }),
-      ),
-      `certops-machine:${WORKSPACE_A}:ttx_abc123:executor:one`,
+      machineTokenRateLimitKey(createRequest({ executorId: "executor:one" })),
+      `${key}:executor:one`,
     );
     assert.equal(
       machineTokenRateLimitKey(createRequest({ workspaceId: null })),
@@ -147,80 +181,75 @@ describe("CertOps machine-token rate limiter", () => {
     );
   });
 
-  it("ignores route-param machine IDs by default", () => {
+  it("uses a safe route family without query strings and normalizes dynamic path segments", () => {
+    const req = createRequest({
+      route: null,
+      path: null,
+      originalUrl: `/api/v1/certops/executor/events/123e4567-e89b-12d3-a456-426614174000?authorization=Bearer%20${RAW_TOKEN}`,
+    });
+    const routeFamily = _test.routeFamilyFromRequest(req);
+    const key = machineTokenRateLimitKey(req);
+
+    assert.equal(routeFamily, "api_v1_certops_executor_events_id");
+    assert.equal(key.includes(RAW_TOKEN), false);
+    assert.equal(key.includes("authorization"), false);
     assert.equal(
-      machineTokenRateLimitKey(
-        createRequest({
-          params: {
-            agentId: "attacker-agent",
-            executorId: "attacker-executor",
-          },
-        }),
-      ),
-      `certops-machine:${WORKSPACE_A}:ttx_abc123`,
+      _test.routeFamilyFromRequest(createRequest({
+        routeFamilyResolver: undefined,
+      })),
+      "api_v1_certops_executor_events",
+    );
+    assert.equal(
+      _test.routeFamilyFromRequest(createRequest(), {
+        routeFamilyResolver: () => "evidence uploads?token=never-used",
+      }),
+      "evidence_uploads",
     );
   });
 
-  it("allows explicit opt-in route-param machine IDs through a custom resolver", () => {
+  it("ignores route-param machine IDs unless a route explicitly opts in", () => {
+    const request = createRequest({
+      params: {
+        agentId: "attacker-agent",
+        executorId: "attacker-executor",
+      },
+    });
+    const defaultKey = machineTokenRateLimitKey(request);
+    assert.equal(defaultKey.endsWith(":attacker-agent"), false);
+    assert.equal(defaultKey.endsWith(":attacker-executor"), false);
+
     assert.equal(
-      machineTokenRateLimitKey(
-        createRequest({
-          params: { agentId: "agent-from-route" },
-        }),
-        {
-          machineIdResolver: (req) => req.params.agentId,
-        },
-      ),
-      `certops-machine:${WORKSPACE_A}:ttx_abc123:agent-from-route`,
+      machineTokenRateLimitKey(request, {
+        machineIdResolver: (req) => req.params.agentId,
+      }),
+      `${defaultKey}:attacker-agent`,
     );
   });
 
-  it("allows requests under limit and rejects repeated requests over limit", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 2,
-    });
+  it("separates buckets by route family and shares a bucket within one family", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({ max: 1 });
+    const events = createRequest({ route: { path: "/events" } });
+    const secondEvents = createRequest({ route: { path: "/events" } });
+    const evidence = createRequest({ route: { path: "/evidence" } });
 
-    const first = await runMiddleware(middleware, createRequest());
-    const second = await runMiddleware(middleware, createRequest());
-    const third = await runMiddleware(middleware, createRequest());
-
-    assert.equal(first.nextCalled, true);
-    assert.equal(second.nextCalled, true);
-    assert.equal(third.nextCalled, false);
-    assert.equal(third.res.statusCode, 429);
-    assert.equal(third.res.body.code, CERTOPS_MACHINE_RATE_LIMITED);
-    assert.match(third.res.headers["Retry-After"], /^[1-9][0-9]*$/);
-    assertNoSensitiveResponseData(third.res.body);
+    assert.equal((await runMiddleware(middleware, events)).nextCalled, true);
+    assertRateLimited(await runMiddleware(middleware, secondEvents));
+    assert.equal((await runMiddleware(middleware, evidence)).nextCalled, true);
   });
 
-  it("keeps different token prefixes in separate buckets", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-    });
+  it("keeps different token prefixes, workspaces, and authenticated machine IDs separate", async () => {
+    const middleware = createCertOpsMachineTokenRateLimit({ max: 1 });
 
     assert.equal((await runMiddleware(middleware, createRequest())).nextCalled, true);
     assert.equal(
       (
         await runMiddleware(
           middleware,
-          createRequest({ tokenPrefix: "ttx_def456" }),
+          createRequest({ tokenPrefix: "ttx_fedcba9876543210" }),
         )
       ).nextCalled,
       true,
     );
-    const blocked = await runMiddleware(middleware, createRequest());
-    assert.equal(blocked.res.statusCode, 429);
-  });
-
-  it("keeps different workspaces in separate buckets", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-    });
-
-    assert.equal((await runMiddleware(middleware, createRequest())).nextCalled, true);
     assert.equal(
       (
         await runMiddleware(
@@ -230,76 +259,29 @@ describe("CertOps machine-token rate limiter", () => {
       ).nextCalled,
       true,
     );
-    const blocked = await runMiddleware(middleware, createRequest());
-    assert.equal(blocked.res.statusCode, 429);
-  });
-
-  it("uses authenticated apiToken agent IDs for separate buckets", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-    });
-
     assert.equal(
-      (await runMiddleware(middleware, createRequest({ agentId: "agent-a" })))
-        .nextCalled,
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ agentId: "agent-a" }),
+        )
+      ).nextCalled,
       true,
     );
     assert.equal(
-      (await runMiddleware(middleware, createRequest({ agentId: "agent-b" })))
-        .nextCalled,
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ agentId: "agent-b" }),
+        )
+      ).nextCalled,
       true,
     );
-    const blocked = await runMiddleware(
-      middleware,
-      createRequest({ agentId: "agent-a" }),
-    );
-    assert.equal(blocked.res.statusCode, 429);
   });
 
-  it("ignores varying route params for bucket identity unless explicitly configured", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-    });
-
-    const first = await runMiddleware(
-      middleware,
-      createRequest({ params: { agentId: "agent-a" } }),
-    );
-    const second = await runMiddleware(
-      middleware,
-      createRequest({ params: { agentId: "agent-b" } }),
-    );
-
-    assert.equal(first.nextCalled, true);
-    assert.equal(second.res.statusCode, 429);
-
-    const optInMiddleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-      machineIdResolver: (req) => req.params.agentId,
-    });
-    const optInFirst = await runMiddleware(
-      optInMiddleware,
-      createRequest({ params: { agentId: "agent-a" } }),
-    );
-    const optInSecond = await runMiddleware(
-      optInMiddleware,
-      createRequest({ params: { agentId: "agent-b" } }),
-    );
-
-    assert.equal(optInFirst.nextCalled, true);
-    assert.equal(optInSecond.nextCalled, true);
-  });
-
-  it("fails closed when req.apiToken is missing", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
-      windowMs: 60_000,
-      max: 1,
-    });
+  it("fails closed when post-auth identity is missing", async () => {
     const result = await runMiddleware(
-      middleware,
+      createCertOpsMachineTokenRateLimit(),
       createRequest({ workspaceId: null, tokenPrefix: null }),
     );
 
@@ -309,21 +291,146 @@ describe("CertOps machine-token rate limiter", () => {
   });
 
   it("is independent from req.user and session state", async () => {
-    const middleware = createCertOpsMachineTokenRateLimit({
+    const middleware = createCertOpsMachineTokenRateLimit({ max: 1 });
+
+    assert.equal(
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ user: { id: 1, role: "admin" } }),
+        )
+      ).nextCalled,
+      true,
+    );
+    assertRateLimited(
+      await runMiddleware(
+        middleware,
+        createRequest({ user: { id: 2, role: "viewer" } }),
+      ),
+    );
+  });
+
+  it("treats max: 0 and limit: 0 as block-all while limit takes precedence", async () => {
+    assertRateLimited(
+      await runMiddleware(
+        createCertOpsMachineTokenRateLimit({ max: 0 }),
+        createRequest(),
+      ),
+    );
+    assertRateLimited(
+      await runMiddleware(
+        createCertOpsMachineTokenRateLimit({ limit: 0 }),
+        createRequest(),
+      ),
+    );
+
+    const limitWins = createCertOpsMachineTokenRateLimit({ max: 0, limit: 1 });
+    assert.equal((await runMiddleware(limitWins, createRequest())).nextCalled, true);
+    assertRateLimited(await runMiddleware(limitWins, createRequest()));
+  });
+
+  it("rejects invalid max, limit, and window configuration instead of falling back", () => {
+    for (const options of [
+      { max: -1 },
+      { max: "not-a-number" },
+      { max: true },
+      { limit: -1 },
+      { limit: "not-a-number" },
+      { limit: false },
+      { windowMs: 0 },
+      { windowMs: -1 },
+      { windowMs: "not-a-number" },
+      { windowMs: true },
+    ]) {
+      assert.throws(
+        () => createCertOpsMachineTokenRateLimit(options),
+        (error) => error.code === CERTOPS_MACHINE_RATE_LIMIT_CONFIG_INVALID,
+      );
+    }
+
+    assert.doesNotThrow(() => createCertOpsMachineTokenRateLimit());
+    assert.deepEqual(_test.rateLimitOptions({}), {
+      limit: 120,
       windowMs: 60_000,
-      max: 1,
     });
+  });
 
-    const first = await runMiddleware(
-      middleware,
-      createRequest({ user: { id: 1, role: "admin" } }),
+  it("requires a shared store only when explicitly configured", () => {
+    for (const factory of [
+      createCertOpsMachineTokenRateLimit,
+      createCertOpsMachineTokenPreAuthRateLimit,
+    ]) {
+      assert.throws(
+        () => factory({ requireSharedStore: true }),
+        (error) => error.code === CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED,
+      );
+      assert.equal(typeof factory(), "function");
+      assert.equal(
+        typeof factory({
+          requireSharedStore: true,
+          store: new MemoryStore(),
+        }),
+        "function",
+      );
+    }
+  });
+
+  it("extracts only the public prefix from an exact lower-case M2 token", () => {
+    assert.equal(
+      tokenPrefixFromAuthorization(createRequest()),
+      TOKEN_PREFIX,
     );
-    const second = await runMiddleware(
-      middleware,
-      createRequest({ user: { id: 2, role: "viewer" } }),
+    for (const authorization of [
+      `Bearer ttx__${TOKEN_SECRET}`,
+      `Bearer ttx_${TOKEN_ID}_`,
+      `Bearer TTX_${TOKEN_ID}_${TOKEN_SECRET}`,
+      `Bearer ttx_${TOKEN_ID}_${"A".repeat(64)}`,
+      `Basic ${RAW_TOKEN}`,
+    ]) {
+      assert.equal(
+        tokenPrefixFromAuthorization(createRequest({ authorization })),
+        null,
+      );
+    }
+  });
+
+  it("uses public prefix or IP fallback for pre-auth keys without retaining raw authorization", () => {
+    const validKey = machineTokenPreAuthRateLimitKey(
+      createRequest({
+        params: { workspaceId: WORKSPACE_A },
+        authorization: `Bearer ${RAW_TOKEN}`,
+      }),
+    );
+    const malformedAuthorization = `Bearer ttx__${TOKEN_SECRET}`;
+    const fallbackKey = machineTokenPreAuthRateLimitKey(
+      createRequest({
+        params: { workspaceId: WORKSPACE_A },
+        authorization: malformedAuthorization,
+        ip: "198.51.100.9",
+      }),
     );
 
-    assert.equal(first.nextCalled, true);
-    assert.equal(second.res.statusCode, 429);
+    assert.equal(
+      validKey,
+      `certops-machine-preauth:api_v1_certops_executor_events:${WORKSPACE_A}:prefix:${TOKEN_PREFIX}`,
+    );
+    assert.equal(fallbackKey.endsWith(":ip:198.51.100.9"), true);
+    assert.equal(validKey.includes(RAW_TOKEN), false);
+    assert.equal(fallbackKey.includes(malformedAuthorization), false);
+  });
+
+  it("allows under-limit pre-auth requests and blocks them before authentication when over limit", async () => {
+    const middleware = createCertOpsMachineTokenPreAuthRateLimit({ max: 1 });
+    assert.equal((await runMiddleware(middleware, createRequest())).nextCalled, true);
+    assertRateLimited(await runMiddleware(middleware, createRequest()));
+    assert.equal(
+      (
+        await runMiddleware(
+          middleware,
+          createRequest({ authorization: "Bearer ttx__malformed" }),
+        )
+      ).nextCalled,
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR adds the M2-A4 CertOps dedicated machine-token rate limiter.

It prepares future executor/agent machine-token routes with dedicated rate-limit middleware that is independent from user/session API limits, without adding executor runtime behavior, jobs/evidence persistence, dashboard UI, Cloud overlay, or agent behavior.

This PR adds:

* CertOps machine-token post-auth rate-limit middleware
* CertOps machine-token pre-auth rate-limit middleware
* route-family-aware limiter keys
* per-token/per-workspace limiter buckets
* optional authenticated agent/executor ID key support for future routes
* configurable `windowMs`, `max`, and `limit`
* `limit` precedence over `max`
* `max: 0` / `limit: 0` block-all behavior
* invalid rate-limit configuration failures instead of silent fallback
* shared-store enforcement via `requireSharedStore`
* safe route-family normalization
* safe public token-prefix extraction for pre-auth limiting
* fail-closed behavior when post-auth `req.apiToken` is missing
* `429 CERTOPS_MACHINE_RATE_LIMITED` responses when buckets are exceeded
* `Retry-After` header support
* camelCase `retryAfterSeconds` response field
* unit and integration coverage

The post-auth limiter is intended to run after the M2-A3 machine-token auth middleware and uses only sanitized request identity metadata:

* workspace ID
* public token prefix
* route family
* optional authenticated agent/executor ID

The pre-auth limiter is intended to run before M2-A3 machine-token auth. It provides a cheap DoS guard before database-backed token validation and uses only safe request metadata:

* route family
* route workspace ID when safely available
* public `ttx_<id>` token prefix when the Authorization header matches the exact M2 token shape
* IP fallback for missing or malformed tokens

This PR also confirms the machine-token limiter remains secret-safe:

* raw tokens are never used as limiter keys
* Authorization headers are never used as limiter keys
* token hashes are not used or exposed
* plaintext token secrets are not logged, returned, persisted, or retained in keys
* limiter responses do not reveal token identity, Authorization data, token hashes, private keys, credentials, or other private data
* limiter behavior does not depend on `req.user`, sessions, or blanket authenticated/admin state

This PR does not add new runtime product features.

## Review alignment

This PR addresses the M2-A4 review findings:

* post-auth limiter keys now include route family
* pre-auth limiter exists to protect auth/database work from over-limit floods
* Cloud/shared-store readiness is explicit via `requireSharedStore`
* `max: 0` and `limit: 0` now block all requests
* invalid `max`, `limit`, and `windowMs` values fail configuration instead of silently falling back
* 429 response bodies now use `retryAfterSeconds` instead of `retry_after_seconds`

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* `node --check apps/api/middleware/machine-token-rate-limit.js`: ok
* `node --check tests/unit/certops-machine-token-rate-limit.test.js`: ok
* `node --check tests/integration/certops-machine-token-rate-limit.test.js`: ok
* `node --test tests/unit/certops-machine-token-rate-limit.test.js`: ok
* `node --test tests/unit/certops-api-token-auth.test.js`: ok
* `node --test tests/unit/certops-api-tokens.test.js`: ok
* `node --test tests/unit/certops-m2-contracts.test.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `node --test tests/unit/certops-migration.test.js`: ok
* `pnpm exec mocha tests/integration/certops-machine-token-rate-limit.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-api-token-auth.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-api-tokens.test.js --timeout 60000 --exit`: ok
* `pnpm run test:unit`: ok, 232 passing
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a3-machine-token-auth`.
* PR #50 / M2-A1 should merge first.
* PR #51 / M2-A2 should merge after M2-A1.
* PR #52 / M2-A3 should merge before this PR is retargeted.
* This is an M2-A4 limiter PR, not a jobs/evidence persistence PR.
* Dev A owns this work because it touches backend security middleware and machine-auth rate-limit boundaries.
* Dev B dashboard UI, Cloud overlay, fake executor, fake agent, and timeline work remain split out.
* The limiter is not mounted globally.
* The limiter is independent from user/session API limiters.
* Core/local defaults intentionally use the in-memory `express-rate-limit` store.
* Cloud overlays should pass a distributed/shared store and set `requireSharedStore: true`.
* No executor route implementation is included.
* No executor event handler is included.
* No `certificate_jobs`, `certificate_job_log`, or `certificate_evidence` persistence is included.
* No dashboard UI, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, or connector work is included.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A4 limiter.

## Test plan

* [x] Review machine-token post-auth rate-limit middleware
* [x] Review machine-token pre-auth rate-limit middleware
* [x] Verify limiter is not mounted globally
* [x] Verify limiter is independent from user/session rate limits
* [x] Verify post-auth limiter expects sanitized `req.apiToken` from M2-A3 auth
* [x] Verify post-auth limiter fails closed when `req.apiToken` is missing
* [x] Verify pre-auth limiter can block before machine-token auth validation
* [x] Verify pre-auth limiter does not query the database
* [x] Verify pre-auth limiter does not hash tokens
* [x] Verify pre-auth limiter extracts only the public `ttx_<id>` prefix
* [x] Verify malformed or missing Authorization uses safe fallback keying
* [x] Verify requests under limit call `next`
* [x] Verify repeated requests over limit return `429`
* [x] Verify `Retry-After` is returned on limit exceeded
* [x] Verify response body uses `retryAfterSeconds`
* [x] Verify response body does not use `retry_after_seconds`
* [x] Verify post-auth limiter key uses workspace ID, token prefix, and route family
* [x] Verify different route families do not share buckets
* [x] Verify same route family shares a bucket
* [x] Verify different token prefixes do not share buckets
* [x] Verify different workspace IDs do not share buckets
* [x] Verify optional authenticated agent/executor ID participates in the key when present
* [x] Verify route-param machine IDs are ignored unless explicitly opted in
* [x] Verify route family strips query strings
* [x] Verify route family normalizes dynamic path segments
* [x] Verify raw token is not used as a limiter key
* [x] Verify Authorization header is not used as a limiter key
* [x] Verify token hash is not used or exposed
* [x] Verify response body does not expose raw token, Authorization header, token hash, private keys, credentials, or private data
* [x] Verify `max: 0` blocks all requests
* [x] Verify `limit: 0` blocks all requests
* [x] Verify `limit` takes precedence over `max`
* [x] Verify invalid `max`, `limit`, and `windowMs` fail configuration
* [x] Verify `requireSharedStore: true` requires an injected store
* [x] Verify default Core/local in-memory store behavior still works
* [x] Verify no blanket admin/session behavior is created
* [x] Verify no executor handler, jobs/evidence persistence, dashboard, Cloud, or agent work is included
* [x] Run focused unit tests
* [x] Run focused integration tests
* [x] Run full unit suite
* [x] Run contract checks
