### PR TITLE
Fix Nginx in order to republish v0.9.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,3 +97,4 @@ steps:
       tags: ${{ steps.meta.outputs.worker_tags }}
       cache-from: type=gha
       cache-to: type=gha,mode=max
+```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,114 +1,100 @@
 name: Publish Images
 
 on:
-  workflow_dispatch:
-    inputs:
-      push_latest:
-        description: "Also tag and push :latest"
-        required: false
-        type: boolean
-        default: false
-      tag_suffix:
-        description: "Optional extra tag suffix (e.g. staging-latest, v1.2.3)"
-        required: false
-        type: string
+workflow_dispatch:
+inputs:
+image_tag:
+description: "Image tag to publish"
+required: true
+type: string
+default: "0.9.0"
+push_latest:
+description: "Also tag and push :latest"
+required: false
+type: boolean
+default: true
 
 permissions:
-  contents: read
-  packages: write
+contents: read
+packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  publish:
-    name: Build and Push Images (no tests)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+publish:
+name: Build and Push Images
+runs-on: ubuntu-latest
+timeout-minutes: 30
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+steps:
+  - name: Checkout
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Compute tags
-        id: meta
-        run: |
-          OWNER=${{ github.repository_owner }}
-          SHA_TAG=${{ github.sha }}
-          BRANCH=${GITHUB_REF_NAME//\//-}
-          API_REPO="ghcr.io/${OWNER}/tokentimer-core-api"
-          DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
-          WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
+  - name: Log in to GHCR
+    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
 
-          echo "api_repo=${API_REPO}" >> $GITHUB_OUTPUT
-          echo "dashboard_repo=${DASHBOARD_REPO}" >> $GITHUB_OUTPUT
-          echo "worker_repo=${WORKER_REPO}" >> $GITHUB_OUTPUT
+  - name: Compute tags
+    id: meta
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag }}
+      PUSH_LATEST: ${{ inputs.push_latest }}
+    run: |
+      if ! printf '%s' "$IMAGE_TAG" \
+        | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
+        echo "::error::Invalid Docker image tag: $IMAGE_TAG"
+        exit 1
+      fi
 
-          # Conditionally push latest tags only if explicitly requested
-          if [ "${{ inputs.push_latest }}" = "true" ]; then
-            echo "api_latest=${API_REPO}:latest" >> $GITHUB_OUTPUT
-            echo "dashboard_latest=${DASHBOARD_REPO}:latest" >> $GITHUB_OUTPUT
-            echo "worker_latest=${WORKER_REPO}:latest" >> $GITHUB_OUTPUT
-          fi
-          # Optional extra suffix
-          if [ -n "${{ inputs.tag_suffix }}" ]; then
-            echo "api_extra=${API_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
-            echo "dashboard_extra=${DASHBOARD_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
-            echo "worker_extra=${WORKER_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
-          fi
+      OWNER="${{ github.repository_owner }}"
 
-      - name: Build and push API
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          file: ./deploy/compose/Dockerfile.api
-          push: true
-          platforms: linux/amd64
-          tags: |
-            ${{ steps.meta.outputs.api_repo }}:${{ github.sha }}
-            ${{ steps.meta.outputs.api_repo }}:${{ github.ref_name }}
-            ${{ steps.meta.outputs.api_latest }}
-            ${{ steps.meta.outputs.api_extra }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
+      WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
 
-      - name: Build and push Dashboard
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          file: ./deploy/compose/Dockerfile.dashboard
-          push: true
-          platforms: linux/amd64
-          build-args: |
-            VITE_API_URL=
-          tags: |
-            ${{ steps.meta.outputs.dashboard_repo }}:${{ github.sha }}
-            ${{ steps.meta.outputs.dashboard_repo }}:${{ github.ref_name }}
-            ${{ steps.meta.outputs.dashboard_latest }}
-            ${{ steps.meta.outputs.dashboard_extra }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      {
+        echo "dashboard_tags<<EOF"
+        echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
+        if [ "$PUSH_LATEST" = "true" ]; then
+          echo "${DASHBOARD_REPO}:latest"
+        fi
+        echo "EOF"
 
-      - name: Build and push Worker
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          file: ./deploy/compose/Dockerfile.worker
-          push: true
-          platforms: linux/amd64
-          tags: |
-            ${{ steps.meta.outputs.worker_repo }}:${{ github.sha }}
-            ${{ steps.meta.outputs.worker_repo }}:${{ github.ref_name }}
-            ${{ steps.meta.outputs.worker_latest }}
-            ${{ steps.meta.outputs.worker_extra }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        echo "worker_tags<<EOF"
+        echo "${WORKER_REPO}:${IMAGE_TAG}"
+        if [ "$PUSH_LATEST" = "true" ]; then
+          echo "${WORKER_REPO}:latest"
+        fi
+        echo "EOF"
+      } >> "$GITHUB_OUTPUT"
+
+  - name: Build and push Dashboard
+    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+    with:
+      context: .
+      file: ./deploy/compose/Dockerfile.dashboard
+      push: true
+      platforms: linux/amd64
+      build-args: |
+        VITE_API_URL=
+      tags: ${{ steps.meta.outputs.dashboard_tags }}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max
+
+  - name: Build and push Worker
+    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+    with:
+      context: .
+      file: ./deploy/compose/Dockerfile.worker
+      push: true
+      platforms: linux/amd64
+      tags: ${{ steps.meta.outputs.worker_tags }}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max
+```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,97 +1,99 @@
 name: Publish Images
 
 on:
-  workflow_dispatch:
-    inputs:
-      image_tag:
-        description: "Image tag to publish"
-        required: true
-        type: string
-        default: "0.9.0"
-      push_latest:
-        description: "Also tag and push latest"
-        required: false
-        type: boolean
-        default: true
+workflow_dispatch:
+inputs:
+image_tag:
+description: "Image tag to publish"
+required: true
+type: string
+default: "0.9.0"
+push_latest:
+description: "Also tag and push :latest"
+required: false
+type: boolean
+default: true
 
 permissions:
-  contents: read
-  packages: write
+contents: read
+packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  publish:
-    name: Build and Push Images
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+publish:
+name: Build and Push Images
+runs-on: ubuntu-latest
+timeout-minutes: 30
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+steps:
+  - name: Checkout
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  - name: Log in to GHCR
+    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute image tags
-        id: meta
-        env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
-          PUSH_LATEST: ${{ inputs.push_latest }}
-        run: |
-          if ! printf '%s' "$IMAGE_TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
-            echo "::error::Invalid Docker image tag: $IMAGE_TAG"
-            exit 1
-          fi
+  - name: Compute tags
+    id: meta
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag }}
+      PUSH_LATEST: ${{ inputs.push_latest }}
+    run: |
+      if ! printf '%s' "$IMAGE_TAG" \
+        | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
+        echo "::error::Invalid Docker image tag: $IMAGE_TAG"
+        exit 1
+      fi
 
-          OWNER="${{ github.repository_owner }}"
-          DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
-          WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
+      OWNER="${{ github.repository_owner }}"
 
-          {
-            echo "dashboard_tags<<EOF"
-            echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
-            if [ "$PUSH_LATEST" = "true" ]; then
-              echo "${DASHBOARD_REPO}:latest"
-            fi
-            echo "EOF"
+      DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
+      WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
 
-            echo "worker_tags<<EOF"
-            echo "${WORKER_REPO}:${IMAGE_TAG}"
-            if [ "$PUSH_LATEST" = "true" ]; then
-              echo "${WORKER_REPO}:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+      {
+        echo "dashboard_tags<<EOF"
+        echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
+        if [ "$PUSH_LATEST" = "true" ]; then
+          echo "${DASHBOARD_REPO}:latest"
+        fi
+        echo "EOF"
 
-      - name: Build and push Dashboard
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
-        with:
-          context: .
-          file: ./deploy/compose/Dockerfile.dashboard
-          push: true
-          platforms: linux/amd64
-          build-args: |
-            VITE_API_URL=
-          tags: ${{ steps.meta.outputs.dashboard_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        echo "worker_tags<<EOF"
+        echo "${WORKER_REPO}:${IMAGE_TAG}"
+        if [ "$PUSH_LATEST" = "true" ]; then
+          echo "${WORKER_REPO}:latest"
+        fi
+        echo "EOF"
+      } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Worker
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
-        with:
-          context: .
-          file: ./deploy/compose/Dockerfile.worker
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.worker_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  - name: Build and push Dashboard
+    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+    with:
+      context: .
+      file: ./deploy/compose/Dockerfile.dashboard
+      push: true
+      platforms: linux/amd64
+      build-args: |
+        VITE_API_URL=
+      tags: ${{ steps.meta.outputs.dashboard_tags }}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max
+
+  - name: Build and push Worker
+    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+    with:
+      context: .
+      file: ./deploy/compose/Dockerfile.worker
+      push: true
+      platforms: linux/amd64
+      tags: ${{ steps.meta.outputs.worker_tags }}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,100 +1,114 @@
 name: Publish Images
 
 on:
-workflow_dispatch:
-inputs:
-image_tag:
-description: "Image tag to publish"
-required: true
-type: string
-default: "0.9.0"
-push_latest:
-description: "Also tag and push :latest"
-required: false
-type: boolean
-default: true
+  workflow_dispatch:
+    inputs:
+      push_latest:
+        description: "Also tag and push :latest"
+        required: false
+        type: boolean
+        default: false
+      tag_suffix:
+        description: "Optional extra tag suffix (e.g. staging-latest, v1.2.3)"
+        required: false
+        type: string
 
 permissions:
-contents: read
-packages: write
+  contents: read
+  packages: write
 
 env:
-FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-publish:
-name: Build and Push Images
-runs-on: ubuntu-latest
-timeout-minutes: 30
+  publish:
+    name: Build and Push Images (no tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-steps:
-  - name: Checkout
-    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-  - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  - name: Log in to GHCR
-    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-    with:
-      registry: ghcr.io
-      username: ${{ github.actor }}
-      password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute tags
+        id: meta
+        run: |
+          OWNER=${{ github.repository_owner }}
+          SHA_TAG=${{ github.sha }}
+          BRANCH=${GITHUB_REF_NAME//\//-}
+          API_REPO="ghcr.io/${OWNER}/tokentimer-core-api"
+          DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
+          WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
 
-  - name: Compute tags
-    id: meta
-    env:
-      IMAGE_TAG: ${{ inputs.image_tag }}
-      PUSH_LATEST: ${{ inputs.push_latest }}
-    run: |
-      if ! printf '%s' "$IMAGE_TAG" \
-        | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
-        echo "::error::Invalid Docker image tag: $IMAGE_TAG"
-        exit 1
-      fi
+          echo "api_repo=${API_REPO}" >> $GITHUB_OUTPUT
+          echo "dashboard_repo=${DASHBOARD_REPO}" >> $GITHUB_OUTPUT
+          echo "worker_repo=${WORKER_REPO}" >> $GITHUB_OUTPUT
 
-      OWNER="${{ github.repository_owner }}"
+          # Conditionally push latest tags only if explicitly requested
+          if [ "${{ inputs.push_latest }}" = "true" ]; then
+            echo "api_latest=${API_REPO}:latest" >> $GITHUB_OUTPUT
+            echo "dashboard_latest=${DASHBOARD_REPO}:latest" >> $GITHUB_OUTPUT
+            echo "worker_latest=${WORKER_REPO}:latest" >> $GITHUB_OUTPUT
+          fi
+          # Optional extra suffix
+          if [ -n "${{ inputs.tag_suffix }}" ]; then
+            echo "api_extra=${API_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+            echo "dashboard_extra=${DASHBOARD_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+            echo "worker_extra=${WORKER_REPO}:${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+          fi
 
-      DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
-      WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
+      - name: Build and push API
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          file: ./deploy/compose/Dockerfile.api
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.api_repo }}:${{ github.sha }}
+            ${{ steps.meta.outputs.api_repo }}:${{ github.ref_name }}
+            ${{ steps.meta.outputs.api_latest }}
+            ${{ steps.meta.outputs.api_extra }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      {
-        echo "dashboard_tags<<EOF"
-        echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
-        if [ "$PUSH_LATEST" = "true" ]; then
-          echo "${DASHBOARD_REPO}:latest"
-        fi
-        echo "EOF"
+      - name: Build and push Dashboard
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          file: ./deploy/compose/Dockerfile.dashboard
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            VITE_API_URL=
+          tags: |
+            ${{ steps.meta.outputs.dashboard_repo }}:${{ github.sha }}
+            ${{ steps.meta.outputs.dashboard_repo }}:${{ github.ref_name }}
+            ${{ steps.meta.outputs.dashboard_latest }}
+            ${{ steps.meta.outputs.dashboard_extra }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-        echo "worker_tags<<EOF"
-        echo "${WORKER_REPO}:${IMAGE_TAG}"
-        if [ "$PUSH_LATEST" = "true" ]; then
-          echo "${WORKER_REPO}:latest"
-        fi
-        echo "EOF"
-      } >> "$GITHUB_OUTPUT"
-
-  - name: Build and push Dashboard
-    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-    with:
-      context: .
-      file: ./deploy/compose/Dockerfile.dashboard
-      push: true
-      platforms: linux/amd64
-      build-args: |
-        VITE_API_URL=
-      tags: ${{ steps.meta.outputs.dashboard_tags }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
-
-  - name: Build and push Worker
-    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-    with:
-      context: .
-      file: ./deploy/compose/Dockerfile.worker
-      push: true
-      platforms: linux/amd64
-      tags: ${{ steps.meta.outputs.worker_tags }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
-```
+      - name: Build and push Worker
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          file: ./deploy/compose/Dockerfile.worker
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.worker_repo }}:${{ github.sha }}
+            ${{ steps.meta.outputs.worker_repo }}:${{ github.ref_name }}
+            ${{ steps.meta.outputs.worker_latest }}
+            ${{ steps.meta.outputs.worker_extra }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,4 +97,3 @@ steps:
       tags: ${{ steps.meta.outputs.worker_tags }}
       cache-from: type=gha
       cache-to: type=gha,mode=max
-```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,99 +1,97 @@
 name: Publish Images
 
 on:
-workflow_dispatch:
-inputs:
-image_tag:
-description: "Image tag to publish"
-required: true
-type: string
-default: "0.9.0"
-push_latest:
-description: "Also tag and push :latest"
-required: false
-type: boolean
-default: true
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to publish"
+        required: true
+        type: string
+        default: "0.9.0"
+      push_latest:
+        description: "Also tag and push latest"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
-contents: read
-packages: write
+  contents: read
+  packages: write
 
 env:
-FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-publish:
-name: Build and Push Images
-runs-on: ubuntu-latest
-timeout-minutes: 30
+  publish:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-steps:
-  - name: Checkout
-    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-  - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
-  - name: Log in to GHCR
-    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-    with:
-      registry: ghcr.io
-      username: ${{ github.actor }}
-      password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  - name: Compute tags
-    id: meta
-    env:
-      IMAGE_TAG: ${{ inputs.image_tag }}
-      PUSH_LATEST: ${{ inputs.push_latest }}
-    run: |
-      if ! printf '%s' "$IMAGE_TAG" \
-        | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
-        echo "::error::Invalid Docker image tag: $IMAGE_TAG"
-        exit 1
-      fi
+      - name: Compute image tags
+        id: meta
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          PUSH_LATEST: ${{ inputs.push_latest }}
+        run: |
+          if ! printf '%s' "$IMAGE_TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
+            echo "::error::Invalid Docker image tag: $IMAGE_TAG"
+            exit 1
+          fi
 
-      OWNER="${{ github.repository_owner }}"
+          OWNER="${{ github.repository_owner }}"
+          DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
+          WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
 
-      DASHBOARD_REPO="ghcr.io/${OWNER}/tokentimer-core-dashboard"
-      WORKER_REPO="ghcr.io/${OWNER}/tokentimer-core-worker"
+          {
+            echo "dashboard_tags<<EOF"
+            echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
+            if [ "$PUSH_LATEST" = "true" ]; then
+              echo "${DASHBOARD_REPO}:latest"
+            fi
+            echo "EOF"
 
-      {
-        echo "dashboard_tags<<EOF"
-        echo "${DASHBOARD_REPO}:${IMAGE_TAG}"
-        if [ "$PUSH_LATEST" = "true" ]; then
-          echo "${DASHBOARD_REPO}:latest"
-        fi
-        echo "EOF"
+            echo "worker_tags<<EOF"
+            echo "${WORKER_REPO}:${IMAGE_TAG}"
+            if [ "$PUSH_LATEST" = "true" ]; then
+              echo "${WORKER_REPO}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-        echo "worker_tags<<EOF"
-        echo "${WORKER_REPO}:${IMAGE_TAG}"
-        if [ "$PUSH_LATEST" = "true" ]; then
-          echo "${WORKER_REPO}:latest"
-        fi
-        echo "EOF"
-      } >> "$GITHUB_OUTPUT"
+      - name: Build and push Dashboard
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          file: ./deploy/compose/Dockerfile.dashboard
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            VITE_API_URL=
+          tags: ${{ steps.meta.outputs.dashboard_tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-  - name: Build and push Dashboard
-    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-    with:
-      context: .
-      file: ./deploy/compose/Dockerfile.dashboard
-      push: true
-      platforms: linux/amd64
-      build-args: |
-        VITE_API_URL=
-      tags: ${{ steps.meta.outputs.dashboard_tags }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
-
-  - name: Build and push Worker
-    uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-    with:
-      context: .
-      file: ./deploy/compose/Dockerfile.worker
-      push: true
-      platforms: linux/amd64
-      tags: ${{ steps.meta.outputs.worker_tags }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
+      - name: Build and push Worker
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          file: ./deploy/compose/Dockerfile.worker
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.worker_tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -42,9 +42,10 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r4 \
+    && apk add --no-cache 'nginx~1.28.3' \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4" \
+    && nginx_version="$(apk info -v nginx | sed 's/^nginx-//')" \
+    && test "$(apk version -t "$nginx_version" "1.28.3-r4")" != "<" \
     && mkdir -p /run/nginx
 
 RUN mkdir -p /usr/share/nginx/html && \

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -36,6 +36,7 @@ FROM nginx:1.28.3-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
     && apk del --no-cache \
+        nginx \
         nginx-module-acme \
         nginx-module-geoip \
         nginx-module-image-filter \

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -55,9 +55,10 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-image-filter \
         nginx-module-njs \
         nginx-module-xslt \
-    && apk add --no-cache nginx=1.28.3-r4 \
+    && apk add --no-cache 'nginx~1.28.3' \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4" \
+    && nginx_version="$(apk info -v nginx | sed 's/^nginx-//')" \
+    && test "$(apk version -t "$nginx_version" "1.28.3-r4")" != "<" \
     && mkdir -p /run/nginx
 
 # Create non-root nginx user and prepare writable directories

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -49,6 +49,7 @@ FROM nginx:1.28.3-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
     && apk del --no-cache \
+        nginx \
         nginx-module-acme \
         nginx-module-geoip \
         nginx-module-image-filter \
@@ -56,7 +57,8 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-xslt \
     && apk add --no-cache nginx=1.28.3-r4 \
     && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
-    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4"
+    && test "$(apk list -I nginx | cut -d- -f2- | cut -d' ' -f1)" = "1.28.3-r4" \
+    && mkdir -p /run/nginx
 
 # Create non-root nginx user and prepare writable directories
 RUN addgroup -g 1000 -S tokentimer && adduser -u 1000 -S tokentimer -G tokentimer && \


### PR DESCRIPTION
## Summary

Repair the failed TokenTimer Core 0.9.0 dashboard and worker image publication.

The dashboard image inherited nginx packages from nginx.org while attempting to install an exact Alpine nginx revision. Alpine has since advanced from `1.28.3-r4` to `1.28.3-r5`, making the exact revision pin unsatisfiable.

## Changes

### Docker

* Remove the preinstalled nginx package and unused nginx modules before installing Alpine nginx
* Install the latest Alpine revision in the `1.28.3` series
* Require the installed nginx package to be at least `1.28.3-r4`
* Keep the production and application dashboard Dockerfiles aligned

### Publishing

* Publish dashboard and worker images with an explicit image tag
* Avoid deriving Docker tags from the `fix/0.9.0` branch name
* Allow the repaired images to be published directly as `0.9.0`

## Test plan

* [X] Run the `Publish Images` workflow from `fix/0.9.0` with `image_tag=0.9.0`
* [X] Confirm the dashboard image builds with Alpine nginx `1.28.3-r5` or newer
* [X] Confirm the dashboard and worker `0.9.0` images are available in GHCR
* [x] Revert the `Publish Images` workflow override
