### PR TITLE
fix: CertOps audit metadata, machine-token monitoring opt-in, CNPG TLS verify, 404 footer

### DIFF
--- a/apps/api/db/models/Token.js
+++ b/apps/api/db/models/Token.js
@@ -130,15 +130,17 @@ const create = async (tokenData) => {
     imported_at = null,
     last_used = null,
     created_at = null,
+    certops_api_token_id = null,
   } = tokenData;
 
   const query = `
     INSERT INTO tokens (
       user_id, workspace_id, created_by, name, expiration, type, category, domains, location, used_by, section, contact_group_id,
       issuer, serial_number, subject, key_size, algorithm, license_type, vendor, cost,
-      renewal_url, renewal_date, contacts, description, notes, privileges, imported_at, last_used, created_at, updated_at
+      renewal_url, renewal_date, contacts, description, notes, privileges, imported_at, last_used, created_at, updated_at,
+      certops_api_token_id
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, NOW())
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, NOW(), $30)
     RETURNING *
   `;
 
@@ -172,6 +174,7 @@ const create = async (tokenData) => {
     imported_at || null,
     last_used,
     created_at || null,
+    certops_api_token_id,
   ];
 
   try {
@@ -393,6 +396,17 @@ const deleteAllByUserId = async (userId) => {
   return result.rowCount;
 };
 
+// Delete the TokenTimer monitoring token linked to a revoked/deleted CertOps
+// machine token, if one was created via the "monitor this token" opt-in.
+const deleteByCertOpsApiTokenId = async (certopsApiTokenId, options = {}) => {
+  const db = options.client || pool;
+  const query =
+    "DELETE FROM tokens WHERE certops_api_token_id = $1 RETURNING *";
+  const result = await db.query(query, [certopsApiTokenId]);
+  const token = result.rows[0];
+  return token ? convertNumericFields(token) : null;
+};
+
 // Get tokens by category
 const findByCategory = async (userId, category) => {
   const query = `
@@ -466,6 +480,7 @@ module.exports = {
   update,
   delete: deleteById,
   deleteAllByUserId,
+  deleteByCertOpsApiTokenId,
   findByCategory,
   findExpiringSoon,
   findByDomain,

--- a/apps/api/middleware/validation.js
+++ b/apps/api/middleware/validation.js
@@ -99,6 +99,10 @@ const validateToken = [
         throw new Error("Cost must be less than 1 trillion");
       return true;
     }),
+  body("certopsApiTokenId")
+    .optional()
+    .isUUID()
+    .withMessage("certopsApiTokenId must be a valid UUID"),
   body("key_size")
     .optional()
     .custom((value) => {

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -5,6 +5,10 @@ const { logger } = require("../utils/logger");
 const caPath = process.env.PGSSLROOTCERT;
 const sslMode = process.env.DB_SSL;
 const hasCA = !!caPath;
+const isProduction = process.env.NODE_ENV === "production";
+
+// SSL semantics mirrored from apps/api/db/database.js so migrations don't
+// silently skip server-identity verification when the main API enforces it.
 const sslConfig =
   sslMode === "verify" || hasCA
     ? {
@@ -13,8 +17,10 @@ const sslConfig =
         minVersion: "TLSv1.3",
       }
     : sslMode === "require"
-      ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
-      : false;
+      ? { rejectUnauthorized: isProduction, minVersion: "TLSv1.3" }
+      : sslMode === "require-no-verify"
+        ? { rejectUnauthorized: false, minVersion: "TLSv1.3" }
+        : false;
 
 // Reusable pool for migrations
 const migrationPool = new Pool({

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -1304,6 +1304,24 @@ const migrations = [
         ADD COLUMN IF NOT EXISTS check_claim_id UUID NULL;
     `,
   },
+  {
+    version: 18,
+    name: "tokens_certops_api_token_link",
+    sql: `
+      -- Links a TokenTimer monitoring token to the CertOps machine token it
+      -- was created to track (opt-in checkbox on "store this token now").
+      -- Revoking the CertOps token must delete this row explicitly (revoke
+      -- is an UPDATE, not a DELETE, so ON DELETE CASCADE alone never fires
+      -- on the common path); the FK is a defense-in-depth backstop only.
+      ALTER TABLE tokens
+        ADD COLUMN IF NOT EXISTS certops_api_token_id UUID NULL
+          REFERENCES api_tokens(id) ON DELETE CASCADE;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_tokens_certops_api_token_id
+        ON tokens(certops_api_token_id)
+        WHERE certops_api_token_id IS NOT NULL;
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -487,6 +487,23 @@ router.post(
   requireCertOpsTokenManager,
   async (req, res) => {
     try {
+      // Reject already-expired expiry up front: the service layer also
+      // accepts past dates for internal test fixtures that seed expired
+      // tokens directly, so the future-only rule belongs on this
+      // user-facing create path instead of createApiToken() itself.
+      if (req.body?.expiresAt) {
+        const requestedExpiry = new Date(req.body.expiresAt);
+        if (
+          !Number.isNaN(requestedExpiry.getTime()) &&
+          requestedExpiry.getTime() <= Date.now()
+        ) {
+          return res.status(400).json({
+            error: "API token expiry must be in the future",
+            code: CERTOPS_API_TOKEN_INVALID,
+          });
+        }
+      }
+
       const created = await withCertOpsTokenTransaction(async (client) => {
         const tokenResult = await createApiToken({
           client,

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -53,6 +53,7 @@ const {
 } = require("../services/certops/evidence");
 const { writeAudit } = require("../services/audit");
 const { logger } = require("../utils/logger");
+const Token = require("../db/models/Token");
 
 const CERTOPS_API_TOKEN_NOT_FOUND = "CERTOPS_API_TOKEN_NOT_FOUND";
 
@@ -553,6 +554,30 @@ router.post(
             token: result.token,
             includeRevocation: true,
           });
+          // The user may have opted in to monitor this machine token's
+          // expiration in TokenTimer when it was created; a revoked token
+          // is dead, so keep TokenTimer from tracking (and alerting on) a
+          // credential that no longer works.
+          const deletedMonitoringToken = await Token.deleteByCertOpsApiTokenId(
+            tokenId,
+            { client },
+          );
+          if (deletedMonitoringToken) {
+            await writeAudit({
+              client,
+              actorUserId: req.user.id,
+              subjectUserId: req.user.id,
+              action: "TOKEN_DELETED",
+              targetType: "token",
+              targetId: deletedMonitoringToken.id,
+              channel: null,
+              workspaceId: req.workspace.id,
+              metadata: {
+                name: deletedMonitoringToken.name,
+                reason: "certops_api_token_revoked",
+              },
+            });
+          }
         }
         return result;
       });

--- a/apps/api/routes/tokens.js
+++ b/apps/api/routes/tokens.js
@@ -358,6 +358,7 @@ router.post(
         last_used,
         imported_at,
         created_at,
+        certopsApiTokenId,
       } = req.body;
 
       // Log the request for debugging
@@ -636,6 +637,25 @@ router.post(
         ...tokenData,
         contact_group_id: normalizedContactGroupId,
       };
+
+      // Validate certopsApiTokenId belongs to this workspace before linking,
+      // so a token in one workspace can't be wired to another workspace's
+      // CertOps machine token (and inherit its future revoke-cascade delete).
+      let normalizedCertOpsApiTokenId = null;
+      if (certopsApiTokenId) {
+        const certopsTokenCheck = await pool.query(
+          "SELECT 1 FROM api_tokens WHERE id = $1 AND workspace_id = $2",
+          [certopsApiTokenId, workspaceId],
+        );
+        if (certopsTokenCheck.rowCount === 0) {
+          return res.status(400).json({
+            error: "certopsApiTokenId does not belong to this workspace",
+            code: "VALIDATION_ERROR",
+          });
+        }
+        normalizedCertOpsApiTokenId = certopsApiTokenId;
+      }
+
       const token = await Token.create({
         ...tokenDataWithGroup,
         workspaceId,
@@ -644,6 +664,7 @@ router.post(
         last_used,
         imported_at: imported_at || null,
         created_at: created_at || null,
+        certops_api_token_id: normalizedCertOpsApiTokenId,
       });
       // Audit: token created
       try {

--- a/apps/dashboard/src/components/Footer.jsx
+++ b/apps/dashboard/src/components/Footer.jsx
@@ -55,6 +55,10 @@ const Footer = () => {
   const isLandingPage = location.pathname === '/';
   const isDashboardShellPage = isDashboardShellPath(location.pathname);
   const isAuthShellPage = isAuthShellPath(location.pathname);
+  // Core has no marketing site beyond '/' (which just redirects to /login), so any
+  // path that isn't a known shell page is the 404 catch-all route. Give it the
+  // compact app footer instead of the full-height marketing footer.
+  const isUnknownRoute = !isLandingPage && !isDashboardShellPage && !isAuthShellPage;
   const dashboardTheme = useDashboardThemeColors();
 
   // Use navigation colors to match the navigation bar
@@ -87,7 +91,7 @@ const Footer = () => {
 
   const currentYear = new Date().getFullYear();
 
-  if (isDashboardShellPage || isAuthShellPage) {
+  if (isDashboardShellPage || isAuthShellPage || isUnknownRoute) {
     const {
       pageBg,
       muted,
@@ -122,7 +126,7 @@ const Footer = () => {
         borderColor={border}
         w='100%'
         pl={
-          isAuthShellPage
+          isAuthShellPage || isUnknownRoute
             ? DASHBOARD_PAGE_GUTTER_X
             : {
                 base: 4,

--- a/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
+++ b/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
@@ -98,6 +98,12 @@ function toIsoExpiry(localValue) {
   return date.toISOString();
 }
 
+function nowLocalDatetimeValue() {
+  const date = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 function createErrorMessage(err) {
   const code = err?.response?.data?.code;
   const status = err?.response?.status;
@@ -172,9 +178,13 @@ export default function ApiTokenPanel() {
 
   if (enabled !== true) return null;
 
+  const expiresAtIso = toIsoExpiry(expiresLocal);
+  const expiryInPast = Boolean(expiresAtIso) && new Date(expiresAtIso).getTime() <= Date.now();
+
   const canSubmit =
     Boolean(name.trim()) &&
     scopes.length > 0 &&
+    !expiryInPast &&
     !creating &&
     Boolean(workspaceId);
 
@@ -240,6 +250,12 @@ export default function ApiTokenPanel() {
           workspace_id: workspaceId,
           certopsApiTokenId: createdTokenInfo.id || undefined,
         });
+        // Tell the dashboard's token list (rendered on a different route) to
+        // reload, same as the import/endpoint flows do, so the new TokenTimer
+        // entry shows up without a manual refresh.
+        try {
+          window.dispatchEvent(new CustomEvent('tt:tokens-updated'));
+        } catch (_) {}
       } catch (err) {
         showError(
           'Monitoring not added',
@@ -350,16 +366,21 @@ export default function ApiTokenPanel() {
               </CheckboxGroup>
             </FormControl>
 
-            <FormControl>
+            <FormControl isInvalid={expiryInPast}>
               <FormLabel fontSize='sm'>Expires (optional)</FormLabel>
               <Input
                 type='datetime-local'
                 value={expiresLocal}
                 onChange={event => setExpiresLocal(event.target.value)}
+                min={nowLocalDatetimeValue()}
                 size='sm'
                 maxW='280px'
               />
-              <FormHelperText>Leave empty for no expiry.</FormHelperText>
+              <FormHelperText>
+                {expiryInPast
+                  ? 'Expiry must be in the future.'
+                  : 'Leave empty for no expiry.'}
+              </FormHelperText>
             </FormControl>
 
             <Button

--- a/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
+++ b/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
@@ -36,6 +36,7 @@ import CopyableCodeBlock from '../CopyableCodeBlock.jsx';
 import { DashboardErrorAlert } from '../DashboardPrimitives.jsx';
 import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
 import { showError, showSuccess } from '../../utils/toast.js';
+import { tokenAPI } from '../../utils/apiClient';
 import {
   CERTOPS_TOKEN_NAME_MAX_LENGTH,
   CERTOPS_TOKEN_SCOPES,
@@ -143,6 +144,8 @@ export default function ApiTokenPanel() {
   const [creating, setCreating] = useState(false);
   const [plaintextToken, setPlaintextToken] = useState('');
   const [showOnceOpen, setShowOnceOpen] = useState(false);
+  const [monitorExpiry, setMonitorExpiry] = useState(true);
+  const [createdTokenInfo, setCreatedTokenInfo] = useState(null);
   const [revokeTarget, setRevokeTarget] = useState(null);
   const [revoking, setRevoking] = useState(false);
   const revokeCancelRef = useRef(null);
@@ -155,6 +158,7 @@ export default function ApiTokenPanel() {
     activeWorkspaceRef.current = workspaceId;
     setPlaintextToken('');
     setShowOnceOpen(false);
+    setCreatedTokenInfo(null);
     setRevokeTarget(null);
   }, [workspaceId]);
 
@@ -209,6 +213,10 @@ export default function ApiTokenPanel() {
       setName('');
       setScopes([]);
       setExpiresLocal('');
+      setCreatedTokenInfo({
+        name: result?.token?.name || name.trim(),
+        expiresAt: result?.token?.expiresAt || expiresAt || null,
+      });
       setPlaintextToken(plaintext);
       setShowOnceOpen(true);
       showSuccess('API token created');
@@ -220,9 +228,27 @@ export default function ApiTokenPanel() {
     }
   };
 
-  const handleShowOnceClose = () => {
+  const handleShowOnceClose = async () => {
+    if (monitorExpiry && createdTokenInfo?.expiresAt && workspaceId) {
+      try {
+        await tokenAPI.createToken({
+          name: `${createdTokenInfo.name || 'Machine token'} (CertOps)`,
+          type: 'api_key',
+          category: 'key_secret',
+          expiresAt: createdTokenInfo.expiresAt,
+          workspace_id: workspaceId,
+        });
+      } catch (err) {
+        showError(
+          'Monitoring not added',
+          'The machine token was created, but TokenTimer could not add it for expiration monitoring. Add it manually if needed.'
+        );
+      }
+    }
     setShowOnceOpen(false);
     setPlaintextToken('');
+    setCreatedTokenInfo(null);
+    setMonitorExpiry(true);
     refresh();
   };
 
@@ -490,6 +516,17 @@ export default function ApiTokenPanel() {
                 copyable
                 monospace
               />
+              {createdTokenInfo?.expiresAt ? (
+                <Checkbox
+                  isChecked={monitorExpiry}
+                  onChange={event => setMonitorExpiry(event.target.checked)}
+                  size='sm'
+                >
+                  <Text as='span' fontSize='sm'>
+                    Monitor this token&apos;s expiration with TokenTimer
+                  </Text>
+                </Checkbox>
+              ) : null}
             </VStack>
           </ModalBody>
           <ModalFooter>

--- a/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
+++ b/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
@@ -214,6 +214,7 @@ export default function ApiTokenPanel() {
       setScopes([]);
       setExpiresLocal('');
       setCreatedTokenInfo({
+        id: result?.token?.id || null,
         name: result?.token?.name || name.trim(),
         expiresAt: result?.token?.expiresAt || expiresAt || null,
       });
@@ -237,6 +238,7 @@ export default function ApiTokenPanel() {
           category: 'key_secret',
           expiresAt: createdTokenInfo.expiresAt,
           workspace_id: workspaceId,
+          certopsApiTokenId: createdTokenInfo.id || undefined,
         });
       } catch (err) {
         showError(
@@ -526,6 +528,12 @@ export default function ApiTokenPanel() {
                     Monitor this token&apos;s expiration with TokenTimer
                   </Text>
                 </Checkbox>
+              ) : null}
+              {createdTokenInfo?.expiresAt && monitorExpiry ? (
+                <Text fontSize='xs' color={muted}>
+                  The TokenTimer entry is removed automatically if this
+                  machine token is revoked.
+                </Text>
               ) : null}
             </VStack>
           </ModalBody>

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -617,6 +617,39 @@ export default function Audit({ session, onLogout, onAccountClick }) {
     }
   }
 
+  function formatCertOpsTokenMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.name) parts.push(`Name: ${md.name}`);
+      if (md.token_prefix) parts.push(`Prefix: ${md.token_prefix}`);
+      if (Array.isArray(md.scopes) && md.scopes.length > 0)
+        parts.push(`Scopes: ${md.scopes.join(', ')}`);
+      if (md.status) parts.push(`Status: ${md.status}`);
+      if (md.expires_at)
+        parts.push(`Expiry: ${formatDateTime(md.expires_at)}`);
+      if (md.revoked_at)
+        parts.push(`Revoked: ${formatDateTime(md.revoked_at)}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsJobMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.operation) parts.push(`Operation: ${md.operation}`);
+      if (md.subjectType) parts.push(`Subject: ${md.subjectType}`);
+      if (md.subjectId) parts.push(`Subject ID: ${md.subjectId}`);
+      if (md.source) parts.push(`Source: ${md.source}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
   function formatAuthMetadata(ev) {
     try {
       const md = ev?.metadata || {};
@@ -960,6 +993,20 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       action === 'TOKENS_REASSIGNED_CONTACT_GROUP'
     ) {
       const formatted = formatTokenMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    // CertOps machine tokens and manual jobs
+    if (
+      action === 'CERTOPS_API_TOKEN_CREATED' ||
+      action === 'CERTOPS_API_TOKEN_REVOKED'
+    ) {
+      const formatted = formatCertOpsTokenMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'CERTOPS_JOB_CREATED_MANUAL') {
+      const formatted = formatCertOpsJobMetadata(ev);
       if (formatted) return formatted;
     }
 

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -109,6 +109,18 @@ const ALL_ACTION_TYPES = [
   'TOKENS_IMPORTED',
   'TOKENS_TRANSFERRED_BETWEEN_WORKSPACES',
   'TOKENS_REASSIGNED_CONTACT_GROUP',
+  // CertOps machine tokens, jobs, and inventory
+  'CERTOPS_API_TOKEN_CREATED',
+  'CERTOPS_API_TOKEN_REVOKED',
+  'CERTOPS_JOB_CREATED_MANUAL',
+  'CERTOPS_CERTIFICATE_REGISTERED',
+  'CERTOPS_CERTIFICATE_IMPORTED',
+  'CERTOPS_CERTIFICATE_RETIRED',
+  'CERTOPS_KEY_MATERIAL_REJECTED',
+  'CERTOPS_EVIDENCE_REJECTED',
+  'CERTOPS_EVIDENCE_ACCEPTED',
+  'CERTOPS_EXECUTOR_EVENT_ACCEPTED',
+  'CERTOPS_GENERIC_SECRET_REDACTION_APPLIED',
   // Alert operations
   'ALERT_QUEUED',
   'ALERT_SENT',
@@ -650,6 +662,111 @@ export default function Audit({ session, onLogout, onAccountClick }) {
     }
   }
 
+  function formatCertOpsInventoryMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.source) parts.push(`Source: ${md.source}`);
+      if (md.count != null) parts.push(`Certificates: ${md.count}`);
+      if (Array.isArray(md.fingerprints_sha256) && md.fingerprints_sha256.length > 0) {
+        parts.push(`Fingerprints: ${formatArrayValue(md.fingerprints_sha256)}`);
+      }
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsRetireMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.managedCertificateId)
+        parts.push(`Certificate: ${md.managedCertificateId}`);
+      if (md.tokenId) parts.push(`Token: ${md.tokenId}`);
+      if (md.status) parts.push(`Status: ${md.status}`);
+      if (md.reason) parts.push(`Reason: ${md.reason}`);
+      if (md.fingerprintSha256) parts.push(`Fingerprint: ${md.fingerprintSha256}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsKeyMaterialRejectedMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.code) parts.push(`Rejection: ${md.code}`);
+      if (md.method) parts.push(`Method: ${md.method}`);
+      if (md.path) parts.push(`Path: ${md.path}`);
+      if (md.routeFamily) parts.push(`Route: ${md.routeFamily}`);
+      if (md.apiTokenId) parts.push(`Machine token: ${md.apiTokenId}`);
+      if (md.body_type) parts.push(`Body type: ${md.body_type}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsEvidenceRejectedMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.jobId) parts.push(`Job: ${md.jobId}`);
+      if (md.eventId) parts.push(`Event: ${md.eventId}`);
+      if (md.eventType) parts.push(`Event type: ${md.eventType}`);
+      if (md.rejectionCode) parts.push(`Rejection: ${md.rejectionCode}`);
+      if (Array.isArray(md.evidenceIds) && md.evidenceIds.length > 0) {
+        parts.push(`Evidence items: ${md.evidenceIds.length}`);
+      }
+      if (md.redactionApplied != null) {
+        parts.push(`Redaction applied: ${md.redactionApplied ? 'yes' : 'no'}`);
+      }
+      if (md.redactionCount != null) parts.push(`Redacted fields: ${md.redactionCount}`);
+      if (md.routeFamily) parts.push(`Route: ${md.routeFamily}`);
+      if (md.createdByApiTokenId) parts.push(`Machine token: ${md.createdByApiTokenId}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsExecutorEventMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.jobId) parts.push(`Job: ${md.jobId}`);
+      if (md.executorEventId) parts.push(`Event: ${md.executorEventId}`);
+      if (md.eventType) parts.push(`Event type: ${md.eventType}`);
+      if (md.status) parts.push(`Status: ${md.status}`);
+      if (Array.isArray(md.evidenceIds) && md.evidenceIds.length > 0) {
+        parts.push(`Evidence items: ${md.evidenceIds.length}`);
+      }
+      if (md.apiTokenId) parts.push(`Machine token: ${md.apiTokenId}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatCertOpsRedactionMetadata(ev) {
+    try {
+      const md = ev?.metadata || {};
+      const parts = [];
+      if (md.jobId) parts.push(`Job: ${md.jobId}`);
+      if (md.executorEventId) parts.push(`Event: ${md.executorEventId}`);
+      if (Array.isArray(md.redactedFields) && md.redactedFields.length > 0) {
+        parts.push(`Redacted fields: ${formatArrayValue(md.redactedFields)}`);
+      }
+      if (md.redactionCount != null) parts.push(`Redaction count: ${md.redactionCount}`);
+      if (md.apiTokenId) parts.push(`Machine token: ${md.apiTokenId}`);
+      return parts.length > 0 ? parts.join(' | ') : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
   function formatAuthMetadata(ev) {
     try {
       const md = ev?.metadata || {};
@@ -1007,6 +1124,42 @@ export default function Audit({ session, onLogout, onAccountClick }) {
 
     if (action === 'CERTOPS_JOB_CREATED_MANUAL') {
       const formatted = formatCertOpsJobMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (
+      action === 'CERTOPS_CERTIFICATE_REGISTERED' ||
+      action === 'CERTOPS_CERTIFICATE_IMPORTED'
+    ) {
+      const formatted = formatCertOpsInventoryMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'CERTOPS_CERTIFICATE_RETIRED') {
+      const formatted = formatCertOpsRetireMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'CERTOPS_KEY_MATERIAL_REJECTED') {
+      const formatted = formatCertOpsKeyMaterialRejectedMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'CERTOPS_EVIDENCE_REJECTED') {
+      const formatted = formatCertOpsEvidenceRejectedMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (
+      action === 'CERTOPS_EXECUTOR_EVENT_ACCEPTED' ||
+      action === 'CERTOPS_EVIDENCE_ACCEPTED'
+    ) {
+      const formatted = formatCertOpsExecutorEventMetadata(ev);
+      if (formatted) return formatted;
+    }
+
+    if (action === 'CERTOPS_GENERIC_SECRET_REDACTION_APPLIED') {
+      const formatted = formatCertOpsRedactionMetadata(ev);
       if (formatted) return formatted;
     }
 

--- a/apps/dashboard/src/pages/NotFound.jsx
+++ b/apps/dashboard/src/pages/NotFound.jsx
@@ -26,7 +26,13 @@ export default function NotFound() {
           <Button as={RouterLink} to='/' colorScheme='blue'>
             Go Home
           </Button>
-          <Button as={RouterLink} to='/pricing' variant='ghost'>
+          <Button
+            as='a'
+            href='https://tokentimer.ch/pricing'
+            target='_blank'
+            rel='noopener noreferrer'
+            variant='ghost'
+          >
             View Pricing
           </Button>
           <Button

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -43,6 +43,8 @@ Verify the CRDs are registered:
 kubectl get crd clusters.postgresql.cnpg.io
 ```
 
+When `postgresql.cloudnative.enabled` is true (the default), the chart connects to the in-cluster database with `DB_SSL=verify` and automatically mounts the CA CloudNativePG generates (`<release>-pg-ca` secret) into the API and worker/cronjob pods at `/etc/pg-ssl/ca.crt`. No manual TLS setup is required for the default in-cluster database.
+
 If you already have a PostgreSQL instance, skip the operator entirely and point the chart at your database instead:
 
 ```yaml
@@ -112,7 +114,7 @@ Any env var not exposed as a dedicated values key can be passed through:
 - `api.extraVolumes` / `api.extraVolumeMounts` for the API
 - `worker.extraVolumes` / `worker.extraVolumeMounts` for all workers
 
-Example -- setting delivery window and DB SSL cert for workers:
+Example -- setting delivery window and DB SSL cert for an **external** PostgreSQL instance on workers (not needed for the default in-cluster CloudNativePG database, whose CA is mounted automatically):
 
 ```yaml
 worker:

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -148,6 +148,36 @@ Database host. CloudNativePG exposes <cluster>-rw as the read-write service.
 {{- if .Values.postgresql.cloudnative.enabled }}{{ .Values.postgresql.auth.username }}{{- else }}{{ .Values.postgresql.external.username }}{{- end }}
 {{- end }}
 
+{{/*
+Name of the CloudNativePG-generated CA secret (contains ca.crt) for the
+in-cluster Postgres cluster. Only meaningful when cloudnative is enabled.
+*/}}
+{{- define "tokentimer.pgCaSecretName" -}}
+{{- printf "%s-pg-ca" (include "tokentimer.fullname" .) }}
+{{- end }}
+
+{{- define "tokentimer.pgCaMountPath" -}}
+/etc/pg-ssl
+{{- end }}
+
+{{/*
+Pod volume for the CNPG CA cert. Include only when postgresql.cloudnative.enabled.
+*/}}
+{{- define "tokentimer.pgCaVolume" -}}
+- name: pg-ca
+  secret:
+    secretName: {{ include "tokentimer.pgCaSecretName" . | quote }}
+{{- end }}
+
+{{/*
+Container volume mount for the CNPG CA cert. Include only when postgresql.cloudnative.enabled.
+*/}}
+{{- define "tokentimer.pgCaVolumeMount" -}}
+- name: pg-ca
+  mountPath: {{ include "tokentimer.pgCaMountPath" . }}
+  readOnly: true
+{{- end }}
+
 {{/* ---- ConfigMap / Secret checksums (rollout on helm upgrade) ---- */}}
 
 {{/*
@@ -164,7 +194,8 @@ DB_PORT: {{ include "tokentimer.databasePort" . | quote }}
 DB_NAME: {{ include "tokentimer.databaseName" . | quote }}
 DB_USER: {{ include "tokentimer.databaseUser" . | quote }}
 {{- if .Values.postgresql.cloudnative.enabled }}
-DB_SSL: "require"
+DB_SSL: "verify"
+PGSSLROOTCERT: {{ printf "%s/ca.crt" (include "tokentimer.pgCaMountPath" .) | quote }}
 {{- else if and .Values.postgresql.external.enabled .Values.postgresql.external.sslMode }}
 DB_SSL: {{ .Values.postgresql.external.sslMode | quote }}
 {{- end }}
@@ -353,11 +384,25 @@ secret.secretName and configMap.name may use Helm tpl.
     {{- if hasKey .secret "optional" }}
     optional: {{ .secret.optional }}
     {{- end }}
+    {{- if hasKey .secret "defaultMode" }}
+    defaultMode: {{ .secret.defaultMode }}
+    {{- end }}
+    {{- if .secret.items }}
+    items:
+      {{- toYaml .secret.items | nindent 6 }}
+    {{- end }}
   {{- else if .configMap }}
   configMap:
     name: {{ tpl (.configMap.name | toString) $root | quote }}
     {{- if hasKey .configMap "optional" }}
     optional: {{ .configMap.optional }}
+    {{- end }}
+    {{- if hasKey .configMap "defaultMode" }}
+    defaultMode: {{ .configMap.defaultMode }}
+    {{- end }}
+    {{- if .configMap.items }}
+    items:
+      {{- toYaml .configMap.items | nindent 6 }}
     {{- end }}
   {{- else }}
   {{- omit . "name" | toYaml | nindent 2 }}

--- a/deploy/helm/templates/api-deployment.yaml
+++ b/deploy/helm/templates/api-deployment.yaml
@@ -77,12 +77,18 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolumeMount" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.postgresql.cloudnative.enabled }}
+        {{- include "tokentimer.pgCaVolume" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.api.extraVolumes }}
         {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 8 }}
         {{- end }}

--- a/deploy/helm/templates/cronjob-auto-sync.yaml
+++ b/deploy/helm/templates/cronjob-auto-sync.yaml
@@ -67,6 +67,9 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+                {{- if .Values.postgresql.cloudnative.enabled }}
+                {{- include "tokentimer.pgCaVolumeMount" . | nindent 16 }}
+                {{- end }}
                 {{- with .Values.worker.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
@@ -75,6 +78,9 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolume" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.worker.extraVolumes }}
             {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 12 }}
             {{- end }}

--- a/deploy/helm/templates/cronjob-delivery.yaml
+++ b/deploy/helm/templates/cronjob-delivery.yaml
@@ -67,6 +67,9 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+                {{- if .Values.postgresql.cloudnative.enabled }}
+                {{- include "tokentimer.pgCaVolumeMount" . | nindent 16 }}
+                {{- end }}
                 {{- with .Values.worker.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
@@ -75,6 +78,9 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolume" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.worker.extraVolumes }}
             {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 12 }}
             {{- end }}

--- a/deploy/helm/templates/cronjob-discovery.yaml
+++ b/deploy/helm/templates/cronjob-discovery.yaml
@@ -67,6 +67,9 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+                {{- if .Values.postgresql.cloudnative.enabled }}
+                {{- include "tokentimer.pgCaVolumeMount" . | nindent 16 }}
+                {{- end }}
                 {{- with .Values.worker.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
@@ -75,6 +78,9 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolume" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.worker.extraVolumes }}
             {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 12 }}
             {{- end }}

--- a/deploy/helm/templates/cronjob-endpoint-check.yaml
+++ b/deploy/helm/templates/cronjob-endpoint-check.yaml
@@ -67,6 +67,9 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+                {{- if .Values.postgresql.cloudnative.enabled }}
+                {{- include "tokentimer.pgCaVolumeMount" . | nindent 16 }}
+                {{- end }}
                 {{- with .Values.worker.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
@@ -75,6 +78,9 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolume" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.worker.extraVolumes }}
             {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 12 }}
             {{- end }}

--- a/deploy/helm/templates/cronjob-weekly-digest.yaml
+++ b/deploy/helm/templates/cronjob-weekly-digest.yaml
@@ -67,6 +67,9 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+                {{- if .Values.postgresql.cloudnative.enabled }}
+                {{- include "tokentimer.pgCaVolumeMount" . | nindent 16 }}
+                {{- end }}
                 {{- with .Values.worker.extraVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
@@ -75,6 +78,9 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            {{- if .Values.postgresql.cloudnative.enabled }}
+            {{- include "tokentimer.pgCaVolume" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.worker.extraVolumes }}
             {{- include "tokentimer.renderExtraVolumes" (dict "root" $ "volumes" .) | nindent 12 }}
             {{- end }}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:down": "docker compose -f deploy/compose/docker-compose.test.yml down --volumes --remove-orphans",
     "// --- Full stack in Docker (postgres + API + worker + dashboard) ---": "",
     "docker:build": "docker compose -f deploy/compose/docker-compose.yml build",
-    "docker:up": "docker compose -f deploy/compose/docker-compose.yml up",
+    "docker:up": "docker compose -f deploy/compose/docker-compose.yml up --build",
     "docker:down": "node scripts/docker-down-local.js",
     "docker:down:stack": "docker compose -f deploy/compose/docker-compose.yml down --remove-orphans",
     "docker:down:dev": "docker compose -f deploy/compose/docker-compose.dev.yml down --remove-orphans",

--- a/scripts/dev-help.js
+++ b/scripts/dev-help.js
@@ -30,8 +30,11 @@ HOST-NATIVE (fast iteration; processes run on your machine)
 FULL STACK IN DOCKER (all services containerized)
 -------------------------------------------------
   pnpm docker:up
-      deploy/compose/docker-compose.yml up (foreground).
-      Postgres + API + worker + dashboard all in containers.
+      deploy/compose/docker-compose.yml up --build (foreground).
+      Postgres + API + worker + dashboard all in containers. --build
+      re-checks the image against the Dockerfile/context/build args on
+      every run, so a stale image from a branch switch gets rebuilt
+      automatically (cache hit = no-op if nothing changed).
 
   pnpm docker:down
       Stop all local Docker infra: full stack, dev stack, and postgres-only

--- a/tests/integration/certops-api-token-routes.test.js
+++ b/tests/integration/certops-api-token-routes.test.js
@@ -333,6 +333,21 @@ describe("CertOps API token management routes", function () {
       await tokenAuditCount(fixture.workspaceId, "CERTOPS_API_TOKEN_CREATED"),
     ).to.equal(auditsBefore);
 
+    const pastExpiry = await request(BASE)
+      .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
+      .set("Cookie", fixture.managerSession.cookie)
+      .send({
+        name: "Already expired",
+        scopes: ["certops:events:write"],
+        expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+      });
+    expect(pastExpiry.status).to.equal(400);
+    expect(pastExpiry.body.code).to.equal("CERTOPS_API_TOKEN_INVALID");
+    expectNoTokenLeak(pastExpiry.body);
+    expect(
+      await tokenAuditCount(fixture.workspaceId, "CERTOPS_API_TOKEN_CREATED"),
+    ).to.equal(auditsBefore);
+
     const response = await request(BASE)
       .post(`/api/v1/workspaces/${fixture.workspaceId}/certops/tokens`)
       .set("Cookie", fixture.managerSession.cookie)


### PR DESCRIPTION
## Summary
- Audit.jsx: render metadata for all 11 CertOps audit action types instead of only 3. Machine-token create/revoke and manual-job create were already handled; added formatters for certificate register/import/retire, key-material rejection, evidence rejection/acceptance, executor-event acceptance, and secret-redaction events, since the backend already writes rich metadata for each of these but the frontend silently dropped it. Also added all 11 CertOps actions to the audit filter dropdown, which previously had none.
- ApiTokenPanel.jsx: opt-in checkbox (checked by default) on the store-this-token modal to add newly created CertOps machine tokens to TokenTimer's own expiration monitoring. The TokenTimer token is linked to its source machine token (tokens.certops_api_token_id) and is deleted automatically when that machine token is revoked, so revoked credentials stop generating expiry alerts.
- Helm chart: when postgresql.cloudnative.enabled, auto-mount the CloudNativePG CA secret and switch DB_SSL from require to verify so Postgres TLS is actually certificate-verified in-cluster. Fixed renderExtraVolumes to preserve items/defaultMode. Aligned migrate.js SSL handling with the API/worker.
- Footer.jsx / NotFound.jsx: render the compact dashboard footer on the 404 catch-all instead of the full-height marketing footer, and point View Pricing at the external tokentimer.ch/pricing link instead of a dead internal route.

Note: alert-queue deletion was scoped out of this change set since it would require a new API endpoint.

## Test plan
- [x] pnpm run lint:dashboard
- [x] pnpm run build:dashboard
- [x] pnpm run lint:api / build:api
- [x] pnpm run lint:worker / build:worker
- [x] helm template rendered for cloudnative + external + upgrade scenarios and diffed against expectations
- [x] Manual QA: create a CertOps machine token, confirm checkbox appears and creates a TokenTimer token with matching expiry
- [x] Manual QA: revoke that machine token, confirm the linked TokenTimer token is deleted automatically
- [x] Manual QA: visit an unknown route and confirm compact footer + correct pricing link
- [x] Manual QA: exercise each CertOps action (register/import/retire a certificate, submit invalid/key-material evidence, run an executor event) and confirm the audit log shows readable metadata for each, not a blank cell
