### PR TITLE
feat(certops): add token management routes m2-a8

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -2,6 +2,7 @@
 
 const router = require("express").Router();
 
+const { pool } = require("../db/database");
 const { getApiLimiter } = require("../middleware/rateLimit");
 const {
   PRIVATE_KEY_MATERIAL_REJECTED,
@@ -30,7 +31,7 @@ const {
   CERTOPS_API_TOKEN_SCOPE_INVALID,
   createApiToken,
   listApiTokens,
-  revokeApiToken,
+  revokeApiTokenWithResult,
 } = require("../services/certops/apiTokens");
 const {
   CERTOPS_JOB_INVALID,
@@ -58,6 +59,24 @@ const UUID_PATTERN =
 
 function requireCertOpsWriteRole(req, res, next) {
   if (req.isWorkerCall) return next();
+
+  if (!hasAtLeastRole(req.authz?.workspaceRole, "workspace_manager")) {
+    return res.status(403).json({
+      error: "Forbidden: insufficient role",
+      code: "INSUFFICIENT_ROLE",
+    });
+  }
+
+  return next();
+}
+
+function requireCertOpsTokenManager(req, res, next) {
+  if (req.isWorkerCall || !req.user?.id) {
+    return res.status(403).json({
+      error: "Forbidden: session user required",
+      code: "INSUFFICIENT_ROLE",
+    });
+  }
 
   if (!hasAtLeastRole(req.authz?.workspaceRole, "workspace_manager")) {
     return res.status(403).json({
@@ -317,6 +336,63 @@ function apiTokenMetadata(token) {
   };
 }
 
+function apiTokenAuditMetadata(token, { includeRevocation = false } = {}) {
+  const metadata = {
+    api_token_id: token.id,
+    token_prefix: token.tokenPrefix,
+    name: token.name,
+    scopes: Array.isArray(token.scopes) ? [...token.scopes] : [],
+    status: token.status,
+  };
+
+  if (includeRevocation) {
+    metadata.revoked_at = token.revokedAt;
+  } else {
+    metadata.expires_at = token.expiresAt;
+  }
+
+  return metadata;
+}
+
+async function withCertOpsTokenTransaction(work) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await work(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackError) {
+      // Preserve the original mutation or audit error for the safe route handler.
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function recordApiTokenAudit({
+  client,
+  req,
+  action,
+  token,
+  includeRevocation,
+}) {
+  const actorUserId = req.user.id;
+  await writeAudit({
+    client,
+    actorUserId,
+    subjectUserId: actorUserId,
+    action,
+    targetType: "certops_api_token",
+    targetId: null,
+    workspaceId: req.workspace.id,
+    metadata: apiTokenAuditMetadata(token, { includeRevocation }),
+  });
+}
+
 async function recordInventoryAudit(req, source, certificates) {
   const actorUserId = req.user?.id || null;
   await writeAudit({
@@ -373,15 +449,26 @@ router.post(
   getApiLimiter(),
   rejectKeyMaterial,
   requireCertOpsEnabled,
-  requireCertOpsWriteRole,
+  requireCertOpsTokenManager,
   async (req, res) => {
     try {
-      const created = await createApiToken({
-        workspaceId: req.workspace.id,
-        name: req.body?.name,
-        scopes: req.body?.scopes,
-        expiresAt: req.body?.expiresAt,
-        createdBy: req.user?.id || null,
+      const created = await withCertOpsTokenTransaction(async (client) => {
+        const tokenResult = await createApiToken({
+          client,
+          workspaceId: req.workspace.id,
+          name: req.body?.name,
+          scopes: req.body?.scopes,
+          expiresAt: req.body?.expiresAt,
+          createdBy: req.user.id,
+        });
+        await recordApiTokenAudit({
+          client,
+          req,
+          action: "CERTOPS_API_TOKEN_CREATED",
+          token: tokenResult.token,
+          includeRevocation: false,
+        });
+        return tokenResult;
       });
 
       return res.status(201).json({
@@ -411,26 +498,39 @@ router.post(
   getApiLimiter(),
   rejectKeyMaterial,
   requireCertOpsEnabled,
-  requireCertOpsWriteRole,
+  requireCertOpsTokenManager,
   async (req, res) => {
     const tokenId = tokenIdFromParams(req, res);
     if (!tokenId) return null;
 
     try {
-      const revoked = await revokeApiToken({
-        workspaceId: req.workspace.id,
-        tokenId,
-        revokedBy: req.user?.id || null,
+      const revoked = await withCertOpsTokenTransaction(async (client) => {
+        const result = await revokeApiTokenWithResult({
+          client,
+          workspaceId: req.workspace.id,
+          tokenId,
+          revokedBy: req.user.id,
+        });
+        if (result.token && result.revokedNow) {
+          await recordApiTokenAudit({
+            client,
+            req,
+            action: "CERTOPS_API_TOKEN_REVOKED",
+            token: result.token,
+            includeRevocation: true,
+          });
+        }
+        return result;
       });
 
-      if (!revoked) {
+      if (!revoked.token) {
         return res.status(404).json({
           error: "CertOps API token not found",
           code: CERTOPS_API_TOKEN_NOT_FOUND,
         });
       }
 
-      return res.json({ token: apiTokenMetadata(revoked) });
+      return res.json({ token: apiTokenMetadata(revoked.token) });
     } catch (err) {
       const handled = handleCertOpsError(res, err);
       if (handled) return handled;

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -25,6 +25,14 @@ const {
   retireManagedCertificate,
 } = require("../services/certops/inventory");
 const {
+  CERTOPS_API_TOKEN_INVALID,
+  CERTOPS_API_TOKEN_NAME_INVALID,
+  CERTOPS_API_TOKEN_SCOPE_INVALID,
+  createApiToken,
+  listApiTokens,
+  revokeApiToken,
+} = require("../services/certops/apiTokens");
+const {
   CERTOPS_JOB_INVALID,
   CERTOPS_JOB_LOG_EVENT_TYPE_INVALID,
   CERTOPS_JOB_NOT_FOUND,
@@ -42,6 +50,8 @@ const {
 } = require("../services/certops/evidence");
 const { writeAudit } = require("../services/audit");
 const { logger } = require("../utils/logger");
+
+const CERTOPS_API_TOKEN_NOT_FOUND = "CERTOPS_API_TOKEN_NOT_FOUND";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -147,6 +157,24 @@ function handleCertOpsError(res, err) {
     });
   }
 
+  if (err?.code === CERTOPS_API_TOKEN_NOT_FOUND) {
+    return res.status(404).json({
+      error: "CertOps API token not found",
+      code: CERTOPS_API_TOKEN_NOT_FOUND,
+    });
+  }
+
+  if (
+    err?.code === CERTOPS_API_TOKEN_INVALID ||
+    err?.code === CERTOPS_API_TOKEN_NAME_INVALID ||
+    err?.code === CERTOPS_API_TOKEN_SCOPE_INVALID
+  ) {
+    return res.status(400).json({
+      error: "CertOps API token request is invalid",
+      code: err.code,
+    });
+  }
+
   if (err?.code === CERTOPS_JOB_NOT_FOUND) {
     return res.status(404).json({
       error: "Certificate job not found",
@@ -183,6 +211,18 @@ function jobIdFromParams(req, res) {
     return null;
   }
   return jobId;
+}
+
+function tokenIdFromParams(req, res) {
+  const tokenId = String(req.params.tokenId || "");
+  if (!UUID_PATTERN.test(tokenId)) {
+    res.status(400).json({
+      error: "CertOps API token identifier is invalid",
+      code: CERTOPS_API_TOKEN_INVALID,
+    });
+    return null;
+  }
+  return tokenId;
 }
 
 function jobListOptionsFromRequest(req) {
@@ -259,6 +299,24 @@ function evidenceItem(item) {
   };
 }
 
+function apiTokenMetadata(token) {
+  return {
+    id: token.id,
+    workspaceId: token.workspaceId,
+    name: token.name,
+    tokenPrefix: token.tokenPrefix,
+    scopes: Array.isArray(token.scopes) ? [...token.scopes] : [],
+    status: token.status,
+    expiresAt: token.expiresAt,
+    lastUsedAt: token.lastUsedAt,
+    revokedAt: token.revokedAt,
+    revokedByUserId: token.revokedBy ?? null,
+    createdByUserId: token.createdBy ?? null,
+    createdAt: token.createdAt,
+    updatedAt: token.updatedAt,
+  };
+}
+
 async function recordInventoryAudit(req, source, certificates) {
   const actorUserId = req.user?.id || null;
   await writeAudit({
@@ -281,6 +339,116 @@ async function recordInventoryAudit(req, source, certificates) {
     },
   });
 }
+
+router.get(
+  "/api/v1/workspaces/:id/certops/tokens",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  async (req, res) => {
+    try {
+      const tokens = await listApiTokens({
+        workspaceId: req.workspace.id,
+      });
+      return res.json({ items: tokens.map(apiTokenMetadata) });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps API token list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list CertOps API tokens",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/tokens",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  async (req, res) => {
+    try {
+      const created = await createApiToken({
+        workspaceId: req.workspace.id,
+        name: req.body?.name,
+        scopes: req.body?.scopes,
+        expiresAt: req.body?.expiresAt,
+        createdBy: req.user?.id || null,
+      });
+
+      return res.status(201).json({
+        token: apiTokenMetadata(created.token),
+        plaintextToken: created.plaintextToken,
+      });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps API token create failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to create CertOps API token",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/tokens/:tokenId/revoke",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  async (req, res) => {
+    const tokenId = tokenIdFromParams(req, res);
+    if (!tokenId) return null;
+
+    try {
+      const revoked = await revokeApiToken({
+        workspaceId: req.workspace.id,
+        tokenId,
+        revokedBy: req.user?.id || null,
+      });
+
+      if (!revoked) {
+        return res.status(404).json({
+          error: "CertOps API token not found",
+          code: CERTOPS_API_TOKEN_NOT_FOUND,
+        });
+      }
+
+      return res.json({ token: apiTokenMetadata(revoked) });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps API token revoke failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        tokenId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to revoke CertOps API token",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
 
 router.get(
   "/api/v1/workspaces/:id/certops/jobs",

--- a/apps/api/services/audit.js
+++ b/apps/api/services/audit.js
@@ -15,6 +15,7 @@ const { pool } = require("../db/database");
  */
 
 async function writeAudit({
+  client = null,
   actorUserId = null,
   subjectUserId,
   action,
@@ -24,6 +25,7 @@ async function writeAudit({
   workspaceId = null,
   metadata = {},
 }) {
+  const db = client || pool;
   // Ensure target_id matches schema (INTEGER). If a UUID or non-integer is passed, store NULL.
   let safeTargetId = null;
   try {
@@ -38,7 +40,7 @@ async function writeAudit({
   } catch (_) {
     /* noop */
   }
-  await pool.query(
+  await db.query(
     `INSERT INTO audit_events (actor_user_id, subject_user_id, action, target_type, target_id, channel, metadata, workspace_id)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
     [

--- a/apps/api/services/certops/apiTokens.js
+++ b/apps/api/services/certops/apiTokens.js
@@ -4,6 +4,7 @@ const crypto = require("crypto");
 
 const { pool } = require("../../db/database");
 const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
+const { assertSafePublicValue } = require("./jobs");
 
 const CERTOPS_API_TOKEN_INVALID = "CERTOPS_API_TOKEN_INVALID";
 const CERTOPS_API_TOKEN_MALFORMED = "CERTOPS_API_TOKEN_MALFORMED";
@@ -23,6 +24,14 @@ const TOKEN_RANDOM_BYTES = TOKEN_SECRET_HEX_LENGTH / 2;
 const MAX_TOKEN_CREATE_ATTEMPTS = 3;
 const LAST_USED_UPDATE_INTERVAL = "5 minutes";
 const RAW_TOKEN_PATTERN = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/;
+const RAW_TOKEN_EMBEDDED_PATTERN = new RegExp(
+  `${TOKEN_PREFIX}[a-f0-9]{${TOKEN_ID_HEX_LENGTH}}_[a-f0-9]{${TOKEN_SECRET_HEX_LENGTH}}`,
+  "i",
+);
+const TOKEN_HASH_ASSIGNMENT_PATTERN =
+  /\btoken[_-]?hash\s*[:=]\s*[a-f0-9]{64}\b/i;
+const BARE_BEARER_CREDENTIAL_PATTERN =
+  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}\b/i;
 
 const ALLOWED_SCOPES = Object.freeze([
   "certops:read",
@@ -78,7 +87,34 @@ function normalizeName(value) {
       PRIVATE_KEY_MATERIAL_REJECTED,
     );
   }
+  if (
+    containsRawCertOpsToken(trimmed) ||
+    containsGenericCredentialMaterial(trimmed)
+  ) {
+    throw serviceError("API token name is invalid", CERTOPS_API_TOKEN_NAME_INVALID);
+  }
   return trimmed;
+}
+
+function containsRawCertOpsToken(value) {
+  return RAW_TOKEN_EMBEDDED_PATTERN.test(String(value || ""));
+}
+
+function containsGenericCredentialMaterial(value) {
+  const text = String(value || "");
+  if (
+    TOKEN_HASH_ASSIGNMENT_PATTERN.test(text) ||
+    BARE_BEARER_CREDENTIAL_PATTERN.test(text)
+  ) {
+    return true;
+  }
+
+  try {
+    assertSafePublicValue(text);
+    return false;
+  } catch (_error) {
+    return true;
+  }
 }
 
 function normalizeScopes(scopes) {
@@ -360,23 +396,46 @@ async function getApiTokenById(options) {
   return tokenMetadataFromRow(result.rows[0] || null);
 }
 
-async function revokeApiToken(options) {
-  const result = await (options.client || pool).query(
+async function revokeApiTokenWithResult(options) {
+  const db = options.client || pool;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const result = await db.query(
     `UPDATE api_tokens
         SET status = 'revoked',
-            revoked_at = COALESCE(revoked_at, NOW()),
-            revoked_by = COALESCE(revoked_by, $3),
+            revoked_at = NOW(),
+            revoked_by = $3,
             updated_at = NOW()
       WHERE workspace_id = $1
         AND id = $2
+        AND status = 'active'
       RETURNING ${SAFE_SELECT_FIELDS}`,
     [
-      normalizeWorkspaceId(options.workspaceId),
+      workspaceId,
       options.tokenId,
       options.revokedBy || null,
     ],
   );
-  return tokenMetadataFromRow(result.rows[0] || null);
+
+  if (result.rows[0]) {
+    return {
+      token: tokenMetadataFromRow(result.rows[0]),
+      revokedNow: true,
+    };
+  }
+
+  return {
+    token: await getApiTokenById({
+      client: db,
+      workspaceId,
+      tokenId: options.tokenId,
+    }),
+    revokedNow: false,
+  };
+}
+
+async function revokeApiToken(options) {
+  const result = await revokeApiTokenWithResult(options);
+  return result.token;
 }
 
 async function markApiTokenUsed(options) {
@@ -497,11 +556,14 @@ module.exports = {
   listApiTokens,
   markApiTokenUsed,
   revokeApiToken,
+  revokeApiTokenWithResult,
   validateApiToken,
   _test: {
     RAW_TOKEN_LENGTH,
     TOKEN_ID_HEX_LENGTH,
     TOKEN_SECRET_HEX_LENGTH,
+    containsRawCertOpsToken,
+    containsGenericCredentialMaterial,
     hasRequiredScopes,
     safeCompareSha256Hex,
     scopesFromRow,

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -19,8 +19,9 @@
         "Machine surface for the M2 executor. Scoped API-token (bearer) auth.",
         "CSRF-exempt (token-authenticated, non-cookie), like internal worker requests.",
         "Ingest payloads are scanned and rejected (422) if they contain private key material.",
-        "M2 executor writes are intentionally collapsed into the single ingestion endpoint: POST /api/v1/certops/executor/events.",
-        "Do not add POST /certops/jobs/{jobId}/events or POST /certops/jobs/{jobId}/evidence in M2. Per-job write routes are not part of M2 unless a later ADR changes that."
+        "M2-A8 token management continues to use POST /api/v1/certops/executor/events as the current general executor ingestion endpoint.",
+        "Per-job event and evidence write routes are not implemented by M2-A8. They are staged for M2-A10 / PR #59; their absence here is not a permanent exclusion from M2.",
+        "M2-A10 owns the final route-compat extension and implementation for any per-job executor write routes."
       ]
     },
     "agent": {

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -18,7 +18,9 @@
       "notes": [
         "Machine surface for the M2 executor. Scoped API-token (bearer) auth.",
         "CSRF-exempt (token-authenticated, non-cookie), like internal worker requests.",
-        "Ingest payloads are scanned and rejected (422) if they contain private key material."
+        "Ingest payloads are scanned and rejected (422) if they contain private key material.",
+        "M2 executor writes are intentionally collapsed into the single ingestion endpoint: POST /api/v1/certops/executor/events.",
+        "Do not add POST /certops/jobs/{jobId}/events or POST /certops/jobs/{jobId}/evidence in M2. Per-job write routes are not part of M2 unless a later ADR changes that."
       ]
     },
     "agent": {
@@ -49,8 +51,12 @@
       { "path": "/api/v1/workspaces/{id}/certops/certificates/{certId}/retire", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/imports", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/jobs/{jobId}", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/jobs/{jobId}/log", "method": "GET" },
+      { "path": "/api/v1/workspaces/{id}/certops/jobs/{jobId}/evidence", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/tokens", "method": "POST" },
+      { "path": "/api/v1/workspaces/{id}/certops/tokens/{tokenId}/revoke", "method": "POST" },
       { "path": "/api/v1/certops/executor/events", "method": "POST" },
       { "path": "/api/v1/certops/agent/register", "method": "POST" },
       { "path": "/api/v1/certops/agent/heartbeat", "method": "POST" },

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3544,7 +3544,7 @@ paths:
       tags: [CertOps]
       summary: List CertOps API tokens
       operationId: listCertOpsTokens
-      description: Returns scoped CertOps API-token metadata only. Responses never include plaintext tokens, token secrets, token hashes, Authorization headers, or credential material. M2-A1 reserves a closed contract shape; runtime token storage and management land in later M2 PRs.
+      description: Returns workspace-scoped CertOps API-token metadata only. Plaintext tokens, token hashes, Authorization headers, and credential material are never returned.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
       responses:
@@ -3558,13 +3558,15 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
     post:
       tags: [CertOps]
       summary: Issue a scoped CertOps API token
       operationId: createCertOpsToken
-      description: Issues a scoped CertOps API token. The one-time plaintext token may be returned only in this create response and is never stored in recoverable form. List/get/revoke responses never include plaintext tokens, token secrets, token hashes, Authorization headers, or credential material. M2-A1 reserves a closed contract shape; runtime token storage and management land in later M2 PRs.
+      description: Issues a scoped CertOps API token. The one-time plaintext token is returned only by this create response and is never stored in recoverable form. List and revoke responses never include plaintext tokens, token hashes, Authorization headers, or credential material.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
       requestBody:
@@ -3586,6 +3588,17 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/tokens/{tokenId}/revoke:
@@ -3593,7 +3606,7 @@ paths:
       tags: [CertOps]
       summary: Revoke a scoped CertOps API token
       operationId: revokeCertOpsToken
-      description: Revokes a scoped CertOps API token and returns metadata only. The response never includes plaintext tokens, token secrets, token hashes, Authorization headers, or credential material. M2-A1 reserves a closed contract shape; runtime token revocation lands in a later M2 PR.
+      description: Revokes a scoped CertOps API token within the authorized workspace and returns metadata only. The response never includes plaintext tokens, token hashes, Authorization headers, or credential material.
       parameters:
         - $ref: "#/components/parameters/workspaceIdParam"
         - in: path
@@ -3601,9 +3614,7 @@ paths:
           required: true
           schema:
             type: string
-            minLength: 1
-            maxLength: 128
-            pattern: "^[A-Za-z0-9_.:-]+$"
+            format: uuid
       responses:
         "200":
           description: API token revoked
@@ -3618,7 +3629,29 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          $ref: "#/components/responses/NotFound"
+          description: CertOps is disabled or the API token was not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                certopsDisabled:
+                  value:
+                    error: Endpoint not found
+                    code: NOT_FOUND
+                tokenNotFound:
+                  value:
+                    error: CertOps API token not found
+                    code: CERTOPS_API_TOKEN_NOT_FOUND
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/certops/executor/events:
@@ -4499,9 +4532,7 @@ components:
       properties:
         id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: "^[A-Za-z0-9_.:-]+$"
+          format: uuid
         workspaceId:
           type: string
           format: uuid
@@ -4513,7 +4544,7 @@ components:
           type: string
           minLength: 1
           maxLength: 64
-          pattern: "^ttx_[A-Za-z0-9_.:-]+$"
+          pattern: "^ttx_[a-f0-9]{16}$"
           description: Public lookup prefix only; not sufficient to authenticate.
         scopes:
           type: array
@@ -4540,6 +4571,12 @@ components:
         createdAt:
           type: string
           format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        revokedByUserId:
+          type: integer
+          nullable: true
         createdByUserId:
           type: integer
           nullable: true
@@ -4561,6 +4598,7 @@ components:
           type: string
           minLength: 1
           maxLength: 128
+          description: Public label. Must not contain a raw CertOps token, bearer credential, token hash, private-key material, or generic credential material.
         scopes:
           type: array
           minItems: 1
@@ -4582,9 +4620,9 @@ components:
           $ref: "#/components/schemas/CertOpsApiToken"
         plaintextToken:
           type: string
-          minLength: 1
-          maxLength: 256
-          pattern: "^ttx_[^_]+_[^_]+$"
+          minLength: 85
+          maxLength: 85
+          pattern: "^ttx_[a-f0-9]{16}_[a-f0-9]{64}$"
           description: One-time plaintext token value shown only by the create response.
     CertOpsApiTokenRevokeResponse:
       type: object

--- a/tests/integration/certops-api-token-routes.test.js
+++ b/tests/integration/certops-api-token-routes.test.js
@@ -1,5 +1,3 @@
-const crypto = require("crypto");
-
 const { loadRootEnv } = require("../../scripts/load-root-env");
 
 loadRootEnv();

--- a/tests/integration/certops-api-token-routes.test.js
+++ b/tests/integration/certops-api-token-routes.test.js
@@ -1,0 +1,421 @@
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, request, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+const {
+  createApiToken,
+  validateApiToken,
+} = require("../../apps/api/services/certops/apiTokens");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+async function primaryWorkspaceId(session) {
+  const response = await request(BASE)
+    .get("/api/v1/workspaces?limit=50&offset=0")
+    .set("Cookie", session.cookie)
+    .expect(200);
+  return response.body.items[0].id;
+}
+
+function walkKeys(value, visit) {
+  if (Array.isArray(value)) {
+    for (const item of value) walkKeys(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    visit(key);
+    walkKeys(item, visit);
+  }
+}
+
+function expectNoPrivateKeyFields(value) {
+  const forbiddenFragments = [
+    "privatekey",
+    "privatekeypem",
+    "encryptedprivatekey",
+    "keymaterial",
+    "pfxblob",
+    "jksblob",
+    "tlskey",
+    "caprivatekey",
+    "keystorepassword",
+    "privatekeypassword",
+    "keypassword",
+    "password",
+    "secret",
+    "credential",
+    "tokensecret",
+    "apisecret",
+    "rawsecret",
+    "rawprivatekey",
+    "rawkey",
+    "pemprivatekey",
+  ];
+
+  walkKeys(value, (key) => {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    for (const fragment of forbiddenFragments) {
+      expect(
+        normalized.includes(fragment),
+        `${key} looks like private-key or credential custody`,
+      ).to.equal(false);
+    }
+  });
+}
+
+function expectNoTokenLeak(value, rawTokens = []) {
+  const serialized = JSON.stringify(value);
+  expect(serialized).to.not.include("Authorization");
+  expect(serialized).to.not.include("Bearer ");
+  expect(serialized).to.not.include("token_hash");
+  expect(serialized).to.not.include("tokenHash");
+  expect(serialized).to.not.include("rawToken");
+  expect(serialized).to.not.include("raw token");
+  expect(serialized).to.not.include("PRIVATE KEY");
+  for (const rawToken of rawTokens.filter(Boolean)) {
+    expect(serialized).to.not.include(rawToken);
+  }
+  expectNoPrivateKeyFields(value);
+}
+
+function expectMetadataOnlyToken(token) {
+  expect(token).to.include.keys([
+    "id",
+    "workspaceId",
+    "name",
+    "tokenPrefix",
+    "scopes",
+    "status",
+    "createdAt",
+  ]);
+  expect(token.tokenPrefix).to.match(/^ttx_[^_]+$/);
+  expect(token).to.not.have.property("token_hash");
+  expect(token).to.not.have.property("tokenHash");
+  expect(token).to.not.have.property("plaintextToken");
+}
+
+async function createWorkspaceFixture() {
+  const ownerUser = await TestUtils.createVerifiedTestUser();
+  const ownerSession = await TestUtils.loginTestUser(
+    ownerUser.email,
+    "SecureTest123!@#",
+  );
+  const workspaceId = await primaryWorkspaceId(ownerSession);
+
+  const managerUser = await TestUtils.createVerifiedTestUser();
+  const managerSession = await TestUtils.loginTestUser(
+    managerUser.email,
+    "SecureTest123!@#",
+  );
+  await TestUtils.execQuery(
+    `INSERT INTO workspace_memberships (user_id, workspace_id, role, invited_by)
+     VALUES ($1, $2, 'workspace_manager', $3)
+     ON CONFLICT (user_id, workspace_id) DO UPDATE SET role = EXCLUDED.role`,
+    [managerUser.id, workspaceId, ownerUser.id],
+  );
+
+  const viewerUser = await TestUtils.createVerifiedTestUser();
+  const viewerSession = await TestUtils.loginTestUser(
+    viewerUser.email,
+    "SecureTest123!@#",
+  );
+  await TestUtils.execQuery(
+    `INSERT INTO workspace_memberships (user_id, workspace_id, role, invited_by)
+     VALUES ($1, $2, 'viewer', $3)
+     ON CONFLICT (user_id, workspace_id) DO UPDATE SET role = EXCLUDED.role`,
+    [viewerUser.id, workspaceId, ownerUser.id],
+  );
+
+  const outsiderUser = await TestUtils.createVerifiedTestUser();
+  const outsiderSession = await TestUtils.loginTestUser(
+    outsiderUser.email,
+    "SecureTest123!@#",
+  );
+  const outsiderWorkspaceId = await primaryWorkspaceId(outsiderSession);
+
+  return {
+    managerSession,
+    managerUser,
+    outsiderSession,
+    outsiderUser,
+    outsiderWorkspaceId,
+    ownerSession,
+    ownerUser,
+    viewerSession,
+    viewerUser,
+    workspaceId,
+  };
+}
+
+async function cleanupWorkspaceFixture(fixture) {
+  if (!fixture) return;
+  const workspaceIds = [
+    fixture.workspaceId,
+    fixture.outsiderWorkspaceId,
+  ].filter(Boolean);
+  if (workspaceIds.length > 0) {
+    await TestUtils.execQuery(
+      "DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
+      "DELETE FROM workspaces WHERE id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+  }
+
+  for (const [user, session] of [
+    [fixture.ownerUser, fixture.ownerSession],
+    [fixture.managerUser, fixture.managerSession],
+    [fixture.viewerUser, fixture.viewerSession],
+    [fixture.outsiderUser, fixture.outsiderSession],
+  ]) {
+    if (user?.email && session?.cookie) {
+      await TestUtils.cleanupTestUser(user.email, session.cookie);
+    }
+  }
+}
+
+describe("CertOps API token management routes", function () {
+  this.timeout(60000);
+
+  let fixture;
+
+  before(async () => {
+    await runMigrations();
+    fixture = await createWorkspaceFixture();
+  });
+
+  after(async () => {
+    await cleanupWorkspaceFixture(fixture);
+  });
+
+  it("requires authentication and workspace membership", async () => {
+    const unauthenticated = await request(BASE).get(
+      `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`,
+    );
+    expect(unauthenticated.status).to.be.oneOf([401, 403]);
+    expect(unauthenticated.status).to.not.equal(500);
+    expectNoTokenLeak(unauthenticated.body);
+
+    const forbidden = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.outsiderSession.cookie);
+    expect(forbidden.status).to.equal(403);
+    expectNoTokenLeak(forbidden.body);
+  });
+
+  it("lists metadata for the requested workspace only", async () => {
+    const created = await createApiToken({
+      workspaceId: fixture.workspaceId,
+      name: "Workspace route list",
+      scopes: ["certops:executor:events", "certops:jobs:read"],
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdBy: fixture.ownerUser.id,
+    });
+    const otherWorkspaceToken = await createApiToken({
+      workspaceId: fixture.outsiderWorkspaceId,
+      name: "Other workspace",
+      scopes: ["certops:executor:events"],
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdBy: fixture.outsiderUser.id,
+    });
+
+    const response = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+
+    const ids = response.body.items.map((token) => token.id);
+    expect(ids).to.include(created.token.id);
+    expect(ids).to.not.include(otherWorkspaceToken.token.id);
+    for (const item of response.body.items) {
+      expectMetadataOnlyToken(item);
+    }
+    expectNoTokenLeak(response.body, [
+      created.plaintextToken,
+      otherWorkspaceToken.plaintextToken,
+    ]);
+  });
+
+  it("creates a scoped API token for managers and returns plaintext only once", async () => {
+    const viewerDenied = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .send({
+        name: "Viewer denied",
+        scopes: ["certops:executor:events"],
+      });
+    expect(viewerDenied.status).to.equal(403);
+    expectNoTokenLeak(viewerDenied.body);
+
+    const invalidScope = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        name: "Invalid scope",
+        scopes: ["certops:everything"],
+      });
+    expect(invalidScope.status).to.equal(400);
+    expect(invalidScope.body.code).to.equal("CERTOPS_API_TOKEN_SCOPE_INVALID");
+    expectNoTokenLeak(invalidScope.body);
+
+    const response = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        name: "Executor route token",
+        scopes: ["certops:executor:events", "certops:jobs:read"],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      })
+      .expect(201);
+
+    expect(response.body.plaintextToken).to.match(/^ttx_[^_]+_[^_]+$/);
+    expectMetadataOnlyToken(response.body.token);
+    expect(response.body.token.workspaceId).to.equal(fixture.workspaceId);
+    expect(response.body.token.createdByUserId).to.equal(fixture.managerUser.id);
+    expect(response.body.token.tokenPrefix).to.equal(
+      response.body.plaintextToken.split("_").slice(0, 2).join("_"),
+    );
+    expect(JSON.stringify(response.body.token)).to.not.include(
+      response.body.plaintextToken,
+    );
+    expectNoTokenLeak(response.body.token, [response.body.plaintextToken]);
+
+    const persisted = await TestUtils.execQuery(
+      "SELECT token_prefix, token_hash FROM api_tokens WHERE id = $1",
+      [response.body.token.id],
+    );
+    expect(persisted.rows[0].token_prefix).to.equal(
+      response.body.token.tokenPrefix,
+    );
+    expect(JSON.stringify(persisted.rows[0])).to.not.include(
+      response.body.plaintextToken,
+    );
+
+    const listAfterCreate = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .expect(200);
+    expect(JSON.stringify(listAfterCreate.body)).to.not.include(
+      response.body.plaintextToken,
+    );
+    expectNoTokenLeak(listAfterCreate.body, [response.body.plaintextToken]);
+  });
+
+  it("revokes tokens within the workspace without returning plaintext or hashes", async () => {
+    const created = await createApiToken({
+      workspaceId: fixture.workspaceId,
+      name: "Route revoke",
+      scopes: ["certops:executor:events"],
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdBy: fixture.ownerUser.id,
+    });
+
+    const viewerDenied = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`,
+      )
+      .set("Cookie", fixture.viewerSession.cookie)
+      .send({});
+    expect(viewerDenied.status).to.equal(403);
+    expectNoTokenLeak(viewerDenied.body, [created.plaintextToken]);
+
+    const crossWorkspace = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.outsiderWorkspaceId}/certops/tokens/${created.token.id}/revoke`,
+      )
+      .set("Cookie", fixture.outsiderSession.cookie)
+      .send({});
+    expect(crossWorkspace.status).to.equal(404);
+    expect(crossWorkspace.body.code).to.equal("CERTOPS_API_TOKEN_NOT_FOUND");
+    expectNoTokenLeak(crossWorkspace.body, [created.plaintextToken]);
+
+    const malformed = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/not-a-uuid/revoke`,
+      )
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({});
+    expect(malformed.status).to.equal(400);
+    expect(malformed.status).to.not.equal(500);
+    expect(malformed.body.code).to.equal("CERTOPS_API_TOKEN_INVALID");
+    expectNoTokenLeak(malformed.body, ["not-a-uuid"]);
+
+    const response = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`,
+      )
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({})
+      .expect(200);
+
+    expect(response.body.token.status).to.equal("revoked");
+    expect(response.body.token.revokedByUserId).to.equal(fixture.managerUser.id);
+    expectMetadataOnlyToken(response.body.token);
+    expectNoTokenLeak(response.body, [created.plaintextToken]);
+
+    const afterRevoke = await validateApiToken({
+      workspaceId: fixture.workspaceId,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    expect(afterRevoke.valid).to.equal(false);
+
+    const idempotent = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`,
+      )
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({})
+      .expect(200);
+    expect(idempotent.body.token.status).to.equal("revoked");
+    expectNoTokenLeak(idempotent.body, [created.plaintextToken]);
+  });
+
+  it("rejects private-key material before token creation or revoke handlers run", async () => {
+    const createRejected = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        name: "bad",
+        scopes: ["certops:executor:events"],
+        note: "-----BEGIN PRIVATE KEY-----\nredacted\n-----END PRIVATE KEY-----",
+      });
+    expect(createRejected.status).to.equal(422);
+    expect(createRejected.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expectNoTokenLeak(createRejected.body);
+
+    const created = await createApiToken({
+      workspaceId: fixture.workspaceId,
+      name: "Reject revoke body",
+      scopes: ["certops:executor:events"],
+      createdBy: fixture.ownerUser.id,
+    });
+
+    const revokeRejected = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`,
+      )
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        note: "-----BEGIN PRIVATE KEY-----\nredacted\n-----END PRIVATE KEY-----",
+      });
+    expect(revokeRejected.status).to.equal(422);
+    expect(revokeRejected.body.code).to.equal("PRIVATE_KEY_MATERIAL_REJECTED");
+    expectNoTokenLeak(revokeRejected.body, [created.plaintextToken]);
+
+    const stillValid = await validateApiToken({
+      workspaceId: fixture.workspaceId,
+      rawToken: created.plaintextToken,
+      requiredScopes: ["certops:executor:events"],
+    });
+    expect(stillValid.valid).to.equal(true);
+  });
+});

--- a/tests/integration/certops-api-token-routes.test.js
+++ b/tests/integration/certops-api-token-routes.test.js
@@ -98,6 +98,35 @@ function expectMetadataOnlyToken(token) {
   expect(token).to.not.have.property("plaintextToken");
 }
 
+async function tokenAuditEvents(workspaceId, action, tokenId) {
+  const result = await TestUtils.execQuery(
+    `SELECT actor_user_id,
+            subject_user_id,
+            target_type,
+            target_id,
+            workspace_id,
+            metadata
+       FROM audit_events
+      WHERE workspace_id = $1
+        AND action = $2
+        AND metadata->>'api_token_id' = $3
+      ORDER BY id ASC`,
+    [workspaceId, action, tokenId],
+  );
+  return result.rows;
+}
+
+async function tokenAuditCount(workspaceId, action) {
+  const result = await TestUtils.execQuery(
+    `SELECT COUNT(*)::int AS count
+       FROM audit_events
+      WHERE workspace_id = $1
+        AND action = $2`,
+    [workspaceId, action],
+  );
+  return result.rows[0].count;
+}
+
 async function createWorkspaceFixture() {
   const ownerUser = await TestUtils.createVerifiedTestUser();
   const ownerSession = await TestUtils.loginTestUser(
@@ -159,6 +188,10 @@ async function cleanupWorkspaceFixture(fixture) {
   ].filter(Boolean);
   if (workspaceIds.length > 0) {
     await TestUtils.execQuery(
+      "DELETE FROM audit_events WHERE workspace_id = ANY($1::uuid[])",
+      [workspaceIds],
+    );
+    await TestUtils.execQuery(
       "DELETE FROM api_tokens WHERE workspace_id = ANY($1::uuid[])",
       [workspaceIds],
     );
@@ -213,14 +246,14 @@ describe("CertOps API token management routes", function () {
     const created = await createApiToken({
       workspaceId: fixture.workspaceId,
       name: "Workspace route list",
-      scopes: ["certops:executor:events", "certops:jobs:read"],
+      scopes: ["certops:events:write", "certops:jobs:read"],
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       createdBy: fixture.ownerUser.id,
     });
     const otherWorkspaceToken = await createApiToken({
       workspaceId: fixture.outsiderWorkspaceId,
       name: "Other workspace",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       createdBy: fixture.outsiderUser.id,
     });
@@ -243,15 +276,22 @@ describe("CertOps API token management routes", function () {
   });
 
   it("creates a scoped API token for managers and returns plaintext only once", async () => {
+    const auditsBefore = await tokenAuditCount(
+      fixture.workspaceId,
+      "CERTOPS_API_TOKEN_CREATED",
+    );
     const viewerDenied = await request(BASE)
       .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
       .set("Cookie", fixture.viewerSession.cookie)
       .send({
         name: "Viewer denied",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
       });
     expect(viewerDenied.status).to.equal(403);
     expectNoTokenLeak(viewerDenied.body);
+    expect(
+      await tokenAuditCount(fixture.workspaceId, "CERTOPS_API_TOKEN_CREATED"),
+    ).to.equal(auditsBefore);
 
     const invalidScope = await request(BASE)
       .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
@@ -263,13 +303,16 @@ describe("CertOps API token management routes", function () {
     expect(invalidScope.status).to.equal(400);
     expect(invalidScope.body.code).to.equal("CERTOPS_API_TOKEN_SCOPE_INVALID");
     expectNoTokenLeak(invalidScope.body);
+    expect(
+      await tokenAuditCount(fixture.workspaceId, "CERTOPS_API_TOKEN_CREATED"),
+    ).to.equal(auditsBefore);
 
     const response = await request(BASE)
       .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
       .set("Cookie", fixture.managerSession.cookie)
       .send({
         name: "Executor route token",
-        scopes: ["certops:executor:events", "certops:jobs:read"],
+        scopes: ["certops:events:write", "certops:jobs:read"],
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       })
       .expect(201);
@@ -285,6 +328,28 @@ describe("CertOps API token management routes", function () {
       response.body.plaintextToken,
     );
     expectNoTokenLeak(response.body.token, [response.body.plaintextToken]);
+
+    const createAudits = await tokenAuditEvents(
+      fixture.workspaceId,
+      "CERTOPS_API_TOKEN_CREATED",
+      response.body.token.id,
+    );
+    expect(createAudits).to.have.length(1);
+    expect(createAudits[0]).to.include({
+      actor_user_id: fixture.managerUser.id,
+      subject_user_id: fixture.managerUser.id,
+      target_type: "certops_api_token",
+      target_id: null,
+      workspace_id: fixture.workspaceId,
+    });
+    expect(createAudits[0].metadata).to.deep.include({
+      api_token_id: response.body.token.id,
+      token_prefix: response.body.token.tokenPrefix,
+      name: response.body.token.name,
+      scopes: response.body.token.scopes,
+      status: response.body.token.status,
+    });
+    expectNoTokenLeak(createAudits[0].metadata, [response.body.plaintextToken]);
 
     const persisted = await TestUtils.execQuery(
       "SELECT token_prefix, token_hash FROM api_tokens WHERE id = $1",
@@ -305,16 +370,29 @@ describe("CertOps API token management routes", function () {
       response.body.plaintextToken,
     );
     expectNoTokenLeak(listAfterCreate.body, [response.body.plaintextToken]);
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_CREATED",
+        response.body.token.id,
+      ),
+    ).to.have.length(1);
   });
 
   it("revokes tokens within the workspace without returning plaintext or hashes", async () => {
     const created = await createApiToken({
       workspaceId: fixture.workspaceId,
       name: "Route revoke",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       createdBy: fixture.ownerUser.id,
     });
+    const revokeAuditsBefore = await tokenAuditEvents(
+      fixture.workspaceId,
+      "CERTOPS_API_TOKEN_REVOKED",
+      created.token.id,
+    );
+    expect(revokeAuditsBefore).to.have.length(0);
 
     const viewerDenied = await request(BASE)
       .post(
@@ -324,6 +402,13 @@ describe("CertOps API token management routes", function () {
       .send({});
     expect(viewerDenied.status).to.equal(403);
     expectNoTokenLeak(viewerDenied.body, [created.plaintextToken]);
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        created.token.id,
+      ),
+    ).to.have.length(0);
 
     const crossWorkspace = await request(BASE)
       .post(
@@ -334,6 +419,13 @@ describe("CertOps API token management routes", function () {
     expect(crossWorkspace.status).to.equal(404);
     expect(crossWorkspace.body.code).to.equal("CERTOPS_API_TOKEN_NOT_FOUND");
     expectNoTokenLeak(crossWorkspace.body, [created.plaintextToken]);
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        created.token.id,
+      ),
+    ).to.have.length(0);
 
     const malformed = await request(BASE)
       .post(
@@ -345,6 +437,13 @@ describe("CertOps API token management routes", function () {
     expect(malformed.status).to.not.equal(500);
     expect(malformed.body.code).to.equal("CERTOPS_API_TOKEN_INVALID");
     expectNoTokenLeak(malformed.body, ["not-a-uuid"]);
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        created.token.id,
+      ),
+    ).to.have.length(0);
 
     const response = await request(BASE)
       .post(
@@ -359,10 +458,32 @@ describe("CertOps API token management routes", function () {
     expectMetadataOnlyToken(response.body.token);
     expectNoTokenLeak(response.body, [created.plaintextToken]);
 
+    const revokeAudits = await tokenAuditEvents(
+      fixture.workspaceId,
+      "CERTOPS_API_TOKEN_REVOKED",
+      created.token.id,
+    );
+    expect(revokeAudits).to.have.length(1);
+    expect(revokeAudits[0]).to.include({
+      actor_user_id: fixture.managerUser.id,
+      subject_user_id: fixture.managerUser.id,
+      target_type: "certops_api_token",
+      target_id: null,
+      workspace_id: fixture.workspaceId,
+    });
+    expect(revokeAudits[0].metadata).to.deep.include({
+      api_token_id: created.token.id,
+      token_prefix: created.token.tokenPrefix,
+      name: created.token.name,
+      scopes: created.token.scopes,
+      status: "revoked",
+    });
+    expectNoTokenLeak(revokeAudits[0].metadata, [created.plaintextToken]);
+
     const afterRevoke = await validateApiToken({
       workspaceId: fixture.workspaceId,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     expect(afterRevoke.valid).to.equal(false);
 
@@ -375,6 +496,222 @@ describe("CertOps API token management routes", function () {
       .expect(200);
     expect(idempotent.body.token.status).to.equal("revoked");
     expectNoTokenLeak(idempotent.body, [created.plaintextToken]);
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        created.token.id,
+      ),
+    ).to.have.length(1);
+  });
+
+  it("rejects raw CertOps tokens in names without exposing them or overblocking prefixes", async () => {
+    const tokenA = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        name: "Token A",
+        scopes: ["certops:events:write"],
+      })
+      .expect(201);
+    const tokensBefore = await TestUtils.execQuery(
+      "SELECT COUNT(*)::int AS count FROM api_tokens WHERE workspace_id = $1",
+      [fixture.workspaceId],
+    );
+
+    for (const name of [
+      tokenA.body.plaintextToken,
+      `production-${tokenA.body.plaintextToken}`,
+      `credential=${tokenA.body.plaintextToken}`,
+      "credential=not-a-token",
+      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+      `token_hash=${"a".repeat(64)}`,
+    ]) {
+      const rejected = await request(BASE)
+        .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+        .set("Cookie", fixture.managerSession.cookie)
+        .send({ name, scopes: ["certops:events:write"] });
+      expect(rejected.status).to.equal(400);
+      expect(rejected.body.code).to.equal("CERTOPS_API_TOKEN_NAME_INVALID");
+      expectNoTokenLeak(rejected.body, [tokenA.body.plaintextToken]);
+    }
+
+    const tokensAfterRejectedNames = await TestUtils.execQuery(
+      "SELECT COUNT(*)::int AS count FROM api_tokens WHERE workspace_id = $1",
+      [fixture.workspaceId],
+    );
+    expect(tokensAfterRejectedNames.rows[0].count).to.equal(
+      tokensBefore.rows[0].count,
+    );
+
+    const prefixOnly = tokenA.body.token.tokenPrefix;
+    const prefixAccepted = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({ name: prefixOnly, scopes: ["certops:events:write"] })
+      .expect(201);
+    expect(prefixAccepted.body.token.name).to.equal(prefixOnly);
+    expectNoTokenLeak(prefixAccepted.body.token, [tokenA.body.plaintextToken]);
+
+    const viewerList = await request(BASE)
+      .get(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.viewerSession.cookie)
+      .expect(200);
+    expectNoTokenLeak(viewerList.body, [tokenA.body.plaintextToken]);
+  });
+
+  it("requires a real session manager or admin for token mutations", async () => {
+    const workerKey = process.env.WORKER_API_KEY || process.env.SESSION_SECRET;
+    expect(workerKey).to.be.a("string").and.not.equal("");
+    const createAuditsBefore = await tokenAuditCount(
+      fixture.workspaceId,
+      "CERTOPS_API_TOKEN_CREATED",
+    );
+
+    const workerCreate = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Authorization", `Bearer ${workerKey}`)
+      .send({
+        name: "Worker denied",
+        scopes: ["certops:events:write"],
+      });
+    expect(workerCreate.status).to.equal(403);
+    expectNoTokenLeak(workerCreate.body);
+    expect(
+      await tokenAuditCount(fixture.workspaceId, "CERTOPS_API_TOKEN_CREATED"),
+    ).to.equal(createAuditsBefore);
+
+    const adminCreated = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.ownerSession.cookie)
+      .send({
+        name: "Owner admin token",
+        scopes: ["certops:events:write"],
+      })
+      .expect(201);
+    expect(adminCreated.body.token.createdByUserId).to.equal(
+      fixture.ownerUser.id,
+    );
+
+    const workerRevoked = await request(BASE)
+      .post(
+        `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${adminCreated.body.token.id}/revoke`,
+      )
+      .set("Authorization", `Bearer ${workerKey}`)
+      .send({});
+    expect(workerRevoked.status).to.equal(403);
+    expectNoTokenLeak(workerRevoked.body, [adminCreated.body.plaintextToken]);
+
+    const persisted = await TestUtils.execQuery(
+      "SELECT status FROM api_tokens WHERE id = $1",
+      [adminCreated.body.token.id],
+    );
+    expect(persisted.rows[0].status).to.equal("active");
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        adminCreated.body.token.id,
+      ),
+    ).to.have.length(0);
+  });
+
+  it("writes one revoke audit for concurrent idempotent revocation", async () => {
+    const created = await createApiToken({
+      workspaceId: fixture.workspaceId,
+      name: "Concurrent revoke",
+      scopes: ["certops:events:write"],
+      createdBy: fixture.ownerUser.id,
+    });
+    const url = `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`;
+    const responses = await Promise.all([
+      request(BASE).post(url).set("Cookie", fixture.managerSession.cookie).send({}),
+      request(BASE).post(url).set("Cookie", fixture.ownerSession.cookie).send({}),
+    ]);
+
+    for (const response of responses) {
+      expect(response.status).to.equal(200);
+      expect(response.body.token.status).to.equal("revoked");
+      expectNoTokenLeak(response.body, [created.plaintextToken]);
+    }
+    expect(
+      await tokenAuditEvents(
+        fixture.workspaceId,
+        "CERTOPS_API_TOKEN_REVOKED",
+        created.token.id,
+      ),
+    ).to.have.length(1);
+  });
+
+  it("rolls back token mutations when the corresponding audit write fails", async () => {
+    await TestUtils.execQuery(`
+      CREATE OR REPLACE FUNCTION fail_certops_api_token_audit_for_test()
+      RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action IN ('CERTOPS_API_TOKEN_CREATED', 'CERTOPS_API_TOKEN_REVOKED') THEN
+          RAISE EXCEPTION 'forced CertOps API token audit failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await TestUtils.execQuery(`
+      CREATE TRIGGER fail_certops_api_token_audit_for_test_trigger
+      BEFORE INSERT ON audit_events
+      FOR EACH ROW
+      EXECUTE FUNCTION fail_certops_api_token_audit_for_test();
+    `);
+
+    try {
+      const failedCreate = await request(BASE)
+        .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+        .set("Cookie", fixture.managerSession.cookie)
+        .send({
+          name: "Audit failure create",
+          scopes: ["certops:events:write"],
+        });
+      expect(failedCreate.status).to.equal(500);
+      expectNoTokenLeak(failedCreate.body);
+      const createdRows = await TestUtils.execQuery(
+        "SELECT id FROM api_tokens WHERE workspace_id = $1 AND name = $2",
+        [fixture.workspaceId, "Audit failure create"],
+      );
+      expect(createdRows.rows).to.have.length(0);
+
+      const created = await createApiToken({
+        workspaceId: fixture.workspaceId,
+        name: "Audit failure revoke",
+        scopes: ["certops:events:write"],
+        createdBy: fixture.ownerUser.id,
+      });
+      const failedRevoke = await request(BASE)
+        .post(
+          `/api/v1/workspaces/${fixture.workspaceId}/certops/tokens/${created.token.id}/revoke`,
+        )
+        .set("Cookie", fixture.managerSession.cookie)
+        .send({});
+      expect(failedRevoke.status).to.equal(500);
+      expectNoTokenLeak(failedRevoke.body, [created.plaintextToken]);
+      const revokedRow = await TestUtils.execQuery(
+        "SELECT status FROM api_tokens WHERE id = $1",
+        [created.token.id],
+      );
+      expect(revokedRow.rows[0].status).to.equal("active");
+      expect(
+        await tokenAuditEvents(
+          fixture.workspaceId,
+          "CERTOPS_API_TOKEN_REVOKED",
+          created.token.id,
+        ),
+      ).to.have.length(0);
+    } finally {
+      await TestUtils.execQuery(
+        "DROP TRIGGER IF EXISTS fail_certops_api_token_audit_for_test_trigger ON audit_events",
+      );
+      await TestUtils.execQuery(
+        "DROP FUNCTION IF EXISTS fail_certops_api_token_audit_for_test()",
+      );
+    }
   });
 
   it("rejects private-key material before token creation or revoke handlers run", async () => {
@@ -383,7 +720,7 @@ describe("CertOps API token management routes", function () {
       .set("Cookie", fixture.managerSession.cookie)
       .send({
         name: "bad",
-        scopes: ["certops:executor:events"],
+        scopes: ["certops:events:write"],
         note: "-----BEGIN PRIVATE KEY-----\nredacted\n-----END PRIVATE KEY-----",
       });
     expect(createRejected.status).to.equal(422);
@@ -393,7 +730,7 @@ describe("CertOps API token management routes", function () {
     const created = await createApiToken({
       workspaceId: fixture.workspaceId,
       name: "Reject revoke body",
-      scopes: ["certops:executor:events"],
+      scopes: ["certops:events:write"],
       createdBy: fixture.ownerUser.id,
     });
 
@@ -412,7 +749,7 @@ describe("CertOps API token management routes", function () {
     const stillValid = await validateApiToken({
       workspaceId: fixture.workspaceId,
       rawToken: created.plaintextToken,
-      requiredScopes: ["certops:executor:events"],
+      requiredScopes: ["certops:events:write"],
     });
     expect(stillValid.valid).to.equal(true);
   });

--- a/tests/integration/suites/core-compatible.txt
+++ b/tests/integration/suites/core-compatible.txt
@@ -74,6 +74,7 @@ tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
+tests/integration/certops-api-token-routes.test.js
 tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -88,6 +88,7 @@ tests/integration/certops-migration.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-api-tokens.test.js
+tests/integration/certops-api-token-routes.test.js
 tests/integration/certops-api-token-auth.test.js
 tests/integration/certops-machine-token-rate-limit.test.js
 tests/integration/certops-jobs-evidence.test.js

--- a/tests/unit/certops-api-tokens.test.js
+++ b/tests/unit/certops-api-tokens.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   ALLOWED_SCOPES,
+  CERTOPS_API_TOKEN_NAME_INVALID,
   CERTOPS_API_TOKEN_MALFORMED,
   CERTOPS_API_TOKEN_SCOPE_DENIED,
   CERTOPS_API_TOKEN_SCOPE_INVALID,
@@ -15,6 +16,7 @@ const {
   getApiTokenById,
   listApiTokens,
   revokeApiToken,
+  revokeApiTokenWithResult,
   validateApiToken,
   _test,
 } = require(
@@ -97,7 +99,13 @@ function createMemoryClient() {
         const row = rows.find(
           (item) => item.workspace_id === params[0] && item.id === params[1],
         );
-        if (!row) return { rows: [] };
+        if (
+          !row ||
+          (normalizedSql.includes("AND status = 'active'") &&
+            row.status !== "active")
+        ) {
+          return { rows: [] };
+        }
         row.status = "revoked";
         row.revoked_at = row.revoked_at || new Date("2026-06-30T00:01:00.000Z");
         row.revoked_by = row.revoked_by || params[2] || null;
@@ -319,6 +327,47 @@ describe("CertOps API token service", () => {
     );
   });
 
+  it("rejects complete CertOps raw tokens in names without blocking public prefixes", async () => {
+    const client = createMemoryClient();
+    const existing = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Existing token",
+      scopes: ["certops:events:write"],
+    });
+
+    for (const name of [
+      existing.plaintextToken,
+      `production-${existing.plaintextToken}`,
+      `credential=${existing.plaintextToken}`,
+      "credential=not-a-token",
+      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+      `token_hash=${"a".repeat(64)}`,
+    ]) {
+      await assert.rejects(
+        () =>
+          createApiToken({
+            client,
+            workspaceId: WORKSPACE_A,
+            name,
+            scopes: ["certops:events:write"],
+          }),
+        (error) => error?.code === CERTOPS_API_TOKEN_NAME_INVALID,
+      );
+    }
+
+    await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: existing.token.tokenPrefix,
+      scopes: ["certops:events:write"],
+    });
+    assert.equal(
+      _test.containsRawCertOpsToken(existing.token.tokenPrefix),
+      false,
+    );
+  });
+
   it("validates required scopes and updates last_used_at only on success", async () => {
     const client = createMemoryClient();
     const created = await createApiToken({
@@ -469,6 +518,34 @@ describe("CertOps API token service", () => {
       requiredScopes: ["certops:events:write"],
     });
     assert.equal(result.valid, false);
+  });
+
+  it("reports whether a revoke performed the active-to-revoked transition", async () => {
+    const client = createMemoryClient();
+    const created = await createApiToken({
+      client,
+      workspaceId: WORKSPACE_A,
+      name: "Revocation result",
+      scopes: ["certops:events:write"],
+    });
+
+    const first = await revokeApiTokenWithResult({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+      revokedBy: 321,
+    });
+    const second = await revokeApiTokenWithResult({
+      client,
+      workspaceId: WORKSPACE_A,
+      tokenId: created.token.id,
+      revokedBy: 321,
+    });
+
+    assert.equal(first.revokedNow, true);
+    assert.equal(second.revokedNow, false);
+    assert.equal(first.token.status, "revoked");
+    assert.equal(second.token.status, "revoked");
   });
 
   it("rejects expired tokens", async () => {

--- a/tests/unit/certops-m2-contracts.test.js
+++ b/tests/unit/certops-m2-contracts.test.js
@@ -894,7 +894,60 @@ describe("CertOps M2 contract skeletons", () => {
     }
   });
 
-  it("keeps the committed M2-A1 through M2-A7 diff within the stacked scope", () => {
+  it("documents M2-A8 token management without permanently excluding M2-A10 routes", () => {
+    const tokenPath = openApiPathBlock(
+      "/api/v1/workspaces/{id}/certops/tokens",
+    );
+    const revokePath = openApiPathBlock(
+      "/api/v1/workspaces/{id}/certops/tokens/{tokenId}/revoke",
+    );
+    const createRequest = openApiComponentBlock(
+      "CertOpsApiTokenCreateRequest",
+    );
+    const createResponse = openApiComponentBlock(
+      "CertOpsApiTokenCreateResponse",
+    );
+    const executorNotes = routeCompatContract.namespacePolicy.executor.notes.join(
+      " ",
+    );
+
+    for (const [routePath, method] of [
+      ["/api/v1/workspaces/{id}/certops/tokens", "GET"],
+      ["/api/v1/workspaces/{id}/certops/tokens", "POST"],
+      [
+        "/api/v1/workspaces/{id}/certops/tokens/{tokenId}/revoke",
+        "POST",
+      ],
+    ]) {
+      assert.ok(
+        routeCompatContract.guarantees.stableRoutes.some(
+          (route) => route.path === routePath && route.method === method,
+        ),
+        `${method} ${routePath} must stay frozen in route compat`,
+      );
+    }
+
+    assert.match(tokenPath, /CertOpsApiTokenListResponse/);
+    assert.match(tokenPath, /CertOpsApiTokenCreateRequest/);
+    assert.match(tokenPath, /CertOpsApiTokenCreateResponse/);
+    assert.match(revokePath, /CertOpsApiTokenRevokeResponse/);
+    assert.match(createRequest, /Must not contain a raw CertOps token/);
+    assert.match(createRequest, /bearer credential/);
+    assert.match(createRequest, /token hash/);
+    assert.match(createRequest, /private-key material/);
+    assert.match(
+      createResponse,
+      /\^ttx_\[a-f0-9\]\{16\}_\[a-f0-9\]\{64\}\$/,
+    );
+    assert.match(createResponse, /minLength: 85/);
+    assert.match(createResponse, /maxLength: 85/);
+    assert.match(executorNotes, /M2-A10 \/ PR #59/);
+    assert.match(executorNotes, /not a permanent exclusion from M2/i);
+    assert.doesNotMatch(executorNotes, /not part of M2/i);
+    assert.doesNotMatch(executorNotes, /only M2 executor ingestion endpoint/i);
+  });
+
+  it("keeps the committed M2-A1 through M2-A8 diff within the stacked scope", () => {
     const { ref, files } = prChangedFiles();
     const allowedM2Files = new Set([
       "apps/api/migrations/migrate.js",
@@ -904,12 +957,14 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/index.js",
       "apps/api/routes/certops.js",
       "apps/api/routes/certops-executor.js",
+      "apps/api/services/audit.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
       "apps/api/services/certops/executorEvents.js",
       "apps/api/services/certops/jobs.js",
       "apps/api/utils/secretMaterial.js",
       "tests/integration/certops-api-token-auth.test.js",
+      "tests/integration/certops-api-token-routes.test.js",
       "tests/integration/certops-api-tokens.test.js",
       "tests/integration/certops-executor-events.test.js",
       "tests/integration/certops-job-read-apis.test.js",
@@ -937,7 +992,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.deepEqual(
       files.filter((file) => !unexpectedFiles.includes(file)),
       [],
-      `stacked M2-A1 through M2-A7 diff against ${ref} must stay within the allowed scope`,
+      `stacked M2-A1 through M2-A8 diff against ${ref} must stay within the allowed scope`,
     );
     assert.equal(
       certOpsRoutesSource.includes("/api/v1/certops/executor"),
@@ -948,7 +1003,7 @@ describe("CertOps M2 contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
   });
 
-  it("keeps local app changes within the M2-A2 through M2-A6 backend scope", () => {
+  it("keeps local app changes within the M2-A2 through M2-A8 backend scope", () => {
     const allowedStackedM2Files = new Set([
       "apps/api/migrations/migrate.js",
       "apps/api/middleware/api-token-auth.js",
@@ -957,6 +1012,7 @@ describe("CertOps M2 contract skeletons", () => {
       "apps/api/index.js",
       "apps/api/routes/certops.js",
       "apps/api/routes/certops-executor.js",
+      "apps/api/services/audit.js",
       "apps/api/services/certops/apiTokens.js",
       "apps/api/services/certops/evidence.js",
       "apps/api/services/certops/executorEvents.js",

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -185,9 +185,12 @@ describe("CertOps route hardening", () => {
           block.indexOf("requireCertOpsEnabled"),
         `${routePath} must reject private key material before the rollout gate`,
       );
+      const authorizationMiddleware = routePath.includes("/certops/tokens")
+        ? "requireCertOpsTokenManager"
+        : "requireCertOpsWriteRole";
       assert.ok(
         block.indexOf("requireCertOpsEnabled") <
-          block.indexOf("requireCertOpsWriteRole"),
+          block.indexOf(authorizationMiddleware),
         `${routePath} must check the rollout gate before write authorization`,
       );
     }

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -88,9 +88,12 @@ describe("CertOps route hardening", () => {
       "GET /api/v1/workspaces/:id/certops/jobs/:jobId",
       "GET /api/v1/workspaces/:id/certops/jobs/:jobId/evidence",
       "GET /api/v1/workspaces/:id/certops/jobs/:jobId/log",
+      "GET /api/v1/workspaces/:id/certops/tokens",
       "POST /api/v1/workspaces/:id/certops/certificates",
       "POST /api/v1/workspaces/:id/certops/certificates/:certId/retire",
       "POST /api/v1/workspaces/:id/certops/imports",
+      "POST /api/v1/workspaces/:id/certops/tokens",
+      "POST /api/v1/workspaces/:id/certops/tokens/:tokenId/revoke",
     ].sort());
 
     assert.equal(routesSource.includes("/api/v1/certops/executor"), false);
@@ -115,6 +118,9 @@ describe("CertOps route hardening", () => {
       ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/log"],
       ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/evidence"],
       ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId"],
+      ["get", "/api/v1/workspaces/:id/certops/tokens"],
+      ["post", "/api/v1/workspaces/:id/certops/tokens"],
+      ["post", "/api/v1/workspaces/:id/certops/tokens/:tokenId/revoke"],
     ]) {
       assert.match(routeBlock(method, routePath), /requireCertOpsEnabled/);
     }
@@ -170,6 +176,8 @@ describe("CertOps route hardening", () => {
       "/api/v1/workspaces/:id/certops/certificates",
       "/api/v1/workspaces/:id/certops/certificates/:certId/retire",
       "/api/v1/workspaces/:id/certops/imports",
+      "/api/v1/workspaces/:id/certops/tokens",
+      "/api/v1/workspaces/:id/certops/tokens/:tokenId/revoke",
     ]) {
       const block = routeBlock("post", routePath);
       assert.ok(
@@ -244,6 +252,12 @@ describe("CertOps route hardening", () => {
     assertOpenApiRoute(
       "/api/v1/workspaces/{id}/certops/jobs/{jobId}/evidence",
       "GET",
+    );
+    assertOpenApiRoute("/api/v1/workspaces/{id}/certops/tokens", "GET");
+    assertOpenApiRoute("/api/v1/workspaces/{id}/certops/tokens", "POST");
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/tokens/{tokenId}/revoke",
+      "POST",
     );
   });
 });


### PR DESCRIPTION
## Summary

This PR adds the M2-A8 CertOps API-token management routes and updates the M2 route-compatibility contract for the current stack.

It wires the dashboard-facing CertOps API-token management surface using the hardened M2-A2 API-token service. M2-A8 continues to use the general executor ingestion endpoint, while the per-job event and evidence write routes are explicitly staged for M2-A10 / PR #59.

This PR adds:

* `GET /api/v1/workspaces/:id/certops/tokens`
* `POST /api/v1/workspaces/:id/certops/tokens`
* `POST /api/v1/workspaces/:id/certops/tokens/:tokenId/revoke`
* metadata-only API-token list responses
* one-time plaintext token return on create
* workspace-scoped token revocation
* session-authenticated token issuance and revocation restricted to workspace managers/admins
* worker/internal-call rejection for token issuance and revocation
* rejection of raw CertOps tokens, embedded credentials, bearer credentials, token hashes, private-key material, and generic credential dumps in token names
* transactional `CERTOPS_API_TOKEN_CREATED` audit events
* transactional `CERTOPS_API_TOKEN_REVOKED` audit events
* idempotent and concurrency-safe token revocation without duplicate audit events
* rollback of token creation or revocation when the corresponding audit write fails
* backward-compatible transaction-client support for `writeAudit`
* route-compat coverage for the M2 job detail/log/evidence read routes
* route-compat coverage for token revoke
* OpenAPI schemas for token list, create, and revoke
* exact OpenAPI documentation for the canonical `ttx_<16hex>_<64hex>` plaintext-token format
* route-compat documentation that M2-A8 continues to use the general executor ingestion endpoint
* route-compat staging notes for the per-job event/evidence write routes owned by M2-A10 / PR #59
* integration coverage for authentication, workspace isolation, role enforcement, worker rejection, invalid scopes, token leakage prevention, transactional auditing, concurrent revocation, private-key rejection, and safe failures

This PR does not add dashboard UI, Cloud overlay, fake executor, fake agent, real agent, ACME runtime, cert-manager runtime, Helm/RBAC, connectors, polling APIs, claim APIs, job signing, agent bootstrap credentials, security-events tables, an audit hash-chain, or per-job executor write routes.

The per-job event/evidence write routes are not implemented by M2-A8. They are staged for M2-A10 / PR #59.

## Verification

* `git diff --check`: ok
* conflict-marker check: ok
* active runtime/OpenAPI legacy-scope search: ok
* `node --check apps/api/routes/certops.js`: ok
* `node --check apps/api/services/certops/apiTokens.js`: ok
* `node --check apps/api/services/audit.js`: ok
* `node --check tests/integration/certops-api-token-routes.test.js`: ok
* `node --check tests/unit/certops-api-tokens.test.js`: ok
* `node --check tests/unit/certops-m2-contracts.test.js`: ok
* `node --check tests/unit/certops-routes-hardening.test.js`: ok
* `node --test tests/unit/certops-api-tokens.test.js`: ok
* `node --test tests/unit/certops-api-token-auth.test.js`: ok
* `node --test tests/unit/certops-m2-contracts.test.js`: ok
* `node --test tests/unit/certops-routes-hardening.test.js`: ok
* `node --test tests/unit/certops-machine-token-rate-limit.test.js`: ok
* `node --test tests/unit/certops-jobs.test.js`: ok
* `node --test tests/unit/certops-evidence.test.js`: ok
* `node --test tests/unit/certops-migration.test.js`: ok
* `pnpm run test:unit`: ok, 272 passing
* `pnpm run check:contracts`: ok
* `pnpm run check:contracts:integrity`: ok
* `pnpm exec mocha tests/integration/certops-api-token-routes.test.js --timeout 60000 --exit`: ok, 9 passing
* `pnpm exec mocha tests/integration/certops-api-tokens.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-api-token-auth.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-machine-token-rate-limit.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-job-read-apis.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-executor-events.test.js --timeout 60000 --exit`: ok
* `pnpm exec mocha tests/integration/certops-jobs-evidence.test.js --timeout 60000 --exit`: ok
* raw-token/name leakage checks: ok
* session-manager/admin mutation checks: ok
* worker mutation rejection checks: ok
* transactional create/revoke audit checks: ok
* concurrent revoke audit-idempotency checks: ok
* audit-failure rollback checks: ok

## Notes for reviewer

* This PR is stacked on `feature/certops-m2-a7-job-read-apis`.
* PR #50 / M2-A1 should merge first.
* PR #51 / M2-A2 should merge after M2-A1.
* PR #52 / M2-A3 should merge after M2-A2.
* PR #53 / M2-A4 should merge after M2-A3.
* PR #54 / M2-A5 should merge after M2-A4.
* PR #55 / M2-A6 should merge after M2-A5.
* PR #56 / M2-A7 should merge before this PR is retargeted.
* This is an M2-A8 backend/contract PR, not a dashboard UI PR.
* Dev A owns this work because it touches backend routes, route compatibility, OpenAPI, workspace authorization, machine-credential security boundaries, and audit behavior.
* Dev B dashboard token UI, timeline UI, fake executor, fake agent, and Cloud overlay remain split out.
* Token list and revoke responses return metadata only.
* Token hashes are never returned.
* Raw token material is never returned by list or revoke.
* The plaintext token is returned only once by the create route as `plaintextToken`.
* The plaintext token is not persisted in recoverable form.
* The canonical raw-token format remains `ttx_<16 lowercase hexadecimal characters>_<64 lowercase hexadecimal characters>`.
* The public token prefix remains `ttx_<16 lowercase hexadecimal characters>` and is not sufficient to authenticate.
* Token names cannot contain complete raw CertOps tokens, embedded raw CertOps tokens, bearer credentials, explicit token hashes, private-key material, or generic credential dumps.
* Public prefix-only values remain valid non-secret token metadata.
* Rejected token names are never echoed in response bodies, error messages, audit metadata, or application logs.
* Create and revoke require a real session-authenticated workspace manager/admin.
* Worker/internal calls cannot issue or revoke CertOps API tokens.
* Viewer users can list workspace-scoped token metadata but cannot issue or revoke tokens.
* `createdByUserId`, `revokedByUserId`, and token audit actors always come from the authenticated session user.
* List is workspace-scoped and session-authenticated.
* Workspace scope comes from the authorized workspace route context.
* Request bodies cannot override the authorized workspace scope.
* Token revoke is workspace-scoped and does not allow cross-workspace token changes.
* Successful token creation and its audit event are committed in one transaction.
* First-time token revocation and its audit event are committed in one transaction.
* Creation writes exactly one `CERTOPS_API_TOKEN_CREATED` audit event.
* First-time revocation writes exactly one `CERTOPS_API_TOKEN_REVOKED` audit event.
* Repeated revocation remains idempotent and does not write another revoke audit.
* Concurrent revocation attempts produce one state transition and one revoke audit.
* Audit failures roll back the corresponding credential mutation.
* Token audit metadata contains only public token metadata.
* Token audit metadata never contains plaintext tokens, token hashes, Authorization headers, bearer credentials, private-key material, or generic secrets.
* CertOps API-token UUIDs are stored in audit metadata because the existing audit `target_id` column accepts integer identifiers only.
* `writeAudit` remains backward compatible and accepts an optional transaction client.
* Canonical M2 scopes remain:

  * `certops:read`
  * `certops:events:write`
  * `certops:jobs:read`
  * `certops:evidence:write`
* The legacy `certops:executor:events` and `certops:jobs:write` scopes are not used by active runtime or OpenAPI sources.
* `certops:read` can satisfy read-only scope requirements but does not satisfy write requirements.
* M2-A8 continues to use `POST /api/v1/certops/executor/events` as the current general executor ingestion endpoint.
* This PR does not implement the per-job event/evidence write routes.
* Those routes are staged for M2-A10 / PR #59; their absence from M2-A8 is not a permanent exclusion from M2.
* M2-A10 owns their final route-compat extension and runtime implementation.
* No migration is added by this PR.
* No `security_events` table or audit hash-chain is added.
* CertOps continues to enforce zero private-key custody.
* Private-key material is not accepted, persisted, logged, audited, echoed, processed, returned, generated, exported, transmitted, or stored by this M2-A8 token-management layer.

## Cloud handoff

* Core does not enforce a per-workspace CertOps API-token count cap.
* Cloud M2-B4/B5 must either enforce an environment-configurable active-token cap or explicitly document an accepted unlimited-token policy.
* Cloud must cover the chosen policy with plan/frozen-workspace tests.
* Cloud must update its override and compatibility manifests for the token-management routes.
* This policy belongs to the Dev B Cloud overlay and is intentionally not implemented by this Core PR.

## Test plan

* [x] Verify unauthenticated token-list requests are rejected
* [x] Verify workspace outsiders cannot list tokens
* [x] Verify workspace token list is scoped to the requested workspace
* [x] Verify viewer users can list token metadata
* [x] Verify token list responses do not expose plaintext tokens
* [x] Verify token list responses do not expose token hashes
* [x] Verify token list responses do not expose Authorization headers or credential-shaped fields
* [x] Verify viewer users cannot create tokens
* [x] Verify viewer users cannot revoke tokens
* [x] Verify workspace managers can create scoped tokens
* [x] Verify workspace admins can create scoped tokens
* [x] Verify workspace managers can revoke tokens
* [x] Verify workspace admins can revoke tokens
* [x] Verify worker/internal calls cannot create tokens
* [x] Verify worker/internal calls cannot revoke tokens
* [x] Verify rejected worker mutations do not change credential state
* [x] Verify rejected worker mutations do not write token-management audits
* [x] Verify invalid scopes are rejected safely
* [x] Verify canonical M2 scopes are accepted
* [x] Verify legacy scopes are rejected
* [x] Verify token create returns `plaintextToken` once
* [x] Verify the plaintext token matches the exact canonical format
* [x] Verify token create response metadata does not include token hashes
* [x] Verify created tokens are stored as public prefix plus SHA-256 hash only
* [x] Verify plaintext token material is not persisted in recoverable form
* [x] Verify subsequent list responses do not include the plaintext token
* [x] Verify exact raw CertOps tokens are rejected from token names
* [x] Verify embedded raw CertOps tokens are rejected from token names
* [x] Verify bearer credentials are rejected from token names
* [x] Verify explicit token-hash assignments are rejected from token names
* [x] Verify generic credential dumps are rejected from token names
* [x] Verify public token-prefix-only names remain accepted
* [x] Verify rejected names do not echo raw credential values
* [x] Verify rejected token names are not persisted
* [x] Verify viewer token lists cannot expose a raw token through another token’s name
* [x] Verify successful creation writes exactly one `CERTOPS_API_TOKEN_CREATED` audit
* [x] Verify create audit actor is the authenticated session manager/admin
* [x] Verify create audit workspace is correct
* [x] Verify create audit stores the token UUID in metadata and leaves integer `target_id` null
* [x] Verify create audit metadata contains only safe public token metadata
* [x] Verify create audit metadata contains no plaintext token, token hash, Authorization header, credential, or key material
* [x] Verify listing tokens does not write token-management audits
* [x] Verify token revoke is workspace-scoped
* [x] Verify cross-workspace token revoke returns safe 404
* [x] Verify malformed token IDs return safe 400, not 500
* [x] Verify revoked tokens can no longer authenticate as machine tokens
* [x] Verify first-time revocation writes exactly one `CERTOPS_API_TOKEN_REVOKED` audit
* [x] Verify revoke audit actor is the authenticated session manager/admin
* [x] Verify revoke audit metadata contains no plaintext token, token hash, Authorization header, credential, or key material
* [x] Verify revoke is idempotent for already revoked tokens
* [x] Verify repeated revocation does not duplicate revoke audits
* [x] Verify concurrent revocation produces exactly one revoke audit
* [x] Verify denied, malformed, and cross-workspace mutations write no token-management audit
* [x] Verify create audit failure rolls back token creation
* [x] Verify revoke audit failure rolls back token revocation
* [x] Verify private-key material is rejected before create
* [x] Verify private-key material is rejected before revoke
* [x] Verify private-key rejection does not echo submitted key material
* [x] Verify route-compat includes M2 job detail/log/evidence read routes
* [x] Verify route-compat includes token revoke
* [x] Verify OpenAPI token routes use strict metadata schemas
* [x] Verify OpenAPI documents the exact one-time plaintext-token format
* [x] Verify OpenAPI documents token names as public labels that cannot contain credentials
* [x] Verify OpenAPI list/revoke schemas do not expose plaintext tokens or token hashes
* [x] Verify per-job executor write routes are not implemented by M2-A8
* [x] Verify route-compat stages per-job executor write routes for M2-A10 / PR #59
* [x] Verify no dashboard, Cloud, Enterprise, worker, deploy, agent, fake executor, fake agent, ACME, cert-manager, Helm/RBAC, connector, polling, claim, signing, security-events, or hash-chain work is included
