### PR TITLE
feat(certops): add job read APIs m2-a7

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -24,6 +24,22 @@ const {
   listManagedCertificates,
   retireManagedCertificate,
 } = require("../services/certops/inventory");
+const {
+  CERTOPS_JOB_INVALID,
+  CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
+  CERTOPS_JOB_NOT_FOUND,
+  CERTOPS_JOB_OPERATION_INVALID,
+  CERTOPS_JOB_SOURCE_INVALID,
+  CERTOPS_JOB_STATUS_INVALID,
+  getCertificateJobById,
+  listCertificateJobLog,
+  listCertificateJobs,
+} = require("../services/certops/jobs");
+const {
+  CERTOPS_EVIDENCE_INVALID,
+  CERTOPS_EVIDENCE_TYPE_INVALID,
+  listCertificateEvidence,
+} = require("../services/certops/evidence");
 const { writeAudit } = require("../services/audit");
 const { logger } = require("../utils/logger");
 
@@ -131,7 +147,116 @@ function handleCertOpsError(res, err) {
     });
   }
 
+  if (err?.code === CERTOPS_JOB_NOT_FOUND) {
+    return res.status(404).json({
+      error: "Certificate job not found",
+      code: CERTOPS_JOB_NOT_FOUND,
+    });
+  }
+
+  const certOpsJobBadRequestCodes = new Set([
+    CERTOPS_JOB_INVALID,
+    CERTOPS_JOB_OPERATION_INVALID,
+    CERTOPS_JOB_SOURCE_INVALID,
+    CERTOPS_JOB_STATUS_INVALID,
+    CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
+    CERTOPS_EVIDENCE_INVALID,
+    CERTOPS_EVIDENCE_TYPE_INVALID,
+  ]);
+  if (certOpsJobBadRequestCodes.has(err?.code)) {
+    return res.status(400).json({
+      error: "CertOps job request is invalid",
+      code: err.code,
+    });
+  }
+
   return null;
+}
+
+function jobIdFromParams(req, res) {
+  const jobId = String(req.params.jobId || "");
+  if (!UUID_PATTERN.test(jobId)) {
+    res.status(400).json({
+      error: "CertOps job identifier is invalid",
+      code: CERTOPS_JOB_INVALID,
+    });
+    return null;
+  }
+  return jobId;
+}
+
+function jobListOptionsFromRequest(req) {
+  return {
+    workspaceId: req.workspace.id,
+    limit: req.query.limit,
+    offset: req.query.offset,
+    status: req.query.status,
+    subjectType: req.query.subjectType,
+    subjectId: req.query.subjectId,
+    operation: req.query.operation,
+    source: req.query.source,
+  };
+}
+
+function jobSummary(job) {
+  return {
+    id: job.id,
+    workspaceId: job.workspaceId,
+    operation: job.operation,
+    status: job.status,
+    source: job.source,
+    subjectType: job.subjectType,
+    subjectId: job.subjectId,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    queuedAt: job.queuedAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    cancelledAt: job.cancelledAt,
+    requestedByUserId: job.requestedByUserId,
+    requestedByApiTokenId: job.requestedByApiTokenId,
+  };
+}
+
+function jobDetail(job) {
+  return {
+    ...jobSummary(job),
+    payload: job.payload || {},
+    resultMetadata: job.resultMetadata || {},
+    errorCode: job.errorCode,
+    errorMessage: job.errorMessage,
+  };
+}
+
+function jobLogEntry(entry) {
+  return {
+    id: entry.id,
+    workspaceId: entry.workspaceId,
+    jobId: entry.jobId,
+    eventType: entry.eventType,
+    status: entry.status,
+    message: entry.message,
+    metadata: entry.metadata || {},
+    createdByUserId: entry.createdByUserId,
+    createdByApiTokenId: entry.createdByApiTokenId,
+    createdAt: entry.createdAt,
+  };
+}
+
+function evidenceItem(item) {
+  return {
+    id: item.id,
+    workspaceId: item.workspaceId,
+    jobId: item.jobId,
+    evidenceType: item.evidenceType,
+    subjectType: item.subjectType,
+    subjectId: item.subjectId,
+    metadata: item.metadata || {},
+    observedAt: item.observedAt,
+    createdByUserId: item.createdByUserId,
+    createdByApiTokenId: item.createdByApiTokenId,
+    createdAt: item.createdAt,
+  };
 }
 
 async function recordInventoryAudit(req, source, certificates) {
@@ -156,6 +281,152 @@ async function recordInventoryAudit(req, source, certificates) {
     },
   });
 }
+
+router.get(
+  "/api/v1/workspaces/:id/certops/jobs",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    try {
+      const result = await listCertificateJobs(jobListOptionsFromRequest(req));
+      return res.json({
+        items: result.items.map(jobSummary),
+        pagination: result.pagination,
+      });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps job list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list CertOps jobs",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.get(
+  "/api/v1/workspaces/:id/certops/jobs/:jobId/log",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    const jobId = jobIdFromParams(req, res);
+    if (!jobId) return null;
+
+    try {
+      const result = await listCertificateJobLog({
+        workspaceId: req.workspace.id,
+        jobId,
+        limit: req.query.limit,
+        offset: req.query.offset,
+      });
+      return res.json({
+        items: result.items.map(jobLogEntry),
+        pagination: result.pagination,
+      });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps job log list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        jobId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list CertOps job log",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.get(
+  "/api/v1/workspaces/:id/certops/jobs/:jobId/evidence",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    const jobId = jobIdFromParams(req, res);
+    if (!jobId) return null;
+
+    try {
+      const result = await listCertificateEvidence({
+        workspaceId: req.workspace.id,
+        jobId,
+        limit: req.query.limit,
+        offset: req.query.offset,
+      });
+      return res.json({
+        items: result.items.map(evidenceItem),
+        pagination: result.pagination,
+      });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps job evidence list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        jobId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list CertOps job evidence",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.get(
+  "/api/v1/workspaces/:id/certops/jobs/:jobId",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    const jobId = jobIdFromParams(req, res);
+    if (!jobId) return null;
+
+    try {
+      const job = await getCertificateJobById({
+        workspaceId: req.workspace.id,
+        jobId,
+      });
+
+      if (!job) {
+        return res.status(404).json({
+          error: "Certificate job not found",
+          code: CERTOPS_JOB_NOT_FOUND,
+        });
+      }
+
+      return res.json({ job: jobDetail(job) });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps job detail failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        jobId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to load CertOps job",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
 
 async function retireCertificateHandler(req, res) {
   if (!UUID_PATTERN.test(String(req.params.certId || ""))) {

--- a/apps/api/services/certops/jobs.js
+++ b/apps/api/services/certops/jobs.js
@@ -704,6 +704,45 @@ async function listCertificateJobs(options) {
     conditions.push(`status = $${params.length}`);
   }
 
+  if (options.operation !== undefined && options.operation !== null && options.operation !== "") {
+    const operation = normalizeEnum(
+      options.operation,
+      JOB_OPERATION_SET,
+      CERTOPS_JOB_OPERATION_INVALID,
+      "operation",
+    );
+    params.push(operation);
+    conditions.push(`operation = $${params.length}`);
+  }
+
+  if (options.source !== undefined && options.source !== null && options.source !== "") {
+    const source = normalizeEnum(
+      options.source,
+      JOB_SOURCE_SET,
+      CERTOPS_JOB_SOURCE_INVALID,
+      "source",
+    );
+    params.push(source);
+    conditions.push(`source = $${params.length}`);
+  }
+
+  if (options.subjectType !== undefined && options.subjectType !== null && options.subjectType !== "") {
+    const subjectType = normalizeEnum(
+      options.subjectType,
+      SUBJECT_TYPE_SET,
+      CERTOPS_JOB_INVALID,
+      "subjectType",
+    );
+    params.push(subjectType);
+    conditions.push(`subject_type = $${params.length}`);
+  }
+
+  if (options.subjectId !== undefined && options.subjectId !== null && options.subjectId !== "") {
+    const subjectId = normalizeOptionalShortText(options.subjectId, "subjectId");
+    params.push(subjectId);
+    conditions.push(`subject_id = $${params.length}`);
+  }
+
   params.push(limit, offset);
   const result = await db.query(
     `SELECT ${SAFE_JOB_SELECT_FIELDS}

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3353,11 +3353,15 @@ paths:
       tags: [CertOps]
       summary: List CertOps jobs
       operationId: listCertOpsJobs
-      description: Returns public CertOps job summaries for the workspace. Private key material, raw executor output, token hashes, and credentials are never returned.
+      description: >-
+        Returns paginated public CertOps job summaries for the workspace. Consumers
+        must follow pagination.limit and pagination.offset; long job histories can
+        require multiple requests. Private key material, raw executor output, token
+        hashes, and credentials are never returned.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
-        - $ref: "#/components/parameters/limitParam"
-        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/certOpsReadLimitParam"
+        - $ref: "#/components/parameters/certOpsReadOffsetParam"
         - in: query
           name: status
           schema:
@@ -3398,6 +3402,15 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          description: A filter contained private-key or forbidden secret material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/jobs/{jobId}:
@@ -3443,7 +3456,10 @@ paths:
       tags: [CertOps]
       summary: List CertOps job log entries
       operationId: listCertOpsJobLog
-      description: Returns sanitized timeline entries for one workspace-scoped CertOps job.
+      description: >-
+        Returns paginated sanitized timeline entries for one workspace-scoped
+        CertOps job. Consumers must follow pagination.limit and pagination.offset;
+        long job histories can require multiple requests.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - in: path
@@ -3452,8 +3468,8 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/limitParam"
-        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/certOpsReadLimitParam"
+        - $ref: "#/components/parameters/certOpsReadOffsetParam"
       responses:
         "200":
           description: Job log list
@@ -3483,7 +3499,12 @@ paths:
       tags: [CertOps]
       summary: List CertOps job evidence
       operationId: listCertOpsJobEvidence
-      description: Returns sanitized public evidence metadata for one workspace-scoped CertOps job. Raw secrets, private keys, token hashes, and key-bearing artifacts are never returned.
+      description: >-
+        Returns paginated sanitized public evidence metadata for one
+        workspace-scoped CertOps job. Consumers must follow pagination.limit and
+        pagination.offset; long job histories can require multiple requests. Raw
+        secrets, private keys, token hashes, and key-bearing artifacts are never
+        returned.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - in: path
@@ -3492,8 +3513,8 @@ paths:
           schema:
             type: string
             format: uuid
-        - $ref: "#/components/parameters/limitParam"
-        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/certOpsReadLimitParam"
+        - $ref: "#/components/parameters/certOpsReadOffsetParam"
       responses:
         "200":
           description: Job evidence list
@@ -3818,6 +3839,27 @@ components:
       schema:
         type: integer
         minimum: 0
+    certOpsReadLimitParam:
+      in: query
+      name: limit
+      description: >-
+        Number of items returned. Defaults to 50 when omitted or nonnumeric,
+        is limited to 100, and values below 1 are normalized to 1.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+    certOpsReadOffsetParam:
+      in: query
+      name: offset
+      description: >-
+        Number of items skipped before the page begins. Defaults to 0 when
+        omitted or nonnumeric; negative values are normalized to 0.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
     auditSinceParam:
       in: query
       name: since

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3353,11 +3353,36 @@ paths:
       tags: [CertOps]
       summary: List CertOps jobs
       operationId: listCertOpsJobs
-      description: Returns public CertOps job metadata for the workspace. M2-A1 defines the contract skeleton only; runtime job persistence and dispatch land in later M2 PRs.
+      description: Returns public CertOps job summaries for the workspace. Private key material, raw executor output, token hashes, and credentials are never returned.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/offsetParam"
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled]
+        - in: query
+          name: operation
+          schema:
+            type: string
+            enum: [renew, deploy, reload, revoke, noop]
+        - in: query
+          name: source
+          schema:
+            type: string
+            enum: [api, executor, system, automation, domain-monitor, endpoint-monitor, control-plane, external]
+        - in: query
+          name: subjectType
+          schema:
+            type: string
+            enum: [managed_certificate, certificate_instance, certificate_target, token, domain, endpoint, external]
+        - in: query
+          name: subjectId
+          schema:
+            type: string
+            maxLength: 128
       responses:
         "200":
           description: Job list
@@ -3365,10 +3390,132 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CertOpsJobListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/jobs/{jobId}:
+    get:
+      tags: [CertOps]
+      summary: Get a CertOps job
+      operationId: getCertOpsJob
+      description: Returns one sanitized CertOps job detail for the authorized workspace.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Job detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsJobDetailResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Job not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Certificate job not found
+                code: CERTOPS_JOB_NOT_FOUND
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/jobs/{jobId}/log:
+    get:
+      tags: [CertOps]
+      summary: List CertOps job log entries
+      operationId: listCertOpsJobLog
+      description: Returns sanitized timeline entries for one workspace-scoped CertOps job.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/limitParam"
+        - $ref: "#/components/parameters/offsetParam"
+      responses:
+        "200":
+          description: Job log list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsJobLogListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Job not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Certificate job not found
+                code: CERTOPS_JOB_NOT_FOUND
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/jobs/{jobId}/evidence:
+    get:
+      tags: [CertOps]
+      summary: List CertOps job evidence
+      operationId: listCertOpsJobEvidence
+      description: Returns sanitized public evidence metadata for one workspace-scoped CertOps job. Raw secrets, private keys, token hashes, and key-bearing artifacts are never returned.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/limitParam"
+        - $ref: "#/components/parameters/offsetParam"
+      responses:
+        "200":
+          description: Job evidence list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsEvidenceListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Job not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Certificate job not found
+                code: CERTOPS_JOB_NOT_FOUND
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/tokens:
@@ -4023,39 +4170,23 @@ components:
     CertOpsJob:
       type: object
       additionalProperties: false
-      description: Public M2 job metadata skeleton. Runtime persistence and state transitions land in later M2 PRs.
+      description: Public CertOps job summary for dashboard and timeline reads. Payload and result metadata are omitted from list responses.
       required:
-        - schemaVersion
         - id
         - workspaceId
-        - certificateId
-        - action
+        - operation
         - status
-        - requestedAt
+        - source
         - createdAt
         - updatedAt
       properties:
-        schemaVersion:
-          type: integer
-          enum: [1]
         id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: "^[A-Za-z0-9_.:-]+$"
+          format: uuid
         workspaceId:
           type: string
           format: uuid
-        certificateId:
-          type: string
-          minLength: 1
-          maxLength: 128
-          pattern: "^[A-Za-z0-9_.:-]+$"
-        tokenId:
-          type: integer
-          minimum: 1
-          nullable: true
-        action:
+        operation:
           type: string
           enum: [renew, deploy, reload, revoke, noop]
         status:
@@ -4071,42 +4202,46 @@ components:
             - failed
             - blocked
             - cancelled
-        target:
-          type: object
-          additionalProperties: false
-          nullable: true
-          properties:
-            type:
-              type: string
-              enum: [domain, endpoint, kubernetes, appliance, load-balancer, external]
-            reference:
-              type: string
-              maxLength: 512
-        requestedAt:
+        source:
           type: string
-          format: date-time
-        requestedBy:
-          type: object
-          additionalProperties: false
+          enum: [api, executor, system, automation, domain-monitor, endpoint-monitor, control-plane, external]
+        subjectType:
+          type: string
           nullable: true
-          properties:
-            actorType:
-              type: string
-              enum: [user, system, automation]
-            actorId:
-              type: string
-              maxLength: 128
-              nullable: true
-            displayName:
-              type: string
-              maxLength: 256
-              nullable: true
+          enum: [managed_certificate, certificate_instance, certificate_target, token, domain, endpoint, external]
+        subjectId:
+          type: string
+          maxLength: 128
+          nullable: true
+        requestedByUserId:
+          type: integer
+          nullable: true
+        requestedByApiTokenId:
+          type: string
+          format: uuid
+          nullable: true
         createdAt:
           type: string
           format: date-time
         updatedAt:
           type: string
           format: date-time
+        queuedAt:
+          type: string
+          format: date-time
+          nullable: true
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        cancelledAt:
+          type: string
+          format: date-time
+          nullable: true
     CertOpsJobListResponse:
       type: object
       additionalProperties: false
@@ -4116,6 +4251,187 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CertOpsJob"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+    CertOpsPublicObject:
+      type: object
+      additionalProperties: true
+      description: Sanitized public metadata object. Runtime rejects private-key material, credentials, token secrets, raw secret dumps, and custody-shaped field names before persistence.
+    CertOpsJobDetail:
+      type: object
+      additionalProperties: false
+      required: [id, workspaceId, operation, status, source, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        operation:
+          type: string
+          enum: [renew, deploy, reload, revoke, noop]
+        status:
+          type: string
+          enum: [pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled]
+        source:
+          type: string
+          enum: [api, executor, system, automation, domain-monitor, endpoint-monitor, control-plane, external]
+        subjectType:
+          type: string
+          nullable: true
+          enum: [managed_certificate, certificate_instance, certificate_target, token, domain, endpoint, external]
+        subjectId:
+          type: string
+          maxLength: 128
+          nullable: true
+        requestedByUserId:
+          type: integer
+          nullable: true
+        requestedByApiTokenId:
+          type: string
+          format: uuid
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        queuedAt:
+          type: string
+          format: date-time
+          nullable: true
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        cancelledAt:
+          type: string
+          format: date-time
+          nullable: true
+        payload:
+          $ref: "#/components/schemas/CertOpsPublicObject"
+        resultMetadata:
+          $ref: "#/components/schemas/CertOpsPublicObject"
+        errorCode:
+          type: string
+          maxLength: 128
+          nullable: true
+        errorMessage:
+          type: string
+          maxLength: 1024
+          nullable: true
+    CertOpsJobDetailResponse:
+      type: object
+      additionalProperties: false
+      required: [job]
+      properties:
+        job:
+          $ref: "#/components/schemas/CertOpsJobDetail"
+    CertOpsJobLogEntry:
+      type: object
+      additionalProperties: false
+      required: [id, workspaceId, jobId, eventType, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        jobId:
+          type: string
+          format: uuid
+        eventType:
+          type: string
+          enum: [job.created, job.accepted, job.started, job.progress, job.completed, job.failed, job.rejected, job.cancelled, job.status_updated, evidence.attached]
+        status:
+          type: string
+          nullable: true
+          enum: [pending_approval, approved, rejected, pending, claimed, running, succeeded, failed, blocked, cancelled]
+        message:
+          type: string
+          maxLength: 1024
+          nullable: true
+        metadata:
+          $ref: "#/components/schemas/CertOpsPublicObject"
+        createdByUserId:
+          type: integer
+          nullable: true
+        createdByApiTokenId:
+          type: string
+          format: uuid
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    CertOpsJobLogListResponse:
+      type: object
+      additionalProperties: false
+      required: [items, pagination]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsJobLogEntry"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+    CertOpsEvidenceItem:
+      type: object
+      additionalProperties: false
+      required: [id, workspaceId, evidenceType, metadata, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        jobId:
+          type: string
+          format: uuid
+          nullable: true
+        evidenceType:
+          type: string
+          enum: [certificate.observed, deployment.checked, deployment.updated, validation.passed, validation.failed, policy.checked]
+        subjectType:
+          type: string
+          nullable: true
+          enum: [managed_certificate, certificate_instance, certificate_target, token, domain, endpoint, external]
+        subjectId:
+          type: string
+          maxLength: 128
+          nullable: true
+        metadata:
+          $ref: "#/components/schemas/CertOpsPublicObject"
+        observedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdByUserId:
+          type: integer
+          nullable: true
+        createdByApiTokenId:
+          type: string
+          format: uuid
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    CertOpsEvidenceListResponse:
+      type: object
+      additionalProperties: false
+      required: [items, pagination]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsEvidenceItem"
         pagination:
           $ref: "#/components/schemas/Pagination"
     CertOpsApiTokenScope:

--- a/tests/integration/certops-job-read-apis.test.js
+++ b/tests/integration/certops-job-read-apis.test.js
@@ -1,0 +1,480 @@
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, request, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+const {
+  appendCertificateJobLog,
+  createCertificateJob,
+} = require("../../apps/api/services/certops/jobs");
+const {
+  createCertificateEvidence,
+} = require("../../apps/api/services/certops/evidence");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+async function primaryWorkspaceId(session) {
+  const response = await request(BASE)
+    .get("/api/v1/workspaces?limit=50&offset=0")
+    .set("Cookie", session.cookie)
+    .expect(200);
+  return response.body.items[0].id;
+}
+
+function walkKeys(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkKeys(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    visit(key);
+    walkKeys(item, visit);
+  }
+}
+
+function expectNoPrivateKeyFields(value) {
+  const forbiddenFragments = [
+    "privatekey",
+    "privatekeypem",
+    "encryptedprivatekey",
+    "keymaterial",
+    "pfxblob",
+    "jksblob",
+    "tlskey",
+    "caprivatekey",
+    "keystorepassword",
+    "privatekeypassword",
+    "keypassword",
+    "password",
+    "secret",
+    "credential",
+    "tokensecret",
+    "apisecret",
+    "rawsecret",
+    "rawprivatekey",
+    "rawkey",
+    "pemprivatekey",
+  ];
+
+  walkKeys(value, (key) => {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    for (const fragment of forbiddenFragments) {
+      expect(
+        normalized.includes(fragment),
+        `${key} looks like private-key custody`,
+      ).to.equal(false);
+    }
+  });
+}
+
+function expectNoSensitiveValues(value, extraForbidden = []) {
+  const serialized = JSON.stringify(value);
+  expect(serialized).to.not.include("Authorization");
+  expect(serialized).to.not.include("token_hash");
+  expect(serialized).to.not.include("ttx_");
+  expect(serialized).to.not.include("PRIVATE KEY");
+  expect(serialized).to.not.include("password=swordfish");
+  for (const forbidden of extraForbidden) {
+    expect(serialized).to.not.include(forbidden);
+  }
+  expectNoPrivateKeyFields(value);
+}
+
+async function createWorkspaceFixture() {
+  const ownerUser = await TestUtils.createVerifiedTestUser();
+  const ownerSession = await TestUtils.loginTestUser(
+    ownerUser.email,
+    "SecureTest123!@#",
+  );
+  const workspaceId = await primaryWorkspaceId(ownerSession);
+
+  const viewerUser = await TestUtils.createVerifiedTestUser();
+  const viewerSession = await TestUtils.loginTestUser(
+    viewerUser.email,
+    "SecureTest123!@#",
+  );
+  await TestUtils.execQuery(
+    `INSERT INTO workspace_memberships (user_id, workspace_id, role, invited_by)
+     VALUES ($1, $2, 'viewer', $3)
+     ON CONFLICT (user_id, workspace_id) DO UPDATE SET role = EXCLUDED.role`,
+    [viewerUser.id, workspaceId, ownerUser.id],
+  );
+
+  const outsiderUser = await TestUtils.createVerifiedTestUser();
+  const outsiderSession = await TestUtils.loginTestUser(
+    outsiderUser.email,
+    "SecureTest123!@#",
+  );
+  const outsiderWorkspaceId = await primaryWorkspaceId(outsiderSession);
+
+  return {
+    ownerUser,
+    ownerSession,
+    viewerUser,
+    viewerSession,
+    outsiderUser,
+    outsiderSession,
+    workspaceId,
+    outsiderWorkspaceId,
+  };
+}
+
+async function cleanupWorkspaceFixture(fixture) {
+  if (!fixture) return;
+  const workspaceIds = [
+    fixture.workspaceId,
+    fixture.outsiderWorkspaceId,
+  ].filter(Boolean);
+  if (workspaceIds.length > 0) {
+    await TestUtils.execQuery(
+      "DELETE FROM certificate_evidence WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM certificate_job_log WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM certificate_jobs WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM workspaces WHERE id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+  }
+
+  for (const [user, session] of [
+    [fixture.ownerUser, fixture.ownerSession],
+    [fixture.viewerUser, fixture.viewerSession],
+    [fixture.outsiderUser, fixture.outsiderSession],
+  ]) {
+    if (user?.email && session?.cookie) {
+      await TestUtils.cleanupTestUser(user.email, session.cookie);
+    }
+  }
+}
+
+async function createJobFixture({ ownerUser, workspaceId, outsiderWorkspaceId }) {
+  const deployJob = await createCertificateJob({
+    workspaceId,
+    operation: "deploy",
+    status: "pending",
+    source: "api",
+    subjectType: "managed_certificate",
+    subjectId: "cert-1",
+    payload: {
+      certificateId: "cert-1",
+      target: "kubernetes/default/web-cert",
+    },
+    resultMetadata: {
+      planner: "manual",
+    },
+    requestedByUserId: ownerUser.id,
+  });
+
+  const renewJob = await createCertificateJob({
+    workspaceId,
+    operation: "renew",
+    status: "running",
+    source: "executor",
+    subjectType: "certificate_target",
+    subjectId: "target-1",
+    payload: {
+      certificateId: "cert-2",
+      target: "domain/example.com",
+    },
+    requestedByUserId: ownerUser.id,
+  });
+
+  const otherWorkspaceJob = await createCertificateJob({
+    workspaceId: outsiderWorkspaceId,
+    operation: "deploy",
+    status: "pending",
+    source: "api",
+    subjectType: "managed_certificate",
+    subjectId: "cert-other",
+    payload: { certificateId: "cert-other" },
+    requestedByUserId: ownerUser.id,
+  });
+
+  const deployLog = await appendCertificateJobLog({
+    workspaceId,
+    jobId: deployJob.id,
+    eventType: "job.created",
+    status: "pending",
+    message: "Job pending for dashboard timeline",
+    metadata: { stage: "pending", target: "web-cert" },
+    createdByUserId: ownerUser.id,
+  });
+  await appendCertificateJobLog({
+    workspaceId,
+    jobId: renewJob.id,
+    eventType: "job.progress",
+    status: "running",
+    message: "Renewal in progress",
+    metadata: { stage: "renew" },
+    createdByUserId: ownerUser.id,
+  });
+
+  const deployEvidence = await createCertificateEvidence({
+    workspaceId,
+    jobId: deployJob.id,
+    evidenceType: "deployment.checked",
+    subjectType: "managed_certificate",
+    subjectId: "cert-1",
+    metadata: {
+      deploymentTarget: "kubernetes/default/web-cert",
+      artifactRefs: [
+        {
+          type: "report",
+          reference: "reports/certops/public-observation.json",
+          sha256:
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      ],
+    },
+    observedAt: "2026-07-01T12:00:00.000Z",
+    createdByUserId: ownerUser.id,
+  });
+  await createCertificateEvidence({
+    workspaceId,
+    jobId: renewJob.id,
+    evidenceType: "policy.checked",
+    subjectType: "certificate_target",
+    subjectId: "target-1",
+    metadata: { policy: "public-metadata-only" },
+    observedAt: "2026-07-01T12:05:00.000Z",
+    createdByUserId: ownerUser.id,
+  });
+
+  return {
+    deployEvidence,
+    deployJob,
+    deployLog,
+    otherWorkspaceJob,
+    renewJob,
+  };
+}
+
+describe("CertOps job read APIs", function () {
+  this.timeout(60000);
+
+  let fixture;
+  let jobs;
+
+  before(async () => {
+    await runMigrations();
+    fixture = await createWorkspaceFixture();
+    jobs = await createJobFixture(fixture);
+  });
+
+  after(async () => {
+    await cleanupWorkspaceFixture(fixture);
+  });
+
+  it("requires authentication and workspace membership", async () => {
+    const unauthenticated = await request(BASE).get(
+      `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs`,
+    );
+    expect(unauthenticated.status).to.be.oneOf([401, 403]);
+    expect(unauthenticated.status).to.not.equal(500);
+    expectNoSensitiveValues(unauthenticated.body);
+
+    const forbidden = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs`)
+      .set("Cookie", fixture.outsiderSession.cookie);
+    expect(forbidden.status).to.equal(403);
+    expect(forbidden.status).to.not.equal(500);
+    expectNoSensitiveValues(forbidden.body);
+
+    const crossWorkspaceDetail = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.outsiderWorkspaceId}/certops/jobs/${jobs.deployJob.id}`,
+      )
+      .set("Cookie", fixture.outsiderSession.cookie);
+    expect(crossWorkspaceDetail.status).to.equal(404);
+    expect(crossWorkspaceDetail.body.code).to.equal("CERTOPS_JOB_NOT_FOUND");
+    expectNoSensitiveValues(crossWorkspaceDetail.body);
+  });
+
+  it("lists workspace jobs with pagination and safe filters", async () => {
+    const list = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+
+    const ids = list.body.items.map((item) => item.id);
+    expect(ids).to.include(jobs.deployJob.id);
+    expect(ids).to.include(jobs.renewJob.id);
+    expect(ids).to.not.include(jobs.otherWorkspaceJob.id);
+    expect(list.body.items[0]).to.not.have.property("payload");
+    expect(list.body.items[0]).to.not.have.property("resultMetadata");
+    expectNoSensitiveValues(list.body);
+
+    const firstPage = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?limit=1&offset=0`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(firstPage.body.items).to.have.length(1);
+    expect(firstPage.body.pagination).to.deep.equal({ limit: 1, offset: 0 });
+
+    const statusFiltered = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?status=pending`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(statusFiltered.body.items.map((item) => item.id)).to.include(
+      jobs.deployJob.id,
+    );
+    expect(statusFiltered.body.items.map((item) => item.id)).to.not.include(
+      jobs.renewJob.id,
+    );
+
+    const subjectFiltered = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?subjectType=certificate_target&subjectId=target-1`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(subjectFiltered.body.items.map((item) => item.id)).to.deep.equal([
+      jobs.renewJob.id,
+    ]);
+
+    const operationFiltered = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?operation=deploy&source=api`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .send({ workspaceId: fixture.outsiderWorkspaceId })
+      .expect(200);
+    expect(operationFiltered.body.items.map((item) => item.id)).to.include(
+      jobs.deployJob.id,
+    );
+    expect(operationFiltered.body.items.map((item) => item.id)).to.not.include(
+      jobs.otherWorkspaceJob.id,
+    );
+    expectNoSensitiveValues(operationFiltered.body);
+  });
+
+  it("gets one sanitized job detail", async () => {
+    const response = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${jobs.deployJob.id}`,
+      )
+      .set("Cookie", fixture.ownerSession.cookie)
+      .expect(200);
+
+    expect(response.body.job).to.include({
+      id: jobs.deployJob.id,
+      workspaceId: fixture.workspaceId,
+      operation: "deploy",
+      status: "pending",
+      source: "api",
+      subjectType: "managed_certificate",
+      subjectId: "cert-1",
+    });
+    expect(response.body.job.payload).to.include({
+      certificateId: "cert-1",
+      target: "kubernetes/default/web-cert",
+    });
+    expect(response.body.job.resultMetadata).to.include({ planner: "manual" });
+    expectNoSensitiveValues(response.body);
+  });
+
+  it("returns job log and evidence scoped to the requested workspace job", async () => {
+    const log = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${jobs.deployJob.id}/log`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(log.body.items.map((item) => item.id)).to.include(jobs.deployLog.id);
+    expect(log.body.items.every((item) => item.jobId === jobs.deployJob.id)).to.equal(
+      true,
+    );
+    expect(log.body.items.map((item) => item.eventType)).to.include(
+      "job.created",
+    );
+    expectNoSensitiveValues(log.body);
+
+    const evidence = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${jobs.deployJob.id}/evidence`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(evidence.body.items.map((item) => item.id)).to.include(
+      jobs.deployEvidence.id,
+    );
+    expect(
+      evidence.body.items.every((item) => item.jobId === jobs.deployJob.id),
+    ).to.equal(true);
+    expect(evidence.body.items[0].metadata.artifactRefs[0]).to.include({
+      type: "report",
+      reference: "reports/certops/public-observation.json",
+    });
+    expectNoSensitiveValues(evidence.body);
+
+    for (const suffix of ["log", "evidence"]) {
+      const crossWorkspace = await request(BASE)
+        .get(
+          `/api/v1/workspaces/${fixture.outsiderWorkspaceId}/certops/jobs/${jobs.deployJob.id}/${suffix}`,
+        )
+        .set("Cookie", fixture.outsiderSession.cookie);
+      expect(crossWorkspace.status).to.equal(404);
+      expect(crossWorkspace.body.code).to.equal("CERTOPS_JOB_NOT_FOUND");
+      expectNoSensitiveValues(crossWorkspace.body);
+    }
+  });
+
+  it("handles missing, malformed, and unsafe inputs without internal errors", async () => {
+    const missingJobId = crypto.randomUUID();
+    const missing = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${missingJobId}`)
+      .set("Cookie", fixture.ownerSession.cookie);
+    expect(missing.status).to.equal(404);
+    expect(missing.body.code).to.equal("CERTOPS_JOB_NOT_FOUND");
+    expectNoSensitiveValues(missing.body);
+
+    for (const suffix of ["", "/log", "/evidence"]) {
+      const malformed = await request(BASE)
+        .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/not-a-uuid${suffix}`)
+        .set("Cookie", fixture.ownerSession.cookie);
+      expect(malformed.status).to.equal(400);
+      expect(malformed.status).to.not.equal(500);
+      expect(malformed.body.code).to.equal("CERTOPS_JOB_INVALID");
+      expectNoSensitiveValues(malformed.body, ["not-a-uuid"]);
+    }
+
+    const malformedWorkspace = await request(BASE)
+      .get(`/api/v1/workspaces/not-a-uuid/certops/jobs`)
+      .set("Cookie", fixture.ownerSession.cookie);
+    expect(malformedWorkspace.status).to.equal(400);
+    expect(malformedWorkspace.status).to.not.equal(500);
+    expect(malformedWorkspace.body.code).to.equal("INVALID_WORKSPACE_ID");
+    expectNoSensitiveValues(malformedWorkspace.body, ["not-a-uuid"]);
+
+    const invalidStatus = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?status=deleted`)
+      .set("Cookie", fixture.ownerSession.cookie);
+    expect(invalidStatus.status).to.equal(400);
+    expect(invalidStatus.body.code).to.equal("CERTOPS_JOB_STATUS_INVALID");
+    expectNoSensitiveValues(invalidStatus.body, ["deleted"]);
+
+    const unsafeSubject = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?subjectId=password%3Dswordfish`,
+      )
+      .set("Cookie", fixture.ownerSession.cookie);
+    expect(unsafeSubject.status).to.equal(422);
+    expect(unsafeSubject.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expectNoSensitiveValues(unsafeSubject.body, ["password=swordfish"]);
+  });
+});

--- a/tests/integration/certops-job-read-apis.test.js
+++ b/tests/integration/certops-job-read-apis.test.js
@@ -319,7 +319,34 @@ describe("CertOps job read APIs", function () {
     expect(ids).to.not.include(jobs.otherWorkspaceJob.id);
     expect(list.body.items[0]).to.not.have.property("payload");
     expect(list.body.items[0]).to.not.have.property("resultMetadata");
+    expect(list.body.pagination).to.deep.equal({ limit: 50, offset: 0 });
     expectNoSensitiveValues(list.body);
+
+    const nonNumericPage = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?limit=not-a-number&offset=not-a-number`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(nonNumericPage.body.pagination).to.deep.equal({
+      limit: 50,
+      offset: 0,
+    });
+
+    const cappedPage = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?limit=500`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(cappedPage.body.pagination).to.deep.equal({ limit: 100, offset: 0 });
+
+    const clampedOffsetPage = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?limit=1&offset=-5`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(clampedOffsetPage.body.pagination).to.deep.equal({
+      limit: 1,
+      offset: 0,
+    });
 
     const firstPage = await request(BASE)
       .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/jobs?limit=1&offset=0`)
@@ -402,7 +429,16 @@ describe("CertOps job read APIs", function () {
     expect(log.body.items.map((item) => item.eventType)).to.include(
       "job.created",
     );
+    expect(log.body.pagination).to.deep.equal({ limit: 50, offset: 0 });
     expectNoSensitiveValues(log.body);
+
+    const cappedLog = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${jobs.deployJob.id}/log?limit=500&offset=-5`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(cappedLog.body.pagination).to.deep.equal({ limit: 100, offset: 0 });
 
     const evidence = await request(BASE)
       .get(
@@ -420,7 +456,19 @@ describe("CertOps job read APIs", function () {
       type: "report",
       reference: "reports/certops/public-observation.json",
     });
+    expect(evidence.body.pagination).to.deep.equal({ limit: 50, offset: 0 });
     expectNoSensitiveValues(evidence.body);
+
+    const cappedEvidence = await request(BASE)
+      .get(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/jobs/${jobs.deployJob.id}/evidence?limit=500&offset=-5`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expect(cappedEvidence.body.pagination).to.deep.equal({
+      limit: 100,
+      offset: 0,
+    });
 
     for (const suffix of ["log", "evidence"]) {
       const crossWorkspace = await request(BASE)

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -78,6 +78,7 @@ tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js
 tests/integration/certops-executor-events.test.js
+tests/integration/certops-job-read-apis.test.js
 
 # Integrations
 tests/integration/github.integration.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -92,6 +92,7 @@ tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js
 tests/integration/certops-executor-events.test.js
+tests/integration/certops-job-read-apis.test.js
 tests/integration/database-schema.test.js
 tests/integration/frontend-integration.test.js
 tests/integration/email-content-formatting.test.js

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -817,7 +817,7 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("keeps the committed M2-A1 through M2-A6 diff within the stacked scope", () => {
+  it("keeps the committed M2-A1 through M2-A7 diff within the stacked scope", () => {
     const { ref, files } = prChangedFiles();
     const allowedM2Files = new Set([
       "apps/api/migrations/migrate.js",
@@ -825,6 +825,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/middleware/csrf-exempt.js",
       "apps/api/middleware/machine-token-rate-limit.js",
       "apps/api/index.js",
+      "apps/api/routes/certops.js",
       "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
@@ -834,6 +835,7 @@ describe("CertOps M2 contract skeletons", () => {
       "tests/integration/certops-api-token-auth.test.js",
       "tests/integration/certops-api-tokens.test.js",
       "tests/integration/certops-executor-events.test.js",
+      "tests/integration/certops-job-read-apis.test.js",
       "tests/integration/certops-jobs-evidence.test.js",
       "tests/integration/certops-machine-token-rate-limit.test.js",
       "tests/integration/suites/core-compatible.txt",
@@ -858,7 +860,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.deepEqual(
       files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `stacked M2-A1 through M2-A6 diff against ${ref} must stay within the allowed scope`,
+      `stacked M2-A1 through M2-A7 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -876,6 +878,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/middleware/csrf-exempt.js",
       "apps/api/middleware/machine-token-rate-limit.js",
       "apps/api/index.js",
+      "apps/api/routes/certops.js",
       "apps/api/routes/certops-executor.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -307,6 +307,27 @@ function openApiComponentBlock(componentName) {
   return openApiSource.slice(start, end);
 }
 
+function openApiParameterBlock(parameterName) {
+  const parametersStart = openApiSource.indexOf("\n  parameters:");
+  assert.notEqual(parametersStart, -1, "OpenAPI parameters section missing");
+
+  const marker = `    ${parameterName}:`;
+  const start = openApiSource.indexOf(marker, parametersStart);
+  assert.notEqual(start, -1, `${parameterName} missing from OpenAPI`);
+
+  const remainingParameters = openApiSource.slice(start + marker.length);
+  const nextParameterMatch = remainingParameters.match(/\n    [^\s]/);
+  const nextParameter = nextParameterMatch
+    ? start + marker.length + nextParameterMatch.index
+    : -1;
+  const schemasStart = openApiSource.indexOf("\n  schemas:", start);
+  const end = [nextParameter, schemasStart]
+    .filter((index) => index !== -1)
+    .sort((left, right) => left - right)[0];
+  assert.notEqual(end, undefined, `${parameterName} OpenAPI block end not found`);
+  return openApiSource.slice(start, end);
+}
+
 function openApiComponentEnum(componentName) {
   const block = openApiComponentBlock(componentName);
   const lines = block.split(/\r?\n/);
@@ -814,6 +835,62 @@ describe("CertOps M2 contract skeletons", () => {
         false,
         `${oldScope} must not appear in the M2-A1 OpenAPI`,
       );
+    }
+  });
+
+  it("documents M2-A7 scanner rejection, pagination, and the strict job detail shape", () => {
+    const listPath = openApiPathBlock("/api/v1/workspaces/{id}/certops/jobs");
+    const logPath = openApiPathBlock(
+      "/api/v1/workspaces/{id}/certops/jobs/{jobId}/log",
+    );
+    const evidencePath = openApiPathBlock(
+      "/api/v1/workspaces/{id}/certops/jobs/{jobId}/evidence",
+    );
+    const limitParameter = openApiParameterBlock("certOpsReadLimitParam");
+    const offsetParameter = openApiParameterBlock("certOpsReadOffsetParam");
+    const jobDetail = openApiComponentBlock("CertOpsJobDetail");
+
+    for (const responseCode of ["400", "401", "403", "404", "422", "500"]) {
+      assert.match(listPath, new RegExp(`\\"${responseCode}\\":`));
+    }
+    assert.match(
+      listPath,
+      /"422":\r?\n          description: A filter contained private-key or forbidden secret material\r?\n          content:\r?\n            application\/json:\r?\n              schema:\r?\n                \$ref: "#\/components\/schemas\/ErrorResponse"/,
+    );
+    assert.match(listPath, /PRIVATE_KEY_MATERIAL_REJECTED/);
+
+    for (const pathBlock of [listPath, logPath, evidencePath]) {
+      assert.match(
+        pathBlock,
+        /\$ref: "#\/components\/parameters\/certOpsReadLimitParam"/,
+      );
+      assert.match(
+        pathBlock,
+        /\$ref: "#\/components\/parameters\/certOpsReadOffsetParam"/,
+      );
+      assert.match(pathBlock, /pagination\.limit and\s+pagination\.offset/);
+    }
+    assert.match(limitParameter, /minimum: 1/);
+    assert.match(limitParameter, /maximum: 100/);
+    assert.match(limitParameter, /default: 50/);
+    assert.match(offsetParameter, /minimum: 0/);
+    assert.match(offsetParameter, /default: 0/);
+
+    assert.doesNotMatch(jobDetail, /\ballOf:/);
+    assert.match(jobDetail, /type: object/);
+    assert.match(jobDetail, /additionalProperties: false/);
+    for (const property of [
+      "id",
+      "workspaceId",
+      "operation",
+      "status",
+      "source",
+      "payload",
+      "resultMetadata",
+      "errorCode",
+      "errorMessage",
+    ]) {
+      assert.match(jobDetail, new RegExp(`\\n        ${property}:`));
     }
   });
 

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -74,8 +74,8 @@ function routeBlock(method, routePath) {
   return routesSource.slice(start, end);
 }
 
-describe("CertOps M1 route hardening", () => {
-  it("implements only the frozen M1 workspace inventory routes", () => {
+describe("CertOps route hardening", () => {
+  it("implements only the frozen workspace inventory and M2 read routes", () => {
     const routeMatches = Array.from(
       routesSource.matchAll(/router\.(get|post)\(\n\s+"([^"]+)"/g),
     ).map((match) => `${match[1].toUpperCase()} ${match[2]}`);
@@ -84,6 +84,10 @@ describe("CertOps M1 route hardening", () => {
       "GET /api/v1/workspaces/:id/certops/certificates",
       "GET /api/v1/workspaces/:id/certops/certificates/:certId",
       "GET /api/v1/workspaces/:id/certops/certificates/:certId/instances",
+      "GET /api/v1/workspaces/:id/certops/jobs",
+      "GET /api/v1/workspaces/:id/certops/jobs/:jobId",
+      "GET /api/v1/workspaces/:id/certops/jobs/:jobId/evidence",
+      "GET /api/v1/workspaces/:id/certops/jobs/:jobId/log",
       "POST /api/v1/workspaces/:id/certops/certificates",
       "POST /api/v1/workspaces/:id/certops/certificates/:certId/retire",
       "POST /api/v1/workspaces/:id/certops/imports",
@@ -93,7 +97,7 @@ describe("CertOps M1 route hardening", () => {
     assert.equal(routesSource.includes("/api/v1/certops/agent"), false);
   });
 
-  it("gates every inventory route with certops.enabled", () => {
+  it("gates every workspace CertOps route with certops.enabled", () => {
     for (const [method, routePath] of [
       ["get", "/api/v1/workspaces/:id/certops/certificates"],
       ["post", "/api/v1/workspaces/:id/certops/certificates"],
@@ -107,12 +111,16 @@ describe("CertOps M1 route hardening", () => {
       ],
       ["get", "/api/v1/workspaces/:id/certops/certificates/:certId"],
       ["post", "/api/v1/workspaces/:id/certops/imports"],
+      ["get", "/api/v1/workspaces/:id/certops/jobs"],
+      ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/log"],
+      ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/evidence"],
+      ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId"],
     ]) {
       assert.match(routeBlock(method, routePath), /requireCertOpsEnabled/);
     }
   });
 
-  it("declares specific certificate child routes before generic certificate detail", () => {
+  it("declares specific child routes before generic detail routes", () => {
     const instancesIndex = routesSource.indexOf(
       '"/api/v1/workspaces/:id/certops/certificates/:certId/instances"',
     );
@@ -133,6 +141,27 @@ describe("CertOps M1 route hardening", () => {
     assert.ok(
       retireIndex < detailIndex,
       "retire route must be declared before generic certificate detail",
+    );
+
+    const logIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/jobs/:jobId/log"',
+    );
+    const evidenceIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/jobs/:jobId/evidence"',
+    );
+    const jobDetailIndex = routesSource.indexOf(
+      '"/api/v1/workspaces/:id/certops/jobs/:jobId"',
+    );
+    assert.notEqual(logIndex, -1);
+    assert.notEqual(evidenceIndex, -1);
+    assert.notEqual(jobDetailIndex, -1);
+    assert.ok(
+      logIndex < jobDetailIndex,
+      "job log route must be declared before generic job detail",
+    );
+    assert.ok(
+      evidenceIndex < jobDetailIndex,
+      "job evidence route must be declared before generic job detail",
     );
   });
 
@@ -205,6 +234,16 @@ describe("CertOps M1 route hardening", () => {
     assertOpenApiRoute(
       "/api/v1/workspaces/{id}/certops/certificates/{certId}/retire",
       "POST",
+    );
+    assertOpenApiRoute("/api/v1/workspaces/{id}/certops/jobs", "GET");
+    assertOpenApiRoute("/api/v1/workspaces/{id}/certops/jobs/{jobId}", "GET");
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/jobs/{jobId}/log",
+      "GET",
+    );
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/jobs/{jobId}/evidence",
+      "GET",
     );
   });
 });


### PR DESCRIPTION
## Summary

This PR adds the M2-A7 CertOps read-only job APIs for dashboard/timeline consumption.

It exposes safe workspace-scoped APIs for listing CertOps jobs, reading one job, reading job log/timeline entries, and reading job evidence.

This PR adds:

* `GET /api/v1/workspaces/:id/certops/jobs`
* `GET /api/v1/workspaces/:id/certops/jobs/:jobId`
* `GET /api/v1/workspaces/:id/certops/jobs/:jobId/log`
* `GET /api/v1/workspaces/:id/certops/jobs/:jobId/evidence`
* read-only job filters for status, operation, source, subjectType, and subjectId
* sanitized job summary responses for list views
* sanitized job detail responses for detail/timeline views
* sanitized job log and evidence responses
* OpenAPI documentation for the runtime endpoints
* integration coverage for auth, workspace isolation, filters, malformed inputs, safe errors, and zero-private-key-custody response guarantees

This PR does not add write APIs, DB migrations, executor event changes, dashboard UI, Cloud overlay, fake executor, fake agent, real agent runtime, worker polling, ACME runtime, cert-manager runtime, Helm/RBAC, connectors, or broad orchestration behavior.

## Verification

* `git diff --check`: ok
* `node --check apps/api/routes/certops.js`: ok
* `node --check apps/api/services/certops/jobs.js`: ok
* `node --check tests/integration/certops-job-read-apis.test.js`: ok
* `pnpm exec mocha tests/integration/certops-job-read-apis.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-jobs-evidence.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-executor-events.test.js --timeout 60000 --exit`: ok
* `node --test tests/unit/certops-jobs.test.js`: ok
* `node --test tests/unit/certops-evidence.test.js`: ok
* `node --test tests/unit/certops-m2-contracts.test.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `pnpm run test:unit`: ok
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a6-executor-events`.
* PR #50 / M2-A1 should merge first.
* PR #51 / M2-A2 should merge after M2-A1.
* PR #52 / M2-A3 should merge after M2-A2.
* PR #53 / M2-A4 should merge after M2-A3.
* PR #54 / M2-A5 should merge after M2-A4.
* PR #55 / M2-A6 should merge before this PR is retargeted.
* This is an M2-A7 read-only API PR, not a dashboard UI PR.
* Dev A owns this work because it touches backend routes, service read filters, workspace authorization, OpenAPI, and security boundary behavior.
* Dev B dashboard timeline UI, fake executor, fake agent, and Cloud overlay remain split out.
* These routes use existing session/workspace authentication, not machine-token executor auth.
* Workspace scope comes from the authorized workspace route context.
* The routes do not perform direct SQL persistence.
* Job list responses intentionally omit `payload` and `resultMetadata`.
* Job detail responses may include sanitized public `payload` and `resultMetadata` persisted through M2-A5 services.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A7 read API layer.

## Test plan

* [x] Verify unauthenticated requests are rejected
* [x] Verify workspace outsiders cannot list/read jobs
* [x] Verify workspace members can list jobs
* [x] Verify workspace A cannot read workspace B jobs
* [x] Verify list pagination
* [x] Verify status filter
* [x] Verify operation/source filters
* [x] Verify subjectType/subjectId filters
* [x] Verify list responses omit payload and resultMetadata
* [x] Verify job detail returns sanitized public payload/resultMetadata
* [x] Verify job log is scoped to the requested workspace job
* [x] Verify job evidence is scoped to the requested workspace job
* [x] Verify missing job returns `CERTOPS_JOB_NOT_FOUND`
* [x] Verify malformed jobId returns safe 400, not 500
* [x] Verify malformed workspaceId returns safe 400, not 500
* [x] Verify invalid filters return safe 400/422
* [x] Verify unsafe subjectId is rejected before DB/internal errors
* [x] Verify no raw token, Authorization header, token hash, private key, credential, password, or secret-looking data appears in responses
* [x] Verify no dashboard, Cloud, worker, deploy, agent, fake executor, fake agent, ACME, cert-manager, Helm/RBAC, connector, or DB migration files are changed
