### PR TITLE
fix(deps): patch js-yaml ReDoS via pnpm override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   brace-expansion: 2.1.2
   path-to-regexp: 8.4.0
   yaml: 1.10.3
+  js-yaml: 4.3.0
   rollup: 4.60.0
   flatted: 3.4.2
   serialize-javascript: 7.0.5
@@ -184,8 +185,8 @@ importers:
         specifier: 11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.0
+        version: 4.3.0
       lucide-react:
         specifier: 0.553.0
         version: 0.553.0(react@18.3.1)
@@ -3004,8 +3005,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -4476,7 +4477,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -5479,7 +5480,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 9.0.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5493,7 +5494,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 9.0.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7134,7 +7135,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -7827,7 +7828,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -8076,7 +8077,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   brace-expansion: 2.1.2
   path-to-regexp: 8.4.0
   yaml: 1.10.3
+  js-yaml: 4.3.0
   rollup: 4.60.0
   flatted: 3.4.2
   serialize-javascript: 7.0.5

--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -22,6 +22,7 @@ const REQUIRED_PINS = {
   "brace-expansion": { "*": "2.1.2" },
   "path-to-regexp": { "*": "8.4.0" },
   yaml: { "*": "1.10.3" },
+  "js-yaml": { "*": "4.3.0" },
   rollup: { "*": "4.60.0" },
   flatted: { "*": "3.4.2" },
   "serialize-javascript": { "*": "7.0.5" },


### PR DESCRIPTION
## Summary
- `pnpm audit --prod --audit-level=moderate` flagged a high-severity ReDoS in `js-yaml` (GHSA-52cp-r559-cp3m, vulnerable `>=4.0.0 <4.3.0`), reached transitively via `swagger-jsdoc` and directly by `apps/dashboard`.
- Added a `js-yaml: 4.3.0` pnpm override in `pnpm-workspace.yaml` and the matching required pin in `scripts/check-lockfile-overrides.js`.
- Verified `pnpm install` resolves `js-yaml@4.3.0` everywhere in the lockfile (no other majors present) and `pnpm audit --prod --audit-level=moderate` now reports no known vulnerabilities.

## Test plan
- [x] `pnpm install`
- [x] `pnpm audit --prod --audit-level=moderate` -> clean
- [x] `node scripts/check-lockfile-overrides.js` -> ok
