### PR TITLE
Release TokenTimer Core v0.9.0 with CertOps M0–M2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-19
+
+### Added
+
+- **CertOps M0–M2 (self-hosted)** — gated certificate operations broker under `/api/v1/workspaces/:id/certops/*`, enabled with `CERTOPS_ENABLED=true`. TokenTimer remains zero-custody: private-key material is rejected at the API boundary and never persisted, logged, or returned.
+- **Managed certificate inventory (M1)** — `managed_certificates`, `certificate_targets`, and `certificate_instances` persistence; public PEM import/upsert by fingerprint; inventory list/detail/retire APIs; endpoint/domain-monitor observation bridge; retire-first lifecycle (`revoked` / `decommissioned`) with status mirrored onto the linked token.
+- **Dashboard CertOps surfaces (M1/M2)** — token-detail enrichment (key locality, observation history, retire modal), Import tokens PEM path, Control Center / preferences entry to Certificate operations, and `/certops/operations` for machine API tokens, jobs, and evidence timelines.
+- **Machine executor API (M2)** — workspace-bound CertOps API tokens with scopes `certops:read`, `certops:jobs:read`, `certops:events:write`, `certops:evidence:write`; bearer auth; CSRF exemption on machine routes; dedicated machine-token rate limiting; job/log/evidence persistence; aggregate and per-job executor event ingestion with idempotent replay and monotonic lifecycle transitions.
+- **Manual job creation (M2 amendment)** — `POST /api/v1/workspaces/:id/certops/jobs` (session-authenticated, manager+) plus dashboard "Create manual job" for the pre-scheduler / break-glass path; jobs are always recorded with `source: "api"`.
+- **Contracts and docs** — OpenAPI CertOps paths/schemas, route-compat and evidence/executor-event contracts, enablement docs, and ADR/CONTEXT updates for the CertOps broker model.
+
+### Changed
+
+- **Dashboard shell header alignment** — shared fixed `DASHBOARD_SHELL_HEADER_HEIGHT` so sidebar logo row and header bottom borders stay level.
+- **Worker image module resolution** — compose/dev worker Dockerfiles symlink `apps/api/node_modules` to the worker install tree so copied CertOps bridge modules resolve `pg` / logging deps at runtime.
+- **Version metadata bumped to 0.9.0** across package manifests, contract files, OpenAPI, and Helm chart `version` / `appVersion` / image tags.
+
+### Fixed
+
+- **Private-key rejection hardening** — JKS magic-header detection; key-rejection precedence before plan/role gates on write routes; fail-closed Unicode / mixed-script identity validation on certificate CN/SAN.
+- **Retire and shared-token lifecycle** — retire-first delete gate for managed-backed tokens; terminal status mirrored onto a shared token only when no active sibling managed certificate remains; re-import and monitor observations never revive `revoked` / `decommissioned` rows.
+- **Dashboard isolation and UX** — workspace-switch guards for CertOps loads; audit deep-link scope; show-once token reveal reset on workspace change; fail-closed delete while management status is unresolved; certificate-location empty vs 404 vs server-error states distinguished.
+
+### Security
+
+- **Zero-custody CertOps boundary** — private-key and keystore material rejected with audited `PRIVATE_KEY_MATERIAL_REJECTED`; generic secrets redacted from evidence/executor payloads before persistence; machine tokens never returned after one-time reveal.
+
 ## [0.8.3] - 2026-07-16
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/dashboard/src/components/certops/certopsJobsApi.js
+++ b/apps/dashboard/src/components/certops/certopsJobsApi.js
@@ -162,9 +162,6 @@ export async function createJob(
   if (payload !== undefined) body.payload = payload;
   if (idempotencyKey !== undefined) body.idempotencyKey = idempotencyKey;
 
-  const res = await apiClient.post(
-    `${workspaceBase(workspaceId)}/jobs`,
-    body
-  );
+  const res = await apiClient.post(`${workspaceBase(workspaceId)}/jobs`, body);
   return res.data;
 }

--- a/apps/dashboard/src/pages/certops/CertOpsOperations.jsx
+++ b/apps/dashboard/src/pages/certops/CertOpsOperations.jsx
@@ -29,7 +29,6 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import DashboardShell from '../../components/DashboardShell';
 import { useDashboardShellProps } from '../../hooks/useDashboardShellProps';
 import SEO from '../../components/SEO.jsx';
-import CopyableId from '../../components/CopyableId.jsx';
 import ApiTokenPanel from '../../components/certops/ApiTokenPanel.jsx';
 import EvidenceTimeline from '../../components/certops/EvidenceTimeline.jsx';
 import JobStatusBadge from '../../components/certops/JobStatusBadge.jsx';
@@ -76,9 +75,7 @@ function createJobErrorMessage(err) {
   if (code === 'CERTOPS_JOB_IDEMPOTENCY_CONFLICT') {
     return 'This idempotency key was already used with different job details.';
   }
-  return (
-    err?.response?.data?.error || err?.message || 'Could not create job.'
-  );
+  return err?.response?.data?.error || err?.message || 'Could not create job.';
 }
 
 /**
@@ -145,10 +142,10 @@ function CreateManualJobModal({ isOpen, onClose, onCreated }) {
             <Alert status='info' variant='subtle' borderRadius='md'>
               <AlertIcon boxSize={4} />
               <AlertDescription fontSize='sm'>
-                Manual job creation is an exception path for driving
-                certificate operations before automated scheduling ships. The
-                job is recorded with source &quot;api&quot; and appears at the
-                start of the job&apos;s history.
+                Manual job creation is an exception path for driving certificate
+                operations before automated scheduling ships. The job is
+                recorded with source &quot;api&quot; and appears at the start of
+                the job&apos;s history.
               </AlertDescription>
             </Alert>
             <FormControl isRequired>

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.8.3
-appVersion: "0.8.3"
+version: 0.9.0
+appVersion: "0.9.0"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.8.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.8.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.8.3"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "tokentimer-core",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {
     "//": "Run `pnpm dev:help` for the full command map. Quick pick: host-native = `pnpm dev`; full Docker stack = `pnpm docker:up`.",
-
     "// --- Host-native dev (Postgres in Docker; API + worker + dashboard on your machine) ---": "",
     "dev:help": "node scripts/dev-help.js",
     "dev": "node scripts/dev.js",
@@ -15,7 +14,6 @@
     "dev:api": "node scripts/run-with-env.js pnpm --filter @tokentimer/api dev",
     "dev:worker": "node scripts/run-with-env.js pnpm --filter @tokentimer/worker dev",
     "dev:dashboard": "node scripts/run-with-env.js pnpm --filter @tokentimer/dashboard dev",
-
     "// --- Build / run / migrate ---": "",
     "build": "pnpm run build:api && pnpm run build:worker && pnpm run build:dashboard",
     "build:api": "pnpm --filter @tokentimer/api build",
@@ -29,7 +27,6 @@
     "lint:api": "pnpm --filter @tokentimer/api lint",
     "lint:worker": "pnpm --filter @tokentimer/worker lint",
     "lint:dashboard": "pnpm --filter @tokentimer/dashboard lint",
-
     "// --- Tests ---": "",
     "test:unit": "node scripts/run-unit-tests.js",
     "test:core": "node scripts/run-tests-local.js core",
@@ -44,18 +41,15 @@
     "test:local:integration:complete": "node scripts/run-local-integration-complete.js",
     "test:full:local": "node scripts/run-local-full.js",
     "test:local:full": "node scripts/run-local-full.js",
-
     "// --- CI / contract checks ---": "",
     "check:contracts": "node scripts/check-contracts-manifest.js && node scripts/check-openapi-runtime-coverage.js",
     "check:contracts:integrity": "node scripts/check-contracts-integrity.js",
     "check:openapi:coverage": "node scripts/check-openapi-runtime-coverage.js",
     "check:lockfile-overrides": "node scripts/check-lockfile-overrides.js",
     "check:secret-logging": "node scripts/check-secret-logging.js",
-
     "// --- Integration test Docker stack (deploy/compose/docker-compose.test.yml) ---": "",
     "test:up": "docker compose -f deploy/compose/docker-compose.test.yml up --build -d",
     "test:down": "docker compose -f deploy/compose/docker-compose.test.yml down --volumes --remove-orphans",
-
     "// --- Full stack in Docker (postgres + API + worker + dashboard) ---": "",
     "docker:build": "docker compose -f deploy/compose/docker-compose.yml build",
     "docker:up": "docker compose -f deploy/compose/docker-compose.yml up",
@@ -63,7 +57,6 @@
     "docker:down:stack": "docker compose -f deploy/compose/docker-compose.yml down --remove-orphans",
     "docker:down:dev": "docker compose -f deploy/compose/docker-compose.dev.yml down --remove-orphans",
     "docker:down:all": "node scripts/docker-down-local.js",
-
     "// --- Coverage ---": "",
     "coverage:clean": "node scripts/run-coverage.js --clean-only",
     "coverage:collect": "node scripts/run-coverage.js core --collect-only",
@@ -77,7 +70,6 @@
     "test:coverage:backend": "pnpm run coverage:clean && pnpm run coverage:collect && pnpm run coverage:report:backend && pnpm run coverage:check:backend",
     "test:coverage:frontend": "pnpm run coverage:collect:frontend && pnpm run coverage:check:frontend",
     "test:coverage": "pnpm run test:coverage:backend && pnpm run test:coverage:frontend && pnpm run coverage:merge",
-
     "// --- Helm ---": "",
     "helm:lint": "helm lint deploy/helm",
     "helm:template": "helm template tokentimer deploy/helm -f deploy/helm/ci/ci-values.yaml",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.8.3
+  version: 0.9.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary

TokenTimer Core 0.9.0 packages the CertOps M0–M2 work already merged via #49 into a proper semver release: gated managed-certificate inventory, retire-first lifecycle, machine executor API tokens/jobs/evidence, and the operations dashboard, with a strict zero-private-key custody boundary. Version metadata and Helm image tags move from 0.8.3 to 0.9.0 so self-hosters and downstream Cloud/Enterprise pins can adopt a labeled release.

## Changes

### CertOps
- M0 foundation: gated `/api/v1/workspaces/:id/certops/*` namespace, contracts, enablement flag
- M1 inventory: managed certificates, targets, instances; public PEM import; monitor bridge; retire-first lifecycle with token status mirror
- M2 machine API: scoped API tokens, executor events/evidence, idempotent lifecycle, redaction
- Manual job creation endpoint + dashboard "Create manual job" break-glass path
- Dashboard operations page, token-detail enrichment, Import PEM path, location failure states

### Infra / packaging
- Worker Dockerfiles: `apps/api/node_modules` symlink for CertOps bridge module resolution
- Dashboard shell fixed header height alignment
- Version bumped to 0.9.0 across package manifests, contracts, OpenAPI, Helm `version` / `appVersion` / image tags

### Docs / metadata
- CHANGELOG `[0.9.0]` section documenting CertOps M0–M2

## Test plan
- [x] `pnpm audit --prod --audit-level=moderate` (clean)
- [x] Dashboard / worker / API lint (errors fixed; pre-existing warnings only)
- [x] Dashboard Prettier `--write` then `--check`
- [x] Grype `--fail-on high --only-fixed` on api / dashboard / worker scan images (pass; api medium goldmark only)
- [x] Full `test:ci` intentionally deferred per release request (lint + audit + Grype only)
