### PR TITLE
Release TokenTimer Core v0.9.1 with CertOps Follow-up Fixes and Security Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-20
+
+### Added
+
+- **Machine-token expiration monitoring opt-in** — the CertOps machine API token creation modal now offers a checkbox (checked by default) that, on confirm, creates a linked TokenTimer token so the machine token's expiry is tracked and alerted on like any other credential.
+- **CertOps audit metadata coverage** — all 11 `CERTOPS_*` audit actions (certificate register/import/retire, key-material and evidence rejection, evidence/executor-event acceptance, generic-secret redaction) now render human-readable metadata on the Audit page and are selectable in the action-type filter; previously only 3 of 11 types were formatted.
+
+### Changed
+
+- **`pnpm docker:up` rebuilds stale images automatically** — added `--build` to the compose `up` command so a dashboard/API/worker image left over from a branch switch is rebuilt before the stack starts (cache hit is a no-op when nothing changed); `pnpm dev:help` text updated to match.
+- **Dashboard token list refreshes after machine-token monitoring is added** — creating the linked TokenTimer token now dispatches the same `tt:tokens-updated` event used by the import/endpoint flows, so the new entry (and its plaintext reveal) shows up without a manual page refresh.
+- **`brace-expansion` override bumped to 2.1.2** — closes a high-severity ReDoS advisory (GHSA-3jxr-9vmj-r5cp) pulled in transitively via `swagger-jsdoc` and `react-query`'s dependency tree.
+
+### Fixed
+
+- **CertOps machine tokens can no longer be created already expired** — both the create-token form (disabled submit, `min` datetime, inline helper text) and `POST /api/v1/workspaces/:id/certops/tokens` (400 `CERTOPS_API_TOKEN_INVALID`) reject an `expiresAt` in the past.
+- **Revoking a CertOps machine token now deletes its linked TokenTimer monitoring token** — prevents stale alerts firing for a credential that no longer works; recorded as a `TOKEN_DELETED` audit event with `reason: "certops_api_token_revoked"`.
+- **CloudNativePG TLS verification during migrations** — `DB_SSL=require` now sets `rejectUnauthorized` from `NODE_ENV=production` in `migrate.js`, matching the runtime API's connection pool instead of always disabling certificate verification.
+- **Self-hosted 404 page and footer** — dropped the stale Twitter/Instagram links in favor of Discord, LinkedIn, and GitHub, and fixed the "view pricing" and "read the docs" links that pointed at localhost / outdated destinations.
+
 ## [0.9.0] - 2026-07-19
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/dashboard/src/components/Footer.jsx
+++ b/apps/dashboard/src/components/Footer.jsx
@@ -58,7 +58,8 @@ const Footer = () => {
   // Core has no marketing site beyond '/' (which just redirects to /login), so any
   // path that isn't a known shell page is the 404 catch-all route. Give it the
   // compact app footer instead of the full-height marketing footer.
-  const isUnknownRoute = !isLandingPage && !isDashboardShellPage && !isAuthShellPage;
+  const isUnknownRoute =
+    !isLandingPage && !isDashboardShellPage && !isAuthShellPage;
   const dashboardTheme = useDashboardThemeColors();
 
   // Use navigation colors to match the navigation bar

--- a/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
+++ b/apps/dashboard/src/components/certops/ApiTokenPanel.jsx
@@ -179,7 +179,8 @@ export default function ApiTokenPanel() {
   if (enabled !== true) return null;
 
   const expiresAtIso = toIsoExpiry(expiresLocal);
-  const expiryInPast = Boolean(expiresAtIso) && new Date(expiresAtIso).getTime() <= Date.now();
+  const expiryInPast =
+    Boolean(expiresAtIso) && new Date(expiresAtIso).getTime() <= Date.now();
 
   const canSubmit =
     Boolean(name.trim()) &&
@@ -552,8 +553,8 @@ export default function ApiTokenPanel() {
               ) : null}
               {createdTokenInfo?.expiresAt && monitorExpiry ? (
                 <Text fontSize='xs' color={muted}>
-                  The TokenTimer entry is removed automatically if this
-                  machine token is revoked.
+                  The TokenTimer entry is removed automatically if this machine
+                  token is revoked.
                 </Text>
               ) : null}
             </VStack>

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -638,8 +638,7 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (Array.isArray(md.scopes) && md.scopes.length > 0)
         parts.push(`Scopes: ${md.scopes.join(', ')}`);
       if (md.status) parts.push(`Status: ${md.status}`);
-      if (md.expires_at)
-        parts.push(`Expiry: ${formatDateTime(md.expires_at)}`);
+      if (md.expires_at) parts.push(`Expiry: ${formatDateTime(md.expires_at)}`);
       if (md.revoked_at)
         parts.push(`Revoked: ${formatDateTime(md.revoked_at)}`);
       return parts.length > 0 ? parts.join(' | ') : '';
@@ -668,7 +667,10 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       const parts = [];
       if (md.source) parts.push(`Source: ${md.source}`);
       if (md.count != null) parts.push(`Certificates: ${md.count}`);
-      if (Array.isArray(md.fingerprints_sha256) && md.fingerprints_sha256.length > 0) {
+      if (
+        Array.isArray(md.fingerprints_sha256) &&
+        md.fingerprints_sha256.length > 0
+      ) {
         parts.push(`Fingerprints: ${formatArrayValue(md.fingerprints_sha256)}`);
       }
       return parts.length > 0 ? parts.join(' | ') : '';
@@ -686,7 +688,8 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (md.tokenId) parts.push(`Token: ${md.tokenId}`);
       if (md.status) parts.push(`Status: ${md.status}`);
       if (md.reason) parts.push(`Reason: ${md.reason}`);
-      if (md.fingerprintSha256) parts.push(`Fingerprint: ${md.fingerprintSha256}`);
+      if (md.fingerprintSha256)
+        parts.push(`Fingerprint: ${md.fingerprintSha256}`);
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {
       return '';
@@ -723,9 +726,11 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (md.redactionApplied != null) {
         parts.push(`Redaction applied: ${md.redactionApplied ? 'yes' : 'no'}`);
       }
-      if (md.redactionCount != null) parts.push(`Redacted fields: ${md.redactionCount}`);
+      if (md.redactionCount != null)
+        parts.push(`Redacted fields: ${md.redactionCount}`);
       if (md.routeFamily) parts.push(`Route: ${md.routeFamily}`);
-      if (md.createdByApiTokenId) parts.push(`Machine token: ${md.createdByApiTokenId}`);
+      if (md.createdByApiTokenId)
+        parts.push(`Machine token: ${md.createdByApiTokenId}`);
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {
       return '';
@@ -759,7 +764,8 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (Array.isArray(md.redactedFields) && md.redactedFields.length > 0) {
         parts.push(`Redacted fields: ${formatArrayValue(md.redactedFields)}`);
       }
-      if (md.redactionCount != null) parts.push(`Redaction count: ${md.redactionCount}`);
+      if (md.redactionCount != null)
+        parts.push(`Redaction count: ${md.redactionCount}`);
       if (md.apiTokenId) parts.push(`Machine token: ${md.apiTokenId}`);
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.1
+appVersion: "0.9.1"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.9.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "status": "m2-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes for M1/M2. M1/M2 Core workspace, machine-token executor, job read, job manual-create, evidence, and token-management routes are runtime-stable where implemented and documented in OpenAPI. This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn.",
   "namespacePolicy": {

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.9.0
+  version: 0.9.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   fast-xml-builder: 1.2.0
   fast-xml-parser: 5.7.3
   minimatch: 9.0.9
-  brace-expansion: 2.0.3
+  brace-expansion: 2.1.2
   path-to-regexp: 8.4.0
   yaml: 1.10.3
   rollup: 4.60.0
@@ -1909,8 +1909,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6509,7 +6509,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8048,7 +8048,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ overrides:
   fast-xml-builder: 1.2.0
   fast-xml-parser: 5.7.3
   minimatch: 9.0.9
-  brace-expansion: 2.0.3
+  brace-expansion: 2.1.2
   path-to-regexp: 8.4.0
   yaml: 1.10.3
   rollup: 4.60.0

--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -19,7 +19,7 @@ const REQUIRED_PINS = {
   tar: { "*": "7.5.7" },
   "fast-xml-parser": { "*": "5.7.3" },
   minimatch: { "*": "9.0.9" },
-  "brace-expansion": { "*": "2.0.3" },
+  "brace-expansion": { "*": "2.1.2" },
   "path-to-regexp": { "*": "8.4.0" },
   yaml: { "*": "1.10.3" },
   rollup: { "*": "4.60.0" },

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -245,8 +245,8 @@ describe("CertOps inventory migration", () => {
     );
     assert.equal(certOpsTokenLifecycleMigration.version, 11);
     assert.deepEqual(
-      migrations.slice(-8).map((migration) => migration.version),
-      [10, 11, 12, 13, 14, 15, 16, 17],
+      migrations.slice(-9).map((migration) => migration.version),
+      [10, 11, 12, 13, 14, 15, 16, 17, 18],
     );
     assert.match(
       certOpsTokenLifecycleMigration.sql,
@@ -434,8 +434,31 @@ describe("CertOps inventory migration", () => {
       ownerClaimIdMigration.sql,
       /ALTER TABLE domain_monitors\s+ADD COLUMN IF NOT EXISTS check_claim_id UUID NULL/,
     );
+  });
+
+  it("defines the TokenTimer/CertOps token link migration after the owner-scoped claim ids", () => {
+    const certOpsTokenLinkMigration = migrations.find(
+      (migration) => migration.name === "tokens_certops_api_token_link",
+    );
+    assert.ok(
+      certOpsTokenLinkMigration,
+      "expected tokens_certops_api_token_link migration",
+    );
+    assert.equal(certOpsTokenLinkMigration.version, 18);
+    assert.match(
+      certOpsTokenLinkMigration.sql,
+      /ALTER TABLE tokens\s+ADD COLUMN IF NOT EXISTS certops_api_token_id UUID NULL/,
+    );
+    assert.match(
+      certOpsTokenLinkMigration.sql,
+      /REFERENCES api_tokens\(id\) ON DELETE CASCADE/,
+    );
+    assert.match(
+      certOpsTokenLinkMigration.sql,
+      /uq_tokens_certops_api_token_id/,
+    );
     assert.equal(
-      migrations.some((migration) => migration.version === 18),
+      migrations.some((migration) => migration.version === 19),
       false,
     );
   });


### PR DESCRIPTION
## Summary
Patch release covering the CertOps audit-metadata, machine-token monitoring, and TLS follow-ups from #77, plus a Prettier reflow, a stale unit-test fix for the new token-link migration, and a `brace-expansion` security bump surfaced while running the release checks.

## Changes

### Dashboard
- `Footer.jsx`, `ApiTokenPanel.jsx`, `Audit.jsx`: Prettier `--write` reflow only (line-length wrapping), no logic changes. These files had drifted from the repo's Prettier formatting in the #77 merge.

### Tests
- `tests/unit/certops-migration.test.js`: updated the hardcoded migration-version list and "no migration 18" assertion, which went stale the moment #77 added migration 18 (`tokens_certops_api_token_link`); added dedicated coverage asserting that migration's shape (FK, unique index) and that no migration 19 exists yet.

### Security
- `pnpm-workspace.yaml`, `scripts/check-lockfile-overrides.js`: bumped the `brace-expansion` override pin from `2.0.3` to `2.1.2` — `pnpm audit` flagged the old pin as still vulnerable to GHSA-3jxr-9vmj-r5cp (ReDoS), pulled in transitively via `swagger-jsdoc` and `react-query`.

### Docs / metadata
- Version bumped to 0.9.1 across `package.json`, `apps/*/package.json`, `contracts.manifest.json`, `packages/contracts/**`, `deploy/helm/Chart.yaml`, `deploy/helm/values.yaml` (image tags).
- `CHANGELOG.md`: new `[0.9.1]` entry summarizing the machine-token monitoring opt-in, full CertOps audit metadata coverage, future-only expiry validation, cascade-delete-on-revoke, `docker:up --build`, CNPG TLS verification fix, and footer/404 link fixes shipped in #77.

## Test plan
- [x] `pnpm audit --prod --audit-level=moderate` — clean after the `brace-expansion` bump
- [x] `pnpm --filter @tokentimer/dashboard lint` / `worker lint` / `api lint` — 0 errors
- [x] `pnpm --filter @tokentimer/dashboard exec prettier --check` — passes
- [x] `pnpm run test:unit` — 420/420 passing
- [x] `pnpm run check:contracts && check:contracts:integrity && test:contracts` — passing
- [ ] CI job passes (link the run)
