### PR TITLE
Release TokenTimer Core v0.10.0 with Import Filter Rules and Obsolete-Token Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-21
+
+### Added
+
+- **GitLab pipeline trigger token discovery** — the GitLab integration scan can now inventory CI/CD pipeline trigger tokens (`GET /projects/:id/triggers`) behind a new opt-in `includeTriggerTokens` filter (checkbox "Pipeline Trigger Tokens" in the import modal). Trigger tokens never expire, so they are imported as perpetual entries with owner/project metadata.
+- **Import filter rules (#69)** — ordered include/exclude rules (exact or regex match on token name or description) can be defined in the import modal, are applied server-side to every integration scan (Vault, GitLab, GitHub, AWS, Azure, GCP, Azure AD) and to the shared import endpoint, and persist in auto-sync `scan_params` so scheduled syncs honor them. The preview table gets a one-click "exclude this token" action that appends an exact-match exclude rule, and scan responses report matched/excluded counts.
+- **Obsolete-token cleanup on import and auto-sync** — new opt-in "Remove previously imported tokens no longer found at the source" checkbox for GitLab and GitHub imports (persisted as `cleanupObsolete` in auto-sync `scan_params`). Previously imported tokens that fall inside the scanned scope (provider prefix + scanned source kinds) but were not rediscovered are hard-deleted with a `TOKEN_DELETED` audit event (`reason: "import_cleanup"` / `"auto_sync_cleanup"`); linked alert-queue entries and endpoint monitors are removed with them. A scan that returns zero items never triggers deletion.
+
+### Changed
+
+- **GitLab PAT exclusion keeps admin PATs** — the "exclude user PATs" scan filter now retains PATs owned by GitLab administrators in addition to service-account-like users; only regular-user PATs are filtered out. The modal label reads "Exclude regular-user PATs (keep admin and service accounts)".
+
+### Fixed
+
+- **Control Center perpetual asset count** — the "never expires" stat no longer shows the length of the 5-item preview list when the aggregated bucket count is available; the aggregated count now takes precedence.
+- **Bell notification false "alerts will not reach anyone"** — contact groups whose only destination is a webhook (`webhook_names` / `webhook_name`) are now recognized as reachable, so assigning such a group no longer raises the unreachable-alerts warning.
+
 ## [0.9.1] - 2026-07-20
 
 ### Added
@@ -21,6 +38,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`pnpm docker:up` rebuilds stale images automatically** — added `--build` to the compose `up` command so a dashboard/API/worker image left over from a branch switch is rebuilt before the stack starts (cache hit is a no-op when nothing changed); `pnpm dev:help` text updated to match.
 - **Dashboard token list refreshes after machine-token monitoring is added** — creating the linked TokenTimer token now dispatches the same `tt:tokens-updated` event used by the import/endpoint flows, so the new entry (and its plaintext reveal) shows up without a manual page refresh.
 - **`brace-expansion` override bumped to 2.1.2** — closes a high-severity ReDoS advisory (GHSA-3jxr-9vmj-r5cp) pulled in transitively via `swagger-jsdoc` and `react-query`'s dependency tree.
+- **`js-yaml` override bumped to 4.3.0** — closes a high-severity ReDoS advisory (GHSA-52cp-r559-cp3m) reached transitively via `swagger-jsdoc` and directly by the dashboard.
 
 ### Fixed
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -22,8 +22,33 @@ const { scanAzure } = require("../services/azureIntegration");
 const { scanAzureAD } = require("../services/azureADIntegration");
 const { scanGCP } = require("../services/gcpIntegration");
 const { formatDateYmd } = require("../services/integrationUtils");
+const {
+  validateFilterRules,
+  applyFilterRules,
+} = require("../services/importFilterRules");
+const {
+  validateCleanupRequest,
+  cleanupObsoleteTokens,
+} = require("../services/importCleanup");
 
 const router = require("express").Router();
+
+// Shared post-scan hook (issue #69): applies user-defined include/exclude
+// filter rules to the scanned items and attaches matched/excluded counts so
+// the UI can show a preview. With no rules, the result passes through as-is.
+function applyScanFilterRulesToResult(filterRules, result) {
+  if (!result || !Array.isArray(result.items)) return result;
+  const { items, matchedCount, excludedCount } = applyFilterRules(
+    filterRules,
+    result.items,
+  );
+  result.items = items;
+  result.filterSummary = { matchedCount, excludedCount };
+  if (result.summary && typeof result.summary === "object") {
+    result.summary.filteredOutByRules = excludedCount;
+  }
+  return result;
+}
 
 // --- Vault integration: scan mounts for inventory/expirations ---
 // Note: requireIntegrationQuota handles workspace validation, role check, and quota enforcement
@@ -47,8 +72,15 @@ router.post(
     });
 
     try {
-      const { address, token, include, mounts, maxItemsPerMount, pathPrefix } =
-        req.body || {};
+      const {
+        address,
+        token,
+        include,
+        mounts,
+        maxItemsPerMount,
+        pathPrefix,
+        filterRules,
+      } = req.body || {};
       // Prevent caching of sensitive responses
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
@@ -56,6 +88,9 @@ router.post(
         return res
           .status(400)
           .json(withQuota({ error: "address and token are required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       // Basic allowlist for schemes
       try {
         const u = new URL(address);
@@ -100,6 +135,7 @@ router.post(
             ? pathPrefix.trim().replace(/^\/+|\/+$/g, "")
             : "",
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -593,13 +629,17 @@ router.post(
     });
 
     try {
-      const { baseUrl, token, include, maxItems, filters } = req.body || {};
+      const { baseUrl, token, include, maxItems, filters, filterRules } =
+        req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
       if (!baseUrl || !token)
         return res
           .status(400)
           .json(withQuota({ error: "baseUrl and token are required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       try {
         const u = new URL(baseUrl);
         if (!/^https?:$/.test(u.protocol))
@@ -640,6 +680,7 @@ router.post(
         includeProjectTokens: filters?.includeProjectTokens !== false, // default true
         includeGroupTokens: filters?.includeGroupTokens !== false, // default true
         includeDeployTokens: filters?.includeDeployTokens !== false, // default true
+        includeTriggerTokens: filters?.includeTriggerTokens === true, // default false
         includeSSHKeys: filters?.includeSSHKeys !== false, // default true
         excludeUserPATs: filters?.excludeUserPATs === true, // default false
         includeExpired: filters?.includeExpired === true, // default false
@@ -660,6 +701,7 @@ router.post(
         maxItems: maxItems || 500,
         filters: scanFilters,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -768,13 +810,17 @@ router.post(
     });
 
     try {
-      const { baseUrl, token, include, maxItems } = req.body || {};
+      const { baseUrl, token, include, maxItems, filterRules } =
+        req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
       if (!baseUrl || !token)
         return res
           .status(400)
           .json(withQuota({ error: "baseUrl and token are required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       try {
         const u = new URL(baseUrl);
         if (!/^https?:$/.test(u.protocol))
@@ -840,6 +886,7 @@ router.post(
         },
         maxItems: maxItems || 500,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -1058,6 +1105,7 @@ router.post(
         region,
         include,
         maxItems,
+        filterRules,
       } = req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
@@ -1067,6 +1115,9 @@ router.post(
             error: "accessKeyId and secretAccessKey are required",
           }),
         );
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       if (
         maxItems !== undefined &&
         (!Number.isFinite(maxItems) || maxItems < 1 || maxItems > 2000)
@@ -1093,6 +1144,7 @@ router.post(
         },
         maxItems: maxItems || 500,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -1198,13 +1250,17 @@ router.post(
     });
 
     try {
-      const { vaultUrl, token, include, maxItems } = req.body || {};
+      const { vaultUrl, token, include, maxItems, filterRules } =
+        req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
       if (!vaultUrl || !token)
         return res
           .status(400)
           .json(withQuota({ error: "vaultUrl and token are required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       try {
         const u = new URL(vaultUrl);
         if (!/^https?:$/.test(u.protocol))
@@ -1259,6 +1315,7 @@ router.post(
         },
         maxItems: maxItems || 500,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -1351,13 +1408,17 @@ router.post(
     });
 
     try {
-      const { projectId, accessToken, include, maxItems } = req.body || {};
+      const { projectId, accessToken, include, maxItems, filterRules } =
+        req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
       if (!projectId || !accessToken)
         return res
           .status(400)
           .json(withQuota({ error: "projectId and accessToken are required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       if (
         maxItems !== undefined &&
         (!Number.isFinite(maxItems) || maxItems < 1 || maxItems > 2000)
@@ -1377,6 +1438,7 @@ router.post(
         },
         maxItems: maxItems || 500,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -1477,11 +1539,14 @@ router.post(
     });
 
     try {
-      const { token, include, maxItems } = req.body || {};
+      const { token, include, maxItems, filterRules } = req.body || {};
       res.set("Cache-Control", "no-store");
       res.set("Pragma", "no-cache");
       if (!token)
         return res.status(400).json(withQuota({ error: "token is required" }));
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError)
+        return res.status(400).json(withQuota({ error: filterRulesError }));
       if (typeof token === "string" && token.length > 5000) {
         return res
           .status(400)
@@ -1511,6 +1576,7 @@ router.post(
         },
         maxItems: maxItems || 500,
       });
+      applyScanFilterRulesToResult(filterRules, result);
 
       res.json(withQuota(result));
       try {
@@ -1665,11 +1731,29 @@ router.post(
         return res.status(403).json({ error: "Forbidden" });
       }
       const workspaceId = req.workspace.id;
-      const { items, default_category, default_type, contact_group_id } =
-        req.body || {};
+      const {
+        items,
+        default_category,
+        default_type,
+        contact_group_id,
+        filterRules,
+        cleanup,
+      } = req.body || {};
       if (!Array.isArray(items) || items.length === 0) {
         return res.status(400).json({ error: "items array required" });
       }
+      const filterRulesError = validateFilterRules(filterRules);
+      if (filterRulesError) {
+        return res.status(400).json({ error: filterRulesError });
+      }
+      const cleanupError = validateCleanupRequest(cleanup);
+      if (cleanupError) {
+        return res.status(400).json({ error: cleanupError });
+      }
+      // Issue #69: apply include/exclude rules at import time too, so
+      // auto-sync (which posts scan items here) honors the same rules.
+      const { items: itemsToImport, excludedCount: filteredOutCount } =
+        applyFilterRules(filterRules, items);
       const ALLOWED_TYPES = [
         "ssl_cert",
         "tls_cert",
@@ -1692,7 +1776,7 @@ router.post(
       const updated = [];
       const errors = [];
       const NEVER_EXPIRES_DATE = "2099-12-31"; // Default for tokens without expiration
-      for (const it of items) {
+      for (const it of itemsToImport) {
         try {
           // Sanitize and validate name (HTML escape for XSS protection)
           let name = String(it?.name || "").trim();
@@ -2118,6 +2202,29 @@ router.post(
           });
         }
       }
+      // Item 4 (0.10.0): remove previously imported tokens that are no longer
+      // present at the source. Opt-in via the `cleanup` payload; scoped to the
+      // provider prefix and the source kinds included in this scan.
+      let cleanupDeleted = [];
+      if (cleanup && cleanup.enabled === true) {
+        try {
+          const cleanupResult = await cleanupObsoleteTokens({
+            workspaceId,
+            actorUserId: req.user.id,
+            cleanup,
+            reason: cleanup.reason === "auto_sync_cleanup"
+              ? "auto_sync_cleanup"
+              : "import_cleanup",
+          });
+          cleanupDeleted = cleanupResult.deleted;
+        } catch (cleanupErr) {
+          logger.error("Obsolete token cleanup failed", {
+            error: cleanupErr.message,
+            workspaceId,
+          });
+        }
+      }
+
       try {
         await writeAudit({
           actorUserId: req.user.id,
@@ -2131,6 +2238,8 @@ router.post(
             created_count: created.length,
             updated_count: updated.length,
             error_count: errors.length,
+            filtered_out_count: filteredOutCount,
+            deleted_count: cleanupDeleted.length,
             source: "integration",
           },
         });
@@ -2141,6 +2250,9 @@ router.post(
         created_count: created.length,
         updated_count: updated.length,
         error_count: errors.length,
+        filtered_out_count: filteredOutCount,
+        deleted_count: cleanupDeleted.length,
+        deleted: cleanupDeleted,
         created,
         updated,
         errors,

--- a/apps/api/services/gitlabIntegration.js
+++ b/apps/api/services/gitlabIntegration.js
@@ -347,6 +347,21 @@ async function listDeployTokens({ baseUrl, token, projectId }) {
   }
 }
 
+async function listPipelineTriggers({ baseUrl, token, projectId }) {
+  try {
+    const data = await gitlabRequest({
+      baseUrl,
+      token,
+      method: "GET",
+      path: `/api/v4/projects/${projectId}/triggers`,
+    });
+    return Array.isArray(data) ? data : [];
+  } catch (e) {
+    if (e.status === 404 || e.status === 403) return [];
+    throw e;
+  }
+}
+
 async function listSSHKeys({ baseUrl, token, userId = null }) {
   try {
     const path = userId ? `/api/v4/users/${userId}/keys` : "/api/v4/user/keys";
@@ -373,6 +388,7 @@ async function scanGitLab({
     includeProjectTokens: true,
     includeGroupTokens: true,
     includeDeployTokens: true,
+    includeTriggerTokens: false,
     includeSSHKeys: true,
     excludeUserPATs: false,
     includeExpired: false,
@@ -858,10 +874,12 @@ async function scanGitLab({
                 const username = user?.username || null;
                 const isUserAdmin = user?.is_admin || false;
 
-                // Skip user PATs if excludeUserPATs filter is enabled (keep only service account PATs)
+                // Skip user PATs if excludeUserPATs filter is enabled
+                // (keep administrator and service-account PATs)
                 if (
                   filters.excludeUserPATs &&
                   username &&
+                  !isUserAdmin &&
                   !isServiceAccount(username)
                 ) {
                   skippedUserPATs++;
@@ -1085,6 +1103,87 @@ async function scanGitLab({
       }
     }
 
+    // Scan Pipeline Trigger Tokens
+    // Note: Requires Maintainer/Owner role on the project (GitLab returns
+    // 403/404 otherwise, which we silently skip). Trigger tokens never expire.
+    if (include.tokens && filters.includeTriggerTokens) {
+      try {
+        const projects = await listProjects({
+          baseUrl: normalizedUrl,
+          token,
+          maxItems: 1000,
+        });
+        let triggerTokensCount = 0;
+        let projectsScanned = 0;
+        let projectsWithTriggers = 0;
+
+        logger.info("Scanning GitLab pipeline trigger tokens", {
+          totalProjects: projects.length,
+        });
+
+        for (let i = 0; i < projects.length; i += BATCH_SIZE) {
+          if (items.length >= maxItems) break;
+          const batch = projects.slice(i, i + BATCH_SIZE);
+
+          await Promise.all(
+            batch.map(async (project) => {
+              if (items.length >= maxItems) return;
+              projectsScanned++;
+              try {
+                const triggers = await listPipelineTriggers({
+                  baseUrl: normalizedUrl,
+                  token,
+                  projectId: project.id,
+                });
+
+                if (triggers.length > 0) projectsWithTriggers++;
+
+                for (const trigger of triggers) {
+                  if (items.length >= maxItems) break;
+
+                  items.push({
+                    source: "gitlab-trigger-token",
+                    name:
+                      trigger.description ||
+                      `Pipeline Trigger Token (${trigger.id})`,
+                    category: "key_secret",
+                    type: "api_key",
+                    // Pipeline trigger tokens have no expiry in GitLab
+                    expiration: null,
+                    location: `gitlab:projects/${project.id}/triggers/${trigger.id}`,
+                    project_id: project.id,
+                    project_name: project.name || project.path_with_namespace,
+                    created_at: trigger.created_at || null,
+                    last_used_at: trigger.last_used || null,
+                    gitlab_owner: trigger.owner?.username || null,
+                  });
+                  triggerTokensCount++;
+                }
+              } catch (_e) {
+                // Expected: user may see project but can't access its triggers
+                // (401/403/404). This is normal and we silently skip.
+              }
+            }),
+          );
+        }
+        logger.info("GitLab pipeline trigger tokens scan completed", {
+          projectsScanned,
+          projectsWithTriggers,
+          tokensFound: triggerTokensCount,
+        });
+        summary.push({
+          type: "pipeline_trigger_tokens",
+          found: triggerTokensCount,
+        });
+      } catch (e) {
+        logger.warn("Pipeline trigger tokens scan failed", {
+          error: e.message,
+          status: e.status,
+        });
+        summary.push({ type: "pipeline_trigger_tokens", error: e.message });
+      }
+    }
+
     // Scan SSH Keys (user's own keys only)
     if (include.keys && filters.includeSSHKeys) {
       try {
@@ -1236,6 +1335,8 @@ async function scanGitLab({
       .length,
     groupTokens: items.filter((i) => i.source === "gitlab-group-token").length,
     deployTokens: items.filter((i) => i.source === "gitlab-deploy-token")
+      .length,
+    triggerTokens: items.filter((i) => i.source === "gitlab-trigger-token")
       .length,
     sshKeys: items.filter((i) => i.source === "gitlab-ssh-key").length,
   };

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -1,0 +1,177 @@
+/**
+ * Obsolete-token cleanup for integration imports and auto-sync.
+ *
+ * When a scan completes and cleanup is requested, previously imported tokens
+ * that belong to the scanned provider AND fall inside the scanned scope
+ * (source kinds actually included in this scan) but were NOT rediscovered
+ * are hard-deleted with a TOKEN_DELETED audit event.
+ *
+ * Safety rules:
+ *   - Only tokens in the same workspace.
+ *   - Only tokens whose location starts with the provider prefix (e.g. "gitlab:").
+ *   - Only tokens matching a location pattern of a source kind that was part
+ *     of this scan (a PAT-less scan never deletes PAT entries).
+ *   - Only tokens that were previously imported (imported_at IS NOT NULL).
+ */
+
+const { pool } = require("../db/database");
+const { writeAudit } = require("./audit");
+const { logger } = require("../utils/logger");
+
+const PROVIDER_PREFIXES = {
+  gitlab: "gitlab:",
+  github: "github:",
+  vault: "vault:",
+  aws: "aws:",
+  azure: "azure:",
+  "azure-ad": "azure-ad:",
+  gcp: "gcp:",
+};
+
+// Location shape per scan source kind. A stored token is only eligible for
+// cleanup when its location matches the pattern of a source kind that was
+// included in the current scan.
+const SOURCE_LOCATION_PATTERNS = {
+  "gitlab-pat": /^gitlab:(users\/[^/]+\/)?personal_access_tokens\//,
+  "gitlab-project-token": /^gitlab:projects\/[^/]+\/access_tokens\//,
+  "gitlab-group-token": /^gitlab:groups\/[^/]+\/access_tokens\//,
+  "gitlab-deploy-token": /^gitlab:projects\/[^/]+\/deploy_tokens\//,
+  "gitlab-trigger-token": /^gitlab:projects\/[^/]+\/triggers\//,
+  "gitlab-ssh-key": /^gitlab:user\/keys\//,
+  "github-ssh-key": /^github:user\/keys\//,
+  "github-secret": /^github:repos\/.+\/actions\/secrets\//,
+  "github-deploy-key": /^github:repos\/.+\/keys\//,
+  "vault-kv": /^vault:/,
+  "vault-pki": /^vault:/,
+  "aws-secrets-manager": /^aws:secretsmanager:/,
+  "aws-acm": /^aws:acm:/,
+  "aws-iam-key": /^aws:iam:/,
+  "azure-key-vault-secret": /^azure:.+\/secrets\//,
+  "azure-key-vault-certificate": /^azure:.+\/certificates\//,
+  "azure-key-vault-key": /^azure:.+\/keys\//,
+  "azure-ad-client-secret": /^azure-ad:applications\/.+\/secrets\//,
+  "azure-ad-certificate": /^azure-ad:applications\/.+\/certificates\//,
+  "azure-ad-sp-secret": /^azure-ad:servicePrincipals\/.+\/secrets\//,
+  "azure-ad-sp-certificate": /^azure-ad:servicePrincipals\/.+\/certificates\//,
+  "gcp-secret-manager": /^gcp:.+\/secrets\//,
+};
+
+/**
+ * Validates a cleanup payload. Returns null when valid, otherwise an error
+ * string suitable for a 400 response.
+ */
+function validateCleanupRequest(cleanup) {
+  if (cleanup === undefined || cleanup === null) return null;
+  if (typeof cleanup !== "object" || Array.isArray(cleanup)) {
+    return "cleanup must be an object";
+  }
+  if (cleanup.enabled !== true) return null;
+  if (!PROVIDER_PREFIXES[cleanup.provider]) {
+    return `cleanup.provider must be one of: ${Object.keys(PROVIDER_PREFIXES).join(", ")}`;
+  }
+  if (!Array.isArray(cleanup.scannedSources) || cleanup.scannedSources.length === 0) {
+    return "cleanup.scannedSources must be a non-empty array of source kinds";
+  }
+  for (const s of cleanup.scannedSources) {
+    if (!SOURCE_LOCATION_PATTERNS[s]) {
+      return `cleanup.scannedSources contains unknown source kind: ${s}`;
+    }
+  }
+  if (!Array.isArray(cleanup.scannedLocations)) {
+    return "cleanup.scannedLocations must be an array of location strings";
+  }
+  if (cleanup.scannedLocations.length > 50000) {
+    return "cleanup.scannedLocations is too large";
+  }
+  return null;
+}
+
+/**
+ * Deletes workspace tokens that were previously imported from the given
+ * provider, fall inside the scanned scope, and were not rediscovered.
+ *
+ * @returns {Promise<{deleted: Array<{id:number,name:string,location:string}>}>}
+ */
+async function cleanupObsoleteTokens({
+  workspaceId,
+  actorUserId,
+  cleanup,
+  reason = "import_cleanup",
+}) {
+  const deleted = [];
+  if (!cleanup || cleanup.enabled !== true) return { deleted };
+
+  const prefix = PROVIDER_PREFIXES[cleanup.provider];
+  if (!prefix) return { deleted };
+
+  const patterns = (cleanup.scannedSources || [])
+    .map((s) => SOURCE_LOCATION_PATTERNS[s])
+    .filter(Boolean);
+  if (patterns.length === 0) return { deleted };
+
+  const rediscovered = new Set(
+    (cleanup.scannedLocations || [])
+      .map((l) => String(l || "").trim())
+      .filter(Boolean),
+  );
+
+  // Candidates: previously imported tokens from this provider in this workspace.
+  const candidatesRes = await pool.query(
+    `SELECT id, name, location FROM tokens
+     WHERE workspace_id = $1
+       AND imported_at IS NOT NULL
+       AND location LIKE $2`,
+    [workspaceId, `${prefix}%`],
+  );
+
+  for (const row of candidatesRes.rows) {
+    const location = String(row.location || "");
+    // Only delete inside the scanned scope.
+    if (!patterns.some((p) => p.test(location))) continue;
+    if (rediscovered.has(location)) continue;
+
+    try {
+      // Reuse the manual delete semantics: clear queue entries and linked
+      // endpoint monitors so they don't become orphaned.
+      await pool.query("DELETE FROM alert_queue WHERE token_id = $1", [row.id]);
+      await pool.query("DELETE FROM domain_monitors WHERE token_id = $1", [
+        row.id,
+      ]);
+      await pool.query("DELETE FROM tokens WHERE id = $1", [row.id]);
+      deleted.push({ id: row.id, name: row.name, location });
+      try {
+        await writeAudit({
+          actorUserId: actorUserId || null,
+          subjectUserId: actorUserId || null,
+          action: "TOKEN_DELETED",
+          targetType: "token",
+          targetId: row.id,
+          channel: null,
+          workspaceId,
+          metadata: {
+            name: row.name,
+            location,
+            reason,
+            provider: cleanup.provider,
+          },
+        });
+      } catch (auditErr) {
+        logger.warn("Cleanup audit write failed", { error: auditErr.message });
+      }
+    } catch (delErr) {
+      logger.warn("Obsolete token cleanup failed for token", {
+        tokenId: row.id,
+        error: delErr.message,
+      });
+    }
+  }
+
+  return { deleted };
+}
+
+module.exports = {
+  PROVIDER_PREFIXES,
+  SOURCE_LOCATION_PATTERNS,
+  validateCleanupRequest,
+  cleanupObsoleteTokens,
+};

--- a/apps/api/services/importFilterRules.js
+++ b/apps/api/services/importFilterRules.js
@@ -1,0 +1,134 @@
+/**
+ * Import filter rules (issue #69, V1)
+ *
+ * Ordered list of rules applied uniformly to provider scan results and to
+ * the shared import pipeline. Each rule:
+ *   { action: "include"|"exclude", matchType: "regex"|"exact",
+ *     field: "name"|"description", value: string }
+ *
+ * Semantics:
+ *   - Exclude rules win over include rules.
+ *   - If at least one include rule exists, an item must match an include
+ *     rule to be kept (allowlist behavior).
+ *   - Only exclude rules -> denylist behavior.
+ *   - No rules -> everything is kept (current behavior unchanged).
+ */
+
+const MAX_RULES = 50;
+const MAX_VALUE_LENGTH = 500;
+
+const VALID_ACTIONS = new Set(["include", "exclude"]);
+const VALID_MATCH_TYPES = new Set(["regex", "exact"]);
+const VALID_FIELDS = new Set(["name", "description"]);
+
+/**
+ * Validates a filterRules payload. Returns null when valid, otherwise a
+ * human-readable error string suitable for a 400 response.
+ */
+function validateFilterRules(rules) {
+  if (rules === undefined || rules === null) return null;
+  if (!Array.isArray(rules)) {
+    return "filterRules must be an array";
+  }
+  if (rules.length > MAX_RULES) {
+    return `filterRules cannot contain more than ${MAX_RULES} rules`;
+  }
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    const label = `filterRules[${i}]`;
+    if (!rule || typeof rule !== "object") {
+      return `${label} must be an object`;
+    }
+    if (!VALID_ACTIONS.has(rule.action)) {
+      return `${label}.action must be "include" or "exclude"`;
+    }
+    if (!VALID_MATCH_TYPES.has(rule.matchType)) {
+      return `${label}.matchType must be "regex" or "exact"`;
+    }
+    if (!VALID_FIELDS.has(rule.field)) {
+      return `${label}.field must be "name" or "description"`;
+    }
+    if (typeof rule.value !== "string" || rule.value.length === 0) {
+      return `${label}.value must be a non-empty string`;
+    }
+    if (rule.value.length > MAX_VALUE_LENGTH) {
+      return `${label}.value cannot exceed ${MAX_VALUE_LENGTH} characters`;
+    }
+    if (rule.matchType === "regex") {
+      try {
+        // eslint-disable-next-line no-new
+        new RegExp(rule.value);
+      } catch (e) {
+        return `${label}.value is not a valid regular expression: ${e.message}`;
+      }
+    }
+  }
+  return null;
+}
+
+function getItemField(item, field) {
+  if (!item || typeof item !== "object") return "";
+  if (field === "name") {
+    return typeof item.name === "string" ? item.name : "";
+  }
+  // Description-like field: scan items and import payloads may carry the
+  // provider description under `description` or `notes`.
+  if (typeof item.description === "string") return item.description;
+  if (typeof item.notes === "string") return item.notes;
+  return "";
+}
+
+function ruleMatches(rule, item) {
+  const value = getItemField(item, rule.field);
+  if (rule.matchType === "exact") {
+    return value === rule.value;
+  }
+  try {
+    return new RegExp(rule.value).test(value);
+  } catch (_e) {
+    // Invalid patterns are rejected at validation time; treat as no match.
+    return false;
+  }
+}
+
+/**
+ * Returns true when the item passes the rules (should be kept).
+ */
+function evaluateFilterRules(rules, item) {
+  if (!Array.isArray(rules) || rules.length === 0) return true;
+
+  const includeRules = rules.filter((r) => r.action === "include");
+  const excludeRules = rules.filter((r) => r.action === "exclude");
+
+  // Exclude wins over include.
+  for (const rule of excludeRules) {
+    if (ruleMatches(rule, item)) return false;
+  }
+  if (includeRules.length > 0) {
+    return includeRules.some((rule) => ruleMatches(rule, item));
+  }
+  return true;
+}
+
+/**
+ * Applies rules to an item list. Returns { items, matchedCount, excludedCount }.
+ * With no rules, returns the original list untouched.
+ */
+function applyFilterRules(rules, items) {
+  const list = Array.isArray(items) ? items : [];
+  if (!Array.isArray(rules) || rules.length === 0) {
+    return { items: list, matchedCount: list.length, excludedCount: 0 };
+  }
+  const kept = list.filter((item) => evaluateFilterRules(rules, item));
+  return {
+    items: kept,
+    matchedCount: kept.length,
+    excludedCount: list.length - kept.length,
+  };
+}
+
+module.exports = {
+  validateFilterRules,
+  evaluateFilterRules,
+  applyFilterRules,
+};

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -3909,7 +3909,20 @@ function DashboardView({
           const whatsappIds = Array.isArray(group.whatsapp_contact_ids)
             ? group.whatsapp_contact_ids
             : [];
-          return emailIds.length > 0 || whatsappIds.length > 0;
+          // Webhook channels (Slack/Teams/Discord/...) are valid alert
+          // destinations too; also honor the legacy single webhook_name field.
+          const webhookNames = Array.isArray(group.webhook_names)
+            ? group.webhook_names.filter(Boolean)
+            : [];
+          const hasLegacyWebhook =
+            typeof group.webhook_name === 'string' &&
+            group.webhook_name.trim().length > 0;
+          return (
+            emailIds.length > 0 ||
+            whatsappIds.length > 0 ||
+            webhookNames.length > 0 ||
+            hasLegacyWebhook
+          );
         });
         const currentRole = String(
           dashboardWorkspace?.role || ''

--- a/apps/dashboard/src/components/FilterRulesEditor.jsx
+++ b/apps/dashboard/src/components/FilterRulesEditor.jsx
@@ -1,0 +1,176 @@
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Input,
+  Select,
+  Text,
+  VStack,
+  Badge,
+} from '@chakra-ui/react';
+import { FiPlus, FiTrash2 } from 'react-icons/fi';
+
+const MAX_RULES = 50;
+
+export function isValidFilterRule(rule) {
+  if (!rule || typeof rule.value !== 'string' || rule.value.length === 0) {
+    return false;
+  }
+  if (rule.matchType === 'regex') {
+    try {
+      new RegExp(rule.value);
+    } catch (_) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Returns only the complete, valid rules from the editor state, ready to be
+ * sent to the API. Incomplete rows (empty value, invalid regex) are dropped.
+ */
+export function sanitizeFilterRules(rules) {
+  if (!Array.isArray(rules)) return [];
+  return rules.filter(isValidFilterRule).map(r => ({
+    action: r.action,
+    matchType: r.matchType,
+    field: r.field,
+    value: r.value,
+  }));
+}
+
+/**
+ * Ordered include/exclude rule editor (issue #69).
+ * Rules: { action: 'include'|'exclude', matchType: 'regex'|'exact',
+ *          field: 'name'|'description', value: string }
+ * Exclude rules win; if any include rule exists, items must match one.
+ */
+export default function FilterRulesEditor({
+  rules = [],
+  onChange,
+  borderColor,
+  helpTextColor,
+}) {
+  const addRule = () => {
+    if (rules.length >= MAX_RULES) return;
+    onChange([
+      ...rules,
+      { action: 'exclude', matchType: 'exact', field: 'name', value: '' },
+    ]);
+  };
+
+  const updateRule = (index, patch) => {
+    const next = rules.map((r, i) => (i === index ? { ...r, ...patch } : r));
+    onChange(next);
+  };
+
+  const removeRule = index => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  const regexError = rule => {
+    if (rule.matchType !== 'regex' || !rule.value) return null;
+    try {
+      new RegExp(rule.value);
+      return null;
+    } catch (e) {
+      return e.message;
+    }
+  };
+
+  const hasIncludeRules = rules.some(r => r.action === 'include');
+
+  return (
+    <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+      <HStack justify='space-between' mb={2}>
+        <Text fontSize='sm' fontWeight='medium'>
+          Filter rules
+        </Text>
+        <Button
+          size='xs'
+          leftIcon={<FiPlus />}
+          variant='outline'
+          onClick={addRule}
+          isDisabled={rules.length >= MAX_RULES}
+        >
+          Add rule
+        </Button>
+      </HStack>
+      <Text fontSize='xs' color={helpTextColor} mb={rules.length > 0 ? 3 : 0}>
+        Rules apply to scan results before import. Exclude rules always win.
+        {hasIncludeRules
+          ? ' Since include rules are defined, only items matching an include rule are kept.'
+          : ' Without include rules, everything not excluded is kept.'}
+      </Text>
+      {rules.length > 0 && (
+        <VStack align='stretch' spacing={2}>
+          {rules.map((rule, i) => {
+            const err = regexError(rule);
+            return (
+              <Box key={i}>
+                <HStack spacing={2} align='center' flexWrap='wrap'>
+                  <Select
+                    size='xs'
+                    w='96px'
+                    value={rule.action}
+                    onChange={e => updateRule(i, { action: e.target.value })}
+                  >
+                    <option value='include'>Include</option>
+                    <option value='exclude'>Exclude</option>
+                  </Select>
+                  <Select
+                    size='xs'
+                    w='110px'
+                    value={rule.field}
+                    onChange={e => updateRule(i, { field: e.target.value })}
+                  >
+                    <option value='name'>Name</option>
+                    <option value='description'>Description</option>
+                  </Select>
+                  <Select
+                    size='xs'
+                    w='96px'
+                    value={rule.matchType}
+                    onChange={e => updateRule(i, { matchType: e.target.value })}
+                  >
+                    <option value='exact'>Exact</option>
+                    <option value='regex'>Regex</option>
+                  </Select>
+                  <Input
+                    size='xs'
+                    flex='1'
+                    minW='140px'
+                    placeholder={
+                      rule.matchType === 'regex'
+                        ? 'e.g. ^iac-provisioned:.*'
+                        : 'exact value'
+                    }
+                    value={rule.value}
+                    maxLength={500}
+                    isInvalid={Boolean(err)}
+                    onChange={e => updateRule(i, { value: e.target.value })}
+                  />
+                  <IconButton
+                    size='xs'
+                    variant='ghost'
+                    colorScheme='red'
+                    icon={<FiTrash2 />}
+                    aria-label='Remove rule'
+                    onClick={() => removeRule(i)}
+                  />
+                </HStack>
+                {err ? (
+                  <Badge colorScheme='red' fontSize='2xs' mt={1}>
+                    Invalid regex: {err}
+                  </Badge>
+                ) : null}
+              </Box>
+            );
+          })}
+        </VStack>
+      )}
+    </Box>
+  );
+}

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -928,6 +928,8 @@ export default function ImportTokensModal({
     React.useState(true);
   const [gitlabIncludeDeployTokens, setGitlabIncludeDeployTokens] =
     React.useState(true);
+  const [gitlabIncludeTriggerTokens, setGitlabIncludeTriggerTokens] =
+    React.useState(false);
   const [gitlabIncludeSSHKeys, setGitlabIncludeSSHKeys] = React.useState(false);
   const [gitlabExcludeUserPATs, setGitlabExcludeUserPATs] =
     React.useState(true);
@@ -1015,6 +1017,9 @@ export default function ImportTokensModal({
 
   // Auto-sync state
   const [autoSyncConfig, setAutoSyncConfig] = React.useState(null); // null = not loaded, false = not exists, object = exists
+  const [restoredFilterRules, setRestoredFilterRules] = React.useState(null);
+  const [restoredCleanupObsolete, setRestoredCleanupObsolete] =
+    React.useState(null);
   const [savingAutoSync, setSavingAutoSync] = React.useState(false);
   const [runningAutoSyncNow, setRunningAutoSyncNow] = React.useState(false);
   const autoSyncPollCancelRef = React.useRef(false);
@@ -1066,6 +1071,12 @@ export default function ImportTokensModal({
         // Restore non-secret form fields from scan_params when auto-sync is already configured
         if (existing && existing.scan_params) {
           const sp = existing.scan_params;
+          setRestoredFilterRules(
+            Array.isArray(sp.filterRules) ? sp.filterRules : null
+          );
+          setRestoredCleanupObsolete(
+            typeof sp.cleanupObsolete === 'boolean' ? sp.cleanupObsolete : null
+          );
           switch (source) {
             case 'github':
               if (sp.baseUrl) setGithubBaseUrl(sp.baseUrl);
@@ -1093,6 +1104,10 @@ export default function ImportTokensModal({
                   setGitlabIncludeGroupTokens(sp.filters.includeGroupTokens);
                 if (sp.filters.includeDeployTokens !== undefined)
                   setGitlabIncludeDeployTokens(sp.filters.includeDeployTokens);
+                if (sp.filters.includeTriggerTokens !== undefined)
+                  setGitlabIncludeTriggerTokens(
+                    sp.filters.includeTriggerTokens
+                  );
                 if (sp.filters.includeSSHKeys !== undefined)
                   setGitlabIncludeSSHKeys(sp.filters.includeSSHKeys);
                 if (sp.filters.excludeUserPATs !== undefined)
@@ -1144,6 +1159,11 @@ export default function ImportTokensModal({
           }
         } else if (source === 'aws') {
           setAwsAutoSyncScanParams(null);
+          setRestoredFilterRules(null);
+          setRestoredCleanupObsolete(null);
+        } else {
+          setRestoredFilterRules(null);
+          setRestoredCleanupObsolete(null);
         }
       } catch (_) {
         setAutoSyncConfig(false);
@@ -1213,6 +1233,7 @@ export default function ImportTokensModal({
             includeProjectTokens: gitlabIncludeProjectTokens,
             includeGroupTokens: gitlabIncludeGroupTokens,
             includeDeployTokens: gitlabIncludeDeployTokens,
+            includeTriggerTokens: gitlabIncludeTriggerTokens,
             includeSSHKeys: gitlabIncludeSSHKeys,
             excludeUserPATs: gitlabExcludeUserPATs,
             includeExpired: gitlabIncludeExpired,
@@ -2634,6 +2655,8 @@ export default function ImportTokensModal({
                   extractQuotaFromError={extractQuotaFromError}
                   autoSyncManageMode={autoSyncManageMode}
                   contactGroups={contactGroups}
+                  initialFilterRules={restoredFilterRules}
+                  initialCleanupObsolete={restoredCleanupObsolete}
                 />
               ) : null}
 
@@ -2663,6 +2686,8 @@ export default function ImportTokensModal({
                   formatQuotaError={formatQuotaError}
                   extractQuotaFromError={extractQuotaFromError}
                   contactGroups={contactGroups}
+                  initialFilterRules={restoredFilterRules}
+                  initialCleanupObsolete={restoredCleanupObsolete}
                 />
               ) : null}
 

--- a/apps/dashboard/src/components/IntegrationImportTable.jsx
+++ b/apps/dashboard/src/components/IntegrationImportTable.jsx
@@ -21,7 +21,7 @@ import {
   Alert,
   AlertIcon,
 } from '@chakra-ui/react';
-import { FiEdit2, FiCheck, FiAlertTriangle } from 'react-icons/fi';
+import { FiEdit2, FiCheck, FiAlertTriangle, FiSlash } from 'react-icons/fi';
 import TruncatedText from './TruncatedText';
 import { formatExpirationDate, isNeverExpires } from '../utils/dateUtils';
 
@@ -41,6 +41,7 @@ export default function IntegrationImportTable({
   categoryOptions = ['cert', 'key_secret', 'license', 'general'], // Available categories
   editableFields: _editableFields = ['name', 'category', 'type'], // Which fields are editable (reserved for callers)
   duplicateIndices = new Set(), // Set of indices that are duplicates
+  onExcludeItem, // Optional: one-click "exclude this token" (adds an exact-match exclude filter rule)
 }) {
   const [editingRow, setEditingRow] = React.useState(null);
   const [editValues, setEditValues] = React.useState({});
@@ -465,13 +466,32 @@ export default function IntegrationImportTable({
                         />
                       </HStack>
                     ) : (
-                      <IconButton
-                        icon={<FiEdit2 />}
-                        size='xs'
-                        variant='ghost'
-                        onClick={() => startEditing(index)}
-                        aria-label='Edit'
-                      />
+                      <HStack spacing={0}>
+                        <IconButton
+                          icon={<FiEdit2 />}
+                          size='xs'
+                          variant='ghost'
+                          onClick={() => startEditing(index)}
+                          aria-label='Edit'
+                        />
+                        {onExcludeItem ? (
+                          <Tooltip
+                            label='Exclude this token (adds an exact-match exclude rule)'
+                            fontSize='xs'
+                            hasArrow
+                            placement='top'
+                          >
+                            <IconButton
+                              icon={<FiSlash />}
+                              size='xs'
+                              variant='ghost'
+                              colorScheme='red'
+                              onClick={() => onExcludeItem(index)}
+                              aria-label='Exclude this token'
+                            />
+                          </Tooltip>
+                        ) : null}
+                      </HStack>
                     )}
                   </Td>
                 </Tr>

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -18,6 +18,7 @@ import { githubAPI, integrationAPI, formatDate } from '../../utils/apiClient';
 import { logger } from '../../utils/logger';
 import IntegrationImportTable from '../IntegrationImportTable';
 import BulkIntegrationAssignment from '../BulkIntegrationAssignment';
+import FilterRulesEditor, { sanitizeFilterRules } from '../FilterRulesEditor';
 
 function getGitHubItemDetails(item) {
   const details = [];
@@ -97,6 +98,8 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     contactGroups,
     onSelectionChange,
     autoSyncManageMode = false,
+    initialFilterRules = null,
+    initialCleanupObsolete = null,
   },
   ref
 ) {
@@ -123,6 +126,24 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
   const [showSecret, setShowSecret] = React.useState(false);
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
+  const [filterRules, setFilterRules] = React.useState([]);
+  const [filterSummary, setFilterSummary] = React.useState(null);
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // Source kinds included in the last scan; cleanup only touches these.
+  const [lastScanSources, setLastScanSources] = React.useState([]);
+
+  // Restore persisted rules from auto-sync scan_params
+  React.useEffect(() => {
+    if (Array.isArray(initialFilterRules)) {
+      setFilterRules(initialFilterRules);
+    }
+  }, [initialFilterRules]);
+
+  React.useEffect(() => {
+    if (typeof initialCleanupObsolete === 'boolean') {
+      setCleanupObsolete(initialCleanupObsolete);
+    }
+  }, [initialCleanupObsolete]);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsGithub.size);
@@ -146,6 +167,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     setIsScanning(true);
     setGithubItems([]);
     setGithubSummary([]);
+    setFilterSummary(null);
     try {
       const res = await githubAPI.scan({
         workspaceId,
@@ -158,10 +180,17 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
           deployKeys: githubIncludeDeployKeys,
           secrets: githubIncludeSecrets,
         },
+        filterRules: sanitizeFilterRules(filterRules),
       });
       const items = Array.isArray(res?.items) ? res.items : [];
       setGithubItems(items);
       setGithubSummary(Array.isArray(res?.summary) ? res.summary : []);
+      setFilterSummary(res?.filterSummary || null);
+      const scannedSources = [];
+      if (githubIncludeSSHKeys) scannedSources.push('github-ssh-key');
+      if (githubIncludeDeployKeys) scannedSources.push('github-deploy-key');
+      if (githubIncludeSecrets) scannedSources.push('github-secret');
+      setLastScanSources(scannedSources);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('github');
       }
@@ -178,6 +207,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     } catch (e) {
       setGithubItems([]);
       setGithubSummary([]);
+      setFilterSummary(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -199,6 +229,39 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     });
   };
 
+  // One-click "exclude this token": appends an exact-match exclude rule and
+  // drops the row from the current preview.
+  const excludeGithubItem = index => {
+    const item = githubItems[index];
+    if (!item || !item.name) return;
+    setFilterRules(prev => [
+      ...prev,
+      {
+        action: 'exclude',
+        matchType: 'exact',
+        field: 'name',
+        value: item.name,
+      },
+    ]);
+    setGithubItems(prev => prev.filter((_, i) => i !== index));
+    setSelectedRowsGithub(prev => {
+      const next = new Set();
+      prev.forEach(i => {
+        if (i === index) return;
+        next.add(i > index ? i - 1 : i);
+      });
+      return next;
+    });
+    setFilterSummary(prev =>
+      prev
+        ? {
+            matchedCount: Math.max(0, (prev.matchedCount || 0) - 1),
+            excludedCount: (prev.excludedCount || 0) + 1,
+          }
+        : { matchedCount: githubItems.length - 1, excludedCount: 1 }
+    );
+  };
+
   const importGithubSelected = async () => {
     try {
       const selected = githubItems
@@ -217,6 +280,19 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup:
+          cleanupObsolete && lastScanSources.length > 0
+            ? {
+                enabled: true,
+                provider: 'github',
+                scannedSources: lastScanSources,
+                // All rediscovered locations (whole scan, not just selection)
+                // so unselected-but-still-present tokens are never deleted.
+                scannedLocations: githubItems
+                  .map(it => it.location)
+                  .filter(Boolean),
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -240,6 +316,8 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
           deployKeys: githubIncludeDeployKeys,
           secrets: githubIncludeSecrets,
         },
+        filterRules: sanitizeFilterRules(filterRules),
+        cleanupObsolete,
       },
     }),
   }));
@@ -349,8 +427,38 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
           >
             Repository Secrets
           </Checkbox>
+          <Checkbox
+            isChecked={cleanupObsolete}
+            onChange={e => setCleanupObsolete(e.target.checked)}
+            size='sm'
+            colorScheme='red'
+          >
+            Remove previously imported tokens no longer found at the source
+          </Checkbox>
+          {cleanupObsolete ? (
+            <Text fontSize='xs' color='red.400' pl={6}>
+              Deletes TokenTimer entries (scoped to the scanned GitHub item
+              types) that are missing from this scan. This cannot be undone.
+            </Text>
+          ) : null}
         </VStack>
       </Box>
+      <FilterRulesEditor
+        rules={filterRules}
+        onChange={setFilterRules}
+        borderColor={borderColor}
+        helpTextColor={helpTextColor}
+      />
+      {!autoSyncManageMode && filterSummary ? (
+        <HStack spacing={2}>
+          <Badge colorScheme='green'>
+            {filterSummary.matchedCount} matched
+          </Badge>
+          <Badge colorScheme='red'>
+            {filterSummary.excludedCount} excluded by rules
+          </Badge>
+        </HStack>
+      ) : null}
       {!autoSyncManageMode && githubSummary.length > 0 && (
         <Box
           border='1px solid'
@@ -397,6 +505,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
             getDetailsForItem={getGitHubItemDetails}
             onUpdateItem={updateGithubItem}
             duplicateIndices={githubDuplicates}
+            onExcludeItem={excludeGithubItem}
           />
           <BulkIntegrationAssignment
             selectedCount={selectedRowsGithub.size}

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -18,6 +18,7 @@ import { gitlabAPI, integrationAPI, formatDate } from '../../utils/apiClient';
 import { logger } from '../../utils/logger';
 import IntegrationImportTable from '../IntegrationImportTable';
 import BulkIntegrationAssignment from '../BulkIntegrationAssignment';
+import FilterRulesEditor, { sanitizeFilterRules } from '../FilterRulesEditor';
 
 function getGitLabItemDetails(item) {
   const details = [];
@@ -92,6 +93,8 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     contactGroups,
     onSelectionChange,
     autoSyncManageMode = false,
+    initialFilterRules = null,
+    initialCleanupObsolete = null,
   },
   ref
 ) {
@@ -112,6 +115,8 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     React.useState(true);
   const [gitlabIncludeDeployTokens, setGitlabIncludeDeployTokens] =
     React.useState(true);
+  const [gitlabIncludeTriggerTokens, setGitlabIncludeTriggerTokens] =
+    React.useState(false);
   const [gitlabIncludeSSHKeys, setGitlabIncludeSSHKeys] = React.useState(false);
   const [gitlabExcludeUserPATs, setGitlabExcludeUserPATs] =
     React.useState(true);
@@ -123,6 +128,24 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
   const [showSecret, setShowSecret] = React.useState(false);
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
+  const [filterRules, setFilterRules] = React.useState([]);
+  const [filterSummary, setFilterSummary] = React.useState(null);
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // Source kinds included in the last scan; cleanup only touches these.
+  const [lastScanSources, setLastScanSources] = React.useState([]);
+
+  // Restore persisted rules from auto-sync scan_params
+  React.useEffect(() => {
+    if (Array.isArray(initialFilterRules)) {
+      setFilterRules(initialFilterRules);
+    }
+  }, [initialFilterRules]);
+
+  React.useEffect(() => {
+    if (typeof initialCleanupObsolete === 'boolean') {
+      setCleanupObsolete(initialCleanupObsolete);
+    }
+  }, [initialCleanupObsolete]);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsGitlab.size);
@@ -147,6 +170,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     setIsScanning(true);
     setGitlabItems([]);
     setGitlabSummary([]);
+    setFilterSummary(null);
     try {
       const res = await gitlabAPI.scan({
         workspaceId,
@@ -158,15 +182,28 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
           includeProjectTokens: gitlabIncludeProjectTokens,
           includeGroupTokens: gitlabIncludeGroupTokens,
           includeDeployTokens: gitlabIncludeDeployTokens,
+          includeTriggerTokens: gitlabIncludeTriggerTokens,
           includeSSHKeys: gitlabIncludeSSHKeys,
           excludeUserPATs: gitlabExcludeUserPATs,
           includeExpired: gitlabIncludeExpired,
           includeRevoked: gitlabIncludeRevoked,
         },
+        filterRules: sanitizeFilterRules(filterRules),
       });
       const items = Array.isArray(res?.items) ? res.items : [];
       setGitlabItems(items);
       setGitlabSummary(Array.isArray(res?.summary) ? res.summary : []);
+      setFilterSummary(res?.filterSummary || null);
+      const scannedSources = [];
+      if (gitlabIncludePATs) scannedSources.push('gitlab-pat');
+      if (gitlabIncludeProjectTokens)
+        scannedSources.push('gitlab-project-token');
+      if (gitlabIncludeGroupTokens) scannedSources.push('gitlab-group-token');
+      if (gitlabIncludeDeployTokens) scannedSources.push('gitlab-deploy-token');
+      if (gitlabIncludeTriggerTokens)
+        scannedSources.push('gitlab-trigger-token');
+      if (gitlabIncludeSSHKeys) scannedSources.push('gitlab-ssh-key');
+      setLastScanSources(scannedSources);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('gitlab');
       }
@@ -183,6 +220,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     } catch (e) {
       setGitlabItems([]);
       setGitlabSummary([]);
+      setFilterSummary(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -204,6 +242,39 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     });
   };
 
+  // One-click "exclude this token": appends an exact-match exclude rule and
+  // drops the row from the current preview.
+  const excludeGitlabItem = index => {
+    const item = gitlabItems[index];
+    if (!item || !item.name) return;
+    setFilterRules(prev => [
+      ...prev,
+      {
+        action: 'exclude',
+        matchType: 'exact',
+        field: 'name',
+        value: item.name,
+      },
+    ]);
+    setGitlabItems(prev => prev.filter((_, i) => i !== index));
+    setSelectedRowsGitlab(prev => {
+      const next = new Set();
+      prev.forEach(i => {
+        if (i === index) return;
+        next.add(i > index ? i - 1 : i);
+      });
+      return next;
+    });
+    setFilterSummary(prev =>
+      prev
+        ? {
+            matchedCount: Math.max(0, (prev.matchedCount || 0) - 1),
+            excludedCount: (prev.excludedCount || 0) + 1,
+          }
+        : { matchedCount: gitlabItems.length - 1, excludedCount: 1 }
+    );
+  };
+
   const importGitlabSelected = async () => {
     try {
       const selected = gitlabItems
@@ -222,6 +293,18 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup: cleanupObsolete
+          ? {
+              enabled: true,
+              provider: 'gitlab',
+              scannedSources: lastScanSources,
+              // All rediscovered locations (whole scan, not just selection)
+              // so unselected-but-still-present tokens are never deleted.
+              scannedLocations: gitlabItems
+                .map(it => it.location)
+                .filter(Boolean),
+            }
+          : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -245,11 +328,14 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
           includeProjectTokens: gitlabIncludeProjectTokens,
           includeGroupTokens: gitlabIncludeGroupTokens,
           includeDeployTokens: gitlabIncludeDeployTokens,
+          includeTriggerTokens: gitlabIncludeTriggerTokens,
           includeSSHKeys: gitlabIncludeSSHKeys,
           excludeUserPATs: gitlabExcludeUserPATs,
           includeExpired: gitlabIncludeExpired,
           includeRevoked: gitlabIncludeRevoked,
         },
+        filterRules: sanitizeFilterRules(filterRules),
+        cleanupObsolete,
       },
     }),
   }));
@@ -365,6 +451,13 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
                 Deploy Tokens
               </Checkbox>
               <Checkbox
+                isChecked={gitlabIncludeTriggerTokens}
+                onChange={e => setGitlabIncludeTriggerTokens(e.target.checked)}
+                size='sm'
+              >
+                Pipeline Trigger Tokens
+              </Checkbox>
+              <Checkbox
                 isChecked={gitlabIncludeSSHKeys}
                 onChange={e => setGitlabIncludeSSHKeys(e.target.checked)}
                 size='sm'
@@ -386,7 +479,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
                 size='sm'
                 colorScheme='purple'
               >
-                Exclude users Personal Access Tokens
+                Exclude regular-user PATs (keep admin and service accounts)
               </Checkbox>
               <Checkbox
                 isChecked={gitlabIncludeExpired}
@@ -404,10 +497,40 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
               >
                 Include revoked tokens
               </Checkbox>
+              <Checkbox
+                isChecked={cleanupObsolete}
+                onChange={e => setCleanupObsolete(e.target.checked)}
+                size='sm'
+                colorScheme='red'
+              >
+                Remove previously imported tokens no longer found at the source
+              </Checkbox>
+              {cleanupObsolete ? (
+                <Text fontSize='xs' color='red.400' pl={6}>
+                  Deletes TokenTimer entries (scoped to the scanned GitLab token
+                  types) that are missing from this scan. This cannot be undone.
+                </Text>
+              ) : null}
             </VStack>
           </Box>
         </VStack>
       </Box>
+      <FilterRulesEditor
+        rules={filterRules}
+        onChange={setFilterRules}
+        borderColor={borderColor}
+        helpTextColor={helpTextColor}
+      />
+      {!autoSyncManageMode && filterSummary ? (
+        <HStack spacing={2}>
+          <Badge colorScheme='green'>
+            {filterSummary.matchedCount} matched
+          </Badge>
+          <Badge colorScheme='red'>
+            {filterSummary.excludedCount} excluded by rules
+          </Badge>
+        </HStack>
+      ) : null}
       {!autoSyncManageMode && gitlabSummary.length > 0 && (
         <Box
           border='1px solid'
@@ -452,6 +575,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
             getDetailsForItem={getGitLabItemDetails}
             onUpdateItem={updateGitlabItem}
             duplicateIndices={gitlabDuplicates}
+            onExcludeItem={excludeGitlabItem}
           />
           <BulkIntegrationAssignment
             selectedCount={selectedRowsGitlab.size}

--- a/apps/dashboard/src/hooks/useDashboardShellProps.js
+++ b/apps/dashboard/src/hooks/useDashboardShellProps.js
@@ -189,7 +189,20 @@ export function useDashboardShellProps({
           const whatsappIds = Array.isArray(group.whatsapp_contact_ids)
             ? group.whatsapp_contact_ids
             : [];
-          return emailIds.length > 0 || whatsappIds.length > 0;
+          // Webhook channels (Slack/Teams/Discord/...) are valid alert
+          // destinations too; also honor the legacy single webhook_name field.
+          const webhookNames = Array.isArray(group.webhook_names)
+            ? group.webhook_names.filter(Boolean)
+            : [];
+          const hasLegacyWebhook =
+            typeof group.webhook_name === 'string' &&
+            group.webhook_name.trim().length > 0;
+          return (
+            emailIds.length > 0 ||
+            whatsappIds.length > 0 ||
+            webhookNames.length > 0 ||
+            hasLegacyWebhook
+          );
         });
         const currentRole = String(activeWorkspace?.role || '').toLowerCase();
         const canManageWorkspaceAlerts =

--- a/apps/dashboard/src/pages/ControlCenter.jsx
+++ b/apps/dashboard/src/pages/ControlCenter.jsx
@@ -1039,7 +1039,9 @@ export default function ControlCenter({ session, onLogout, onAccountClick }) {
     return 'Registered in this workspace';
   }, [activeManagedCerts, certOpsLoading, managedCertCount]);
 
-  const neverExpiresCount = neverExpires.length || buckets.neverExpires || 0;
+  // Prefer the workspace-wide aggregate: neverExpires is a preview list capped
+  // by the backend (LIMIT 12), so its length undercounts large inventories.
+  const neverExpiresCount = buckets.neverExpires ?? neverExpires.length ?? 0;
 
   const usageRatio = alertData.planInfo.alertLimitMonth
     ? Math.min(

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -1205,6 +1205,7 @@ export const gitlabAPI = {
     include = { tokens: true, keys: true },
     maxItems = 500,
     filters = {},
+    filterRules = undefined,
   }) => {
     if (!workspaceId) {
       throw new Error('workspaceId is required for integration scans');
@@ -1216,6 +1217,9 @@ export const gitlabAPI = {
         include,
         maxItems,
         filters,
+        ...(Array.isArray(filterRules) && filterRules.length > 0
+          ? { filterRules }
+          : {}),
       };
 
       // Use axios.request with explicit config to ensure timeout is applied
@@ -1252,6 +1256,7 @@ export const githubAPI = {
     token,
     include = { tokens: true, sshKeys: true, deployKeys: true, secrets: true },
     maxItems = 500,
+    filterRules = undefined,
   }) => {
     if (!workspaceId) {
       throw new Error('workspaceId is required for integration scans');
@@ -1262,6 +1267,9 @@ export const githubAPI = {
         token,
         include,
         maxItems,
+        ...(Array.isArray(filterRules) && filterRules.length > 0
+          ? { filterRules }
+          : {}),
       };
       // Use axios.request with explicit config to ensure timeout is applied
       const res = await apiClient.request({
@@ -1469,13 +1477,23 @@ export const azureADAPI = {
 
 // Generic integration import API (shared for all integrations)
 export const integrationAPI = {
-  import: async ({ workspaceId, items, defaults = {} }) => {
+  import: async ({
+    workspaceId,
+    items,
+    defaults = {},
+    filterRules,
+    cleanup,
+  }) => {
     try {
       const payload = {
         items,
         default_category: defaults.category,
         default_type: defaults.type,
         contact_group_id: defaults.contact_group_id || null,
+        ...(Array.isArray(filterRules) && filterRules.length > 0
+          ? { filterRules }
+          : {}),
+        ...(cleanup && cleanup.enabled === true ? { cleanup } : {}),
       };
       const res = await apiClient.post(
         API_ENDPOINTS.INTEGRATION_IMPORT(workspaceId),
@@ -1483,17 +1501,22 @@ export const integrationAPI = {
       );
       const createdCount = res?.data?.created_count || 0;
       const updatedCount = res?.data?.updated_count || 0;
+      const deletedCount = res?.data?.deleted_count || 0;
+      const deletedSuffix =
+        deletedCount > 0
+          ? `, removed ${deletedCount} obsolete token${deletedCount !== 1 ? 's' : ''}`
+          : '';
       if (updatedCount > 0 && createdCount > 0) {
         showSuccessMessage(
-          `Imported ${createdCount} new token${createdCount !== 1 ? 's' : ''}, updated ${updatedCount} existing token${updatedCount !== 1 ? 's' : ''}`
+          `Imported ${createdCount} new token${createdCount !== 1 ? 's' : ''}, updated ${updatedCount} existing token${updatedCount !== 1 ? 's' : ''}${deletedSuffix}`
         );
       } else if (updatedCount > 0) {
         showSuccessMessage(
-          `Updated ${updatedCount} existing token${updatedCount !== 1 ? 's' : ''}`
+          `Updated ${updatedCount} existing token${updatedCount !== 1 ? 's' : ''}${deletedSuffix}`
         );
       } else {
         showSuccessMessage(
-          `Imported ${createdCount} token${createdCount !== 1 ? 's' : ''}`
+          `Imported ${createdCount} token${createdCount !== 1 ? 's' : ''}${deletedSuffix}`
         );
       }
       return res.data;

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -278,6 +278,9 @@ async function runAutoSync() {
             : {};
           let scanUrl;
           let scanBody;
+          const filterRules = Array.isArray(scan_params?.filterRules)
+            ? scan_params.filterRules
+            : undefined;
 
           switch (provider) {
             case "github":
@@ -292,6 +295,7 @@ async function runAutoSync() {
                   secrets: true,
                 },
                 maxItems: scan_params?.maxItems || 500,
+                filterRules,
               };
               break;
             case "gitlab":
@@ -302,6 +306,7 @@ async function runAutoSync() {
                 include: scan_params?.include || { tokens: true, keys: true },
                 maxItems: scan_params?.maxItems || 500,
                 filters: scan_params?.filters || {},
+                filterRules,
               };
               break;
             default:
@@ -321,17 +326,66 @@ async function runAutoSync() {
           //    what a user gets when importing manually from the dashboard.
           let importedCount = 0;
           let importErrorCount = 0;
+          let deletedCount = 0;
           if (itemsCount > 0) {
             const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
+            // Cleanup of obsolete tokens is only attempted when the scan
+            // returned at least one item, so an empty/broken scan can never
+            // mass-delete a workspace.
+            let cleanup;
+            if (scan_params?.cleanupObsolete === true) {
+              const scannedSources = [];
+              if (provider === "gitlab") {
+                const f = scan_params?.filters || {};
+                if (f.includePATs !== false) scannedSources.push("gitlab-pat");
+                if (f.includeProjectTokens !== false)
+                  scannedSources.push("gitlab-project-token");
+                if (f.includeGroupTokens !== false)
+                  scannedSources.push("gitlab-group-token");
+                if (f.includeDeployTokens !== false)
+                  scannedSources.push("gitlab-deploy-token");
+                if (f.includeTriggerTokens === true)
+                  scannedSources.push("gitlab-trigger-token");
+                if (f.includeSSHKeys === true)
+                  scannedSources.push("gitlab-ssh-key");
+              } else if (provider === "github") {
+                const inc = scan_params?.include || {
+                  tokens: true,
+                  sshKeys: true,
+                  deployKeys: true,
+                  secrets: true,
+                };
+                if (inc.sshKeys) scannedSources.push("github-ssh-key");
+                if (inc.deployKeys) scannedSources.push("github-deploy-key");
+                if (inc.secrets) scannedSources.push("github-secret");
+              }
+              if (scannedSources.length > 0) {
+                cleanup = {
+                  enabled: true,
+                  provider,
+                  scannedSources,
+                  scannedLocations: (scanResult.items || [])
+                    .map((it) => it.location)
+                    .filter(Boolean),
+                  reason: "auto_sync_cleanup",
+                };
+              }
+            }
             const importResponse = await axios.post(
               importUrl,
-              { items: scanResult.items },
+              { items: scanResult.items, ...(cleanup ? { cleanup } : {}) },
               { timeout: 60000, headers: authHeaders },
             );
             const importResult = importResponse.data || {};
             importedCount =
               (importResult.created_count || 0) + (importResult.updated_count || 0);
             importErrorCount = importResult.error_count || 0;
+            deletedCount = importResult.deleted_count || 0;
+            if (deletedCount > 0) {
+              logger.info(
+                `Auto-sync cleanup removed ${deletedCount} obsolete token(s) for config ${config.id}`,
+              );
+            }
           }
 
           // A run only counts as a real success if items that were scanned

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.9.1
-appVersion: "0.9.1"
+version: 0.10.0
+appVersion: "0.10.0"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.9.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "status": "m2-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes for M1/M2. M1/M2 Core workspace, machine-token executor, job read, job manual-create, evidence, and token-management routes are runtime-stable where implemented and documented in OpenAPI. This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn.",
   "namespacePolicy": {

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.9.1
+  version: 0.10.0
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/unit/import-cleanup.unit.test.js
+++ b/tests/unit/import-cleanup.unit.test.js
@@ -1,0 +1,147 @@
+"use strict";
+
+/**
+ * Unit tests for importCleanup validation and scope patterns.
+ * DB-dependent deletion behavior is covered by integration tests.
+ * Only the pure exports are exercised here; requiring the module creates a
+ * pg Pool but never connects.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const {
+  validateCleanupRequest,
+  SOURCE_LOCATION_PATTERNS,
+  PROVIDER_PREFIXES,
+} = require("../../apps/api/services/importCleanup");
+
+describe("importCleanup.validateCleanupRequest", () => {
+  it("accepts undefined/null (cleanup not requested)", () => {
+    assert.strictEqual(validateCleanupRequest(undefined), null);
+    assert.strictEqual(validateCleanupRequest(null), null);
+  });
+
+  it("rejects non-object payloads", () => {
+    assert.match(validateCleanupRequest("yes"), /must be an object/);
+    assert.match(validateCleanupRequest([1]), /must be an object/);
+  });
+
+  it("ignores payloads with enabled !== true", () => {
+    assert.strictEqual(validateCleanupRequest({ enabled: false }), null);
+    assert.strictEqual(validateCleanupRequest({}), null);
+  });
+
+  it("requires a known provider when enabled", () => {
+    assert.match(
+      validateCleanupRequest({ enabled: true, provider: "bitbucket" }),
+      /provider must be one of/,
+    );
+  });
+
+  it("requires non-empty scannedSources with known kinds", () => {
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scannedSources: [],
+      }),
+      /non-empty array/,
+    );
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scannedSources: ["gitlab-unknown"],
+      }),
+      /unknown source kind/,
+    );
+  });
+
+  it("requires scannedLocations array", () => {
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scannedSources: ["gitlab-pat"],
+        scannedLocations: "gitlab:x",
+      }),
+      /must be an array/,
+    );
+  });
+
+  it("accepts a valid payload", () => {
+    assert.strictEqual(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scannedSources: ["gitlab-pat", "gitlab-deploy-token"],
+        scannedLocations: ["gitlab:personal_access_tokens/1"],
+      }),
+      null,
+    );
+  });
+});
+
+describe("importCleanup.SOURCE_LOCATION_PATTERNS", () => {
+  it("gitlab-pat matches both PAT location shapes", () => {
+    const p = SOURCE_LOCATION_PATTERNS["gitlab-pat"];
+    assert.strictEqual(p.test("gitlab:personal_access_tokens/42"), true);
+    assert.strictEqual(
+      p.test("gitlab:users/alice/personal_access_tokens/42"),
+      true,
+    );
+    assert.strictEqual(p.test("gitlab:projects/7/access_tokens/42"), false);
+  });
+
+  it("gitlab token type patterns are mutually exclusive", () => {
+    const samples = {
+      "gitlab-project-token": "gitlab:projects/7/access_tokens/1",
+      "gitlab-group-token": "gitlab:groups/3/access_tokens/1",
+      "gitlab-deploy-token": "gitlab:projects/7/deploy_tokens/1",
+      "gitlab-trigger-token": "gitlab:projects/7/triggers/1",
+      "gitlab-ssh-key": "gitlab:user/keys/1",
+    };
+    for (const [kind, location] of Object.entries(samples)) {
+      assert.strictEqual(
+        SOURCE_LOCATION_PATTERNS[kind].test(location),
+        true,
+        `${kind} should match ${location}`,
+      );
+      for (const [otherKind, pattern] of Object.entries(
+        SOURCE_LOCATION_PATTERNS,
+      )) {
+        if (otherKind === kind || !otherKind.startsWith("gitlab-")) continue;
+        assert.strictEqual(
+          pattern.test(location),
+          false,
+          `${otherKind} should not match ${location}`,
+        );
+      }
+    }
+  });
+
+  it("github patterns match the integration location shapes", () => {
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["github-ssh-key"].test("github:user/keys/9"),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["github-secret"].test(
+        "github:repos/org/repo/actions/secrets/MY_SECRET",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["github-deploy-key"].test(
+        "github:repos/org/repo/keys/12",
+      ),
+      true,
+    );
+  });
+
+  it("every provider prefix has a colon suffix", () => {
+    for (const prefix of Object.values(PROVIDER_PREFIXES)) {
+      assert.strictEqual(prefix.endsWith(":"), true);
+    }
+  });
+});

--- a/tests/unit/import-filter-rules.unit.test.js
+++ b/tests/unit/import-filter-rules.unit.test.js
@@ -1,0 +1,204 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const {
+  validateFilterRules,
+  evaluateFilterRules,
+  applyFilterRules,
+} = require("../../apps/api/services/importFilterRules");
+
+describe("importFilterRules.validateFilterRules", () => {
+  it("accepts undefined/null (no rules)", () => {
+    assert.strictEqual(validateFilterRules(undefined), null);
+    assert.strictEqual(validateFilterRules(null), null);
+  });
+
+  it("accepts an empty array", () => {
+    assert.strictEqual(validateFilterRules([]), null);
+  });
+
+  it("rejects a non-array payload", () => {
+    assert.match(validateFilterRules("nope"), /must be an array/);
+  });
+
+  it("rejects an invalid action", () => {
+    const err = validateFilterRules([
+      { action: "keep", matchType: "exact", field: "name", value: "x" },
+    ]);
+    assert.match(err, /action/);
+  });
+
+  it("rejects an invalid matchType", () => {
+    const err = validateFilterRules([
+      { action: "include", matchType: "glob", field: "name", value: "x" },
+    ]);
+    assert.match(err, /matchType/);
+  });
+
+  it("rejects an invalid field", () => {
+    const err = validateFilterRules([
+      { action: "include", matchType: "exact", field: "location", value: "x" },
+    ]);
+    assert.match(err, /field/);
+  });
+
+  it("rejects an empty value", () => {
+    const err = validateFilterRules([
+      { action: "include", matchType: "exact", field: "name", value: "" },
+    ]);
+    assert.match(err, /non-empty string/);
+  });
+
+  it("rejects an invalid regex with a clear error", () => {
+    const err = validateFilterRules([
+      { action: "include", matchType: "regex", field: "name", value: "[" },
+    ]);
+    assert.match(err, /not a valid regular expression/);
+  });
+
+  it("accepts a valid mixed rule set", () => {
+    const err = validateFilterRules([
+      {
+        action: "include",
+        matchType: "regex",
+        field: "description",
+        value: "^iac-provisioned:.*",
+      },
+      { action: "exclude", matchType: "exact", field: "name", value: "temp" },
+    ]);
+    assert.strictEqual(err, null);
+  });
+});
+
+describe("importFilterRules.evaluateFilterRules", () => {
+  const item = (name, description) => ({ name, description });
+
+  it("keeps everything when no rules are defined", () => {
+    assert.strictEqual(evaluateFilterRules([], item("a", "b")), true);
+    assert.strictEqual(evaluateFilterRules(undefined, item("a", "b")), true);
+  });
+
+  it("denylist: only exclude rules keep non-matching items", () => {
+    const rules = [
+      { action: "exclude", matchType: "exact", field: "name", value: "bad" },
+    ];
+    assert.strictEqual(evaluateFilterRules(rules, item("good", "")), true);
+    assert.strictEqual(evaluateFilterRules(rules, item("bad", "")), false);
+  });
+
+  it("allowlist: any include rule requires items to match one", () => {
+    const rules = [
+      {
+        action: "include",
+        matchType: "regex",
+        field: "description",
+        value: "^iac-provisioned:",
+      },
+    ];
+    assert.strictEqual(
+      evaluateFilterRules(rules, item("t1", "iac-provisioned: ci")),
+      true,
+    );
+    assert.strictEqual(
+      evaluateFilterRules(rules, item("t2", "manually created")),
+      false,
+    );
+  });
+
+  it("exclude wins over include", () => {
+    const rules = [
+      {
+        action: "include",
+        matchType: "regex",
+        field: "name",
+        value: ".*",
+      },
+      {
+        action: "exclude",
+        matchType: "exact",
+        field: "name",
+        value: "secret-token",
+      },
+    ];
+    assert.strictEqual(evaluateFilterRules(rules, item("other", "")), true);
+    assert.strictEqual(
+      evaluateFilterRules(rules, item("secret-token", "")),
+      false,
+    );
+  });
+
+  it("include by exact value overrides missing convention (targeted include)", () => {
+    const rules = [
+      {
+        action: "include",
+        matchType: "regex",
+        field: "description",
+        value: "^iac-provisioned:",
+      },
+      {
+        action: "include",
+        matchType: "exact",
+        field: "name",
+        value: "legacy-but-ours",
+      },
+    ];
+    assert.strictEqual(
+      evaluateFilterRules(rules, item("legacy-but-ours", "no convention")),
+      true,
+    );
+    assert.strictEqual(
+      evaluateFilterRules(rules, item("random", "no convention")),
+      false,
+    );
+  });
+
+  it("matches description via notes fallback", () => {
+    const rules = [
+      {
+        action: "include",
+        matchType: "regex",
+        field: "description",
+        value: "^iac-",
+      },
+    ];
+    assert.strictEqual(
+      evaluateFilterRules(rules, { name: "x", notes: "iac-managed" }),
+      true,
+    );
+  });
+
+  it("treats missing fields as empty strings", () => {
+    const rules = [
+      { action: "exclude", matchType: "regex", field: "description", value: "^$" },
+    ];
+    assert.strictEqual(evaluateFilterRules(rules, { name: "x" }), false);
+  });
+});
+
+describe("importFilterRules.applyFilterRules", () => {
+  it("returns original list and zero excluded with no rules", () => {
+    const items = [{ name: "a" }, { name: "b" }];
+    const res = applyFilterRules([], items);
+    assert.strictEqual(res.items, items);
+    assert.strictEqual(res.matchedCount, 2);
+    assert.strictEqual(res.excludedCount, 0);
+  });
+
+  it("reports matched and excluded counts", () => {
+    const rules = [
+      { action: "exclude", matchType: "regex", field: "name", value: "^tmp-" },
+    ];
+    const res = applyFilterRules(rules, [
+      { name: "tmp-1" },
+      { name: "keep" },
+      { name: "tmp-2" },
+    ]);
+    assert.strictEqual(res.matchedCount, 1);
+    assert.strictEqual(res.excludedCount, 2);
+    assert.deepStrictEqual(
+      res.items.map((i) => i.name),
+      ["keep"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
TokenTimer Core 0.10.0 is a minor release focused on the token import pipeline: ordered include/exclude filter rules for scans and imports (issue #69), opt-in cleanup of previously imported tokens no longer found at the source, GitLab pipeline trigger token discovery, and smarter GitLab PAT filtering that keeps admin and service-account PATs. It also fixes the Control Center perpetual asset count and the bell notification false warning for webhook-only contact groups.

## Changes

### API
- New `importFilterRules` service: validated, ordered include/exclude rules (exact/regex on name/description), applied on all integration scan endpoints and the shared import endpoint; responses report `filtered_out_count`
- New `importCleanup` service: opt-in hard delete of previously imported tokens from the scanned provider scope that were not rediscovered, with `TOKEN_DELETED` audit events; wired into the shared import endpoint
- GitLab integration: pipeline trigger token discovery via `GET /projects/:id/triggers` behind the new `includeTriggerTokens` filter (default off)
- GitLab integration: `excludeUserPATs` now keeps administrator-owned PATs in addition to service-account PATs

### Dashboard
- New `FilterRulesEditor` component in the import modal (GitLab and GitHub) with scan preview counts and one-click exclude from the results table
- Import modal: Pipeline Trigger Tokens checkbox, updated PAT filter label, and opt-in "remove obsolete tokens" checkbox with clear warning copy
- Filter rules and cleanup settings persist into auto-sync `scan_params` and are restored when managing an existing auto-sync
- Control Center: fixed perpetual asset count using the aggregated bucket count instead of the preview list length
- Bell notification: contact groups with only webhook destinations no longer flagged as unreachable

### Worker
- Auto-sync worker forwards persisted `filterRules` to scans and builds the cleanup payload from `scan_params.cleanupObsolete`

### Docs / metadata
- CHANGELOG entry for 0.10.0
- Version bumped 0.9.1 -> 0.10.0 across manifests, contracts, and Helm chart

## Test plan
- [x] CI job passes (link the run)