### PR TITLE
fix(deps): pnpm 11.13.0, repo-root Docker contexts, and Grype base-image bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -69,7 +69,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -97,7 +97,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -148,7 +148,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -191,7 +191,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -226,7 +226,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
-          version: "10.33.4"
+          version: "11.13.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,8 +10,8 @@ ignore:
   # brace-expansion: lockfile pins 2.0.3 (patched); Grype reports 2.0.2
   - vulnerability: GHSA-f886-m6hf-6m8v
 
-  # Node 22.22.2 includes all fixes below per nodejs.org/blog/release/v22.22.2
-  # but Grype DB omits 22.x from the fixed-version list
+  # Node 22.23.0 includes all fixes below per nodejs.org/blog/release/v22.23.0
+  # but Grype DB may still omit 22.x from the fixed-version list for older CVEs
   - vulnerability: CVE-2026-21710
   - vulnerability: CVE-2026-21713
   - vulnerability: CVE-2026-21714

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
+- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy; standalone `apps/*/Dockerfile*` builds inject `allowBuilds` because their Docker context lacks the repo-root workspace file.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy; standalone `apps/*/Dockerfile*` builds inject `allowBuilds` because their Docker context lacks the repo-root workspace file.
+- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
+- **Docker builds** — `apps/api` and `apps/dashboard` Dockerfiles now require repo-root build context (same pattern as worker/compose) so they copy the canonical `pnpm-workspace.yaml` `allowBuilds` allowlist; compose test/dev contexts and volume mounts updated accordingly.
+- **Base images** — Node `22.22.2` → `22.23.0` and Go `1.26.4` → `1.26.5` across Dockerfiles to clear Grype high/fixed CVEs in the image binaries.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410).
+- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410).
+
 ### Fixed
 
 - **GitLab auto-sync (#63)** — `ImportGitLabForm.getCredentials()` now maps `includePATs` / `includeSSHKeys` into `scanParams.filters` (matching the scan endpoint's expected shape) instead of the unused `scanParams.include`; auto-sync filter selections for PATs and SSH keys are honored again.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,8 +36,14 @@ RUN subfinder -version
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
-# Copy package files
+# Copy package files. Standalone apps/api context: inject allowBuilds for pnpm 11.
 COPY package.json pnpm-lock.yaml* ./
+RUN printf '%s\n' \
+      'allowBuilds:' \
+      '  "@scarf/scarf": true' \
+      '  esbuild: true' \
+      '  sharp: true' \
+      > pnpm-workspace.yaml
 
 # Ensure production mode for installs/runtime
 ENV NODE_ENV=production

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.26.4-alpine3.23 AS subfinder-builder
+# Build context must be the repo root.
+# Prefer deploy/compose/Dockerfile.api for production Compose/CI images.
+FROM golang:1.26.5-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -14,12 +16,10 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.22.2-slim
+FROM node:22.23.0-slim
 
-# Create app directory
 WORKDIR /app
 
-# Install security updates and runtime packages
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -29,46 +29,29 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     && groupadd -r nodejs -g 1001 \
     && useradd -r -u 1001 -g nodejs nodejs
 
-# Install subfinder v2.14.0 for Domain Checker discovery.
 COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
-# Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
-# Copy package files. Standalone apps/api context: inject allowBuilds for pnpm 11.
-COPY package.json pnpm-lock.yaml* ./
-RUN printf '%s\n' \
-      'allowBuilds:' \
-      '  "@scarf/scarf": true' \
-      '  esbuild: true' \
-      '  sharp: true' \
-      > pnpm-workspace.yaml
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY --chown=nodejs:nodejs packages ./packages
+COPY --chown=nodejs:nodejs apps/api ./apps/api
 
-# Ensure production mode for installs/runtime
 ENV NODE_ENV=production
 
-# Install production dependencies (using frozen lockfile for deterministic builds)
-RUN pnpm install --prod --frozen-lockfile && \
-    pnpm audit --audit-level=high || true
+RUN pnpm install --prod --frozen-lockfile --filter @tokentimer/api... && \
+    (pnpm audit --audit-level=high || true)
 
-# Copy source code (node_modules should not be in build context).
-# --chown instead of a later `RUN chown -R /app`: the blanket chown duplicated
-# every layer (source + node_modules) and roughly doubled the image size.
-# node_modules stays root-owned; the app only needs read access at runtime.
-COPY --chown=nodejs:nodejs . .
+WORKDIR /app/apps/api
 
 USER nodejs
 
-# Expose port
 EXPOSE 4000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:4000/', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
-# Use tini for proper signal handling
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-# Start the application
 CMD ["node", "index.js"]

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -45,8 +45,16 @@ RUN subfinder -version
 ENV COREPACK_HOME=/opt/corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
-# Copy package files
+# Copy package files. apps/api is a standalone Docker context, so write a
+# minimal pnpm-workspace.yaml with allowBuilds (pnpm 11 requires this; the
+# repo-root workspace file is not available in this build context).
 COPY package.json ./
+RUN printf '%s\n' \
+      'allowBuilds:' \
+      '  "@scarf/scarf": true' \
+      '  esbuild: true' \
+      '  sharp: true' \
+      > pnpm-workspace.yaml
 
 # Install all dependencies (including dev dependencies for testing).
 # Never swallow install failures, otherwise runtime can miss required modules.

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM golang:1.26.4-alpine3.23 AS subfinder-builder
+# Build context must be the repo root (see docker-compose.*.yml).
+FROM golang:1.26.5-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -14,9 +15,8 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.22.2-slim
+FROM node:22.23.0-slim
 
-# Create app directory
 WORKDIR /app
 
 # Install security updates and essential packages for development/testing
@@ -45,41 +45,31 @@ RUN subfinder -version
 ENV COREPACK_HOME=/opt/corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
-# Copy package files. apps/api is a standalone Docker context, so write a
-# minimal pnpm-workspace.yaml with allowBuilds (pnpm 11 requires this; the
-# repo-root workspace file is not available in this build context).
-COPY package.json ./
-RUN printf '%s\n' \
-      'allowBuilds:' \
-      '  "@scarf/scarf": true' \
-      '  esbuild: true' \
-      '  sharp: true' \
-      > pnpm-workspace.yaml
+# Copy workspace config, root package.json, and lockfile from repo root
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 
-# Install all dependencies (including dev dependencies for testing).
-# Never swallow install failures, otherwise runtime can miss required modules.
-RUN pnpm install --no-frozen-lockfile && \
+# Copy workspace packages and the api app. --chown instead of a later
+# `RUN chown -R /app`, which duplicated source + node_modules into a second
+# layer. node_modules stays root-owned (read-only).
+COPY --chown=nodejs:nodejs packages ./packages
+COPY --chown=nodejs:nodejs apps/api ./apps/api
+
+# Install all dependencies (including dev) using frozen lockfile
+RUN pnpm install --frozen-lockfile --filter @tokentimer/api... && \
     (pnpm audit --audit-level=high || true)
 
-# Copy source code. --chown instead of a later `RUN chown -R /app`: the
-# blanket chown duplicated every layer (source + node_modules) into a second
-# copy. node_modules stays root-owned; runtime only reads it.
-COPY --chown=nodejs:nodejs . .
-# Dev containers may write transient files into the project root; chown the
-# /app directory inode only (non-recursive: metadata, no layer duplication).
-RUN chown nodejs:nodejs /app
+# Dev containers may write transient files into the app directory.
+RUN chown nodejs:nodejs /app /app/apps/api
+
+WORKDIR /app/apps/api
 
 USER nodejs
 
-# Expose port
 EXPOSE 4000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:4000/', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
-# Use tini for proper signal handling
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-# Start the application in development mode
 CMD ["pnpm", "start"]

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -43,7 +43,7 @@ RUN subfinder -version
 # world-readable so the non-root runtime user reuses it instead of
 # downloading pnpm again (or worse, an unpinned latest) at container start.
 ENV COREPACK_HOME=/opt/corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate && chmod -R a+rX /opt/corepack
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
 # Copy package files
 COPY package.json ./

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.13.0",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -17,8 +17,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
-# Copy package files
+# Copy package files. Standalone apps/dashboard context: inject allowBuilds for pnpm 11.
 COPY package.json pnpm-lock.yaml* ./
+RUN printf '%s\n' \
+      'allowBuilds:' \
+      '  "@scarf/scarf": true' \
+      '  esbuild: true' \
+      '  sharp: true' \
+      > pnpm-workspace.yaml
 
 # Install all dependencies with security audit (using frozen lockfile for deterministic builds)
 RUN pnpm install --frozen-lockfile && \

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,45 +1,33 @@
-FROM node:22.22.2-slim AS build
+# Build context must be the repo root.
+# Prefer deploy/compose/Dockerfile.dashboard for production Compose/CI images.
+FROM node:22.23.0-slim AS build
 
-# Build arguments (leave empty by default so production uses relative /api)
 ARG VITE_API_URL=
 ARG API_URL=
 ARG REACT_APP_ENVIRONMENT=production
 
 WORKDIR /app
 
-# Install essential packages for building
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     make \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
-# Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
-# Copy package files. Standalone apps/dashboard context: inject allowBuilds for pnpm 11.
-COPY package.json pnpm-lock.yaml* ./
-RUN printf '%s\n' \
-      'allowBuilds:' \
-      '  "@scarf/scarf": true' \
-      '  esbuild: true' \
-      '  sharp: true' \
-      > pnpm-workspace.yaml
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY apps/dashboard/package.json ./apps/dashboard/
 
-# Install all dependencies with security audit (using frozen lockfile for deterministic builds)
-RUN pnpm install --frozen-lockfile && \
-    pnpm audit --audit-level=high || true
+RUN pnpm install --frozen-lockfile --filter @tokentimer/dashboard... && \
+    (pnpm audit --audit-level=high || true)
 
-# Copy source code
-COPY . .
+COPY apps/dashboard ./apps/dashboard
 
-# Set environment variables for build and keep API_URL fallback compatibility
 ENV REACT_APP_ENVIRONMENT=$REACT_APP_ENVIRONMENT
 
-# Build the application
-RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm run build
+RUN VITE_API_URL="${VITE_API_URL:-$API_URL}" pnpm --filter @tokentimer/dashboard run build
 
-# Production stage with Nginx
 FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
@@ -56,34 +44,23 @@ RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache nginx=1.28.3-r4 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
     && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4" \
-    # Alpine's nginx build defaults to pid /run/nginx/nginx.pid (the official image
-    # used /var/run/nginx.pid); the directory only exists when created here.
     && mkdir -p /run/nginx
 
-# Create non-root user for Nginx
 RUN mkdir -p /usr/share/nginx/html && \
     addgroup -g 1001 -S nginx-user && \
     adduser -S nginx-user -u 1001
 
-# Copy built application
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/apps/dashboard/dist /usr/share/nginx/html
 
-# Copy custom Nginx configuration
-COPY nginx.conf /etc/nginx/nginx.conf
-
-# Runtime env injection for SPA
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY apps/dashboard/nginx.conf /etc/nginx/nginx.conf
+COPY apps/dashboard/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-# Change ownership of web files
 RUN chown -R nginx-user:nginx-user /usr/share/nginx/html
 
-# Expose unprivileged port
 EXPOSE 8080
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
-# Start via entrypoint to generate /usr/share/nginx/html/env.js from env vars
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,14 +1,13 @@
-FROM node:22.22.2-alpine3.23
+# Build context must be the repo root (see docker-compose.*.yml).
+FROM node:22.23.0-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
 RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
-# Create app directory
 WORKDIR /app
 
-# Create non-root user
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
@@ -18,36 +17,27 @@ RUN addgroup -g 1001 -S nodejs && \
 ENV COREPACK_HOME=/opt/corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
-# Copy package files. Standalone apps/dashboard context: inject allowBuilds for pnpm 11.
-COPY package.json ./
-RUN printf '%s\n' \
-      'allowBuilds:' \
-      '  "@scarf/scarf": true' \
-      '  esbuild: true' \
-      '  sharp: true' \
-      > pnpm-workspace.yaml
+# Copy workspace config, root package.json, and lockfile from repo root
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 
-# Install dependencies (including dev dependencies for Vite)
-RUN pnpm install --no-frozen-lockfile
+# Copy dashboard package. Vite only writes its dependency cache under
+# node_modules/.vite, so that path needs ownership; the rest stays root-owned.
+COPY --chown=nodejs:nodejs apps/dashboard ./apps/dashboard
 
-# Copy source code. --chown instead of a blanket `RUN chown -R /app`, which
-# duplicated source + node_modules into a second layer. Vite only writes its
-# dependency cache under node_modules/.vite, so that is the one path that
-# needs ownership; the rest of node_modules stays root-owned (read-only).
-COPY --chown=nodejs:nodejs . .
-# Vite writes its dep cache to node_modules/.vite and a transient bundled
-# config (vite.config.js.timestamp-*.mjs) into the project root, so chown the
-# /app directory inode (non-recursive: metadata only, no layer duplication).
-RUN mkdir -p node_modules/.vite && chown -R nodejs:nodejs node_modules/.vite && chown nodejs:nodejs /app
+# Install dependencies (including Vite) using frozen lockfile
+RUN pnpm install --frozen-lockfile --filter @tokentimer/dashboard...
+
+RUN mkdir -p /app/apps/dashboard/node_modules/.vite \
+    && chown -R nodejs:nodejs /app/apps/dashboard/node_modules/.vite \
+    && chown nodejs:nodejs /app /app/apps/dashboard
+
+WORKDIR /app/apps/dashboard
 
 USER nodejs
 
-# Expose Vite dev server port
 EXPOSE 5173
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:5173/ || exit 1
 
-# Start Vite dev server with host binding for Docker
 CMD ["pnpm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -18,8 +18,14 @@ RUN addgroup -g 1001 -S nodejs && \
 ENV COREPACK_HOME=/opt/corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
-# Copy package files
+# Copy package files. Standalone apps/dashboard context: inject allowBuilds for pnpm 11.
 COPY package.json ./
+RUN printf '%s\n' \
+      'allowBuilds:' \
+      '  "@scarf/scarf": true' \
+      '  esbuild: true' \
+      '  sharp: true' \
+      > pnpm-workspace.yaml
 
 # Install dependencies (including dev dependencies for Vite)
 RUN pnpm install --no-frozen-lockfile

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN addgroup -g 1001 -S nodejs && \
 # world-readable so the non-root runtime user reuses it instead of
 # downloading pnpm again (or worse, an unpinned latest) at container start.
 ENV COREPACK_HOME=/opt/corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate && chmod -R a+rX /opt/corepack
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate && chmod -R a+rX /opt/corepack
 
 # Copy package files
 COPY package.json ./

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.1",
   "private": true,
   "license": "BUSL-1.1",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23
+FROM node:22.23.0-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -13,7 +13,7 @@ RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Ensure production mode
 ENV NODE_ENV=production

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Copy workspace config, root package.json, and lockfile from repo root
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23
+FROM node:22.23.0-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
 RUN apk update && apk upgrade --no-cache \

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.1",
   "private": true,
   "license": "BUSL-1.1",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.13.0",
   "type": "module",
   "main": "src/queue-manager.js",
   "scripts": {

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,5 +1,5 @@
 # TokenTimer API Dockerfile
-FROM golang:1.26.4-alpine3.23 AS subfinder-builder
+FROM golang:1.26.5-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -15,7 +15,7 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.23.0-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -30,7 +30,7 @@ COPY --from=subfinder-builder /go/bin/subfinder /usr/local/bin/subfinder
 RUN subfinder -version
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Create non-root user (UID/GID 1000 is taken by the built-in node user)
 RUN addgroup -g 1001 -S tokentimer && adduser -u 1001 -S tokentimer -G tokentimer

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade --no-cache \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /app
 

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -1,5 +1,5 @@
 # TokenTimer Dashboard Dockerfile
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.23.0-alpine3.23 AS builder
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,5 +1,5 @@
 # TokenTimer Worker Dockerfile
-FROM node:22.22.2-alpine3.23
+FROM node:22.23.0-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -11,7 +11,7 @@ RUN apk update && apk upgrade --no-cache \
 RUN apk add --no-cache curl
 
 # Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 # Create non-root user (UID/GID 1000 is taken by the built-in node user)
 RUN addgroup -g 1001 -S tokentimer && adduser -u 1001 -S tokentimer -G tokentimer

--- a/deploy/compose/docker-compose.dev.yml
+++ b/deploy/compose/docker-compose.dev.yml
@@ -28,8 +28,8 @@ services:
 
   api:
     build:
-      context: ../../apps/api
-      dockerfile: Dockerfile.dev
+      context: ../..
+      dockerfile: apps/api/Dockerfile.dev
       cache_from:
         - node:22-slim
     container_name: tokentimer-core-api-dev
@@ -78,16 +78,18 @@ services:
     networks:
       - tokentimer-network
     volumes:
-      - ../../apps/api:/app
+      - ../../apps/api:/app/apps/api
       - ../../packages/contracts/openapi:/contracts/openapi:ro
       - /app/node_modules
+      - /app/apps/api/node_modules
+    working_dir: /app/apps/api
     restart: unless-stopped
     command: sh -c "pnpm run migrate && pnpm start"
 
   dashboard:
     build:
-      context: ../../apps/dashboard
-      dockerfile: Dockerfile.dev
+      context: ../..
+      dockerfile: apps/dashboard/Dockerfile.dev
       cache_from:
         - node:22-alpine
     container_name: tokentimer-core-dashboard-dev
@@ -97,8 +99,10 @@ services:
       - VITE_API_URL=${API_URL:-http://localhost:4000}
       - VITE_ENVIRONMENT=development
     volumes:
-      - ../../apps/dashboard:/app
+      - ../../apps/dashboard:/app/apps/dashboard
       - /app/node_modules
+      - /app/apps/dashboard/node_modules
+    working_dir: /app/apps/dashboard
     depends_on:
       - api
     networks:

--- a/deploy/compose/docker-compose.test.yml
+++ b/deploy/compose/docker-compose.test.yml
@@ -31,8 +31,8 @@ services:
   # ---- API (backend) ----------------------------------------
   api:
     build:
-      context: ../../apps/api
-      dockerfile: Dockerfile.dev
+      context: ../..
+      dockerfile: apps/api/Dockerfile.dev
     container_name: tokentimer-core-api-test
     ports:
       - "${TT_TEST_API_PORT:-4000}:4000"
@@ -78,9 +78,11 @@ services:
       - tokentimer-test
     restart: "no"
     volumes:
-      - ../../apps/api:/app
+      - ../../apps/api:/app/apps/api
       - /app/node_modules
+      - /app/apps/api/node_modules
       - ../../.coverage/v8-api:/tmp/v8-coverage
+    working_dir: /app/apps/api
     command: ["node", "coverage-bootstrap.cjs"]
 
   # ---- Worker: endpoint (SSL) checks -----------------------

--- a/deploy/compose/docker-compose.test.yml
+++ b/deploy/compose/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       - DELIVERY_WINDOW_DEFAULT_START=00:00
       - DELIVERY_WINDOW_DEFAULT_END=23:59
       - NODE_V8_COVERAGE=${NODE_V8_COVERAGE:+/tmp/v8-coverage}
-      - NODE_OPTIONS=${NODE_V8_COVERAGE:+--require=/app/coverage-flush-hook.cjs}
+      - NODE_OPTIONS=${NODE_V8_COVERAGE:+--require=/app/apps/api/coverage-flush-hook.cjs}
     depends_on:
       postgres:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "helm:template": "helm template tokentimer deploy/helm -f deploy/helm/ci/ci-values.yaml",
     "helm:verify": "bash scripts/helm-template-verify.sh"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.13.0",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   ip-address: 10.2.0
   form-data: 4.0.6
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - "@scarf/scarf"
+allowBuilds:
+  esbuild: true
+  sharp: true
+  "@scarf/scarf": true

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -18,7 +18,7 @@ const collectOnly = process.argv.includes("--collect-only");
 const containerCoverageDirs = [
   {
     dir: path.join(coverageRoot, "v8-api"),
-    pathMap: [["file:///app/", `file://${repoRoot}/apps/api/`]],
+    pathMap: [["file:///app/apps/api/", `file://${repoRoot}/apps/api/`]],
   },
   {
     dir: path.join(coverageRoot, "v8-worker-delivery"),


### PR DESCRIPTION
## Summary

- Upgrade pnpm from 10.33.4 to 11.13.0 across CI, `packageManager` fields, and Dockerfiles so `pnpm audit` works after npm retired the legacy audit API (HTTP 410).
- Migrate `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
- Switch `apps/api` and `apps/dashboard` Docker builds to repo-root context so they copy the canonical `pnpm-workspace.yaml` (no synthetic printf workspace).
- Bump Node `22.22.2` → `22.23.0` and Go `1.26.4` → `1.26.5` to clear Grype high/fixed CVEs in image binaries.

## Test plan

- [x] `pnpm audit --prod --audit-level=moderate` passes locally on pnpm 11.13.0
- [ ] CI `worker_quality` / `backend_quality` audit steps pass
- [ ] Compose image builds succeed with repo-root context
- [ ] Grype scan on API/dashboard/worker images clears Node/Go binary CVEs above threshold