### PR TITLE
feat(certops): wire executor event ingestion m2-a6

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -596,6 +596,8 @@ app.use(require("./routes/account"));
 app.use(require("./routes/integrations"));
 // --- CERTOPS (extracted to routes/certops.js) ---
 app.use(require("./routes/certops"));
+// --- CERTOPS EXECUTOR (machine-token routes) ---
+app.use(require("./routes/certops-executor"));
 // --- ADMIN (extracted to routes/admin.js) ---
 app.use(require("./routes/admin"));
 

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -1064,6 +1064,44 @@ const migrations = [
         WHERE subject_type IS NOT NULL AND subject_id IS NOT NULL;
     `,
   },
+  {
+    version: 14,
+    name: "certops_executor_event_idempotency",
+    sql: `
+      -- Executor event records hold only a hash of the normalized public
+      -- envelope and a safe accepted response. They never retain request
+      -- bodies, bearer tokens, credentials, or private-key material.
+      CREATE TABLE IF NOT EXISTS certificate_executor_events (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        job_id UUID NOT NULL,
+        executor_event_id TEXT NOT NULL
+          CHECK (char_length(btrim(executor_event_id)) BETWEEN 1 AND 128),
+        request_hash TEXT NOT NULL
+          CHECK (request_hash ~ '^[a-f0-9]{64}$'),
+        response JSONB NOT NULL DEFAULT '{}'::jsonb,
+        status TEXT NOT NULL DEFAULT 'accepted'
+          CHECK (status IN ('accepted', 'claimed', 'running', 'succeeded', 'failed', 'rejected', 'blocked', 'cancelled')),
+        created_by_api_token_id UUID NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT uq_certificate_executor_events_workspace_job_event
+          UNIQUE (workspace_id, job_id, executor_event_id),
+        CONSTRAINT fk_certificate_executor_events_job
+          FOREIGN KEY (workspace_id, job_id)
+          REFERENCES certificate_jobs(workspace_id, id)
+          ON DELETE CASCADE,
+        CONSTRAINT fk_certificate_executor_events_api_token
+          FOREIGN KEY (workspace_id, created_by_api_token_id)
+          REFERENCES api_tokens(workspace_id, id)
+          ON DELETE SET NULL (created_by_api_token_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_certificate_executor_events_workspace_job_created
+        ON certificate_executor_events(workspace_id, job_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_certificate_executor_events_workspace_event
+        ON certificate_executor_events(workspace_id, executor_event_id);
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/routes/certops-executor.js
+++ b/apps/api/routes/certops-executor.js
@@ -19,6 +19,7 @@ const {
   PRIVATE_KEY_MATERIAL_REJECTED,
   appendCertificateJobLog,
   assertSafePublicValue,
+  fieldNameLooksForbidden,
   getCertificateJobById,
   normalizePublicObject,
   serviceError,
@@ -38,6 +39,11 @@ const CERTOPS_EXECUTOR_WORKSPACE_MISMATCH =
   "CERTOPS_EXECUTOR_WORKSPACE_MISMATCH";
 
 const EXECUTOR_EVENT_SCOPE = "certops:executor:events";
+const PUBLIC_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const METADATA_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
+const METADATA_VALUE_TYPES = new Set(["string", "number", "boolean"]);
 const EXECUTOR_EVENT_TYPES = new Set([
   "job.accepted",
   "job.started",
@@ -83,7 +89,45 @@ function requiredTrimmedString(value, fieldName, code) {
   return trimmed;
 }
 
-function optionalTrimmedString(value, fieldName, maxLength = 1024) {
+function requiredPublicId(value, fieldName, code, maxLength = 128) {
+  const trimmed = requiredTrimmedString(value, fieldName, code);
+  if (trimmed.length > maxLength || !PUBLIC_ID_PATTERN.test(trimmed)) {
+    throw executorEventError(`${fieldName} is invalid`, code);
+  }
+  assertSafePublicValue(trimmed);
+  return trimmed;
+}
+
+function requiredUuid(value, fieldName, code) {
+  const trimmed = requiredTrimmedString(value, fieldName, code);
+  if (!UUID_PATTERN.test(trimmed)) {
+    throw executorEventError(`${fieldName} is invalid`, code);
+  }
+  assertSafePublicValue(trimmed);
+  return trimmed;
+}
+
+function optionalPublicId(value, fieldName, maxLength = 128) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw executorEventError(
+      `${fieldName} is invalid`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > maxLength || !PUBLIC_ID_PATTERN.test(trimmed)) {
+    throw executorEventError(
+      `${fieldName} is invalid`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  assertSafePublicValue(trimmed);
+  return trimmed;
+}
+
+function optionalPublicText(value, fieldName, maxLength = 1024) {
   if (value === undefined || value === null || value === "") return null;
   if (typeof value !== "string") {
     throw executorEventError(`${fieldName} is invalid`, CERTOPS_EXECUTOR_EVENT_INVALID);
@@ -95,6 +139,13 @@ function optionalTrimmedString(value, fieldName, maxLength = 1024) {
   }
   assertSafePublicValue(trimmed);
   return trimmed;
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (Buffer.isBuffer(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function normalizeOccurredAt(value) {
@@ -148,26 +199,74 @@ function metadataEntriesToObject(entries, fieldName) {
       CERTOPS_EXECUTOR_EVENT_INVALID,
     );
   }
+  if (entries.length > 32) {
+    throw executorEventError(
+      `${fieldName} contains too many entries`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
 
   const metadata = {};
   for (const entry of entries) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    if (!isPlainObject(entry)) {
       throw executorEventError(
         `${fieldName} entry is invalid`,
         CERTOPS_EXECUTOR_EVENT_INVALID,
       );
     }
-    const name = requiredTrimmedString(
+
+    const keys = Object.keys(entry);
+    if (
+      keys.length !== 2 ||
+      !keys.includes("name") ||
+      !keys.includes("value")
+    ) {
+      throw executorEventError(
+        `${fieldName} entry is invalid`,
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    const name = requiredPublicId(
       entry.name,
       `${fieldName}.name`,
       CERTOPS_EXECUTOR_EVENT_INVALID,
+      64,
     );
+    if (!METADATA_NAME_PATTERN.test(name) || fieldNameLooksForbidden(name)) {
+      throw executorEventError(
+        `${fieldName}.name is invalid`,
+        PRIVATE_KEY_MATERIAL_REJECTED,
+      );
+    }
     if (!Object.prototype.hasOwnProperty.call(entry, "value")) {
       throw executorEventError(
         `${fieldName}.value is required`,
         CERTOPS_EXECUTOR_EVENT_INVALID,
       );
     }
+
+    const value = entry.value;
+    assertSafePublicValue(value);
+    if (value !== null) {
+      const valueType = typeof value;
+      if (
+        !METADATA_VALUE_TYPES.has(valueType) ||
+        (valueType === "number" && !Number.isFinite(value))
+      ) {
+        throw executorEventError(
+          `${fieldName}.value is invalid`,
+          CERTOPS_EXECUTOR_EVENT_INVALID,
+        );
+      }
+      if (valueType === "string" && value.length > 512) {
+        throw executorEventError(
+          `${fieldName}.value is too long`,
+          CERTOPS_EXECUTOR_EVENT_INVALID,
+        );
+      }
+    }
+
     metadata[name] = entry.value;
   }
 
@@ -187,7 +286,7 @@ function eventMetadataFromBody(body, occurredAt) {
     ["executorId", "executorId"],
     ["attemptId", "attemptId"],
   ]) {
-    const value = optionalTrimmedString(body[sourceKey], sourceKey, 128);
+    const value = optionalPublicId(body[sourceKey], sourceKey);
     if (value) metadata[targetKey] = value;
   }
 
@@ -196,15 +295,14 @@ function eventMetadataFromBody(body, occurredAt) {
 }
 
 function evidenceSubjectFromItem(item) {
-  const certificateId = optionalTrimmedString(item.certificateId, "certificateId", 128);
+  const certificateId = optionalPublicId(item.certificateId, "certificateId");
   if (certificateId) {
     return { subjectType: "managed_certificate", subjectId: certificateId };
   }
 
-  const certificateInstanceId = optionalTrimmedString(
+  const certificateInstanceId = optionalPublicId(
     item.certificateInstanceId,
     "certificateInstanceId",
-    128,
   );
   if (certificateInstanceId) {
     return {
@@ -213,7 +311,7 @@ function evidenceSubjectFromItem(item) {
     };
   }
 
-  const targetId = optionalTrimmedString(item.targetId, "targetId", 128);
+  const targetId = optionalPublicId(item.targetId, "targetId");
   if (targetId) {
     return { subjectType: "certificate_target", subjectId: targetId };
   }
@@ -224,16 +322,24 @@ function evidenceSubjectFromItem(item) {
 function evidenceMetadataFromItem(item) {
   const metadata = {};
   for (const [targetKey, sourceKey] of [
-    ["evidenceId", "evidenceId"],
     ["source", "source"],
     ["status", "status"],
     ["fingerprintSha256", "fingerprintSha256"],
     ["summary", "summary"],
+  ]) {
+    const maxLength =
+      sourceKey === "summary" ? 1024 : sourceKey === "fingerprintSha256" ? 64 : 128;
+    const value = optionalPublicText(item[sourceKey], sourceKey, maxLength);
+    if (value) metadata[targetKey] = value;
+  }
+
+  for (const [targetKey, sourceKey] of [
+    ["evidenceId", "evidenceId"],
     ["certificateId", "certificateId"],
     ["certificateInstanceId", "certificateInstanceId"],
     ["targetId", "targetId"],
   ]) {
-    const value = optionalTrimmedString(item[sourceKey], sourceKey, 1024);
+    const value = optionalPublicId(item[sourceKey], sourceKey);
     if (value) metadata[targetKey] = value;
   }
 
@@ -282,7 +388,7 @@ function normalizeExecutorEventBody(body, apiToken) {
     );
   }
 
-  const bodyWorkspaceId = requiredTrimmedString(
+  const bodyWorkspaceId = requiredUuid(
     body.workspaceId,
     "workspaceId",
     CERTOPS_EXECUTOR_EVENT_INVALID,
@@ -297,12 +403,12 @@ function normalizeExecutorEventBody(body, apiToken) {
 
   const eventType = normalizeEventType(body.eventType);
   const status = normalizeStatus(body.status);
-  const jobId = requiredTrimmedString(
+  const jobId = requiredUuid(
     body.jobId,
     "jobId",
     CERTOPS_EXECUTOR_JOB_REQUIRED,
   );
-  const eventId = requiredTrimmedString(
+  const eventId = requiredPublicId(
     body.eventId,
     "eventId",
     CERTOPS_EXECUTOR_EVENT_INVALID,
@@ -313,7 +419,7 @@ function normalizeExecutorEventBody(body, apiToken) {
     eventId,
     eventType,
     jobId,
-    message: optionalTrimmedString(body.message, "message", 1024),
+    message: optionalPublicText(body.message, "message", 1024),
     occurredAt,
     logStatus: LOG_STATUS_BY_EVENT_TYPE[eventType] || status,
     jobStatus: JOB_STATUS_BY_EVENT_TYPE[eventType] || null,

--- a/apps/api/routes/certops-executor.js
+++ b/apps/api/routes/certops-executor.js
@@ -9,7 +9,13 @@ const {
   createCertOpsMachineTokenPreAuthRateLimit,
   createCertOpsMachineTokenRateLimit,
 } = require("../middleware/machine-token-rate-limit");
+const {
+  requireCertOpsEnabled,
+} = require("../middleware/require-certops-enabled");
 const { logger } = require("../utils/logger");
+const {
+  CERTOPS_API_TOKEN_SCOPE_DENIED,
+} = require("../services/certops/apiTokens");
 const {
   CERTOPS_JOB_INVALID,
   CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
@@ -32,15 +38,22 @@ const {
   CERTOPS_EVIDENCE_TYPE_INVALID,
   createCertificateEvidence,
 } = require("../services/certops/evidence");
+const {
+  CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT,
+  ingestExecutorEvent,
+} = require("../services/certops/executorEvents");
 
 const CERTOPS_EXECUTOR_EVENT_INVALID = "CERTOPS_EXECUTOR_EVENT_INVALID";
 const CERTOPS_EXECUTOR_EVENT_TYPE_INVALID =
   "CERTOPS_EXECUTOR_EVENT_TYPE_INVALID";
+const CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH =
+  "CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH";
 const CERTOPS_EXECUTOR_JOB_REQUIRED = "CERTOPS_EXECUTOR_JOB_REQUIRED";
 const CERTOPS_EXECUTOR_WORKSPACE_MISMATCH =
   "CERTOPS_EXECUTOR_WORKSPACE_MISMATCH";
 
 const EXECUTOR_EVENT_SCOPE = "certops:events:write";
+const EXECUTOR_EVIDENCE_SCOPE = "certops:evidence:write";
 const PUBLIC_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -75,16 +88,18 @@ const EXECUTOR_EVENT_STATUSES = new Set([
 ]);
 const LOG_STATUSES_SET = new Set(LOG_STATUSES);
 
-const LOG_STATUS_BY_EVENT_TYPE = Object.freeze({
-  "job.accepted": "approved",
-  "job.started": "running",
-  "job.progress": "running",
-  "job.completed": "succeeded",
-  "job.failed": "failed",
-  "job.rejected": "rejected",
+const ALLOWED_STATUSES_BY_EVENT_TYPE = Object.freeze({
+  "job.accepted": new Set(["claimed"]),
+  "job.started": new Set(["running"]),
+  "job.progress": new Set(["claimed", "running"]),
+  "job.completed": new Set(["succeeded"]),
+  "job.failed": new Set(["failed"]),
+  "job.rejected": new Set(["rejected"]),
+  "evidence.attached": new Set(["accepted"]),
 });
 
 const JOB_STATUS_BY_EVENT_TYPE = Object.freeze({
+  "job.accepted": "claimed",
   "job.started": "running",
   "job.completed": "succeeded",
   "job.failed": "failed",
@@ -228,6 +243,16 @@ function normalizeStatus(value) {
     throw executorEventError("Executor event status is invalid", CERTOPS_JOB_STATUS_INVALID);
   }
   return status;
+}
+
+function assertEventStatusMatch(eventType, status) {
+  const allowedStatuses = ALLOWED_STATUSES_BY_EVENT_TYPE[eventType];
+  if (!allowedStatuses?.has(status)) {
+    throw executorEventError(
+      "Executor event status does not match the event type",
+      CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH,
+    );
+  }
 }
 
 function metadataEntriesToObject(entries, fieldName) {
@@ -527,6 +552,7 @@ function normalizeExecutorEventBody(body, apiToken) {
 
   const eventType = normalizeEventType(body.eventType);
   const status = normalizeStatus(body.status);
+  assertEventStatusMatch(eventType, status);
   const jobId = requiredUuid(
     body.jobId,
     "jobId",
@@ -545,16 +571,14 @@ function normalizeExecutorEventBody(body, apiToken) {
     jobId,
     message: optionalPublicText(body.message, "message", 1024),
     occurredAt,
-    logStatus:
-      LOG_STATUS_BY_EVENT_TYPE[eventType] ||
-      (LOG_STATUSES_SET.has(status) ? status : null),
+    logStatus: LOG_STATUSES_SET.has(status) ? status : null,
     jobStatus: JOB_STATUS_BY_EVENT_TYPE[eventType] || null,
     metadata: eventMetadataFromBody(body, occurredAt),
     evidence: evidenceItemsFromBody(body),
   };
 }
 
-async function persistEvidenceItems({ body, event, workspaceId, apiToken }) {
+async function persistEvidenceItems({ client, body, event, workspaceId, apiToken }) {
   const created = [];
   for (const item of event.evidence) {
     if (!item || typeof item !== "object" || Array.isArray(item)) {
@@ -571,6 +595,7 @@ async function persistEvidenceItems({ body, event, workspaceId, apiToken }) {
     );
     const subject = evidenceSubjectFromItem(item);
     const evidence = await createCertificateEvidence({
+      client,
       workspaceId,
       jobId: event.jobId,
       evidenceType,
@@ -607,13 +632,26 @@ function handleExecutorEventError(res, error) {
     });
   }
 
+  if (
+    error?.code === CERTOPS_JOB_STATUS_TRANSITION_INVALID ||
+    error?.code === CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT
+  ) {
+    return res.status(409).json({
+      error:
+        error.code === CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT
+          ? "Executor event conflicts with a previously accepted event"
+          : "Executor event conflicts with the current certificate job status",
+      code: error.code,
+    });
+  }
+
   const badRequestCodes = new Set([
     CERTOPS_EXECUTOR_EVENT_INVALID,
     CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
+    CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH,
     CERTOPS_EXECUTOR_JOB_REQUIRED,
     CERTOPS_JOB_INVALID,
     CERTOPS_JOB_STATUS_INVALID,
-    CERTOPS_JOB_STATUS_TRANSITION_INVALID,
     CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
     CERTOPS_EVIDENCE_INVALID,
     CERTOPS_EVIDENCE_TYPE_INVALID,
@@ -632,47 +670,68 @@ async function executorEventsHandler(req, res) {
   try {
     const workspaceId = req.apiToken.workspaceId;
     const event = normalizeExecutorEventBody(req.body, req.apiToken);
-    const job = await getCertificateJobById({
+    const result = await ingestExecutorEvent({
       workspaceId,
       jobId: event.jobId,
-    });
+      eventId: event.eventId,
+      request: event,
+      apiTokenId: req.apiToken.id,
+      process: async (client) => {
+        const job = await getCertificateJobById({
+          client,
+          workspaceId,
+          jobId: event.jobId,
+        });
+        if (!job) {
+          throw executorEventError(
+            "Certificate job not found",
+            CERTOPS_JOB_NOT_FOUND,
+          );
+        }
 
-    if (!job) {
-      throw executorEventError("Certificate job not found", CERTOPS_JOB_NOT_FOUND);
-    }
+        let updatedJob = job;
+        if (event.jobStatus) {
+          updatedJob = await updateCertificateJobStatus({
+            client,
+            workspaceId,
+            jobId: event.jobId,
+            status: event.jobStatus,
+          });
+        }
 
-    const log = await appendCertificateJobLog({
-      workspaceId,
-      jobId: event.jobId,
-      eventType: event.eventType,
-      status: event.logStatus,
-      message: event.message,
-      metadata: event.metadata,
-      createdByApiTokenId: req.apiToken.id,
-    });
+        const log = await appendCertificateJobLog({
+          client,
+          workspaceId,
+          jobId: event.jobId,
+          eventType: event.eventType,
+          status: event.logStatus,
+          message: event.message,
+          metadata: event.metadata,
+          createdByApiTokenId: req.apiToken.id,
+        });
 
-    let updatedJob = null;
-    if (event.jobStatus) {
-      updatedJob = await updateCertificateJobStatus({
-        workspaceId,
-        jobId: event.jobId,
-        status: event.jobStatus,
-      });
-    }
+        const evidence = await persistEvidenceItems({
+          client,
+          body: req.body,
+          event,
+          workspaceId,
+          apiToken: req.apiToken,
+        });
 
-    const evidence = await persistEvidenceItems({
-      body: req.body,
-      event,
-      workspaceId,
-      apiToken: req.apiToken,
+        const response = {
+          ok: true,
+          eventId: log.id,
+          jobId: event.jobId,
+          status: updatedJob.status,
+        };
+        if (evidence[0]?.id) response.evidenceId = evidence[0].id;
+        return response;
+      },
     });
 
     return res.status(202).json({
-      ok: true,
-      eventId: log.id,
-      jobId: event.jobId,
-      status: updatedJob?.status || job.status,
-      evidenceId: evidence[0]?.id,
+      ...result.response,
+      ...(result.duplicate ? { duplicate: true } : {}),
     });
   } catch (error) {
     const handled = handleExecutorEventError(res, error);
@@ -691,6 +750,30 @@ async function executorEventsHandler(req, res) {
   }
 }
 
+function requestCarriesEvidence(req) {
+  const body = req.body;
+  return Boolean(
+    body &&
+      typeof body === "object" &&
+      (body.eventType === "evidence.attached" ||
+        (Array.isArray(body.evidence) && body.evidence.length > 0)),
+  );
+}
+
+function requireExecutorEvidenceScope(req, res, next) {
+  if (
+    !requestCarriesEvidence(req) ||
+    req.apiToken?.scopes?.includes(EXECUTOR_EVIDENCE_SCOPE)
+  ) {
+    return next();
+  }
+
+  return res.status(403).json({
+    error: "CertOps API token scope denied",
+    code: CERTOPS_API_TOKEN_SCOPE_DENIED,
+  });
+}
+
 function createCertOpsExecutorRouter(options = {}) {
   const certOpsExecutorRouter = router();
   const preAuthRateLimitMiddleware =
@@ -704,6 +787,8 @@ function createCertOpsExecutorRouter(options = {}) {
       scopes: [EXECUTOR_EVENT_SCOPE],
       resolveWorkspaceId: workspaceIdHintFromBody,
     });
+  const certOpsEnabledMiddleware =
+    options.certOpsEnabledMiddleware || requireCertOpsEnabled;
   const rateLimitMiddleware =
     options.rateLimitMiddleware ||
     createCertOpsMachineTokenRateLimit(options.rateLimitOptions || {});
@@ -711,8 +796,10 @@ function createCertOpsExecutorRouter(options = {}) {
   certOpsExecutorRouter.post(
     "/api/v1/certops/executor/events",
     preAuthRateLimitMiddleware,
+    certOpsEnabledMiddleware,
     authMiddleware,
     rateLimitMiddleware,
+    requireExecutorEvidenceScope,
     executorEventsHandler,
   );
 
@@ -725,13 +812,18 @@ module.exports = defaultRouter;
 module.exports.createCertOpsExecutorRouter = createCertOpsExecutorRouter;
 module.exports._test = {
   CERTOPS_EXECUTOR_EVENT_INVALID,
+  CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH,
   CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
   CERTOPS_EXECUTOR_JOB_REQUIRED,
   CERTOPS_EXECUTOR_WORKSPACE_MISMATCH,
   EXECUTOR_EVENT_TYPES,
+  EXECUTOR_EVIDENCE_SCOPE,
+  EXECUTOR_EVENT_SCOPE,
+  assertEventStatusMatch,
   evidenceMetadataFromItem,
   evidenceSubjectFromItem,
   handleExecutorEventError,
   metadataEntriesToObject,
   normalizeExecutorEventBody,
+  requestCarriesEvidence,
 };

--- a/apps/api/routes/certops-executor.js
+++ b/apps/api/routes/certops-executor.js
@@ -44,6 +44,14 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const METADATA_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
 const METADATA_VALUE_TYPES = new Set(["string", "number", "boolean"]);
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const ARTIFACT_REF_TYPES = new Set([
+  "log",
+  "report",
+  "certificate",
+  "deployment",
+  "external",
+]);
 const EXECUTOR_EVENT_TYPES = new Set([
   "job.accepted",
   "job.started",
@@ -136,6 +144,24 @@ function optionalPublicText(value, fieldName, maxLength = 1024) {
   if (!trimmed) return null;
   if (trimmed.length > maxLength) {
     throw executorEventError(`${fieldName} is too long`, CERTOPS_EXECUTOR_EVENT_INVALID);
+  }
+  assertSafePublicValue(trimmed);
+  return trimmed;
+}
+
+function requiredPublicText(value, fieldName, maxLength = 512) {
+  if (typeof value !== "string") {
+    throw executorEventError(
+      `${fieldName} is invalid`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maxLength) {
+    throw executorEventError(
+      `${fieldName} is invalid`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
   }
   assertSafePublicValue(trimmed);
   return trimmed;
@@ -319,6 +345,78 @@ function evidenceSubjectFromItem(item) {
   return { subjectType: null, subjectId: null };
 }
 
+function normalizeArtifactRefs(value) {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw executorEventError(
+      "artifactRefs must be an array",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  if (value.length > 16) {
+    throw executorEventError(
+      "artifactRefs contains too many items",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+
+  return value.map((item) => {
+    if (!isPlainObject(item)) {
+      throw executorEventError(
+        "artifactRefs item is invalid",
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    const keys = Object.keys(item);
+    const allowedKeys = new Set(["type", "reference", "sha256"]);
+    if (
+      !keys.includes("type") ||
+      !keys.includes("reference") ||
+      keys.some((key) => !allowedKeys.has(key))
+    ) {
+      throw executorEventError(
+        "artifactRefs item is invalid",
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    const type = requiredPublicText(item.type, "artifactRefs.type", 64);
+    if (!ARTIFACT_REF_TYPES.has(type)) {
+      throw executorEventError(
+        "artifactRefs.type is invalid",
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    const reference = requiredPublicText(
+      item.reference,
+      "artifactRefs.reference",
+      512,
+    );
+    const normalized = { type, reference };
+
+    if (Object.prototype.hasOwnProperty.call(item, "sha256")) {
+      if (item.sha256 === null) {
+        normalized.sha256 = null;
+      } else if (
+        typeof item.sha256 === "string" &&
+        SHA256_HEX_PATTERN.test(item.sha256)
+      ) {
+        assertSafePublicValue(item.sha256);
+        normalized.sha256 = item.sha256;
+      } else {
+        throw executorEventError(
+          "artifactRefs.sha256 is invalid",
+          CERTOPS_EXECUTOR_EVENT_INVALID,
+        );
+      }
+    }
+
+    return normalized;
+  });
+}
+
 function evidenceMetadataFromItem(item) {
   const metadata = {};
   for (const [targetKey, sourceKey] of [
@@ -346,8 +444,9 @@ function evidenceMetadataFromItem(item) {
   if (typeof item.redactionApplied === "boolean") {
     metadata.redactionApplied = item.redactionApplied;
   }
-  if (Array.isArray(item.artifactRefs) && item.artifactRefs.length > 0) {
-    metadata.artifactRefs = item.artifactRefs;
+  const artifactRefs = normalizeArtifactRefs(item.artifactRefs);
+  if (artifactRefs !== undefined) {
+    metadata.artifactRefs = artifactRefs;
   }
 
   const entries = metadataEntriesToObject(item.metadata, "evidence.metadata");
@@ -368,7 +467,19 @@ function evidenceItemsFromBody(body) {
       CERTOPS_EXECUTOR_EVENT_INVALID,
     );
   }
-  return body.evidence;
+  return body.evidence.map((item) => {
+    if (!isPlainObject(item)) {
+      throw executorEventError(
+        "evidence item is invalid",
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    return {
+      ...item,
+      artifactRefs: normalizeArtifactRefs(item.artifactRefs),
+    };
+  });
 }
 
 function normalizeExecutorEventBody(body, apiToken) {

--- a/apps/api/routes/certops-executor.js
+++ b/apps/api/routes/certops-executor.js
@@ -6,6 +6,7 @@ const {
   createCertOpsApiTokenAuth,
 } = require("../middleware/api-token-auth");
 const {
+  createCertOpsMachineTokenPreAuthRateLimit,
   createCertOpsMachineTokenRateLimit,
 } = require("../middleware/machine-token-rate-limit");
 const { logger } = require("../utils/logger");
@@ -14,6 +15,7 @@ const {
   CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
   CERTOPS_JOB_NOT_FOUND,
   CERTOPS_JOB_STATUS_INVALID,
+  CERTOPS_JOB_STATUS_TRANSITION_INVALID,
   JOB_LOG_EVENT_TYPES,
   LOG_STATUSES,
   PRIVATE_KEY_MATERIAL_REJECTED,
@@ -38,7 +40,7 @@ const CERTOPS_EXECUTOR_JOB_REQUIRED = "CERTOPS_EXECUTOR_JOB_REQUIRED";
 const CERTOPS_EXECUTOR_WORKSPACE_MISMATCH =
   "CERTOPS_EXECUTOR_WORKSPACE_MISMATCH";
 
-const EXECUTOR_EVENT_SCOPE = "certops:executor:events";
+const EXECUTOR_EVENT_SCOPE = "certops:events:write";
 const PUBLIC_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -61,10 +63,20 @@ const EXECUTOR_EVENT_TYPES = new Set([
   "job.rejected",
   "evidence.attached",
 ]);
+const EXECUTOR_EVENT_STATUSES = new Set([
+  "accepted",
+  "claimed",
+  "running",
+  "succeeded",
+  "failed",
+  "rejected",
+  "blocked",
+  "cancelled",
+]);
 const LOG_STATUSES_SET = new Set(LOG_STATUSES);
 
 const LOG_STATUS_BY_EVENT_TYPE = Object.freeze({
-  "job.accepted": "accepted",
+  "job.accepted": "approved",
   "job.started": "running",
   "job.progress": "running",
   "job.completed": "succeeded",
@@ -76,6 +88,7 @@ const JOB_STATUS_BY_EVENT_TYPE = Object.freeze({
   "job.started": "running",
   "job.completed": "succeeded",
   "job.failed": "failed",
+  "job.rejected": "rejected",
 });
 
 function executorEventError(message, code) {
@@ -211,7 +224,7 @@ function normalizeStatus(value) {
     "status",
     CERTOPS_JOB_STATUS_INVALID,
   );
-  if (!LOG_STATUSES_SET.has(status) || status === "queued") {
+  if (!EXECUTOR_EVENT_STATUSES.has(status)) {
     throw executorEventError("Executor event status is invalid", CERTOPS_JOB_STATUS_INVALID);
   }
   return status;
@@ -532,7 +545,9 @@ function normalizeExecutorEventBody(body, apiToken) {
     jobId,
     message: optionalPublicText(body.message, "message", 1024),
     occurredAt,
-    logStatus: LOG_STATUS_BY_EVENT_TYPE[eventType] || status,
+    logStatus:
+      LOG_STATUS_BY_EVENT_TYPE[eventType] ||
+      (LOG_STATUSES_SET.has(status) ? status : null),
     jobStatus: JOB_STATUS_BY_EVENT_TYPE[eventType] || null,
     metadata: eventMetadataFromBody(body, occurredAt),
     evidence: evidenceItemsFromBody(body),
@@ -598,6 +613,7 @@ function handleExecutorEventError(res, error) {
     CERTOPS_EXECUTOR_JOB_REQUIRED,
     CERTOPS_JOB_INVALID,
     CERTOPS_JOB_STATUS_INVALID,
+    CERTOPS_JOB_STATUS_TRANSITION_INVALID,
     CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
     CERTOPS_EVIDENCE_INVALID,
     CERTOPS_EVIDENCE_TYPE_INVALID,
@@ -677,6 +693,11 @@ async function executorEventsHandler(req, res) {
 
 function createCertOpsExecutorRouter(options = {}) {
   const certOpsExecutorRouter = router();
+  const preAuthRateLimitMiddleware =
+    options.preAuthRateLimitMiddleware ||
+    createCertOpsMachineTokenPreAuthRateLimit(
+      options.preAuthRateLimitOptions || options.rateLimitOptions || {},
+    );
   const authMiddleware =
     options.authMiddleware ||
     createCertOpsApiTokenAuth({
@@ -689,6 +710,7 @@ function createCertOpsExecutorRouter(options = {}) {
 
   certOpsExecutorRouter.post(
     "/api/v1/certops/executor/events",
+    preAuthRateLimitMiddleware,
     authMiddleware,
     rateLimitMiddleware,
     executorEventsHandler,

--- a/apps/api/routes/certops-executor.js
+++ b/apps/api/routes/certops-executor.js
@@ -1,0 +1,498 @@
+"use strict";
+
+const router = require("express").Router;
+
+const {
+  createCertOpsApiTokenAuth,
+} = require("../middleware/api-token-auth");
+const {
+  createCertOpsMachineTokenRateLimit,
+} = require("../middleware/machine-token-rate-limit");
+const { logger } = require("../utils/logger");
+const {
+  CERTOPS_JOB_INVALID,
+  CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
+  CERTOPS_JOB_NOT_FOUND,
+  CERTOPS_JOB_STATUS_INVALID,
+  JOB_LOG_EVENT_TYPES,
+  LOG_STATUSES,
+  PRIVATE_KEY_MATERIAL_REJECTED,
+  appendCertificateJobLog,
+  assertSafePublicValue,
+  getCertificateJobById,
+  normalizePublicObject,
+  serviceError,
+  updateCertificateJobStatus,
+} = require("../services/certops/jobs");
+const {
+  CERTOPS_EVIDENCE_INVALID,
+  CERTOPS_EVIDENCE_TYPE_INVALID,
+  createCertificateEvidence,
+} = require("../services/certops/evidence");
+
+const CERTOPS_EXECUTOR_EVENT_INVALID = "CERTOPS_EXECUTOR_EVENT_INVALID";
+const CERTOPS_EXECUTOR_EVENT_TYPE_INVALID =
+  "CERTOPS_EXECUTOR_EVENT_TYPE_INVALID";
+const CERTOPS_EXECUTOR_JOB_REQUIRED = "CERTOPS_EXECUTOR_JOB_REQUIRED";
+const CERTOPS_EXECUTOR_WORKSPACE_MISMATCH =
+  "CERTOPS_EXECUTOR_WORKSPACE_MISMATCH";
+
+const EXECUTOR_EVENT_SCOPE = "certops:executor:events";
+const EXECUTOR_EVENT_TYPES = new Set([
+  "job.accepted",
+  "job.started",
+  "job.progress",
+  "job.completed",
+  "job.failed",
+  "job.rejected",
+  "evidence.attached",
+]);
+const LOG_STATUSES_SET = new Set(LOG_STATUSES);
+
+const LOG_STATUS_BY_EVENT_TYPE = Object.freeze({
+  "job.accepted": "accepted",
+  "job.started": "running",
+  "job.progress": "running",
+  "job.completed": "succeeded",
+  "job.failed": "failed",
+  "job.rejected": "rejected",
+});
+
+const JOB_STATUS_BY_EVENT_TYPE = Object.freeze({
+  "job.started": "running",
+  "job.completed": "succeeded",
+  "job.failed": "failed",
+});
+
+function executorEventError(message, code) {
+  return serviceError(message, code);
+}
+
+function workspaceIdHintFromBody(req) {
+  return typeof req.body?.workspaceId === "string" ? req.body.workspaceId : null;
+}
+
+function requiredTrimmedString(value, fieldName, code) {
+  if (typeof value !== "string") {
+    throw executorEventError(`${fieldName} is required`, code);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw executorEventError(`${fieldName} is required`, code);
+  }
+  return trimmed;
+}
+
+function optionalTrimmedString(value, fieldName, maxLength = 1024) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw executorEventError(`${fieldName} is invalid`, CERTOPS_EXECUTOR_EVENT_INVALID);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > maxLength) {
+    throw executorEventError(`${fieldName} is too long`, CERTOPS_EXECUTOR_EVENT_INVALID);
+  }
+  assertSafePublicValue(trimmed);
+  return trimmed;
+}
+
+function normalizeOccurredAt(value) {
+  const occurredAt = requiredTrimmedString(
+    value,
+    "occurredAt",
+    CERTOPS_EXECUTOR_EVENT_INVALID,
+  );
+  const date = new Date(occurredAt);
+  if (Number.isNaN(date.getTime())) {
+    throw executorEventError(
+      "occurredAt is invalid",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  return date.toISOString();
+}
+
+function normalizeEventType(value) {
+  const eventType = requiredTrimmedString(
+    value,
+    "eventType",
+    CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
+  );
+  if (!EXECUTOR_EVENT_TYPES.has(eventType)) {
+    throw executorEventError(
+      "Executor event type is invalid",
+      CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
+    );
+  }
+  return eventType;
+}
+
+function normalizeStatus(value) {
+  const status = requiredTrimmedString(
+    value,
+    "status",
+    CERTOPS_JOB_STATUS_INVALID,
+  );
+  if (!LOG_STATUSES_SET.has(status) || status === "queued") {
+    throw executorEventError("Executor event status is invalid", CERTOPS_JOB_STATUS_INVALID);
+  }
+  return status;
+}
+
+function metadataEntriesToObject(entries, fieldName) {
+  if (entries === undefined || entries === null) return {};
+  if (!Array.isArray(entries)) {
+    throw executorEventError(
+      `${fieldName} must be a public metadata array`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+
+  const metadata = {};
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw executorEventError(
+        `${fieldName} entry is invalid`,
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+    const name = requiredTrimmedString(
+      entry.name,
+      `${fieldName}.name`,
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+    if (!Object.prototype.hasOwnProperty.call(entry, "value")) {
+      throw executorEventError(
+        `${fieldName}.value is required`,
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+    metadata[name] = entry.value;
+  }
+
+  return normalizePublicObject(metadata, fieldName);
+}
+
+function eventMetadataFromBody(body, occurredAt) {
+  const metadata = {
+    executorEventId: body.eventId,
+    executorEventType: body.eventType,
+    executorStatus: body.status,
+    occurredAt,
+  };
+
+  for (const [targetKey, sourceKey] of [
+    ["certificateId", "certificateId"],
+    ["executorId", "executorId"],
+    ["attemptId", "attemptId"],
+  ]) {
+    const value = optionalTrimmedString(body[sourceKey], sourceKey, 128);
+    if (value) metadata[targetKey] = value;
+  }
+
+  const entries = metadataEntriesToObject(body.metadata, "metadata");
+  return normalizePublicObject({ ...metadata, ...entries }, "metadata");
+}
+
+function evidenceSubjectFromItem(item) {
+  const certificateId = optionalTrimmedString(item.certificateId, "certificateId", 128);
+  if (certificateId) {
+    return { subjectType: "managed_certificate", subjectId: certificateId };
+  }
+
+  const certificateInstanceId = optionalTrimmedString(
+    item.certificateInstanceId,
+    "certificateInstanceId",
+    128,
+  );
+  if (certificateInstanceId) {
+    return {
+      subjectType: "certificate_instance",
+      subjectId: certificateInstanceId,
+    };
+  }
+
+  const targetId = optionalTrimmedString(item.targetId, "targetId", 128);
+  if (targetId) {
+    return { subjectType: "certificate_target", subjectId: targetId };
+  }
+
+  return { subjectType: null, subjectId: null };
+}
+
+function evidenceMetadataFromItem(item) {
+  const metadata = {};
+  for (const [targetKey, sourceKey] of [
+    ["evidenceId", "evidenceId"],
+    ["source", "source"],
+    ["status", "status"],
+    ["fingerprintSha256", "fingerprintSha256"],
+    ["summary", "summary"],
+    ["certificateId", "certificateId"],
+    ["certificateInstanceId", "certificateInstanceId"],
+    ["targetId", "targetId"],
+  ]) {
+    const value = optionalTrimmedString(item[sourceKey], sourceKey, 1024);
+    if (value) metadata[targetKey] = value;
+  }
+
+  if (typeof item.redactionApplied === "boolean") {
+    metadata.redactionApplied = item.redactionApplied;
+  }
+  if (Array.isArray(item.artifactRefs) && item.artifactRefs.length > 0) {
+    metadata.artifactRefs = item.artifactRefs;
+  }
+
+  const entries = metadataEntriesToObject(item.metadata, "evidence.metadata");
+  return normalizePublicObject({ ...metadata, ...entries }, "metadata");
+}
+
+function evidenceItemsFromBody(body) {
+  if (body.evidence === undefined || body.evidence === null) return [];
+  if (!Array.isArray(body.evidence)) {
+    throw executorEventError(
+      "evidence must be an array",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  if (body.evidence.length > 16) {
+    throw executorEventError(
+      "evidence contains too many items",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+  return body.evidence;
+}
+
+function normalizeExecutorEventBody(body, apiToken) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw executorEventError(
+      "Executor event body is invalid",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+
+  assertSafePublicValue(body);
+
+  if (body.schemaVersion !== 1) {
+    throw executorEventError(
+      "Executor event schemaVersion is invalid",
+      CERTOPS_EXECUTOR_EVENT_INVALID,
+    );
+  }
+
+  const bodyWorkspaceId = requiredTrimmedString(
+    body.workspaceId,
+    "workspaceId",
+    CERTOPS_EXECUTOR_EVENT_INVALID,
+  );
+  const workspaceId = apiToken?.workspaceId;
+  if (!workspaceId || bodyWorkspaceId !== workspaceId) {
+    throw executorEventError(
+      "Executor event workspace mismatch",
+      CERTOPS_EXECUTOR_WORKSPACE_MISMATCH,
+    );
+  }
+
+  const eventType = normalizeEventType(body.eventType);
+  const status = normalizeStatus(body.status);
+  const jobId = requiredTrimmedString(
+    body.jobId,
+    "jobId",
+    CERTOPS_EXECUTOR_JOB_REQUIRED,
+  );
+  const eventId = requiredTrimmedString(
+    body.eventId,
+    "eventId",
+    CERTOPS_EXECUTOR_EVENT_INVALID,
+  );
+  const occurredAt = normalizeOccurredAt(body.occurredAt);
+
+  return {
+    eventId,
+    eventType,
+    jobId,
+    message: optionalTrimmedString(body.message, "message", 1024),
+    occurredAt,
+    logStatus: LOG_STATUS_BY_EVENT_TYPE[eventType] || status,
+    jobStatus: JOB_STATUS_BY_EVENT_TYPE[eventType] || null,
+    metadata: eventMetadataFromBody(body, occurredAt),
+    evidence: evidenceItemsFromBody(body),
+  };
+}
+
+async function persistEvidenceItems({ body, event, workspaceId, apiToken }) {
+  const created = [];
+  for (const item of event.evidence) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw executorEventError(
+        "evidence item is invalid",
+        CERTOPS_EXECUTOR_EVENT_INVALID,
+      );
+    }
+
+    const evidenceType = requiredTrimmedString(
+      item.eventType || item.evidenceType,
+      "evidence.eventType",
+      CERTOPS_EVIDENCE_TYPE_INVALID,
+    );
+    const subject = evidenceSubjectFromItem(item);
+    const evidence = await createCertificateEvidence({
+      workspaceId,
+      jobId: event.jobId,
+      evidenceType,
+      subjectType: subject.subjectType,
+      subjectId: subject.subjectId,
+      metadata: evidenceMetadataFromItem(item),
+      observedAt: item.observedAt || body.occurredAt,
+      createdByApiTokenId: apiToken.id,
+    });
+    created.push(evidence);
+  }
+  return created;
+}
+
+function handleExecutorEventError(res, error) {
+  if (error?.code === PRIVATE_KEY_MATERIAL_REJECTED) {
+    return res.status(422).json({
+      error: "Private key material is not accepted in CertOps executor events",
+      code: PRIVATE_KEY_MATERIAL_REJECTED,
+    });
+  }
+
+  if (error?.code === CERTOPS_JOB_NOT_FOUND) {
+    return res.status(404).json({
+      error: "Certificate job not found",
+      code: CERTOPS_JOB_NOT_FOUND,
+    });
+  }
+
+  if (error?.code === CERTOPS_EXECUTOR_WORKSPACE_MISMATCH) {
+    return res.status(403).json({
+      error: "Executor event workspace mismatch",
+      code: CERTOPS_EXECUTOR_WORKSPACE_MISMATCH,
+    });
+  }
+
+  const badRequestCodes = new Set([
+    CERTOPS_EXECUTOR_EVENT_INVALID,
+    CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
+    CERTOPS_EXECUTOR_JOB_REQUIRED,
+    CERTOPS_JOB_INVALID,
+    CERTOPS_JOB_STATUS_INVALID,
+    CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
+    CERTOPS_EVIDENCE_INVALID,
+    CERTOPS_EVIDENCE_TYPE_INVALID,
+  ]);
+  if (badRequestCodes.has(error?.code)) {
+    return res.status(400).json({
+      error: "Executor event is invalid",
+      code: error.code,
+    });
+  }
+
+  return null;
+}
+
+async function executorEventsHandler(req, res) {
+  try {
+    const workspaceId = req.apiToken.workspaceId;
+    const event = normalizeExecutorEventBody(req.body, req.apiToken);
+    const job = await getCertificateJobById({
+      workspaceId,
+      jobId: event.jobId,
+    });
+
+    if (!job) {
+      throw executorEventError("Certificate job not found", CERTOPS_JOB_NOT_FOUND);
+    }
+
+    const log = await appendCertificateJobLog({
+      workspaceId,
+      jobId: event.jobId,
+      eventType: event.eventType,
+      status: event.logStatus,
+      message: event.message,
+      metadata: event.metadata,
+      createdByApiTokenId: req.apiToken.id,
+    });
+
+    let updatedJob = null;
+    if (event.jobStatus) {
+      updatedJob = await updateCertificateJobStatus({
+        workspaceId,
+        jobId: event.jobId,
+        status: event.jobStatus,
+      });
+    }
+
+    const evidence = await persistEvidenceItems({
+      body: req.body,
+      event,
+      workspaceId,
+      apiToken: req.apiToken,
+    });
+
+    return res.status(202).json({
+      ok: true,
+      eventId: log.id,
+      jobId: event.jobId,
+      status: updatedJob?.status || job.status,
+      evidenceId: evidence[0]?.id,
+    });
+  } catch (error) {
+    const handled = handleExecutorEventError(res, error);
+    if (handled) return handled;
+
+    logger.error("CertOps executor event ingestion failed", {
+      error: error.message,
+      code: error.code || null,
+      workspaceId: req.apiToken?.workspaceId || null,
+      apiTokenId: req.apiToken?.id || null,
+    });
+    return res.status(500).json({
+      error: "Failed to ingest CertOps executor event",
+      code: "INTERNAL_ERROR",
+    });
+  }
+}
+
+function createCertOpsExecutorRouter(options = {}) {
+  const certOpsExecutorRouter = router();
+  const authMiddleware =
+    options.authMiddleware ||
+    createCertOpsApiTokenAuth({
+      scopes: [EXECUTOR_EVENT_SCOPE],
+      resolveWorkspaceId: workspaceIdHintFromBody,
+    });
+  const rateLimitMiddleware =
+    options.rateLimitMiddleware ||
+    createCertOpsMachineTokenRateLimit(options.rateLimitOptions || {});
+
+  certOpsExecutorRouter.post(
+    "/api/v1/certops/executor/events",
+    authMiddleware,
+    rateLimitMiddleware,
+    executorEventsHandler,
+  );
+
+  return certOpsExecutorRouter;
+}
+
+const defaultRouter = createCertOpsExecutorRouter();
+
+module.exports = defaultRouter;
+module.exports.createCertOpsExecutorRouter = createCertOpsExecutorRouter;
+module.exports._test = {
+  CERTOPS_EXECUTOR_EVENT_INVALID,
+  CERTOPS_EXECUTOR_EVENT_TYPE_INVALID,
+  CERTOPS_EXECUTOR_JOB_REQUIRED,
+  CERTOPS_EXECUTOR_WORKSPACE_MISMATCH,
+  EXECUTOR_EVENT_TYPES,
+  evidenceMetadataFromItem,
+  evidenceSubjectFromItem,
+  handleExecutorEventError,
+  metadataEntriesToObject,
+  normalizeExecutorEventBody,
+};

--- a/apps/api/services/certops/executorEvents.js
+++ b/apps/api/services/certops/executorEvents.js
@@ -1,0 +1,171 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const { pool } = require("../../db/database");
+const { CERTOPS_JOB_NOT_FOUND, serviceError } = require("./jobs");
+
+const CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT =
+  "CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT";
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalize(value[key])]),
+  );
+}
+
+function requestHash(value) {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+function parseResponse(value) {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch (_error) {
+      return {};
+    }
+  }
+  return value;
+}
+
+function idempotencyConflict() {
+  return serviceError(
+    "Executor event ID was already used with a different event",
+    CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT,
+  );
+}
+
+async function findExecutorEvent(client, workspaceId, jobId, eventId) {
+  const result = await client.query(
+    `SELECT id, request_hash, response
+       FROM certificate_executor_events
+      WHERE workspace_id = $1
+        AND job_id = $2
+        AND executor_event_id = $3
+      LIMIT 1`,
+    [workspaceId, jobId, eventId],
+  );
+  return result.rows[0] || null;
+}
+
+async function lockJob(client, workspaceId, jobId) {
+  const result = await client.query(
+    `SELECT id
+       FROM certificate_jobs
+      WHERE workspace_id = $1
+        AND id = $2
+      FOR UPDATE`,
+    [workspaceId, jobId],
+  );
+  if (!result.rows[0]) {
+    throw serviceError("Certificate job not found", CERTOPS_JOB_NOT_FOUND);
+  }
+}
+
+async function insertExecutorEvent({
+  client,
+  workspaceId,
+  jobId,
+  eventId,
+  hash,
+  apiTokenId,
+}) {
+  const result = await client.query(
+    `INSERT INTO certificate_executor_events (
+       workspace_id,
+       job_id,
+       executor_event_id,
+       request_hash,
+       created_by_api_token_id
+     )
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (workspace_id, job_id, executor_event_id) DO NOTHING
+     RETURNING id`,
+    [workspaceId, jobId, eventId, hash, apiTokenId || null],
+  );
+  return result.rows[0] || null;
+}
+
+async function storeExecutorEventResponse(client, id, response) {
+  await client.query(
+    `UPDATE certificate_executor_events
+        SET response = $2::jsonb,
+            status = 'accepted'
+      WHERE id = $1`,
+    [id, JSON.stringify(response)],
+  );
+}
+
+async function ingestExecutorEvent({
+  workspaceId,
+  jobId,
+  eventId,
+  request,
+  apiTokenId,
+  process,
+}) {
+  const hash = requestHash(request);
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    const existing = await findExecutorEvent(client, workspaceId, jobId, eventId);
+    if (existing) {
+      if (existing.request_hash !== hash) throw idempotencyConflict();
+      await client.query("COMMIT");
+      return { response: parseResponse(existing.response), duplicate: true };
+    }
+
+    // Serializing event processing on the job also closes the gap between a
+    // replay lookup and unique-key reservation by another executor retry.
+    await lockJob(client, workspaceId, jobId);
+    const inserted = await insertExecutorEvent({
+      client,
+      workspaceId,
+      jobId,
+      eventId,
+      hash,
+      apiTokenId,
+    });
+
+    if (!inserted) {
+      const replay = await findExecutorEvent(client, workspaceId, jobId, eventId);
+      if (!replay || replay.request_hash !== hash) throw idempotencyConflict();
+      await client.query("COMMIT");
+      return { response: parseResponse(replay.response), duplicate: true };
+    }
+
+    const response = await process(client);
+    await storeExecutorEventResponse(client, inserted.id, response);
+    await client.query("COMMIT");
+    return { response, duplicate: false };
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackError) {
+      // The original persistence error is more useful to the caller.
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = {
+  CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT,
+  ingestExecutorEvent,
+  _test: {
+    canonicalize,
+    requestHash,
+  },
+};

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -4499,13 +4499,27 @@ components:
     CertOpsExecutorEventAcceptedResponse:
       type: object
       additionalProperties: false
-      required: [accepted, code]
+      required: [ok, eventId, jobId, status]
       properties:
-        accepted:
+        ok:
           type: boolean
-        code:
+          enum: [true]
+        eventId:
           type: string
-          enum: [CERTOPS_EXECUTOR_EVENT_ACCEPTED]
+          minLength: 1
+          maxLength: 128
+          pattern: "^[A-Za-z0-9_.:-]+$"
+          description: Server-side job log event identifier for the accepted executor event.
+        jobId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled]
+        evidenceId:
+          type: string
+          format: uuid
+          nullable: true
     SessionUser:
       type: object
       required: [id, email]

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3458,7 +3458,7 @@ paths:
       tags: [CertOps Agent]
       summary: Report executor events
       operationId: createCertOpsExecutorEvent
-      description: M2 external executor reporting envelope for normalized job and evidence events. Scoped-token authenticated. Payloads containing private key material are rejected (422). Older operational lifecycle names such as csr-generated, issued, deployed, validated, reloaded, rolled-back, key-generated-locally, key-not-exported, and revocation-* are represented in M2 as normalized job/evidence events. Richer agent-executed job protocol and job signing are deferred to M4. M2-A1 defines the contract skeleton only; runtime auth, rate limiting, persistence, and redaction enforcement land in later M2 PRs.
+      description: M2 external executor reporting envelope for normalized job and evidence events. Lifecycle events require `certops:events:write`; evidence-bearing events additionally require `certops:evidence:write`. The route is hidden with 404 when `certops.enabled` is disabled. `eventId` is idempotent within a workspace and job: exact retries return 202 without repeating side effects, while a different accepted envelope using the same key returns 409. Payloads containing private key material are rejected with 422. Older operational lifecycle names such as csr-generated, issued, deployed, validated, reloaded, rolled-back, key-generated-locally, key-not-exported, and revocation-* are represented in M2 as normalized job/evidence events. Richer agent-executed job protocol and job signing are deferred to M4.
       security:
         - certOpsTokenAuth: []
       requestBody:
@@ -3474,8 +3474,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CertOpsExecutorEventAcceptedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The event conflicts with the current job state or a prior event with the same workspace, job, and eventId
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Request rejected because it contained private key material
           content:
@@ -4520,6 +4532,10 @@ components:
           type: string
           format: uuid
           nullable: true
+        duplicate:
+          type: boolean
+          default: false
+          description: True only when this response is an exact idempotent replay; no lifecycle, evidence, or audit side effects were repeated.
     SessionUser:
       type: object
       required: [id, email]

--- a/tests/integration/certops-executor-events.test.js
+++ b/tests/integration/certops-executor-events.test.js
@@ -9,7 +9,10 @@ loadRootEnv();
 const { expect, TestUtils } = require("./setup");
 const { requireMigrateModule } = require("./variant-paths");
 const { runMigrations } = requireMigrateModule();
-const { createApiToken } = require("../../apps/api/services/certops/apiTokens");
+const {
+  createApiToken,
+  getApiTokenById,
+} = require("../../apps/api/services/certops/apiTokens");
 const {
   createCertificateJob,
   getCertificateJobById,
@@ -68,6 +71,10 @@ async function createWorkspacePair(label) {
 
 async function cleanupWorkspacePair(ownerId, workspaceIds) {
   await TestUtils.execQuery(
+    "DELETE FROM certificate_executor_events WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery(
     "DELETE FROM certificate_evidence WHERE workspace_id = ANY($1::uuid[])",
     [workspaceIds],
   );
@@ -89,7 +96,12 @@ async function cleanupWorkspacePair(ownerId, workspaceIds) {
   await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
 }
 
-function buildExecutorApp({ rateLimitOptions, csrf = false } = {}) {
+function buildExecutorApp({
+  rateLimitOptions,
+  csrf = false,
+  authMiddleware,
+  certOpsEnabledMiddleware,
+} = {}) {
   const app = express();
   app.use(express.json());
 
@@ -109,6 +121,8 @@ function buildExecutorApp({ rateLimitOptions, csrf = false } = {}) {
   app.use(
     createCertOpsExecutorRouter({
       rateLimitOptions: rateLimitOptions || { windowMs: 60_000, max: 100 },
+      authMiddleware,
+      certOpsEnabledMiddleware,
     }),
   );
   app.post("/api/v1/workspaces/:id/certops/unrelated-write", (_req, res) =>
@@ -174,6 +188,17 @@ async function countJobArtifacts({ workspaceId, jobId }) {
     logs: logs.items.length,
     evidence: evidence.items.length,
   };
+}
+
+async function countExecutorEventRecords({ workspaceId, jobId }) {
+  const result = await TestUtils.execQuery(
+    `SELECT COUNT(*)::integer AS count
+       FROM certificate_executor_events
+      WHERE workspace_id = $1
+        AND job_id = $2`,
+    [workspaceId, jobId],
+  );
+  return result.rows[0].count;
 }
 
 function expectNoSensitiveValues(body, rawToken, extraForbidden = []) {
@@ -258,6 +283,64 @@ describe("CertOps executor event ingestion", function () {
       expect(ok.body.user).to.equal(undefined);
       expect(ok.body.authenticated).to.equal(undefined);
       expectNoSensitiveValues(ok.body, scoped.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("hides executor ingestion when CertOps is disabled before token validation or persistence", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-disabled",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write"],
+      });
+      let authCalls = 0;
+      const app = buildExecutorApp({
+        certOpsEnabledMiddleware: (_req, res) =>
+          res.status(404).json({ error: "Endpoint not found", code: "NOT_FOUND" }),
+        authMiddleware: (_req, _res, next) => {
+          authCalls += 1;
+          return next();
+        },
+      });
+      const before = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: job.id,
+      });
+      const response = await supertest(app)
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: job.id }));
+      const after = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: job.id,
+      });
+      const persistedToken = await getApiTokenById({
+        workspaceId: workspaceA,
+        tokenId: token.token.id,
+      });
+
+      expect(response.status).to.equal(404);
+      expect(response.body).to.deep.equal({
+        error: "Endpoint not found",
+        code: "NOT_FOUND",
+      });
+      expect(authCalls).to.equal(0);
+      expect(after).to.deep.equal(before);
+      expect(
+        await countExecutorEventRecords({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        }),
+      ).to.equal(0);
+      expect(persistedToken.lastUsedAt).to.equal(null);
+      expectNoSensitiveValues(response.body, token.plaintextToken);
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
     }
@@ -432,6 +515,449 @@ describe("CertOps executor event ingestion", function () {
     }
   });
 
+  it("rejects eventType and status mismatches before any persistence", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-status-mismatch",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write"],
+      });
+      const app = buildExecutorApp();
+
+      for (const [eventType, status] of [
+        ["job.completed", "failed"],
+        ["job.failed", "succeeded"],
+        ["job.started", "succeeded"],
+      ]) {
+        const before = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const response = await supertest(app)
+          .post("/api/v1/certops/executor/events")
+          .set("Authorization", `Bearer ${token.plaintextToken}`)
+          .send(
+            eventPayload({
+              workspaceId: workspaceA,
+              jobId: job.id,
+              eventType,
+              status,
+            }),
+          );
+        const after = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+
+        expect(response.status).to.equal(400);
+        expect(response.body.code).to.equal(
+          "CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH",
+        );
+        expect(after).to.deep.equal(before);
+        expect(
+          await countExecutorEventRecords({
+            workspaceId: workspaceA,
+            jobId: job.id,
+          }),
+        ).to.equal(0);
+        expect(
+          (
+            await getCertificateJobById({
+              workspaceId: workspaceA,
+              jobId: job.id,
+            })
+          ).status,
+        ).to.equal("pending");
+        expectNoSensitiveValues(response.body, token.plaintextToken);
+      }
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("requires evidence scope before scanning or persisting evidence-bearing events", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-evidence-scope",
+    );
+
+    try {
+      const eventsToken = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write"],
+      });
+      const evidenceToken = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write", "certops:evidence:write"],
+      });
+      const app = buildExecutorApp();
+      const lifecycleJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const evidenceJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const validEvidence = {
+        schemaVersion: 1,
+        evidenceId: `evidence-${crypto.randomUUID()}`,
+        jobId: evidenceJob.id,
+        workspaceId: workspaceA,
+        certificateId: "cert-1",
+        eventType: "certificate.observed",
+        source: "executor",
+        observedAt: new Date().toISOString(),
+      };
+
+      const lifecycle = await supertest(app)
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${eventsToken.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: lifecycleJob.id }));
+      expect(lifecycle.status).to.equal(202);
+
+      for (const body of [
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: evidenceJob.id,
+          eventType: "evidence.attached",
+          status: "accepted",
+        }),
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: evidenceJob.id,
+          eventType: "job.progress",
+          status: "running",
+          evidence: [validEvidence],
+        }),
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: evidenceJob.id,
+          eventType: "job.progress",
+          status: "running",
+          evidence: [{ ...validEvidence, privateKey: PRIVATE_KEY_PEM }],
+        }),
+      ]) {
+        const before = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: evidenceJob.id,
+        });
+        const response = await supertest(app)
+          .post("/api/v1/certops/executor/events")
+          .set("Authorization", `Bearer ${eventsToken.plaintextToken}`)
+          .send(body);
+        const after = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: evidenceJob.id,
+        });
+
+        expect(response.status).to.equal(403);
+        expect(response.body.code).to.equal("CERTOPS_API_TOKEN_SCOPE_DENIED");
+        expect(after).to.deep.equal(before);
+        expect(
+          await countExecutorEventRecords({
+            workspaceId: workspaceA,
+            jobId: evidenceJob.id,
+          }),
+        ).to.equal(0);
+        expectNoSensitiveValues(response.body, eventsToken.plaintextToken);
+      }
+
+      const accepted = await supertest(app)
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${evidenceToken.plaintextToken}`)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: evidenceJob.id,
+            eventType: "evidence.attached",
+            status: "accepted",
+            evidence: [validEvidence],
+          }),
+        );
+      expect(accepted.status).to.equal(202);
+      expect(accepted.body.evidenceId).to.be.a("string").that.is.not.empty;
+      expectNoSensitiveValues(accepted.body, evidenceToken.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("does not reopen terminal jobs when late lifecycle events arrive", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-terminal",
+    );
+
+    try {
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write"],
+      });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+
+      const terminalCases = [
+        {
+          initialStatus: "running",
+          terminalEventType: "job.completed",
+          terminalStatus: "succeeded",
+          timestamp: "completedAt",
+        },
+        {
+          initialStatus: "running",
+          terminalEventType: "job.failed",
+          terminalStatus: "failed",
+          timestamp: "completedAt",
+        },
+        {
+          initialStatus: "cancelled",
+          terminalEventType: null,
+          terminalStatus: "cancelled",
+          timestamp: "cancelledAt",
+        },
+      ];
+
+      for (const terminalCase of terminalCases) {
+        const job = await createJob({
+          workspaceId: workspaceA,
+          ownerId,
+          status: terminalCase.initialStatus,
+        });
+
+        if (terminalCase.terminalEventType) {
+          const terminal = await supertest(app)
+            .post(route)
+            .set("Authorization", `Bearer ${token.plaintextToken}`)
+            .send(
+              eventPayload({
+                workspaceId: workspaceA,
+                jobId: job.id,
+                eventType: terminalCase.terminalEventType,
+                status: terminalCase.terminalStatus,
+              }),
+            );
+          expect(terminal.status).to.equal(202);
+        }
+
+        const beforeJob = await getCertificateJobById({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const beforeArtifacts = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const late = await supertest(app)
+          .post(route)
+          .set("Authorization", `Bearer ${token.plaintextToken}`)
+          .send(
+            eventPayload({
+              workspaceId: workspaceA,
+              jobId: job.id,
+              eventType: "job.started",
+              status: "running",
+            }),
+          );
+        const afterJob = await getCertificateJobById({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const afterArtifacts = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+
+        expect(late.status).to.equal(409);
+        expect(late.body.code).to.equal(
+          "CERTOPS_JOB_STATUS_TRANSITION_INVALID",
+        );
+        expect(afterJob.status).to.equal(terminalCase.terminalStatus);
+        expect(afterJob[terminalCase.timestamp]).to.equal(
+          beforeJob[terminalCase.timestamp],
+        );
+        expect(afterJob[terminalCase.timestamp]).to.be.a("string").that.is.not
+          .empty;
+        expect(afterArtifacts).to.deep.equal(beforeArtifacts);
+        expectNoSensitiveValues(late.body, token.plaintextToken);
+      }
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("processes executor events atomically and idempotently", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-idempotency",
+    );
+
+    try {
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:events:write", "certops:evidence:write"],
+      });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      const replayJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const replayPayload = eventPayload({
+        workspaceId: workspaceA,
+        jobId: replayJob.id,
+      });
+      const first = await supertest(app).post(route).set("Authorization", auth).send(replayPayload);
+      const afterFirst = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: replayJob.id,
+      });
+      const replay = await supertest(app).post(route).set("Authorization", auth).send(replayPayload);
+      const afterReplay = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: replayJob.id,
+      });
+
+      expect(first.status).to.equal(202);
+      expect(first.body.duplicate).to.equal(undefined);
+      expect(replay.status).to.equal(202);
+      expect(replay.body).to.include({ ...first.body, duplicate: true });
+      expect(afterReplay).to.deep.equal(afterFirst);
+      expect(
+        await countExecutorEventRecords({
+          workspaceId: workspaceA,
+          jobId: replayJob.id,
+        }),
+      ).to.equal(1);
+      expectNoSensitiveValues(replay.body, token.plaintextToken);
+
+      const conflictJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const conflictPayload = eventPayload({
+        workspaceId: workspaceA,
+        jobId: conflictJob.id,
+        eventType: "job.progress",
+        status: "running",
+      });
+      const conflictFirst = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(conflictPayload);
+      const beforeConflict = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: conflictJob.id,
+      });
+      const conflict = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send({ ...conflictPayload, status: "claimed" });
+      const afterConflict = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: conflictJob.id,
+      });
+
+      expect(conflictFirst.status).to.equal(202);
+      expect(conflict.status).to.equal(409);
+      expect(conflict.body.code).to.equal(
+        "CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT",
+      );
+      expect(afterConflict).to.deep.equal(beforeConflict);
+      expectNoSensitiveValues(conflict.body, token.plaintextToken);
+
+      const evidenceJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const evidencePayload = eventPayload({
+        workspaceId: workspaceA,
+        jobId: evidenceJob.id,
+        eventType: "evidence.attached",
+        status: "accepted",
+        evidence: [
+          {
+            schemaVersion: 1,
+            evidenceId: `evidence-${crypto.randomUUID()}`,
+            jobId: evidenceJob.id,
+            workspaceId: workspaceA,
+            certificateId: "cert-1",
+            eventType: "certificate.observed",
+            source: "executor",
+            observedAt: new Date().toISOString(),
+            summary: "Initial public observation",
+          },
+        ],
+      });
+      const evidenceFirst = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(evidencePayload);
+      const beforeEvidenceConflict = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: evidenceJob.id,
+      });
+      const evidenceConflict = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send({
+          ...evidencePayload,
+          evidence: [
+            { ...evidencePayload.evidence[0], summary: "Changed public observation" },
+          ],
+        });
+      const afterEvidenceConflict = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: evidenceJob.id,
+      });
+
+      expect(evidenceFirst.status).to.equal(202);
+      expect(evidenceConflict.status).to.equal(409);
+      expect(evidenceConflict.body.code).to.equal(
+        "CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT",
+      );
+      expect(afterEvidenceConflict).to.deep.equal(beforeEvidenceConflict);
+
+      const rollbackJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const beforeRollback = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: rollbackJob.id,
+      });
+      const rollback = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: rollbackJob.id,
+            eventType: "evidence.attached",
+            status: "accepted",
+            evidence: [
+              {
+                schemaVersion: 1,
+                evidenceId: `evidence-${crypto.randomUUID()}`,
+                jobId: rollbackJob.id,
+                workspaceId: workspaceA,
+                eventType: "not-a-valid-evidence-type",
+                source: "executor",
+                observedAt: new Date().toISOString(),
+              },
+            ],
+          }),
+        );
+      const afterRollback = await countJobArtifacts({
+        workspaceId: workspaceA,
+        jobId: rollbackJob.id,
+      });
+
+      expect(rollback.status).to.equal(400);
+      expect(rollback.body.code).to.equal("CERTOPS_EVIDENCE_TYPE_INVALID");
+      expect(afterRollback).to.deep.equal(beforeRollback);
+      expect(
+        await countExecutorEventRecords({
+          workspaceId: workspaceA,
+          jobId: rollbackJob.id,
+        }),
+      ).to.equal(0);
+      expectNoSensitiveValues(rollback.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
   it("creates sanitized evidence and appends evidence.attached logs", async () => {
     const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
       "certops-executor-events-evidence",
@@ -442,7 +968,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:events:write"],
+        scopes: ["certops:events:write", "certops:evidence:write"],
       });
       const response = await supertest(buildExecutorApp())
         .post("/api/v1/certops/executor/events")
@@ -536,7 +1062,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:events:write"],
+        scopes: ["certops:events:write", "certops:evidence:write"],
       });
       const app = buildExecutorApp();
       const route = "/api/v1/certops/executor/events";

--- a/tests/integration/certops-executor-events.test.js
+++ b/tests/integration/certops-executor-events.test.js
@@ -20,6 +20,7 @@ const {
 } = require("../../apps/api/services/certops/evidence");
 const {
   createCsrfExemptMiddleware,
+  isCertOpsMachineTokenCsrfExemptPath,
 } = require("../../apps/api/middleware/csrf-exempt");
 const {
   createCertOpsExecutorRouter,
@@ -100,6 +101,7 @@ function buildExecutorApp({ rateLimitOptions, csrf = false } = {}) {
           error: "Invalid CSRF token",
           code: "EBADCSRFTOKEN",
         }),
+        { allowPath: isCertOpsMachineTokenCsrfExemptPath },
       ),
     );
   }
@@ -133,7 +135,7 @@ async function createScopedToken({ workspaceId, ownerId, scopes }) {
   });
 }
 
-async function createJob({ workspaceId, ownerId }) {
+async function createJob({ workspaceId, ownerId, status = "pending" }) {
   return createCertificateJob({
     workspaceId,
     operation: "deploy",
@@ -145,6 +147,7 @@ async function createJob({ workspaceId, ownerId }) {
       fingerprintSha256:
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     },
+    status,
     requestedByUserId: ownerId,
   });
 }
@@ -193,7 +196,7 @@ describe("CertOps executor event ingestion", function () {
     await runMigrations();
   });
 
-  it("requires a valid machine token with certops:executor:events scope", async () => {
+  it("requires a valid machine token with certops:events:write scope", async () => {
     const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
       "certops-executor-events-auth",
     );
@@ -203,7 +206,7 @@ describe("CertOps executor event ingestion", function () {
       const scoped = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const jobsOnly = await createScopedToken({
         workspaceId: workspaceA,
@@ -246,8 +249,12 @@ describe("CertOps executor event ingestion", function () {
         .send(payload);
       expect(ok.status).to.equal(202);
       expect(ok.body.ok).to.equal(true);
+      expect(ok.body.eventId).to.be.a("string").that.is.not.empty;
       expect(ok.body.jobId).to.equal(job.id);
       expect(ok.body.status).to.equal("running");
+      expect(ok.body.evidenceId).to.equal(undefined);
+      expect(ok.body.accepted).to.equal(undefined);
+      expect(ok.body.code).to.equal(undefined);
       expect(ok.body.user).to.equal(undefined);
       expect(ok.body.authenticated).to.equal(undefined);
       expectNoSensitiveValues(ok.body, scoped.plaintextToken);
@@ -266,7 +273,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const app = buildExecutorApp({ rateLimitOptions: { windowMs: 60_000, max: 1 } });
       const route = "/api/v1/certops/executor/events";
@@ -300,7 +307,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const app = buildExecutorApp({ csrf: true });
 
@@ -330,7 +337,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const route = "/api/v1/certops/executor/events";
 
@@ -348,7 +355,11 @@ describe("CertOps executor event ingestion", function () {
         })).status,
       ).to.equal("running");
 
-      const completedJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const completedJob = await createJob({
+        workspaceId: workspaceA,
+        ownerId,
+        status: "running",
+      });
       const completed = await supertest(app)
         .post(route)
         .set("Authorization", `Bearer ${token.plaintextToken}`)
@@ -369,7 +380,11 @@ describe("CertOps executor event ingestion", function () {
         })).status,
       ).to.equal("succeeded");
 
-      const failedJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const failedJob = await createJob({
+        workspaceId: workspaceA,
+        ownerId,
+        status: "running",
+      });
       const failed = await supertest(app)
         .post(route)
         .set("Authorization", `Bearer ${token.plaintextToken}`)
@@ -397,13 +412,13 @@ describe("CertOps executor event ingestion", function () {
           }),
         );
       expect(progress.status).to.equal(202);
-      expect(progress.body.status).to.equal("queued");
+      expect(progress.body.status).to.equal("pending");
       expect(
         (await getCertificateJobById({
           workspaceId: workspaceA,
           jobId: progressJob.id,
         })).status,
-      ).to.equal("queued");
+      ).to.equal("pending");
 
       const logs = await listCertificateJobLog({
         workspaceId: workspaceA,
@@ -427,7 +442,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const response = await supertest(buildExecutorApp())
         .post("/api/v1/certops/executor/events")
@@ -521,7 +536,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const app = buildExecutorApp();
       const route = "/api/v1/certops/executor/events";
@@ -627,7 +642,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const job = await createJob({ workspaceId: workspaceA, ownerId });
       const app = buildExecutorApp();
@@ -683,7 +698,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const job = await createJob({ workspaceId: workspaceA, ownerId });
       const app = buildExecutorApp();
@@ -856,7 +871,7 @@ describe("CertOps executor event ingestion", function () {
       const tokenA = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const response = await supertest(buildExecutorApp())
         .post("/api/v1/certops/executor/events")
@@ -870,7 +885,7 @@ describe("CertOps executor event ingestion", function () {
         workspaceId: workspaceB,
         jobId: jobB.id,
       });
-      expect(jobBStatus.status).to.equal("queued");
+      expect(jobBStatus.status).to.equal("pending");
       expectNoSensitiveValues(response.body, tokenA.plaintextToken);
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
@@ -887,7 +902,7 @@ describe("CertOps executor event ingestion", function () {
       const token = await createScopedToken({
         workspaceId: workspaceA,
         ownerId,
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
       const app = buildExecutorApp();
       const route = "/api/v1/certops/executor/events";

--- a/tests/integration/certops-executor-events.test.js
+++ b/tests/integration/certops-executor-events.test.js
@@ -1,0 +1,625 @@
+const crypto = require("crypto");
+const { createRequire } = require("module");
+const supertest = require("supertest");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+const { createApiToken } = require("../../apps/api/services/certops/apiTokens");
+const {
+  createCertificateJob,
+  getCertificateJobById,
+  listCertificateJobLog,
+} = require("../../apps/api/services/certops/jobs");
+const {
+  listCertificateEvidence,
+} = require("../../apps/api/services/certops/evidence");
+const {
+  createCsrfExemptMiddleware,
+} = require("../../apps/api/middleware/csrf-exempt");
+const {
+  createCertOpsExecutorRouter,
+} = require("../../apps/api/routes/certops-executor");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
+
+const PRIVATE_KEY_PEM =
+  "-----BEGIN RSA PRIVATE KEY-----\nRkFLRS1OT1QtQS1SRUFMLUtFWQ==\n-----END RSA PRIVATE KEY-----";
+
+async function createWorkspacePair(label) {
+  const ownerEmail = `${label}-${Date.now()}-${crypto.randomUUID()}@example.com`;
+  const owner = await TestUtils.execQuery(
+    `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+     VALUES ($1, $2, $3, $4, 'local', TRUE)
+     RETURNING id`,
+    [
+      ownerEmail.toLowerCase(),
+      ownerEmail,
+      label,
+      "not-used-in-certops-executor-events-test",
+    ],
+  );
+  const ownerId = owner.rows[0].id;
+  const workspaceA = crypto.randomUUID();
+  const workspaceB = crypto.randomUUID();
+
+  await TestUtils.execQuery(
+    `INSERT INTO workspaces (id, name, created_by, plan)
+     VALUES ($1, $2, $3, 'oss'), ($4, $5, $3, 'oss')`,
+    [
+      workspaceA,
+      `${label} A`,
+      ownerId,
+      workspaceB,
+      `${label} B`,
+    ],
+  );
+
+  return { ownerId, workspaceA, workspaceB };
+}
+
+async function cleanupWorkspacePair(ownerId, workspaceIds) {
+  await TestUtils.execQuery(
+    "DELETE FROM certificate_evidence WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery(
+    "DELETE FROM certificate_job_log WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery(
+    "DELETE FROM certificate_jobs WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery(
+    "DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])",
+    [workspaceIds],
+  );
+  await TestUtils.execQuery("DELETE FROM workspaces WHERE id = ANY($1::uuid[])", [
+    workspaceIds,
+  ]);
+  await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+}
+
+function buildExecutorApp({ rateLimitOptions, csrf = false } = {}) {
+  const app = express();
+  app.use(express.json());
+
+  if (csrf) {
+    app.use(
+      "/api",
+      createCsrfExemptMiddleware((_req, res) =>
+        res.status(403).json({
+          error: "Invalid CSRF token",
+          code: "EBADCSRFTOKEN",
+        }),
+      ),
+    );
+  }
+
+  app.use(
+    createCertOpsExecutorRouter({
+      rateLimitOptions: rateLimitOptions || { windowMs: 60_000, max: 100 },
+    }),
+  );
+  app.post("/api/v1/workspaces/:id/certops/unrelated-write", (_req, res) =>
+    res.status(200).json({ ok: true }),
+  );
+  app.use((err, _req, res, next) => {
+    if (res.headersSent) return next(err);
+    return res.status(500).json({
+      error: "Internal test harness error",
+      code: err?.code || "INTERNAL_ERROR",
+    });
+  });
+
+  return app;
+}
+
+async function createScopedToken({ workspaceId, ownerId, scopes }) {
+  return createApiToken({
+    workspaceId,
+    name: "Executor",
+    scopes,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    createdBy: ownerId,
+  });
+}
+
+async function createJob({ workspaceId, ownerId }) {
+  return createCertificateJob({
+    workspaceId,
+    operation: "deploy",
+    source: "api",
+    subjectType: "managed_certificate",
+    subjectId: `cert-${crypto.randomUUID()}`,
+    payload: {
+      deploymentTarget: "kubernetes/default/web-cert",
+      fingerprintSha256:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
+    requestedByUserId: ownerId,
+  });
+}
+
+function eventPayload({ workspaceId, jobId, eventType = "job.started", status = "running", ...overrides }) {
+  return {
+    schemaVersion: 1,
+    eventId: `event-${crypto.randomUUID()}`,
+    workspaceId,
+    jobId,
+    eventType,
+    status,
+    occurredAt: new Date().toISOString(),
+    message: "Executor event accepted",
+    metadata: [{ name: "executor", value: "test-executor" }],
+    ...overrides,
+  };
+}
+
+function expectNoSensitiveValues(body, rawToken) {
+  const serialized = JSON.stringify(body);
+  expect(serialized).to.not.include(rawToken);
+  expect(serialized).to.not.include(`Bearer ${rawToken}`);
+  expect(serialized).to.not.include("Authorization");
+  expect(serialized).to.not.include("token_hash");
+  expect(serialized).to.not.include("PRIVATE KEY");
+  expect(serialized).to.not.include("password=swordfish");
+}
+
+describe("CertOps executor event ingestion", function () {
+  this.timeout(60000);
+
+  before(async () => {
+    await runMigrations();
+  });
+
+  it("requires a valid machine token with certops:executor:events scope", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-auth",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const scoped = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const jobsOnly = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:jobs:read"],
+      });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const payload = eventPayload({ workspaceId: workspaceA, jobId: job.id });
+
+      const missing = await supertest(app).post(route).send(payload);
+      expect(missing.status).to.equal(401);
+      expect(missing.body.code).to.equal("CERTOPS_API_TOKEN_UNAUTHORIZED");
+
+      const malformed = await supertest(app)
+        .post(route)
+        .set("Authorization", "Bearer ttx__bad")
+        .send(payload);
+      expect(malformed.status).to.equal(401);
+      expect(JSON.stringify(malformed.body)).to.not.include("ttx__bad");
+
+      const missingScope = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${jobsOnly.plaintextToken}`)
+        .send(payload);
+      expect(missingScope.status).to.equal(403);
+      expect(missingScope.body.code).to.equal("CERTOPS_API_TOKEN_SCOPE_DENIED");
+      expectNoSensitiveValues(missingScope.body, jobsOnly.plaintextToken);
+
+      const wrongWorkspaceHint = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${scoped.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceB, jobId: job.id }));
+      expect(wrongWorkspaceHint.status).to.equal(401);
+      expectNoSensitiveValues(wrongWorkspaceHint.body, scoped.plaintextToken);
+
+      const ok = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${scoped.plaintextToken}`)
+        .send(payload);
+      expect(ok.status).to.equal(202);
+      expect(ok.body.ok).to.equal(true);
+      expect(ok.body.jobId).to.equal(job.id);
+      expect(ok.body.status).to.equal("running");
+      expect(ok.body.user).to.equal(undefined);
+      expect(ok.body.authenticated).to.equal(undefined);
+      expectNoSensitiveValues(ok.body, scoped.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("applies the machine-token rate limiter", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-rate-limit",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const app = buildExecutorApp({ rateLimitOptions: { windowMs: 60_000, max: 1 } });
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      const first = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: job.id, eventType: "job.progress" }));
+      const second = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: job.id, eventType: "job.progress" }));
+
+      expect(first.status).to.equal(202);
+      expect(second.status).to.equal(429);
+      expect(second.body.code).to.equal("CERTOPS_MACHINE_RATE_LIMITED");
+      expectNoSensitiveValues(second.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("is CSRF-exempt only for the executor machine-token namespace", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-csrf",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const app = buildExecutorApp({ csrf: true });
+
+      const accepted = await supertest(app)
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: job.id }));
+      expect(accepted.status).to.equal(202);
+
+      const unrelated = await supertest(app)
+        .post(`/api/v1/workspaces/${workspaceA}/certops/unrelated-write`)
+        .send({});
+      expect(unrelated.status).to.equal(403);
+      expect(unrelated.body.code).to.equal("EBADCSRFTOKEN");
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("persists lifecycle events through job services", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-lifecycle",
+    );
+
+    try {
+      const app = buildExecutorApp();
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const route = "/api/v1/certops/executor/events";
+
+      const startedJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const started = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: startedJob.id }));
+      expect(started.status).to.equal(202);
+      expect(started.body.status).to.equal("running");
+      expect(
+        (await getCertificateJobById({
+          workspaceId: workspaceA,
+          jobId: startedJob.id,
+        })).status,
+      ).to.equal("running");
+
+      const completedJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const completed = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: completedJob.id,
+            eventType: "job.completed",
+            status: "succeeded",
+          }),
+        );
+      expect(completed.status).to.equal(202);
+      expect(completed.body.status).to.equal("succeeded");
+      expect(
+        (await getCertificateJobById({
+          workspaceId: workspaceA,
+          jobId: completedJob.id,
+        })).status,
+      ).to.equal("succeeded");
+
+      const failedJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const failed = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: failedJob.id,
+            eventType: "job.failed",
+            status: "failed",
+          }),
+        );
+      expect(failed.status).to.equal(202);
+      expect(failed.body.status).to.equal("failed");
+
+      const progressJob = await createJob({ workspaceId: workspaceA, ownerId });
+      const progress = await supertest(app)
+        .post(route)
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: progressJob.id,
+            eventType: "job.progress",
+            status: "running",
+          }),
+        );
+      expect(progress.status).to.equal(202);
+      expect(progress.body.status).to.equal("queued");
+      expect(
+        (await getCertificateJobById({
+          workspaceId: workspaceA,
+          jobId: progressJob.id,
+        })).status,
+      ).to.equal("queued");
+
+      const logs = await listCertificateJobLog({
+        workspaceId: workspaceA,
+        jobId: startedJob.id,
+      });
+      expect(logs.items.map((item) => item.eventType)).to.include("job.started");
+      expect(logs.items[0].createdByApiTokenId).to.equal(token.token.id);
+      expectNoSensitiveValues(started.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("creates sanitized evidence and appends evidence.attached logs", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-evidence",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const response = await supertest(buildExecutorApp())
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${token.plaintextToken}`)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            eventType: "evidence.attached",
+            status: "accepted",
+            evidence: [
+              {
+                schemaVersion: 1,
+                evidenceId: `evidence-${crypto.randomUUID()}`,
+                jobId: job.id,
+                workspaceId: workspaceA,
+                certificateId: "cert-1",
+                eventType: "certificate.observed",
+                source: "executor",
+                observedAt: new Date().toISOString(),
+                fingerprintSha256:
+                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                summary: "Observed public certificate fingerprint",
+                metadata: [{ name: "issuer", value: "TokenTimer Test CA" }],
+              },
+            ],
+          }),
+        );
+
+      expect(response.status).to.equal(202);
+      expect(response.body.evidenceId).to.be.a("string").that.is.not.empty;
+      const evidence = await listCertificateEvidence({
+        workspaceId: workspaceA,
+        jobId: job.id,
+      });
+      expect(evidence.items).to.have.length(1);
+      expect(evidence.items[0]).to.include({
+        evidenceType: "certificate.observed",
+        subjectType: "managed_certificate",
+        subjectId: "cert-1",
+        createdByApiTokenId: token.token.id,
+      });
+      expect(evidence.items[0].metadata.issuer).to.equal("TokenTimer Test CA");
+
+      const logs = await listCertificateJobLog({
+        workspaceId: workspaceA,
+        jobId: job.id,
+      });
+      expect(logs.items.map((item) => item.eventType)).to.include(
+        "evidence.attached",
+      );
+      expectNoSensitiveValues(response.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("returns safe errors for missing jobs and malformed events", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-errors",
+    );
+
+    try {
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      const missingJob = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: crypto.randomUUID() }));
+      expect(missingJob.status).to.equal(404);
+      expect(missingJob.body.code).to.equal("CERTOPS_JOB_NOT_FOUND");
+
+      const invalidType = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            eventType: "job.created",
+          }),
+        );
+      expect(invalidType.status).to.equal(400);
+      expect(invalidType.body.code).to.equal(
+        "CERTOPS_EXECUTOR_EVENT_TYPE_INVALID",
+      );
+
+      const invalidStatus = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            status: "queued",
+          }),
+        );
+      expect(invalidStatus.status).to.equal(400);
+      expect(invalidStatus.body.code).to.equal("CERTOPS_JOB_STATUS_INVALID");
+      expectNoSensitiveValues(invalidStatus.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("enforces workspace isolation through the authenticated token workspace", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-isolation",
+    );
+
+    try {
+      const jobB = await createJob({ workspaceId: workspaceB, ownerId });
+      const tokenA = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const response = await supertest(buildExecutorApp())
+        .post("/api/v1/certops/executor/events")
+        .set("Authorization", `Bearer ${tokenA.plaintextToken}`)
+        .send(eventPayload({ workspaceId: workspaceA, jobId: jobB.id }));
+
+      expect(response.status).to.equal(404);
+      expect(response.body.code).to.equal("CERTOPS_JOB_NOT_FOUND");
+
+      const jobBStatus = await getCertificateJobById({
+        workspaceId: workspaceB,
+        jobId: jobB.id,
+      });
+      expect(jobBStatus.status).to.equal("queued");
+      expectNoSensitiveValues(response.body, tokenA.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects private-key and secret-looking payloads before persistence", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-security",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      const dangerousBodies = [
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          privateKey: "not-allowed",
+        }),
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          message: PRIVATE_KEY_PEM,
+        }),
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          message: "password=swordfish",
+        }),
+        eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          metadata: [{ name: "credential", value: "abc" }],
+        }),
+      ];
+
+      for (const body of dangerousBodies) {
+        const beforeLogs = await listCertificateJobLog({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const response = await supertest(app)
+          .post(route)
+          .set("Authorization", auth)
+          .send(body);
+        const afterLogs = await listCertificateJobLog({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+
+        expect(response.status).to.equal(422);
+        expect(response.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+        expect(afterLogs.items).to.have.length(beforeLogs.items.length);
+        expectNoSensitiveValues(response.body, token.plaintextToken);
+      }
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+});

--- a/tests/integration/certops-executor-events.test.js
+++ b/tests/integration/certops-executor-events.test.js
@@ -451,6 +451,19 @@ describe("CertOps executor event ingestion", function () {
                 fingerprintSha256:
                   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 summary: "Observed public certificate fingerprint",
+                artifactRefs: [
+                  {
+                    type: "report",
+                    reference: "reports/certops/public-observation.json",
+                    sha256:
+                      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                  },
+                  {
+                    type: "log",
+                    reference: "executor-log-1",
+                    sha256: null,
+                  },
+                ],
                 metadata: [{ name: "issuer", value: "TokenTimer Test CA" }],
               },
             ],
@@ -471,6 +484,19 @@ describe("CertOps executor event ingestion", function () {
         createdByApiTokenId: token.token.id,
       });
       expect(evidence.items[0].metadata.issuer).to.equal("TokenTimer Test CA");
+      expect(evidence.items[0].metadata.artifactRefs).to.deep.equal([
+        {
+          type: "report",
+          reference: "reports/certops/public-observation.json",
+          sha256:
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        },
+        {
+          type: "log",
+          reference: "executor-log-1",
+          sha256: null,
+        },
+      ]);
 
       const logs = await listCertificateJobLog({
         workspaceId: workspaceA,
@@ -480,6 +506,113 @@ describe("CertOps executor event ingestion", function () {
         "evidence.attached",
       );
       expectNoSensitiveValues(response.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects malformed evidence artifactRefs before job log or evidence persistence", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-artifact-refs",
+    );
+
+    try {
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      function eventWithArtifactRefs(artifactRefs) {
+        return eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          eventType: "evidence.attached",
+          status: "accepted",
+          evidence: [
+            {
+              schemaVersion: 1,
+              evidenceId: `evidence-${crypto.randomUUID()}`,
+              jobId: job.id,
+              workspaceId: workspaceA,
+              certificateId: "cert-1",
+              eventType: "certificate.observed",
+              source: "executor",
+              observedAt: new Date().toISOString(),
+              artifactRefs,
+            },
+          ],
+        });
+      }
+
+      async function expectArtifactRefsRejected({
+        artifactRefs,
+        status = 400,
+        code = "CERTOPS_EXECUTOR_EVENT_INVALID",
+        forbidden = [],
+      }) {
+        const before = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const response = await supertest(app)
+          .post(route)
+          .set("Authorization", auth)
+          .send(eventWithArtifactRefs(artifactRefs));
+        const after = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+
+        expect(response.status).to.equal(status);
+        expect(response.status).to.not.equal(500);
+        expect(response.body.code).to.equal(code);
+        expect(response.body.code).to.not.equal("INTERNAL_ERROR");
+        expect(after).to.deep.equal(before);
+        expectNoSensitiveValues(response.body, token.plaintextToken, forbidden);
+      }
+
+      const validArtifactRef = {
+        type: "report",
+        reference: "reports/certops/public-observation.json",
+        sha256:
+          "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      };
+
+      await expectArtifactRefsRejected({
+        artifactRefs: Array.from({ length: 17 }, () => validArtifactRef),
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ ...validArtifactRef, type: "archive" }],
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ type: "log" }],
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ ...validArtifactRef, reference: "a".repeat(513) }],
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ ...validArtifactRef, sha256: "not-a-sha256" }],
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ ...validArtifactRef, extra: "not-allowed" }],
+      });
+
+      await expectArtifactRefsRejected({
+        artifactRefs: [{ type: "log", reference: "password=swordfish" }],
+        status: 422,
+        code: "PRIVATE_KEY_MATERIAL_REJECTED",
+        forbidden: ["password=swordfish"],
+      });
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
     }

--- a/tests/integration/certops-executor-events.test.js
+++ b/tests/integration/certops-executor-events.test.js
@@ -164,7 +164,16 @@ function eventPayload({ workspaceId, jobId, eventType = "job.started", status = 
   };
 }
 
-function expectNoSensitiveValues(body, rawToken) {
+async function countJobArtifacts({ workspaceId, jobId }) {
+  const logs = await listCertificateJobLog({ workspaceId, jobId });
+  const evidence = await listCertificateEvidence({ workspaceId, jobId });
+  return {
+    logs: logs.items.length,
+    evidence: evidence.items.length,
+  };
+}
+
+function expectNoSensitiveValues(body, rawToken, extraForbidden = []) {
   const serialized = JSON.stringify(body);
   expect(serialized).to.not.include(rawToken);
   expect(serialized).to.not.include(`Bearer ${rawToken}`);
@@ -172,6 +181,9 @@ function expectNoSensitiveValues(body, rawToken) {
   expect(serialized).to.not.include("token_hash");
   expect(serialized).to.not.include("PRIVATE KEY");
   expect(serialized).to.not.include("password=swordfish");
+  for (const value of extraForbidden) {
+    expect(serialized).to.not.include(value);
+  }
 }
 
 describe("CertOps executor event ingestion", function () {
@@ -524,6 +536,178 @@ describe("CertOps executor event ingestion", function () {
       expect(invalidStatus.status).to.equal(400);
       expect(invalidStatus.body.code).to.equal("CERTOPS_JOB_STATUS_INVALID");
       expectNoSensitiveValues(invalidStatus.body, token.plaintextToken);
+    } finally {
+      await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
+    }
+  });
+
+  it("rejects malformed IDs and metadata at the route boundary", async () => {
+    const { ownerId, workspaceA, workspaceB } = await createWorkspacePair(
+      "certops-executor-events-boundary",
+    );
+
+    try {
+      const token = await createScopedToken({
+        workspaceId: workspaceA,
+        ownerId,
+        scopes: ["certops:executor:events"],
+      });
+      const job = await createJob({ workspaceId: workspaceA, ownerId });
+      const app = buildExecutorApp();
+      const route = "/api/v1/certops/executor/events";
+      const auth = `Bearer ${token.plaintextToken}`;
+
+      async function expectRejectedWithoutPersistence({
+        body,
+        status,
+        statuses,
+        code,
+        forbidden = [],
+      }) {
+        const before = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+        const response = await supertest(app)
+          .post(route)
+          .set("Authorization", auth)
+          .send(body);
+        const after = await countJobArtifacts({
+          workspaceId: workspaceA,
+          jobId: job.id,
+        });
+
+        if (statuses) {
+          expect(response.status).to.be.oneOf(statuses);
+        } else {
+          expect(response.status).to.equal(status);
+        }
+        expect(response.status).to.not.equal(500);
+        expect(response.body.code).to.not.equal("INTERNAL_ERROR");
+        if (code) expect(response.body.code).to.equal(code);
+        expect(after).to.deep.equal(before);
+        expectNoSensitiveValues(response.body, token.plaintextToken, forbidden);
+        return response;
+      }
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({ workspaceId: workspaceA, jobId: "not-a-uuid" }),
+        status: 400,
+      });
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({ workspaceId: "not-a-uuid", jobId: job.id }),
+        statuses: [400, 401, 403],
+      });
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          eventId: "a".repeat(129),
+        }),
+        status: 400,
+        code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+      });
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          eventId: "event/bad",
+        }),
+        status: 400,
+        code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+      });
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          metadata: Array.from({ length: 33 }, (_value, index) => ({
+            name: `m${index}`,
+            value: index,
+          })),
+        }),
+        status: 400,
+        code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+      });
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          metadata: [{ name: "a".repeat(65), value: "too-long-name" }],
+        }),
+        status: 400,
+        code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+      });
+
+      for (const forbiddenName of ["privateKey", "credential"]) {
+        await expectRejectedWithoutPersistence({
+          body: eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            metadata: [{ name: forbiddenName, value: "not-allowed" }],
+          }),
+          status: 422,
+          code: "PRIVATE_KEY_MATERIAL_REJECTED",
+          forbidden: [forbiddenName],
+        });
+      }
+
+      await expectRejectedWithoutPersistence({
+        body: eventPayload({
+          workspaceId: workspaceA,
+          jobId: job.id,
+          metadata: [{ name: "longValue", value: "a".repeat(513) }],
+        }),
+        status: 400,
+        code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+      });
+
+      for (const value of [{ nested: "object" }, ["array"]]) {
+        await expectRejectedWithoutPersistence({
+          body: eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            metadata: [{ name: "badValue", value }],
+          }),
+          status: 400,
+          code: "CERTOPS_EXECUTOR_EVENT_INVALID",
+        });
+      }
+
+      const safe = await supertest(app)
+        .post(route)
+        .set("Authorization", auth)
+        .send(
+          eventPayload({
+            workspaceId: workspaceA,
+            jobId: job.id,
+            eventType: "job.progress",
+            status: "running",
+            metadata: [
+              { name: "executor", value: "test-executor" },
+              { name: "attempt", value: 2 },
+              { name: "canary", value: true },
+            ],
+          }),
+        );
+      expect(safe.status).to.equal(202);
+      const logs = await listCertificateJobLog({
+        workspaceId: workspaceA,
+        jobId: job.id,
+      });
+      const progressLog = logs.items.find(
+        (item) => item.eventType === "job.progress",
+      );
+      expect(progressLog.metadata).to.include({
+        executor: "test-executor",
+        attempt: 2,
+        canary: true,
+      });
+      expectNoSensitiveValues(safe.body, token.plaintextToken);
     } finally {
       await cleanupWorkspacePair(ownerId, [workspaceA, workspaceB]);
     }

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -77,6 +77,7 @@ tests/integration/certops-api-tokens.test.js
 tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js
+tests/integration/certops-executor-events.test.js
 
 # Integrations
 tests/integration/github.integration.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -91,6 +91,7 @@ tests/integration/certops-api-tokens.test.js
 tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js
+tests/integration/certops-executor-events.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -24,6 +24,10 @@ const certOpsRoutesSource = fs.readFileSync(
   path.join(repoRoot, "apps/api/routes/certops.js"),
   "utf8",
 );
+const certOpsExecutorRoutesSource = fs.readFileSync(
+  path.join(repoRoot, "apps/api/routes/certops-executor.js"),
+  "utf8",
+);
 const {
   JOB_STATUSES,
   LOG_STATUSES,
@@ -300,7 +304,6 @@ function openApiComponentBlock(componentName) {
     nextComponent === -1
       ? openApiSource.length
       : start + marker.length + nextComponent;
-
   return openApiSource.slice(start, end);
 }
 
@@ -605,6 +608,27 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(validate({ ...validJobPayload(), privateKey: "nope" }), false);
   });
 
+  it("documents the executor event 202 response shape returned by runtime", () => {
+    const schemaBlock = openApiComponentBlock(
+      "CertOpsExecutorEventAcceptedResponse",
+    );
+
+    assert.match(schemaBlock, /required: \[ok, eventId, jobId, status\]/);
+    assert.doesNotMatch(schemaBlock, /required: \[accepted, code\]/);
+    assert.doesNotMatch(schemaBlock, /\n        accepted:/);
+    assert.doesNotMatch(schemaBlock, /\n        code:/);
+    assert.match(schemaBlock, /\n        ok:\r?\n          type: boolean\r?\n          enum: \[true\]/);
+    assert.match(schemaBlock, /\n        eventId:\r?\n          type: string/);
+    assert.match(schemaBlock, /maxLength: 128/);
+    assert.match(schemaBlock, /pattern: "\^\[A-Za-z0-9_\.\:-\]\+\$"/);
+    assert.match(schemaBlock, /\n        jobId:\r?\n          type: string\r?\n          format: uuid/);
+    assert.match(
+      schemaBlock,
+      /\n        status:\r?\n          type: string\r?\n          enum: \[pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled\]/,
+    );
+    assert.match(schemaBlock, /\n        evidenceId:\r?\n          type: string\r?\n          format: uuid\r?\n          nullable: true/);
+  });
+
   it("keeps the executor event route aligned between OpenAPI and route compat", () => {
     const routePath = "/api/v1/certops/executor/events";
     const method = "POST";
@@ -629,6 +653,18 @@ describe("CertOps M2 contract skeletons", () => {
     assert.match(
       routeBlock,
       /\$ref: "#\/components\/schemas\/CertOpsExecutorEventAcceptedResponse"/,
+    );
+  });
+
+  it("uses the canonical machine event scope and ordered rate-limit guards", () => {
+    assert.match(
+      certOpsExecutorRoutesSource,
+      /const EXECUTOR_EVENT_SCOPE = "certops:events:write"/,
+    );
+    assert.doesNotMatch(certOpsExecutorRoutesSource, /certops:executor:events/);
+    assert.match(
+      certOpsExecutorRoutesSource,
+      /certOpsExecutorRouter\.post\(\s*"\/api\/v1\/certops\/executor\/events",\s*preAuthRateLimitMiddleware,\s*authMiddleware,\s*rateLimitMiddleware,\s*executorEventsHandler,/s,
     );
   });
 

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -759,19 +759,22 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("keeps the committed M2-A1 through M2-A5 diff within the stacked scope", () => {
+  it("keeps the committed M2-A1 through M2-A6 diff within the stacked scope", () => {
     const { ref, files } = prChangedFiles();
     const allowedM2Files = new Set([
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",
       "apps/api/middleware/csrf-exempt.js",
       "apps/api/middleware/machine-token-rate-limit.js",
+      "apps/api/index.js",
+      "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
       "apps/api/services/certops/jobs.js",
       "apps/api/utils/secretMaterial.js",
       "tests/integration/certops-api-token-auth.test.js",
       "tests/integration/certops-api-tokens.test.js",
+      "tests/integration/certops-executor-events.test.js",
       "tests/integration/certops-jobs-evidence.test.js",
       "tests/integration/certops-machine-token-rate-limit.test.js",
       "tests/integration/suites/core-compatible.txt",
@@ -796,7 +799,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.deepEqual(
       files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `stacked M2-A1 through M2-A5 diff against ${ref} must stay within the allowed scope`,
+      `stacked M2-A1 through M2-A6 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -807,12 +810,14 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
   });
 
-  it("keeps local app changes within the M2-A2 through M2-A5 backend scope", () => {
+  it("keeps local app changes within the M2-A2 through M2-A6 backend scope", () => {
     const allowedStackedM2Files = new Set([
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",
       "apps/api/middleware/csrf-exempt.js",
       "apps/api/middleware/machine-token-rate-limit.js",
+      "apps/api/index.js",
+      "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
       "apps/api/services/certops/jobs.js",

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -627,6 +627,10 @@ describe("CertOps M2 contract skeletons", () => {
       /\n        status:\r?\n          type: string\r?\n          enum: \[pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled\]/,
     );
     assert.match(schemaBlock, /\n        evidenceId:\r?\n          type: string\r?\n          format: uuid\r?\n          nullable: true/);
+    assert.match(
+      schemaBlock,
+      /\n        duplicate:\r?\n          type: boolean\r?\n          default: false/,
+    );
   });
 
   it("keeps the executor event route aligned between OpenAPI and route compat", () => {
@@ -654,17 +658,35 @@ describe("CertOps M2 contract skeletons", () => {
       routeBlock,
       /\$ref: "#\/components\/schemas\/CertOpsExecutorEventAcceptedResponse"/,
     );
+    assert.match(routeBlock, /certops:events:write/);
+    assert.match(routeBlock, /certops:evidence:write/);
+    assert.doesNotMatch(routeBlock, /certops:executor:events/);
+    assert.match(routeBlock, /"404":/);
+    assert.match(routeBlock, /"409":/);
+    assert.match(routeBlock, /PRIVATE_KEY_MATERIAL_REJECTED/);
   });
 
-  it("uses the canonical machine event scope and ordered rate-limit guards", () => {
+  it("uses canonical executor scopes with feature, auth, and rate-limit guards", () => {
     assert.match(
       certOpsExecutorRoutesSource,
       /const EXECUTOR_EVENT_SCOPE = "certops:events:write"/,
     );
+    assert.match(
+      certOpsExecutorRoutesSource,
+      /const EXECUTOR_EVIDENCE_SCOPE = "certops:evidence:write"/,
+    );
     assert.doesNotMatch(certOpsExecutorRoutesSource, /certops:executor:events/);
     assert.match(
       certOpsExecutorRoutesSource,
-      /certOpsExecutorRouter\.post\(\s*"\/api\/v1\/certops\/executor\/events",\s*preAuthRateLimitMiddleware,\s*authMiddleware,\s*rateLimitMiddleware,\s*executorEventsHandler,/s,
+      /certOpsExecutorRouter\.post\(\s*"\/api\/v1\/certops\/executor\/events",\s*preAuthRateLimitMiddleware,\s*certOpsEnabledMiddleware,\s*authMiddleware,\s*rateLimitMiddleware,\s*requireExecutorEvidenceScope,\s*executorEventsHandler,/s,
+    );
+    assert.match(
+      certOpsExecutorRoutesSource,
+      /CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT/,
+    );
+    assert.match(
+      certOpsExecutorRoutesSource,
+      /CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH/,
     );
   });
 
@@ -806,6 +828,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
+      "apps/api/services/certops/executorEvents.js",
       "apps/api/services/certops/jobs.js",
       "apps/api/utils/secretMaterial.js",
       "tests/integration/certops-api-token-auth.test.js",
@@ -856,6 +879,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
+      "apps/api/services/certops/executorEvents.js",
       "apps/api/services/certops/jobs.js",
       "apps/api/utils/secretMaterial.js",
     ]);

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -31,6 +31,8 @@ const CERTOPS_JOB_TABLES = [
   "certificate_evidence",
 ];
 
+const CERTOPS_EXECUTOR_EVENT_TABLES = ["certificate_executor_events"];
+
 const BASELINE_CERTOPS_COLUMNS = {
   certificate_profiles: [
     "id",
@@ -136,6 +138,9 @@ const certOpsApiTokensMigration = migrations.find(
 const certOpsJobsEvidenceMigration = migrations.find(
   (migration) => migration.name === "certops_jobs_evidence_schema",
 );
+const certOpsExecutorEventMigration = migrations.find(
+  (migration) => migration.name === "certops_executor_event_idempotency",
+);
 
 function getTableBlock(tableName, migration = certOpsMigration) {
   const marker = `CREATE TABLE IF NOT EXISTS ${tableName} (`;
@@ -190,8 +195,8 @@ describe("CertOps inventory migration", () => {
     );
     assert.equal(certOpsTokenLifecycleMigration.version, 11);
     assert.deepEqual(
-      migrations.slice(-4).map((migration) => migration.version),
-      [10, 11, 12, 13],
+      migrations.slice(-5).map((migration) => migration.version),
+      [10, 11, 12, 13, 14],
     );
     assert.match(
       certOpsTokenLifecycleMigration.sql,
@@ -320,6 +325,54 @@ describe("CertOps inventory migration", () => {
     );
   });
 
+  it("defines idempotent, workspace-scoped executor event records", () => {
+    assert.ok(
+      certOpsExecutorEventMigration,
+      "expected certops_executor_event_idempotency migration",
+    );
+    assert.equal(certOpsExecutorEventMigration.version, 14);
+
+    for (const tableName of CERTOPS_EXECUTOR_EVENT_TABLES) {
+      assert.match(
+        certOpsExecutorEventMigration.sql,
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${tableName} \\(`),
+      );
+      assert.match(
+        getTableBlock(tableName, certOpsExecutorEventMigration),
+        /workspace_id UUID NOT NULL REFERENCES workspaces\(id\) ON DELETE CASCADE/,
+      );
+    }
+
+    const table = getTableBlock(
+      "certificate_executor_events",
+      certOpsExecutorEventMigration,
+    );
+    assert.match(
+      table,
+      /UNIQUE \(workspace_id, job_id, executor_event_id\)/,
+    );
+    assert.match(
+      table,
+      /FOREIGN KEY \(workspace_id, job_id\)\s+REFERENCES certificate_jobs\(workspace_id, id\)\s+ON DELETE CASCADE/,
+    );
+    assert.match(
+      table,
+      /FOREIGN KEY \(workspace_id, created_by_api_token_id\)\s+REFERENCES api_tokens\(workspace_id, id\)\s+ON DELETE SET NULL \(created_by_api_token_id\)/,
+    );
+    assert.match(table, /request_hash TEXT NOT NULL/);
+    assert.match(table, /response JSONB NOT NULL DEFAULT '\{\}'::jsonb/);
+    assert.doesNotMatch(
+      table,
+      /private_key|privateKey|key_material|pfx|jks|password|credential|secret|authorization|token_hash/i,
+    );
+    for (const indexName of [
+      "idx_certificate_executor_events_workspace_job_created",
+      "idx_certificate_executor_events_workspace_event",
+    ]) {
+      assert.match(certOpsExecutorEventMigration.sql, new RegExp(indexName));
+    }
+  });
+
   it("creates every CertOps table idempotently", () => {
     for (const tableName of CERTOPS_TABLES) {
       assert.match(
@@ -350,6 +403,23 @@ describe("CertOps inventory migration", () => {
     );
     assert.doesNotMatch(
       certOpsJobsEvidenceMigration.sql,
+      /CREATE (?:UNIQUE )?INDEX (?!IF NOT EXISTS)/,
+    );
+  });
+
+  it("creates executor event records idempotently", () => {
+    for (const tableName of CERTOPS_EXECUTOR_EVENT_TABLES) {
+      assert.match(
+        certOpsExecutorEventMigration.sql,
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${tableName} \\(`),
+      );
+    }
+    assert.doesNotMatch(
+      certOpsExecutorEventMigration.sql,
+      /CREATE TABLE (?!IF NOT EXISTS)/,
+    );
+    assert.doesNotMatch(
+      certOpsExecutorEventMigration.sql,
       /CREATE (?:UNIQUE )?INDEX (?!IF NOT EXISTS)/,
     );
   });
@@ -421,6 +491,24 @@ describe("CertOps inventory migration", () => {
       for (const columnName of getColumnNames(
         tableName,
         certOpsJobsEvidenceMigration,
+      )) {
+        const hit = FORBIDDEN_CUSTODY_COLUMNS.find((fragment) =>
+          columnName.toLowerCase().includes(fragment.toLowerCase()),
+        );
+        assert.equal(
+          hit,
+          undefined,
+          `${tableName}.${columnName} looks like private-key custody`,
+        );
+      }
+    }
+  });
+
+  it("does not define private-key custody columns in executor event records", () => {
+    for (const tableName of CERTOPS_EXECUTOR_EVENT_TABLES) {
+      for (const columnName of getColumnNames(
+        tableName,
+        certOpsExecutorEventMigration,
       )) {
         const hit = FORBIDDEN_CUSTODY_COLUMNS.find((fragment) =>
           columnName.toLowerCase().includes(fragment.toLowerCase()),
@@ -553,6 +641,10 @@ describe("CertOps inventory migration", () => {
   it("defers dedicated security events and audit hash-chain storage beyond M2", () => {
     assert.doesNotMatch(
       certOpsJobsEvidenceMigration.sql,
+      /\bsecurity_events\b|\bprev_hash\b|\brow_hash\b|\balert_queue\b/i,
+    );
+    assert.doesNotMatch(
+      certOpsExecutorEventMigration.sql,
       /\bsecurity_events\b|\bprev_hash\b|\brow_hash\b|\balert_queue\b/i,
     );
   });


### PR DESCRIPTION
## Summary

This PR adds the M2-A6 CertOps executor event ingestion route.

It wires the external executor event API using the M2-A3 machine-token auth middleware, the M2-A4 machine-token rate limiter, and the M2-A5 jobs/evidence persistence services.

This PR adds:

* `POST /api/v1/certops/executor/events`
* `certops.enabled` gating for the machine-token executor route
* scoped CertOps API-token authentication with `certops:events:write`
* additional `certops:evidence:write` enforcement for evidence-bearing executor events
* dedicated pre-auth and post-auth machine-token rate limiting
* workspace-scoped executor event ingestion
* token-workspace-authoritative request handling
* lifecycle job log persistence
* lifecycle job status updates through the M2-A5 monotonic FSM
* event/status mismatch rejection
* safe terminal-state handling for late or out-of-order lifecycle events
* transactional executor event ingestion
* executor event idempotency by workspace, job, and event ID
* exact replay handling without duplicate side effects
* conflict detection for repeated event IDs with different payloads
* sanitized evidence persistence for `evidence.attached`
* recursive private-key/secret material rejection
* OpenAPI coverage for feature flag, scope, idempotency, conflict, and private-key rejection behavior
* integration coverage for auth, scope, rate limit, CSRF, lifecycle, evidence, idempotency, workspace isolation, disabled-feature behavior, and safe errors

This PR does not add dashboard UI, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, connectors, polling APIs, claim APIs, job signing, agent bootstrap credentials, security-events tables, audit hash-chain, or broad job orchestration behavior.

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* syntax checks: ok
* `pnpm exec mocha tests/integration/certops-executor-events.test.js --timeout 60000 --exit`: ok, 15 passing
* `pnpm exec mocha tests/integration/certops-jobs-evidence.test.js --timeout 60000 --exit`: ok, 6 passing
* `pnpm exec mocha tests/integration/certops-machine-token-rate-limit.test.js --timeout 60000 --exit`: ok, 3 passing
* `pnpm exec mocha tests/integration/certops-api-token-auth.test.js --timeout 60000 --exit`: ok, 3 passing
* `pnpm exec mocha tests/integration/certops-api-tokens.test.js --timeout 60000 --exit`: ok, 4 passing
* `pnpm run test:unit`: ok, 268 passing
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a5-jobs-evidence-persistence`.
* PR #50 / M2-A1 should merge first.
* PR #51 / M2-A2 should merge after M2-A1.
* PR #52 / M2-A3 should merge after M2-A2.
* PR #53 / M2-A4 should merge after M2-A3.
* PR #54 / M2-A5 should merge before this PR is retargeted.
* This is an M2-A6 executor event ingestion PR, not a dashboard/timeline PR.
* Dev A owns this work because it touches backend route wiring, auth, rate limiting, workspace scoping, idempotency, and security boundary behavior.
* Dev B dashboard UI, Cloud overlay, fake executor, fake agent, and timeline work remain split out.
* Machine token workspace identity is authoritative.
* Request body `workspaceId` cannot override `req.apiToken.workspaceId`.
* Route persistence goes through the M2-A5 jobs/evidence services.
* The route does not use session auth, `req.user`, admin flags, or blanket authenticated state.
* The route is CSRF-exempt only through the existing narrow machine-token executor events path.
* Lifecycle executor events require `certops:events:write`.
* Evidence-bearing executor events additionally require `certops:evidence:write`.
* The legacy `certops:executor:events` scope is not used or documented.
* Disabled CertOps returns `404 NOT_FOUND` before token validation or persistence.
* Exact event replays return `202` with `duplicate: true` and do not duplicate logs, evidence, status changes, or audit rows.
* Conflicting event replays return `409 CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT`.
* No acceptance-audit path is introduced in this PR.
* No dashboard, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, connector, polling, claim API, job signing, or agent bootstrap work is included.
* No `security_events` table, audit hash-chain, alert-queue wiring, or M11 security-event work is included.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A6 executor event route.
* Executor event idempotency records retain only workspace ID, job ID, executor event ID, a SHA-256 hash of the normalized public envelope, safe response metadata, status, API-token reference, and timestamps.
* Executor event idempotency records do not store request bodies, bearer tokens, credentials, token hashes, private keys, PFX/JKS blobs, passwords, or other secret material.

## Test plan

* [x] Verify missing Authorization returns 401
* [x] Verify malformed Bearer token returns 401
* [x] Verify valid machine token with `certops:events:write` succeeds for lifecycle events
* [x] Verify token missing executor event scope returns 403
* [x] Verify `certops.enabled = false` returns 404
* [x] Verify disabled CertOps does not validate/touch tokens
* [x] Verify disabled CertOps does not persist logs, evidence, status changes, or executor event records
* [x] Verify machine-token rate limiter returns 429
* [x] Verify CSRF exemption remains narrow
* [x] Verify job.started appends a log and updates job status to running
* [x] Verify job.completed appends a log and updates job status to succeeded
* [x] Verify job.failed appends a log and updates job status to failed
* [x] Verify job.progress appends a log without unsafe status transition
* [x] Verify event/status mismatch returns `400 CERTOPS_EXECUTOR_EVENT_STATUS_MISMATCH`
* [x] Verify job.completed with failed status is rejected
* [x] Verify job.failed with succeeded status is rejected
* [x] Verify job.started with succeeded status is rejected
* [x] Verify late job.started does not reopen succeeded jobs
* [x] Verify late job.started does not reopen failed jobs
* [x] Verify late job.started does not reopen cancelled jobs
* [x] Verify invalid lifecycle regression returns safe 409
* [x] Verify events-only token cannot send `evidence.attached`
* [x] Verify events-only token cannot send non-empty evidence payloads
* [x] Verify events-only token receives 403 before private-key payload normalization for evidence-bearing events
* [x] Verify token with both `certops:events:write` and `certops:evidence:write` can attach evidence
* [x] Verify evidence.attached creates sanitized evidence and appends a log
* [x] Verify exact event replay returns duplicate true
* [x] Verify exact event replay does not duplicate job logs
* [x] Verify exact event replay does not duplicate evidence
* [x] Verify exact event replay does not duplicate status updates or audit rows
* [x] Verify same eventId with different lifecycle payload returns `409 CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT`
* [x] Verify same eventId with different evidence payload returns `409 CERTOPS_EXECUTOR_EVENT_IDEMPOTENCY_CONFLICT`
* [x] Verify failed evidence persistence rolls back prior side effects
* [x] Verify missing job returns safe 404
* [x] Verify invalid event type returns safe 400
* [x] Verify invalid status returns safe 400
* [x] Verify token workspace isolation
* [x] Verify body workspace cannot override token workspace
* [x] Verify private-key-looking fields are rejected before persistence
* [x] Verify PEM private-key-looking values are rejected before persistence
* [x] Verify credential/password/secret-looking values are rejected before persistence
* [x] Verify malformed IDs are rejected safely before DB/internal errors
* [x] Verify overlong or invalid metadata is rejected safely
* [x] Verify artifactRefs are contract-shaped and rejected safely when malformed
* [x] Verify no raw token, Authorization header, token hash, private key, or secret-looking data appears in responses
* [x] Verify no dashboard, Cloud, worker, deploy, agent, fake executor, fake agent, ACME, cert-manager, Helm/RBAC, connector, polling, claim API, job signing, security-events, or hash-chain work is included