### PR TITLE
fix(helm): update template-verify to assert DB_SSL=verify for CloudNativePG

### DIFF
--- a/scripts/helm-template-verify.sh
+++ b/scripts/helm-template-verify.sh
@@ -65,11 +65,11 @@ grep -n "TRUST_PROXY_HOPS" "${OUT}/rendered-full-test.yaml" | head -3 || true
 grep -n "kind: HorizontalPodAutoscaler" "${OUT}/rendered-full-test.yaml" | head -3 || true
 grep -n "kind: Cluster" "${OUT}/rendered-full-test.yaml" | head -3 || true
 
-echo "==> assert DB_SSL=require when CloudNativePG is enabled (defaults + minimal)"
+echo "==> assert DB_SSL=verify when CloudNativePG is enabled (defaults + minimal)"
 for name in defaults minimal; do
   rendered="${OUT}/rendered-${name}.yaml"
-  if ! grep -qE 'DB_SSL:[[:space:]]*"?require"?' "${rendered}"; then
-    echo "helm-template-verify: FAIL missing DB_SSL=require in ${name} render" >&2
+  if ! grep -qE 'DB_SSL:[[:space:]]*"?verify"?' "${rendered}"; then
+    echo "helm-template-verify: FAIL missing DB_SSL=verify in ${name} render" >&2
     grep -n 'DB_SSL\|cloudnative' "${rendered}" | head -20 >&2 || true
     exit 1
   fi


### PR DESCRIPTION
## Summary
Fixes a CI failure introduced by #77/#80: `scripts/helm-template-verify.sh` still asserted `DB_SSL=require` for the CloudNativePG in-cluster scenario, but #77 intentionally switched that default to `DB_SSL=verify` (real certificate verification via the auto-mounted CNPG CA), matching what `deploy/helm/README.md` already documents. This PR was carved out of #80 after that PR merged without the fix commit landing on `main` (the release branch was deleted post-merge before the follow-up push attached).

## Changes

### CI / scripts
- `scripts/helm-template-verify.sh`: updated the `defaults` + `minimal` scenario assertion (and its failure message) to require `DB_SSL: verify` instead of `DB_SSL: require` for the CloudNativePG-enabled render, matching the chart's actual `_helpers.tpl` output since #77.

## Test plan
- [x] `bash scripts/helm-template-verify.sh` — passes locally (lint, all 5 scenario renders, spot-checks, and the `DB_SSL=verify` assertion all green)
- [ ] CI job passes (link the run)
