### PR TITLE
Release TokenTimer Core v0.8.2 with GitLab Auto-Sync Fix and pnpm 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
-- **Docker builds** — `apps/api` and `apps/dashboard` Dockerfiles now require repo-root build context (same pattern as worker/compose) so they copy the canonical `pnpm-workspace.yaml` `allowBuilds` allowlist; compose test/dev contexts and volume mounts updated accordingly.
-- **Base images** — Node `22.22.2` → `22.23.0` and Go `1.26.4` → `1.26.5` across Dockerfiles to clear Grype high/fixed CVEs in the image binaries.
+## [0.8.2] - 2026-07-15
 
 ### Fixed
 
 - **GitLab auto-sync (#63)** — `ImportGitLabForm.getCredentials()` now maps `includePATs` / `includeSSHKeys` into `scanParams.filters` (matching the scan endpoint's expected shape) instead of the unused `scanParams.include`; auto-sync filter selections for PATs and SSH keys are honored again.
 - **Auto-sync "Save changes"** — filter changes (`scan_params`) are now sent on every save, even when the PAT/token field is left blank; only `credentials` remain gated behind re-entering a secret, since filters never contain sensitive data.
 - **Auto-sync worker status** — a run is now recorded as `partial` (with a descriptive `last_sync_error`) instead of `success` when items were scanned but none were actually imported, or when the import step reports per-item errors; the dashboard surfaces this via a warning banner and toast instead of a silent success message.
+
+### Changed
+
+- **pnpm 11.13.0** — upgraded from 10.33.4 so `pnpm audit` uses npm's bulk advisories endpoint after the legacy audit API was retired (HTTP 410); migrated `onlyBuiltDependencies` to `allowBuilds` for pnpm 11 build-script policy.
+- **Docker builds** — `apps/api` and `apps/dashboard` Dockerfiles now require repo-root build context (same pattern as worker/compose) so they copy the canonical `pnpm-workspace.yaml` `allowBuilds` allowlist; compose test/dev contexts, coverage flush-hook path, and V8 coverage path remaps updated accordingly.
+- **Base images** — Node `22.22.2` → `22.23.0` and Go `1.26.4` → `1.26.5` across Dockerfiles to clear Grype high/fixed CVEs in the image binaries.
+- **Version metadata bumped to 0.8.2** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
 
 ## [0.8.1] - 2026-06-22
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.8.2
+appVersion: "0.8.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.8.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.8.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.8.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.8.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.8.1
+  version: 0.8.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary

Patch release that restores GitLab auto-sync filter persistence, upgrades pnpm so audits work after npm's legacy API retirement, and clears Grype findings in Node/Go base images. Self-hosters on 0.8.1 should upgrade for correct GitLab auto-sync imports and a maintainable supply-chain baseline.

## Changes

### Auto-sync
- GitLab PAT/SSH filter selections map into `scanParams.filters` again (#63)
- Save changes persists `scan_params` without re-entering secrets
- Worker records `partial` when a run scans but imports nothing

### Infra / deps
- pnpm 10.33.4 → 11.13.0; `onlyBuiltDependencies` → `allowBuilds`
- API/dashboard Docker builds use repo-root context + canonical workspace file
- Node 22.23.0 and Go 1.26.5 base images; coverage path remaps for the new layout

### Docs / metadata
- Version bumped to 0.8.2 across manifests, OpenAPI, contracts, and Helm

## Test plan
- [x] Agent fast gate (audit, lint, Prettier, unit, contracts)
- [x] CI green on pnpm PR: https://github.com/tokentimerch/tokentimer-core/actions/runs/29448917665
- [ ] CI green on this release PR