### PR TITLE
feat(certops): agent runtime - signed-job dispatch, renewal, deploy, verify

### DIFF
--- a/docs/certops/agent.md
+++ b/docs/certops/agent.md
@@ -1,4 +1,4 @@
-# TokenTimer Agent (M4 bootstrap + M5 runtime)
+# TokenTimer Agent (bootstrap + execution runtime)
 
 Reference for operators installing and running the TokenTimer Agent, the
 outbound-only execution-plane process under `packages/agent`. See
@@ -21,14 +21,14 @@ and never accepts inbound connections. No listening port, no firewall holes.
 
 Two milestone scopes ship in this package:
 
-- **M4 bootstrap**: config and credential storage, agent-local policy engine
+- **Observe-only bootstrap**: config and credential storage, agent-local policy engine
   (default deny), the register/heartbeat/claim/result/evidence protocol
   client, schema-safe evidence construction, and observe-only filesystem
-  certificate discovery. In M4 mode the agent never executes jobs: every
+  certificate discovery. In observe-only mode the agent never executes jobs: every
   policy-allowed job is reported back as `blocked` with an explanatory
   message, and every policy-rejected job is reported as `rejected` with
   evidence.
-- **M5 signed-job dispatch** (opt-in via `execution.enabled`): claimed jobs
+- **signed-job dispatch** (opt-in via `execution.enabled`): claimed jobs
   run through the full trust chain (Ed25519 signature verification against a
   pinned key, replay cache, clock window check, agent-local policy) before
   any execution. Execution modules cover key generation and CSR building
@@ -36,7 +36,7 @@ Two milestone scopes ship in this package:
   certificate deployment (`src/deploy`), validate-then-reload service helpers
   (`src/reload`), and post-deploy fingerprint verification (`src/verify`).
 
-When `execution` is absent from config or `enabled` is `false`, the M4
+When `execution` is absent from config or `enabled` is `false`, the observe-only
 bootstrap behavior is preserved exactly.
 
 ## 2. Install and run
@@ -105,7 +105,7 @@ Top level:
 | `declaredCommandProfileNames` | string[] | `[]` | Reported at registration. |
 | `policy` | object or null | null | Agent-local allowlists (below). Null means every allowlist is empty: default deny. |
 | `discovery` | object or null | null | Null disables discovery entirely. |
-| `execution` | object or null | null | Null is treated as `{ enabled: false }` (M4 mode). |
+| `execution` | object or null | null | Null is treated as `{ enabled: false }` (observe-only mode). |
 
 `policy` block (deep validation in `src/policy/loadPolicyConfig`, fail-loud):
 
@@ -124,7 +124,7 @@ Top level:
 | `directories` | string[] | required | Directories to scan for certificates. |
 | `intervalMs` | positive int | 3600000 | Hourly by default. |
 
-`execution` block (M5):
+`execution` block (signed-job execution):
 
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
@@ -168,7 +168,7 @@ Flow:
   `ntpSynced`, `uptimeSeconds`, `pinnedSigningKeyId`, and (on the envelope)
   `clockOffsetMs`. With execution enabled, `clockOffsetMs` is the clock
   estimator's current median and `pinnedSigningKeyId` is the pinned key id;
-  in M4 mode both stay null. An HTTP 410 response means the control plane
+  in observe-only mode both stay null. An HTTP 410 response means the control plane
   retired this agent: it exits cleanly, no respawn loop.
 - **claim**: every `pollIntervalMs`, requests up to `maxJobs` (the main loop
   uses 1) and processes each returned job.
@@ -207,7 +207,7 @@ verifies every job against it (`verifyJobSignature`):
 
 1. Structural checks on `signature` (base64, 64-1024 chars), `signingKeyId`,
    `nonce` (16-128 chars, `[A-Za-z0-9_.:-]`), `issuedAt`, `expiresAt`. A job
-   missing any of these (e.g. a plain M2 payload) is rejected with
+   missing any of these (e.g. a plain unsigned payload) is rejected with
    `job_integrity_failed`: unsigned jobs never execute.
 2. `job.signingKeyId` must equal the pinned key id. A mismatch (rotation lag
    or forgery) rejects with `job_integrity_failed`.
@@ -275,7 +275,7 @@ Policy path checks are lexical only; the deploy module re-checks the
 realpath-resolved destination immediately before write so a symlink cannot
 escape the allowlisted roots.
 
-## 5. Renewal execution chain (M5)
+## 5. Renewal execution chain
 
 `handleSignedJob` in `src/index.js` runs the fixed order:
 
@@ -287,7 +287,7 @@ Any `{ allowed: false }` verdict reports `policy.checked` evidence plus a
 `rejected` result with that `rejectionReason` and stops the chain.
 
 Supported actions: `renew`, `deploy`, `reload`, `noop`. `revoke` is always
-`blocked` (out of M5 Dev B scope). `deploy` without a `certificatePem` field
+`blocked` (out of scope for this agent build). `deploy` without a `certificatePem` field
 is `blocked` (see section 7).
 
 For `renew` (`executeRenewJob`):
@@ -378,12 +378,12 @@ Layers, from outermost in:
 
 ## 7. Documented deviations and forward-compatible fields
 
-The M2 job payload (`packages/contracts/certops/job-payload.schema.json`)
-does not yet define the M5 execution fields, so the agent applies these
-documented deviations until the M5 job-type contract lands:
+The base job payload (`packages/contracts/certops/job-payload.schema.json`)
+does not yet define the signed-execution fields, so the agent applies these
+documented deviations until the executable job-type contract lands:
 
 - Unsigned jobs are rejected with `job_integrity_failed` whenever execution
-  is enabled; a plain M2 payload without `signature`/`nonce`/`signingKeyId`/
+  is enabled; a plain unsigned payload without `signature`/`nonce`/`signingKeyId`/
   `issuedAt`/`expiresAt` fails signed-field validation.
 - No domains list in the schema: the CSR CN and the ACME `-d` domain come
   from `job.target.reference`.
@@ -391,12 +391,12 @@ documented deviations until the M5 job-type contract lands:
   `target.reference` is used as the deploy destination when it is an
   absolute path (POSIX or Windows form); neither present means the job fails
   with a clear message.
-- `deploy` without `certificatePem` is `blocked` (the M2 payload has no such
-  field; awaiting the M5 deploy contract).
-- `revoke` is always `blocked` (out of M5 Dev B scope).
-- No `attemptId` in the M2 payload: the agent derives a local
+- `deploy` without `certificatePem` is `blocked` (the base payload has no such
+  field; awaiting the deploy job contract).
+- `revoke` is always `blocked` (out of scope for this agent build).
+- No `attemptId` in the base payload: the agent derives a local
   `local-<jobId>-<timestamp>` id so result reporting stays schema-valid.
-- Forward-compatible fields honored when present but not yet in the M2
+- Forward-compatible fields honored when present but not yet in the base
   schema: `keyRotation` (forces key regeneration), `verifyHost`/`verifyPort`
   (enables the live TLS probe), `reloadService` + `reloadCommandRefs`
   (enables the reload step), `acmeKind` (`certbot` or `acme.sh`), and
@@ -431,8 +431,8 @@ Common terminal states and what to look for:
   not carry `signingKeyId`/`signingPublicKeyPem`). Re-register the agent
   against a control plane that dispatches signing key info. The heartbeat's
   `pinnedSigningKeyId` will be null until then.
-- **Job `blocked`, "M4 bootstrap" message**: `execution.enabled` is not
-  true. This is the expected M4 behavior, not an error.
+- **Job `blocked`, "does not execute jobs yet" message**: `execution.enabled` is not
+  true. This is the expected observe-only behavior, not an error.
 - **`rejected` with `job_integrity_failed`**: missing/malformed signed
   fields, a signing key id mismatch (rotation lag or forgery), a signature
   that does not verify against the canonical payload, or a malformed

--- a/docs/certops/agent.md
+++ b/docs/certops/agent.md
@@ -1,0 +1,469 @@
+# TokenTimer Agent (M4 bootstrap + M5 runtime)
+
+Reference for operators installing and running the TokenTimer Agent, the
+outbound-only execution-plane process under `packages/agent`. See
+`docs/certops/CONTEXT.md` for domain language, ADR-0001 (zero private-key
+custody), ADR-0002 (outbound-only protocol, agent-local policy wins), and
+ADR-0003 (job signing and replay protection).
+
+## 1. What the agent is
+
+The agent is a Node.js daemon that runs on customer infrastructure and is the
+only CertOps component that ever touches private keys. The TokenTimer control
+plane plans and audits certificate lifecycle work; the agent executes it. Keys
+are generated, stored, and used exclusively on the host the agent runs on. The
+control plane never receives or stores private key material, and the agent
+enforces that invariant locally as well: every module is written to stay safe
+against an untrusted or compromised control plane.
+
+The agent is outbound-only. It opens HTTPS connections to the control plane
+and never accepts inbound connections. No listening port, no firewall holes.
+
+Two milestone scopes ship in this package:
+
+- **M4 bootstrap**: config and credential storage, agent-local policy engine
+  (default deny), the register/heartbeat/claim/result/evidence protocol
+  client, schema-safe evidence construction, and observe-only filesystem
+  certificate discovery. In M4 mode the agent never executes jobs: every
+  policy-allowed job is reported back as `blocked` with an explanatory
+  message, and every policy-rejected job is reported as `rejected` with
+  evidence.
+- **M5 signed-job dispatch** (opt-in via `execution.enabled`): claimed jobs
+  run through the full trust chain (Ed25519 signature verification against a
+  pinned key, replay cache, clock window check, agent-local policy) before
+  any execution. Execution modules cover key generation and CSR building
+  (`src/keys`), ACME renewal via certbot/acme.sh (`src/acme`), atomic
+  certificate deployment (`src/deploy`), validate-then-reload service helpers
+  (`src/reload`), and post-deploy fingerprint verification (`src/verify`).
+
+When `execution` is absent from config or `enabled` is `false`, the M4
+bootstrap behavior is preserved exactly.
+
+## 2. Install and run
+
+Requirements: Node >= 22 (`packages/agent/package.json` `engines`; the
+protocol client uses the built-in global `fetch`). The package has zero
+runtime dependencies.
+
+Entry point: `packages/agent/bin/tokentimer-agent.js` (also exposed as the
+`tokentimer-agent` bin). Start it with:
+
+```
+node packages/agent/bin/tokentimer-agent.js
+```
+
+or `pnpm start` from `packages/agent`. There are no CLI flags; configuration
+is via `config.json` and `TOKENTIMER_AGENT_*` environment variables.
+
+### Config directory
+
+Resolution order (`resolveConfigDir`): explicit argument >
+`TOKENTIMER_AGENT_CONFIG_DIR` env var > OS default. OS defaults:
+
+- Linux/macOS: `~/.config/tokentimer-agent`
+- Windows: `%APPDATA%\tokentimer-agent`
+
+The directory is created with mode 0700 and the mode is re-asserted on every
+write (best-effort on Windows, where POSIX modes are not meaningful). Files
+inside it:
+
+| File | Contents | Mode |
+|------|----------|------|
+| `config.json` | Non-secret runtime config (below) | inherited |
+| `credential` | Registration credential `ttagent_<id>_<secret>` | 0600 |
+| `signing-key-pin.json` | Pinned control-plane job-signing public key (`signingKeyId`, `publicKeyPem`) | 0600 |
+| `replay-store.json` | Consumed-nonce replay cache (default location) | 0600 |
+| `keys/` | Agent-generated private keys, `<certificateId>.key.pem` (default location) | dir 0700, keys 0600 |
+
+### First-run registration
+
+With no stored credential, the agent requires `TOKENTIMER_AGENT_BOOTSTRAP_TOKEN`
+(and optionally `TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID`) in the environment.
+The bootstrap token is single-use and never persisted. Registration stores
+the assigned `agentId` in `config.json`, the issued credential in
+`credential`, and, when the register response carries one, pins the control
+plane's job-signing public key in `signing-key-pin.json` (trust-on-first-use,
+ADR-0003). A stored credential with no `agentId` in `config.json` is an
+inconsistent config directory and aborts startup.
+
+### Config reference (`config.json`)
+
+Validation is fail-loud: a malformed value aborts startup with a descriptive
+error instead of being silently normalized. Field names and defaults below
+come from `packages/agent/src/config/index.js`.
+
+Top level:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `serverUrl` | string | required | Control plane base URL. Env override: `TOKENTIMER_AGENT_SERVER_URL`. |
+| `agentId` | string or null | null | Assigned at registration; matches `^[A-Za-z0-9_.:-]{1,128}$`. |
+| `protocolVersion` | string | `"1.0.0"` | Semver `x.y.z`. |
+| `heartbeatIntervalMs` | positive int | 30000 | Env override: `TOKENTIMER_AGENT_HEARTBEAT_MS`. |
+| `pollIntervalMs` | positive int | 15000 | Claim loop interval. Env override: `TOKENTIMER_AGENT_POLL_MS`. |
+| `declaredTargetSelectors` | string[] | `[]` | Target scope this agent declares; exact match at policy time. |
+| `declaredCommandProfileNames` | string[] | `[]` | Reported at registration. |
+| `policy` | object or null | null | Agent-local allowlists (below). Null means every allowlist is empty: default deny. |
+| `discovery` | object or null | null | Null disables discovery entirely. |
+| `execution` | object or null | null | Null is treated as `{ enabled: false }` (M4 mode). |
+
+`policy` block (deep validation in `src/policy/loadPolicyConfig`, fail-loud):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `allowedCommands` | object | Maps profile name to `{ argv: string[] }`. Every argv element is rejected at load time if it contains a shell metacharacter (`; \| & $ ` > <` or CR/LF). |
+| `allowedPaths` | string[] | Normalized to absolute paths; containment is segment-aware (no sibling-prefix collisions). |
+| `allowedCaEndpoints` | string[] | Full-URL exact match after trailing-slash normalization. |
+| `allowedDnsZones` | string[] | Suffix match with dot boundary (`sub.example.com` covered by `example.com`, `evilexample.com` is not). |
+| `allowedDnsProviders` | string[] | Exact match. |
+
+`discovery` block:
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `directories` | string[] | required | Directories to scan for certificates. |
+| `intervalMs` | positive int | 3600000 | Hourly by default. |
+
+`execution` block (M5):
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `enabled` | boolean | false | Opt-in; an upgraded agent never starts executing without it. |
+| `dryRun` | boolean | true | Plan-only execution with zero side effects (see section 5). |
+| `keysDir` | string | `<configDir>/keys` | Private keys, 0600 in 0700 dir. |
+| `replayStorePath` | string | `<configDir>/replay-store.json` | Persisted replay cache. |
+| `clockDriftToleranceMs` | positive int | 30000 | Slack applied to the signed-job validity window. |
+
+## 3. Protocol
+
+The agent speaks the envelope defined in
+`packages/contracts/certops/agent-protocol.schema.json` over four frozen
+routes (`src/protocol/index.js` `ROUTES`):
+
+| Message | Route |
+|---------|-------|
+| `register` | `POST /api/v1/certops/agent/register` |
+| `heartbeat` | `POST /api/v1/certops/agent/heartbeat` |
+| `claim` | `POST /api/v1/certops/agent/jobs/claim` |
+| `result`, `evidence` | `POST /api/v1/certops/agent/jobs/results` |
+
+Result and evidence share one route; the envelope's `messageType`
+disambiguates server-side. Every envelope carries `schemaVersion` (1),
+`protocolVersion`, `messageType`, `agentId`, `sentAt`, and optionally
+`workspaceId` and `clockOffsetMs`. Messages must never carry private key
+material (schema-level rule, enforced again by the evidence builder).
+
+Authentication: `register` uses the bootstrap token as a Bearer token;
+everything else uses the stored `ttagent_...` credential as a Bearer token.
+The credential is never placed in a request body and never logged
+(`redactCredentialForLogging` returns a fixed placeholder unconditionally).
+
+Flow:
+
+- **register**: sends `bootstrapTokenId`, `agentVersion`, `hostname`,
+  `platform`, `nodeVersion`, `declaredTargetSelectors`,
+  `declaredCommandProfileNames`. Response returns `agentId`, `credential`,
+  and optionally `signingKeyId` + `signingPublicKeyPem` for TOFU pinning.
+- **heartbeat**: every `heartbeatIntervalMs`, sends `agentVersion`,
+  `ntpSynced`, `uptimeSeconds`, `pinnedSigningKeyId`, and (on the envelope)
+  `clockOffsetMs`. With execution enabled, `clockOffsetMs` is the clock
+  estimator's current median and `pinnedSigningKeyId` is the pinned key id;
+  in M4 mode both stay null. An HTTP 410 response means the control plane
+  retired this agent: it exits cleanly, no respawn loop.
+- **claim**: every `pollIntervalMs`, requests up to `maxJobs` (the main loop
+  uses 1) and processes each returned job.
+- **result/evidence**: terminal job outcome (`succeeded`, `failed`,
+  `rejected`, `blocked`, plus `rejectionReason`, `keyRotated`,
+  `errorMessage`, `clockOffsetMs`) and per-step evidence bodies.
+
+Backoff and jitter: poll loops apply +/-20% jitter to every interval
+(`jitteredDelay`) to avoid fleet thundering herd. `withRetry` provides
+exponential backoff with full jitter (defaults: 5 attempts, 250 ms base,
+30 s cap). A failed tick is logged and never kills the loop.
+
+Clock offset estimation: every successful (2xx) response's HTTP `Date` header
+is fed to the clock module (`onServerDate` ->
+`createClockOffsetEstimator().estimateFromResponseDate`). Offset is
+`serverTime - localTime`; positive means the local clock is behind the
+server. The estimator keeps a rolling window of the last 5 samples and
+reports the median, because the Date header has 1-second resolution and
+individual samples are contaminated by network latency. This is a coarse
+drift detector for the signed-job time window, not an NTP replacement.
+
+## 4. Job security model
+
+With execution enabled, no job runs without passing every gate below. All
+gates produce the same rejection shape
+`{ allowed: false, rejectionReason, detail }` so evidence and result
+reporting handle them uniformly.
+
+### Ed25519 signature verification with TOFU pinning
+
+Jobs are signed by a control-plane Ed25519 operational key (HMAC is
+explicitly rejected by ADR-0003: a shared symmetric secret would let any
+agent forge jobs for any other agent). The agent pins the public key at
+registration (`signing-key-pin.json`: `signingKeyId` + `publicKeyPem`) and
+verifies every job against it (`verifyJobSignature`):
+
+1. Structural checks on `signature` (base64, 64-1024 chars), `signingKeyId`,
+   `nonce` (16-128 chars, `[A-Za-z0-9_.:-]`), `issuedAt`, `expiresAt`. A job
+   missing any of these (e.g. a plain M2 payload) is rejected with
+   `job_integrity_failed`: unsigned jobs never execute.
+2. `job.signingKeyId` must equal the pinned key id. A mismatch (rotation lag
+   or forgery) rejects with `job_integrity_failed`.
+3. `crypto.verify` over the canonical payload bytes.
+
+A present-but-corrupted pin file fails startup loudly (never silently
+unpinned). If execution is enabled but no key is pinned yet, jobs are
+reported `blocked` (not rejected): an agent-side precondition failure, not a
+verdict about the job.
+
+### Canonical payload
+
+The signature covers a deterministic canonical JSON serialization of the job
+excluding the top-level `signature` field (`canonicalizeJobPayload`): keys
+sorted lexicographically at every level, arrays in original order, no
+whitespace, standard JSON string escaping, UTF-8 bytes. Non-finite numbers
+and `undefined` anywhere in the tree are rejected. The control plane must
+implement the identical algorithm byte for byte; `signJobPayload` in the same
+module is the reference implementation used by the test harness.
+
+### Replay cache
+
+`src/replay` keeps a persisted cache of consumed `nonce + jobId` pairs
+(JSON file, 0600, default 5000 entries). Persistence matters because a job's
+validity window can outlive an agent process; without it, a restart would
+reopen the replay window. Semantics:
+
+- `check` is read-only and runs early in the chain; `consume` records the
+  pair and runs only after all other gates pass, immediately before
+  execution. A rejected job therefore does not burn its nonce, but a crash
+  mid-execution can never allow a replay.
+- A corrupted or unreadable store throws at startup. A tampered replay store
+  is treated as a security signal, not a recoverable glitch.
+- When the cache is full after sweeping expired entries, new jobs are
+  rejected with `job_replay_rejected` rather than evicting unexpired nonces
+  (eviction would reopen the replay window for exactly the evicted job).
+
+### Clock drift window checks
+
+`checkJobTimeWindow` validates `now + clockOffsetMs` against
+`[issuedAt - tolerance, expiresAt + tolerance]` with
+`execution.clockDriftToleranceMs` (default 30000 ms) slack. `expiresAt`
+before `issuedAt` is malformed regardless of any clock and rejects with
+`job_integrity_failed`; a future-dated or expired job rejects with
+`clock_drift_suspected` (both are plausibly clock-related, and a genuinely
+replayed job is independently caught by the replay cache).
+
+### Agent-local policy
+
+The policy engine (`src/policy`) is the sole authority on whether a job's
+command, path, CA endpoint, DNS zone/provider, and target selector are
+allowed on this host. Local policy always wins over control-plane intent
+(ADR-0002); the control plane only ever sends opaque references that are
+looked up against agent-local config. With no `policy` block every allowlist
+is empty and everything is denied; the agent still runs so operators see
+policy rejections as evidence instead of silent failures.
+
+`evaluateJob` check order: `checkNoKeyExport` (always first, never
+overridable by any config; any custody-shaped intent rejects with
+`key_export_requested`), then `checkTargetScope`, `checkCommandRef`,
+`checkPath`, `checkCaEndpoint`, `checkDnsZone`, `checkDnsProvider`. Each
+dimension is only checked when present on the job.
+
+Policy path checks are lexical only; the deploy module re-checks the
+realpath-resolved destination immediately before write so a symlink cannot
+escape the allowlisted roots.
+
+## 5. Renewal execution chain (M5)
+
+`handleSignedJob` in `src/index.js` runs the fixed order:
+
+```
+signature verify -> replay check -> clock window -> policy -> replay consume -> execute
+```
+
+Any `{ allowed: false }` verdict reports `policy.checked` evidence plus a
+`rejected` result with that `rejectionReason` and stops the chain.
+
+Supported actions: `renew`, `deploy`, `reload`, `noop`. `revoke` is always
+`blocked` (out of M5 Dev B scope). `deploy` without a `certificatePem` field
+is `blocked` (see section 7).
+
+For `renew` (`executeRenewJob`):
+
+1. **Keys** (`src/keys`): the private key lives at
+   `<keysDir>/<certificateId>.key.pem`. An existing key is reused; one is
+   generated only when absent, or when `job.keyRotation` is truthy
+   (forward-compatible field). `keyRotated` in the result reports whether a
+   new key was generated. Supported algorithms: `ec-p256` (default),
+   `rsa-2048`, `rsa-3072`, `ed25519`. Keys are written 0600 in 0700 dirs and
+   the exported PEM buffer is zeroized after the write; no exported function
+   ever returns private key material.
+2. **CSR** (`generateCsr`): PKCS#10, CN and single SAN from
+   `target.reference`, written to a job-scoped temp path
+   `<keysDir>/<jobId>.csr.pem` (0600) and removed after the ACME step.
+3. **ACME** (`src/acme`): `job.commandRef` must resolve through
+   `policyEngine.checkCommandRef` to an allowlisted `{ argv }` profile;
+   `job.caEndpoint` is required and re-checked against the CA allowlist
+   inside the adapter as defense in depth. The adapter (`certbot` by
+   default, or `acme.sh` when `job.acmeKind` says so) shells out via
+   `child_process.execFile` without a shell, in CSR mode (`certbot certonly
+   --csr` / `acme.sh --signcsr`), staging the certificate to
+   `<keysDir>/<jobId>.cert.pem`. No private key and no DNS credentials ever
+   appear in argv; DNS credentials live in the ACME tool's own host-side
+   config files. Default exec timeout is 10 minutes.
+4. **Deploy** (`src/deploy`): atomic install to the resolved `certPath` with
+   target-config re-validation, realpath containment re-check via the policy
+   `checkPath` callback, idempotent skip for byte-identical content,
+   timestamped backup before overwrite, temp-file-plus-rename atomic write
+   with fsync, automatic rollback on failure, and a per-destination async
+   mutex. Deployed files get mode 0600. The module throws if the payload
+   contains a PEM private-key marker, regardless of what the caller claims.
+5. **Reload** (`src/reload`, only when the job carries `reloadService`):
+   validate-then-reload for `nginx`, `apache`, or `haproxy`. The job must
+   name `reloadCommandRefs.validate` and `.reload`, both resolved through
+   the command allowlist; commands run via `execFile` with `shell: false`
+   and a 30 s default timeout. A failing validate command means the reload
+   command never runs.
+6. **Verify** (`src/verify`): the deployed PEM's leaf certificate is
+   fingerprinted (sha256, lowercase hex, no colons). A live TLS probe
+   against the endpoint runs only when the job provides `verifyHost`
+   (port from `verifyPort`, default 443); the probe compares the served
+   certificate's DER sha256 against the deployed fingerprint. The probe
+   deliberately uses `rejectUnauthorized: false`: fingerprint byte-identity
+   is the verification, and chain trust would wrongly fail private CAs and
+   staging CAs.
+
+`deploy` jobs run steps 4-6 with the job-supplied `certificatePem`; `reload`
+jobs run step 5 only; `noop` reports a `validation.passed` evidence item and
+succeeds.
+
+Dry-run mode (`execution.dryRun`, default true): all trust gates still run,
+then instead of executing, the agent reports one `policy.checked` evidence
+item per step the action would run (with `dryRun: true` metadata) and
+returns `succeeded` with `keyRotated` null. Zero filesystem or exec side
+effects; the keys/acme/deploy/reload/verify modules are never called.
+
+## 6. Zero-custody guarantees
+
+Layers, from outermost in:
+
+- **Config**: `writeSigningKeyPin` refuses to pin anything that does not look
+  like PEM public key material and rejects any input containing a private-key
+  marker. The credential is a bearer secret (not key material) but gets the
+  same 0600 discipline and is never logged; `redactCredentialForLogging`
+  returns a fixed placeholder for any input.
+- **Discovery**: never reads private key bytes. Key presence detection is
+  filename heuristics plus a bounded content peek (first 4096 bytes checked
+  for a PEM private-key header); results carry only the boolean
+  `coLocatedKeyDetected`.
+- **Keys**: exported functions return only paths, public key PEM, CSR PEM,
+  and fingerprints; every return value is deep-scanned by the shared
+  detector (`apps/api/utils/secretMaterial.js`) before it leaves the module.
+  Private key PEM buffers are zeroized after writes (documented JS limit:
+  KeyObject/OpenSSL internal memory cannot be zeroized from JS).
+- **Evidence**: `buildEvidenceItem`/`buildEvidenceBody` reject values
+  containing private key material and defensively redact generic secret
+  patterns; metadata names must match the schema's deny-pattern (no
+  `private-key`, `password`, `secret`, `credential`, ... fragments).
+  `assertEvidencePayloadSafe` is a final deep scan run immediately before
+  every evidence POST.
+- **ACME and reload output**: stdout/stderr excerpts are bounded (1024/512
+  chars) and replaced wholesale with `[redacted]` if they contain a
+  `PRIVATE KEY` marker; never partially scrubbed.
+- **Deploy**: throws on any payload containing a PEM private-key header.
+- **Policy**: `checkNoKeyExport` rejects any key-export intent
+  unconditionally; there is no config knob that permits it.
+
+## 7. Documented deviations and forward-compatible fields
+
+The M2 job payload (`packages/contracts/certops/job-payload.schema.json`)
+does not yet define the M5 execution fields, so the agent applies these
+documented deviations until the M5 job-type contract lands:
+
+- Unsigned jobs are rejected with `job_integrity_failed` whenever execution
+  is enabled; a plain M2 payload without `signature`/`nonce`/`signingKeyId`/
+  `issuedAt`/`expiresAt` fails signed-field validation.
+- No domains list in the schema: the CSR CN and the ACME `-d` domain come
+  from `job.target.reference`.
+- `certPath` resolution: an explicit `job.certPath` wins; otherwise
+  `target.reference` is used as the deploy destination when it is an
+  absolute path (POSIX or Windows form); neither present means the job fails
+  with a clear message.
+- `deploy` without `certificatePem` is `blocked` (the M2 payload has no such
+  field; awaiting the M5 deploy contract).
+- `revoke` is always `blocked` (out of M5 Dev B scope).
+- No `attemptId` in the M2 payload: the agent derives a local
+  `local-<jobId>-<timestamp>` id so result reporting stays schema-valid.
+- Forward-compatible fields honored when present but not yet in the M2
+  schema: `keyRotation` (forces key regeneration), `verifyHost`/`verifyPort`
+  (enables the live TLS probe), `reloadService` + `reloadCommandRefs`
+  (enables the reload step), `acmeKind` (`certbot` or `acme.sh`), and
+  `commandRef`/`caEndpoint`/`dnsZone`/`dnsProvider` on the policy
+  descriptor.
+- Ed25519 CSR generation is not supported: `generateCsr` throws a clear
+  error for ed25519 keys (use `ec-p256` or `rsa-*` when a CSR is needed).
+
+## 8. Windows notes
+
+The agent primarily targets POSIX hosts, but it runs (and its tests run) on
+Windows:
+
+- POSIX file modes (0600/0700) are asserted best-effort: `chmod` calls are
+  wrapped and failures ignored on win32, where the POSIX mode model does not
+  apply. Tests asserting modes are skipped on win32.
+- Directory fsync after the deploy rename is skipped on win32 (opening a
+  directory for fsync fails there); the file-content fsync before rename
+  still runs on every platform.
+- Symlink-dependent tests are skipped where symlink creation requires
+  privileges; the realpath containment check itself still runs.
+- The default config directory is `%APPDATA%\tokentimer-agent`.
+- Absolute-path detection accepts POSIX (`/...`), Windows drive (`C:\...`),
+  and UNC (`\\...`) forms.
+
+## 9. Troubleshooting
+
+Common terminal states and what to look for:
+
+- **Job `blocked`, "no control-plane signing key is pinned yet"**: execution
+  is enabled but `signing-key-pin.json` is absent (the register response did
+  not carry `signingKeyId`/`signingPublicKeyPem`). Re-register the agent
+  against a control plane that dispatches signing key info. The heartbeat's
+  `pinnedSigningKeyId` will be null until then.
+- **Job `blocked`, "M4 bootstrap" message**: `execution.enabled` is not
+  true. This is the expected M4 behavior, not an error.
+- **`rejected` with `job_integrity_failed`**: missing/malformed signed
+  fields, a signing key id mismatch (rotation lag or forgery), a signature
+  that does not verify against the canonical payload, or a malformed
+  validity window (`expiresAt` before `issuedAt`). The `policy.checked`
+  evidence item's summary carries the specific detail. If it persists after
+  a control-plane key rotation, re-register to re-pin.
+- **`rejected` with `clock_drift_suspected`**: the adjusted time fell
+  outside `[issuedAt - tolerance, expiresAt + tolerance]`. Check NTP sync on
+  the agent host, and compare the heartbeat's `clockOffsetMs` against
+  `execution.clockDriftToleranceMs`. Stale dispatches (jobs queued longer
+  than their validity window) produce the same reason.
+- **`rejected` with `job_replay_rejected`**: the nonce+jobId pair was
+  already consumed, or the replay cache is full of unexpired entries (the
+  detail string distinguishes the two). A full cache means the control plane
+  is dispatching faster than nonces expire; it never silently evicts.
+- **`rejected` with a policy reason** (`target_out_of_scope`,
+  `command_not_allowlisted`, `path_not_allowlisted`,
+  `ca_endpoint_not_allowlisted`, `dns_zone_not_allowlisted`,
+  `dns_provider_not_allowlisted`, `key_export_requested`): the agent-local
+  allowlist does not cover the job's reference. Fix the agent's `policy`
+  block (or `declaredTargetSelectors`); the control plane cannot override
+  this.
+- **Startup failure mentioning the replay store**: the store file exists but
+  is corrupted or unreadable. This is treated as a tamper signal; inspect
+  the file before deleting it manually.
+- **Startup failure mentioning the signing key pin**: `signing-key-pin.json`
+  is corrupted. Re-register the agent to re-pin.
+- **Heartbeat stops and the process exits with a "retired" log line**: the
+  control plane returned HTTP 410; this is a clean, intentional shutdown.
+
+Log lines are prefixed `tokentimer-agent:` on stderr. Evidence for rejected
+jobs arrives as `policy.checked` items; execution steps report
+`validation.passed`/`validation.failed`/`deployment.updated` items with a
+`step` metadata entry (`acme`, `deploy`, `reload`, `verify`).

--- a/packages/agent/src/acme/acme.test.js
+++ b/packages/agent/src/acme/acme.test.js
@@ -1,0 +1,471 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createAcmeAdapter,
+  listSupportedAdapters,
+  SHELL_METACHARACTER_PATTERN,
+  OUTPUT_EXCERPT_MAX_CHARS,
+} = require("./index.js");
+
+const CA_ENDPOINT = "https://acme-v02.api.letsencrypt.org/directory";
+const CSR_PATH = "/etc/tokentimer-agent/csr/web-01.csr.pem";
+const OUT_CERT_PATH = "/etc/nginx/tls/web-01.crt.pem";
+const DOMAINS = ["example.com", "www.example.com"];
+
+const allowAll = () => ({ allowed: true });
+
+/**
+ * execFile stub factory: records calls, invokes the callback with a
+ * configurable outcome. Mimics child_process.execFile's
+ * (file, args, options, callback) signature.
+ */
+function makeExecStub({ error = null, stdout = "", stderr = "" } = {}) {
+  const calls = [];
+  function execFileStub(file, args, options, callback) {
+    calls.push({ file, args, options });
+    process.nextTick(() => callback(error, stdout, stderr));
+  }
+  execFileStub.calls = calls;
+  return execFileStub;
+}
+
+function certbotAdapter(execFileImpl, extra = {}) {
+  return createAcmeAdapter({
+    kind: "certbot",
+    commandProfile: { argv: ["certbot"] },
+    execFileImpl,
+    ...extra,
+  });
+}
+
+function acmeShAdapter(execFileImpl, extra = {}) {
+  return createAcmeAdapter({
+    kind: "acme.sh",
+    commandProfile: { argv: ["/root/.acme.sh/acme.sh"] },
+    execFileImpl,
+    ...extra,
+  });
+}
+
+function baseRenewalInputs(overrides = {}) {
+  return {
+    caEndpoint: CA_ENDPOINT,
+    domains: [...DOMAINS],
+    csrPath: CSR_PATH,
+    outCertPath: OUT_CERT_PATH,
+    checkCaEndpoint: allowAll,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// listSupportedAdapters
+// ---------------------------------------------------------------------------
+
+test("listSupportedAdapters returns certbot and acme.sh", () => {
+  assert.deepEqual(listSupportedAdapters(), ["certbot", "acme.sh"]);
+});
+
+test("listSupportedAdapters returns a fresh copy each call", () => {
+  const first = listSupportedAdapters();
+  first.push("mutated");
+  assert.deepEqual(listSupportedAdapters(), ["certbot", "acme.sh"]);
+});
+
+// ---------------------------------------------------------------------------
+// createAcmeAdapter validation
+// ---------------------------------------------------------------------------
+
+test("createAcmeAdapter throws on an unsupported kind", () => {
+  assert.throws(
+    () => createAcmeAdapter({ kind: "lego", commandProfile: { argv: ["lego"] } }),
+    /unsupported adapter kind/,
+  );
+});
+
+test("createAcmeAdapter throws on a missing/malformed command profile", () => {
+  assert.throws(() => createAcmeAdapter({ kind: "certbot" }), /commandProfile/);
+  assert.throws(
+    () => createAcmeAdapter({ kind: "certbot", commandProfile: { argv: "certbot" } }),
+    /commandProfile/,
+  );
+  assert.throws(
+    () => createAcmeAdapter({ kind: "certbot", commandProfile: { argv: [] } }),
+    /must not be empty/,
+  );
+});
+
+test("createAcmeAdapter throws on shell metacharacters in the profile argv", () => {
+  assert.throws(
+    () =>
+      createAcmeAdapter({
+        kind: "certbot",
+        commandProfile: { argv: ["certbot", "; rm -rf /"] },
+      }),
+    /disallowed shell metacharacter/,
+  );
+});
+
+test("createAcmeAdapter throws on a non-positive timeoutMs", () => {
+  assert.throws(
+    () =>
+      createAcmeAdapter({
+        kind: "certbot",
+        commandProfile: { argv: ["certbot"] },
+        timeoutMs: 0,
+      }),
+    /timeoutMs/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// argv construction: certbot
+// ---------------------------------------------------------------------------
+
+test("certbot adapter builds the documented argv (dryRun: false)", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(execStub.calls.length, 1);
+  assert.equal(execStub.calls[0].file, "certbot");
+  assert.deepEqual(execStub.calls[0].args, [
+    "certonly",
+    "--non-interactive",
+    "--csr",
+    CSR_PATH,
+    "--server",
+    CA_ENDPOINT,
+    "-d",
+    "example.com",
+    "-d",
+    "www.example.com",
+    "--cert-path",
+    OUT_CERT_PATH,
+  ]);
+  assert.deepEqual(result.argvUsed, ["certbot", ...execStub.calls[0].args]);
+  assert.equal(result.renewed, true);
+  assert.equal(result.exitCode, 0);
+});
+
+test("certbot adapter appends --dry-run when dryRun: true, before extraArgs", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(
+    baseRenewalInputs({ dryRun: true, extraArgs: ["--preferred-chain", "ISRG Root X1"] }),
+  );
+
+  assert.deepEqual(result.argvUsed, [
+    "certbot",
+    "certonly",
+    "--non-interactive",
+    "--csr",
+    CSR_PATH,
+    "--server",
+    CA_ENDPOINT,
+    "-d",
+    "example.com",
+    "-d",
+    "www.example.com",
+    "--cert-path",
+    OUT_CERT_PATH,
+    "--dry-run",
+    "--preferred-chain",
+    "ISRG Root X1",
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// argv construction: acme.sh
+// ---------------------------------------------------------------------------
+
+test("acme.sh adapter builds the documented argv (dryRun: false)", async () => {
+  const execStub = makeExecStub();
+  const adapter = acmeShAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(execStub.calls.length, 1);
+  assert.equal(execStub.calls[0].file, "/root/.acme.sh/acme.sh");
+  assert.deepEqual(execStub.calls[0].args, [
+    "--signcsr",
+    "--csr",
+    CSR_PATH,
+    "--server",
+    CA_ENDPOINT,
+    "-d",
+    "example.com",
+    "-d",
+    "www.example.com",
+    "--cert-file",
+    OUT_CERT_PATH,
+  ]);
+  assert.deepEqual(result.argvUsed, [
+    "/root/.acme.sh/acme.sh",
+    ...execStub.calls[0].args,
+  ]);
+  assert.equal(result.renewed, true);
+});
+
+test("acme.sh adapter appends --test when dryRun: true", async () => {
+  const execStub = makeExecStub();
+  const adapter = acmeShAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs({ dryRun: true }));
+
+  assert.deepEqual(result.argvUsed, [
+    "/root/.acme.sh/acme.sh",
+    "--signcsr",
+    "--csr",
+    CSR_PATH,
+    "--server",
+    CA_ENDPOINT,
+    "-d",
+    "example.com",
+    "-d",
+    "www.example.com",
+    "--cert-file",
+    OUT_CERT_PATH,
+    "--test",
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// checkCaEndpoint defense-in-depth re-check
+// ---------------------------------------------------------------------------
+
+test("runRenewal short-circuits on CA rejection and never execs", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+  const rejection = {
+    allowed: false,
+    rejectionReason: "ca_endpoint_not_allowlisted",
+    detail: `CA endpoint "${CA_ENDPOINT}" is not present in the agent-local CA endpoint allowlist.`,
+  };
+
+  const result = await adapter.runRenewal(
+    baseRenewalInputs({ checkCaEndpoint: () => rejection }),
+  );
+
+  // Passed through unchanged (same object identity) so dispatch reports it
+  // uniformly with every other policy rejection.
+  assert.equal(result, rejection);
+  assert.equal(execStub.calls.length, 0);
+});
+
+test("runRenewal passes the job's caEndpoint to the checkCaEndpoint callback", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+  const seen = [];
+
+  await adapter.runRenewal(
+    baseRenewalInputs({
+      checkCaEndpoint: (url) => {
+        seen.push(url);
+        return { allowed: true };
+      },
+    }),
+  );
+
+  assert.deepEqual(seen, [CA_ENDPOINT]);
+});
+
+// ---------------------------------------------------------------------------
+// programmer-error validation
+// ---------------------------------------------------------------------------
+
+test("runRenewal rejects on shell metacharacters in extraArgs, without exec", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+
+  await assert.rejects(
+    adapter.runRenewal(
+      baseRenewalInputs({ extraArgs: ["--post-hook", "reload; rm -rf /"] }),
+    ),
+    /extraArgs\[1\] contains a disallowed shell metacharacter/,
+  );
+  assert.equal(execStub.calls.length, 0);
+});
+
+test("runRenewal rejects on shell metacharacters in a domain", async () => {
+  const adapter = certbotAdapter(makeExecStub());
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ domains: ["example.com", "evil.com`id`"] })),
+    /domains\[1\] contains a disallowed shell metacharacter/,
+  );
+});
+
+test("runRenewal rejects on empty or non-string domains", async () => {
+  const adapter = certbotAdapter(makeExecStub());
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ domains: [] })),
+    /non-empty domains array/,
+  );
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ domains: ["example.com", 42] })),
+    /domains\[1\] must be a non-empty string/,
+  );
+});
+
+test("runRenewal rejects on relative csrPath / outCertPath", async () => {
+  const adapter = certbotAdapter(makeExecStub());
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ csrPath: "csr/web-01.csr.pem" })),
+    /csrPath must be an absolute path/,
+  );
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ outCertPath: "tls/web-01.crt.pem" })),
+    /outCertPath must be an absolute path/,
+  );
+});
+
+test("runRenewal accepts Windows-style absolute paths", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub);
+  const result = await adapter.runRenewal(
+    baseRenewalInputs({
+      csrPath: "C:\\certops\\csr\\web-01.csr.pem",
+      outCertPath: "C:\\certops\\tls\\web-01.crt.pem",
+    }),
+  );
+  assert.equal(result.renewed, true);
+});
+
+test("runRenewal rejects when checkCaEndpoint is missing", async () => {
+  const adapter = certbotAdapter(makeExecStub());
+  await assert.rejects(
+    adapter.runRenewal(baseRenewalInputs({ checkCaEndpoint: undefined })),
+    /checkCaEndpoint callback/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// exec outcomes: nonzero exit, timeout/kill, spawn failure
+// ---------------------------------------------------------------------------
+
+test("nonzero exit => renewed: false with exit code and excerpts", async () => {
+  const error = Object.assign(new Error("Command failed"), { code: 1 });
+  const execStub = makeExecStub({
+    error,
+    stdout: "Attempting renewal...",
+    stderr: "Some challenges have failed.",
+  });
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.renewed, false);
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.stdoutExcerpt, "Attempting renewal...");
+  assert.equal(result.stderrExcerpt, "Some challenges have failed.");
+  assert.ok(Array.isArray(result.argvUsed));
+});
+
+test("timeout/kill (no numeric exit code) => renewed: false with exitCode null", async () => {
+  // execFile reports a timeout kill with error.killed=true and a non-numeric
+  // code (the signal lives on error.signal).
+  const error = Object.assign(new Error("timed out"), {
+    killed: true,
+    signal: "SIGTERM",
+  });
+  const execStub = makeExecStub({ error, stdout: "partial output" });
+  const adapter = certbotAdapter(execStub, { timeoutMs: 5 });
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.renewed, false);
+  assert.equal(result.exitCode, null);
+  assert.equal(result.stdoutExcerpt, "partial output");
+});
+
+test("adapter passes its timeoutMs through to exec options", async () => {
+  const execStub = makeExecStub();
+  const adapter = certbotAdapter(execStub, { timeoutMs: 123456 });
+  await adapter.runRenewal(baseRenewalInputs());
+  assert.equal(execStub.calls[0].options.timeout, 123456);
+});
+
+test("spawn failure (ENOENT string code) => renewed: false with exitCode null", async () => {
+  const error = Object.assign(new Error("spawn certbot ENOENT"), {
+    code: "ENOENT",
+  });
+  const execStub = makeExecStub({ error });
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.renewed, false);
+  assert.equal(result.exitCode, null);
+});
+
+// ---------------------------------------------------------------------------
+// excerpt bounding and redaction
+// ---------------------------------------------------------------------------
+
+test("stdout/stderr excerpts are bounded to the documented maximum", async () => {
+  const longOut = "a".repeat(OUTPUT_EXCERPT_MAX_CHARS + 500);
+  const longErr = "b".repeat(OUTPUT_EXCERPT_MAX_CHARS + 500);
+  const execStub = makeExecStub({ stdout: longOut, stderr: longErr });
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.stdoutExcerpt.length, OUTPUT_EXCERPT_MAX_CHARS);
+  assert.equal(result.stderrExcerpt.length, OUTPUT_EXCERPT_MAX_CHARS);
+  assert.equal(result.stdoutExcerpt, longOut.slice(0, OUTPUT_EXCERPT_MAX_CHARS));
+});
+
+test("excerpt containing a PRIVATE KEY marker is redacted wholesale", async () => {
+  const execStub = makeExecStub({
+    stdout: "-----BEGIN RSA PRIVATE KEY-----\nnot-real-key-material\n",
+    stderr: "warning: something mentioned a PRIVATE KEY block",
+  });
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.stdoutExcerpt, "[redacted]");
+  assert.equal(result.stderrExcerpt, "[redacted]");
+});
+
+test("PRIVATE KEY marker beyond the excerpt window still triggers redaction", async () => {
+  const stdout = "x".repeat(OUTPUT_EXCERPT_MAX_CHARS + 10) + " PRIVATE KEY ";
+  const execStub = makeExecStub({ stdout });
+  const adapter = certbotAdapter(execStub);
+
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.stdoutExcerpt, "[redacted]");
+});
+
+// ---------------------------------------------------------------------------
+// misc invariants
+// ---------------------------------------------------------------------------
+
+test("shell metacharacter pattern matches the policy module's characters", () => {
+  for (const char of [";", "|", "&", "$", "`", ">", "<", "\n", "\r"]) {
+    assert.equal(SHELL_METACHARACTER_PATTERN.test(`x${char}y`), true);
+  }
+  assert.equal(SHELL_METACHARACTER_PATTERN.test("--cert-path=/a/b"), false);
+});
+
+test("mutating the profile after adapter creation does not change exec argv", async () => {
+  const profile = { argv: ["certbot"] };
+  const execStub = makeExecStub();
+  const adapter = createAcmeAdapter({
+    kind: "certbot",
+    commandProfile: profile,
+    execFileImpl: execStub,
+  });
+
+  profile.argv.push("--sneaky-extra");
+  const result = await adapter.runRenewal(baseRenewalInputs());
+
+  assert.equal(result.argvUsed.includes("--sneaky-extra"), false);
+  assert.equal(execStub.calls[0].file, "certbot");
+});

--- a/packages/agent/src/acme/index.js
+++ b/packages/agent/src/acme/index.js
@@ -1,9 +1,9 @@
 "use strict";
 
 /**
- * ACME exec adapters (CertOps M5).
+ * ACME exec adapters.
  *
- * CertOps plan 7.3 / 7.5: renewal happens agent-side by shelling out to an
+ * Renewal happens agent-side by shelling out to an
  * operator-installed ACME tool (certbot or acme.sh) rather than embedding an
  * ACME client library. This is a deliberate decision to avoid adding new
  * dependencies for now; the exec-adapter surface below is intentionally
@@ -34,8 +34,8 @@
  *     and CSR on the host; this module only points the ACME tool at the CSR
  *     file. certbot's `--csr` mode (and acme.sh's `--signcsr`) sign an
  *     externally supplied CSR and therefore never need the private key.
- *   - DNS credentials never appear in argv either: per plan 7.5 (DNS-01
- *     credential locality), they live in the ACME tool's own configuration
+ *   - DNS credentials never appear in argv either: per the DNS-01
+ *     credential-locality invariant, they live in the ACME tool's own configuration
  *     files on the host (e.g. certbot's --dns-*-credentials ini, acme.sh's
  *     account.conf), referenced at most by path through the allowlisted
  *     command profile. argvUsed in the result is therefore safe to include

--- a/packages/agent/src/acme/index.js
+++ b/packages/agent/src/acme/index.js
@@ -1,0 +1,435 @@
+"use strict";
+
+/**
+ * ACME exec adapters (CertOps M5).
+ *
+ * CertOps plan 7.3 / 7.5: renewal happens agent-side by shelling out to an
+ * operator-installed ACME tool (certbot or acme.sh) rather than embedding an
+ * ACME client library. This is a deliberate decision to avoid adding new
+ * dependencies for now; the exec-adapter surface below is intentionally
+ * small so an embedded client could replace it later without changing the
+ * dispatch layer's contract.
+ *
+ * Trust and policy model:
+ *   - All exec goes through the agent-local policy command allowlist. The
+ *     dispatch layer resolves a command profile *name* to concrete argv via
+ *     the policy engine (policy.checkCommandRef) and hands this module the
+ *     resulting `{ argv: string[] }` profile. This module never receives a
+ *     profile name and never consults policy config itself.
+ *   - CA endpoints must be checked against the policy caEndpoints allowlist
+ *     BY THE CALLER before dispatch. runRenewal additionally requires a
+ *     `checkCaEndpoint` callback and re-checks the endpoint as defense in
+ *     depth; a `{ allowed: false, rejectionReason, detail }` rejection from
+ *     that callback is returned unchanged so dispatch reports it uniformly
+ *     with every other policy rejection shape.
+ *   - Commands are exec'd via child_process.execFile WITHOUT a shell. This
+ *     module never builds shell strings, and it re-validates every argv
+ *     element (profile, mapped arguments, extraArgs) against the same
+ *     shell-metacharacter pattern the policy module uses, as defense in
+ *     depth against a misconfigured profile or malicious job input.
+ *
+ * Zero-custody-preserving design (D5 / ADR-0001):
+ *   - No private key is ever passed to, read by, or produced by this
+ *     module. Renewal is CSR-based: the keys module generates the keypair
+ *     and CSR on the host; this module only points the ACME tool at the CSR
+ *     file. certbot's `--csr` mode (and acme.sh's `--signcsr`) sign an
+ *     externally supplied CSR and therefore never need the private key.
+ *   - DNS credentials never appear in argv either: per plan 7.5 (DNS-01
+ *     credential locality), they live in the ACME tool's own configuration
+ *     files on the host (e.g. certbot's --dns-*-credentials ini, acme.sh's
+ *     account.conf), referenced at most by path through the allowlisted
+ *     command profile. argvUsed in the result is therefore safe to include
+ *     in evidence by construction.
+ *
+ * Adapter argv contract (documented here as the source of truth; the exact
+ * flags may be tuned when real-world testing against live CAs happens, but
+ * any change must update this table and the sibling tests):
+ *
+ *   certbot  : profile.argv ++ [
+ *                "certonly", "--non-interactive",
+ *                "--csr", csrPath,
+ *                "--server", caEndpoint,
+ *                "-d", domain      (repeated per domain, in input order),
+ *                "--cert-path", outCertPath,
+ *                "--dry-run"       (only when dryRun),
+ *              ] ++ extraArgs
+ *
+ *   acme.sh  : profile.argv ++ [
+ *                "--signcsr",
+ *                "--csr", csrPath,
+ *                "--server", caEndpoint,
+ *                "-d", domain      (repeated per domain, in input order),
+ *                "--cert-file", outCertPath,
+ *                "--test"          (only when dryRun),
+ *              ] ++ extraArgs
+ *
+ * This module is self-contained: it accepts plain data as function
+ * parameters and does not import sibling agent modules (policy, config,
+ * keys, etc.). Wiring profile resolution + policy checks + this adapter
+ * together is the dispatch layer's job.
+ */
+
+const childProcess = require("node:child_process");
+
+/**
+ * Mirrors the policy module's SHELL_METACHARACTER_PATTERN (duplicated, not
+ * imported, to keep this module self-contained): ; | & $ ` > < CR LF.
+ * Commands run without a shell, so this is defense in depth against
+ * misconfigured profiles / hostile job input, not a shell-injection vector
+ * by itself.
+ */
+const SHELL_METACHARACTER_PATTERN = /[;|&$`><\r\n]/;
+
+/** Default exec timeout: ACME issuance can legitimately be slow (DNS-01
+ * propagation waits, CA retries), so default generously to 10 minutes. */
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Hard cap on stdout/stderr excerpt length carried into results/evidence. */
+const OUTPUT_EXCERPT_MAX_CHARS = 1024;
+
+/** Marker whose presence anywhere in an output excerpt causes the whole
+ * excerpt to be replaced, never partially scrubbed: a tool that echoes key
+ * material is a config problem and its output must not leak into evidence. */
+const PRIVATE_KEY_MARKER = "PRIVATE KEY";
+const REDACTED_EXCERPT_PLACEHOLDER = "[redacted]";
+
+const SUPPORTED_ADAPTER_KINDS = Object.freeze(["certbot", "acme.sh"]);
+
+/**
+ * @returns {string[]} adapter kinds accepted by createAcmeAdapter.
+ */
+function listSupportedAdapters() {
+  return [...SUPPORTED_ADAPTER_KINDS];
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Throws if any element of `argv` is not a non-empty string or contains a
+ * shell metacharacter. `label` names the offending input in the error so
+ * misconfigurations fail loudly and legibly.
+ *
+ * @param {string} label
+ * @param {unknown[]} argv
+ * @returns {void}
+ */
+function assertSafeArgvElements(label, argv) {
+  argv.forEach((element, index) => {
+    if (!isNonEmptyString(element)) {
+      throw new Error(
+        `acme: ${label}[${index}] must be a non-empty string (got ${typeof element})`,
+      );
+    }
+    if (SHELL_METACHARACTER_PATTERN.test(element)) {
+      throw new Error(
+        `acme: ${label}[${index}] contains a disallowed shell metacharacter: ${JSON.stringify(element)}`,
+      );
+    }
+  });
+}
+
+/**
+ * POSIX-or-Windows absolute path check without importing node:path
+ * platform-specific behavior surprises: the agent primarily targets POSIX
+ * hosts (plan framing) but tests run on Windows too, so accept either an
+ * absolute POSIX path ("/...") or a Windows drive/UNC path.
+ *
+ * @param {string} candidate
+ * @returns {boolean}
+ */
+function isAbsolutePathLike(candidate) {
+  return (
+    /^\//.test(candidate) ||
+    /^[A-Za-z]:[\\/]/.test(candidate) ||
+    /^\\\\/.test(candidate)
+  );
+}
+
+/**
+ * Bounds an output string to OUTPUT_EXCERPT_MAX_CHARS and redacts it
+ * wholesale if it contains the PRIVATE KEY marker. Redaction is checked on
+ * the FULL output (not just the excerpt window) so a key echoed past the
+ * first 1024 chars still triggers redaction of what would be kept.
+ *
+ * @param {unknown} output raw stdout/stderr (string or Buffer or undefined)
+ * @returns {string}
+ */
+function boundAndRedactExcerpt(output) {
+  const text =
+    typeof output === "string"
+      ? output
+      : Buffer.isBuffer(output)
+        ? output.toString("utf8")
+        : "";
+
+  if (text.includes(PRIVATE_KEY_MARKER)) {
+    return REDACTED_EXCERPT_PLACEHOLDER;
+  }
+
+  return text.slice(0, OUTPUT_EXCERPT_MAX_CHARS);
+}
+
+/**
+ * Builds the adapter-kind-specific argument tail (everything after the
+ * allowlisted profile argv, before extraArgs). See the module-level
+ * "Adapter argv contract" table.
+ *
+ * @param {"certbot"|"acme.sh"} kind
+ * @param {{ caEndpoint: string, domains: string[], csrPath: string, outCertPath: string, dryRun: boolean }} inputs
+ * @returns {string[]}
+ */
+function buildAdapterArgs(kind, { caEndpoint, domains, csrPath, outCertPath, dryRun }) {
+  const domainFlags = domains.flatMap((domain) => ["-d", domain]);
+
+  if (kind === "certbot") {
+    return [
+      "certonly",
+      "--non-interactive",
+      "--csr",
+      csrPath,
+      "--server",
+      caEndpoint,
+      ...domainFlags,
+      "--cert-path",
+      outCertPath,
+      ...(dryRun ? ["--dry-run"] : []),
+    ];
+  }
+
+  // kind === "acme.sh" (createAcmeAdapter has already validated kind)
+  return [
+    "--signcsr",
+    "--csr",
+    csrPath,
+    "--server",
+    caEndpoint,
+    ...domainFlags,
+    "--cert-file",
+    outCertPath,
+    ...(dryRun ? ["--test"] : []),
+  ];
+}
+
+/**
+ * Promise wrapper around an execFile-shaped implementation, exec'ing
+ * WITHOUT a shell, resolving with exit information instead of rejecting on
+ * nonzero exit / timeout (those are operational outcomes, not programmer
+ * errors).
+ *
+ * @param {Function} execFileImpl (file, args, options, callback) => void
+ * @param {string[]} argv full argv; argv[0] is the file to execute
+ * @param {number} timeoutMs
+ * @returns {Promise<{ exitCode: number|null, stdout: unknown, stderr: unknown, execError: Error|null }>}
+ */
+function execWithoutShell(execFileImpl, argv, timeoutMs) {
+  const [file, ...args] = argv;
+
+  return new Promise((resolve) => {
+    execFileImpl(
+      file,
+      args,
+      {
+        timeout: timeoutMs,
+        // Explicitly no `shell` option: arguments are passed as an array to
+        // the OS exec facility and are never interpreted by a shell.
+        windowsHide: true,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          // error.code is the exit code for nonzero exits; null for kills
+          // (timeout => SIGTERM) and spawn failures (ENOENT etc.).
+          const exitCode = typeof error.code === "number" ? error.code : null;
+          resolve({ exitCode, stdout, stderr, execError: error });
+          return;
+        }
+        resolve({ exitCode: 0, stdout, stderr, execError: null });
+      },
+    );
+  });
+}
+
+/**
+ * Creates an ACME exec adapter bound to one tool kind and one allowlisted
+ * command profile.
+ *
+ * @param {object} options
+ * @param {"certbot"|"acme.sh"} options.kind which tool the profile invokes.
+ * @param {{ argv: string[] }} options.commandProfile the concrete argv the
+ *   dispatch layer resolved from the agent-local policy command allowlist
+ *   (policy.checkCommandRef). Never a shell string.
+ * @param {Function} [options.execFileImpl] injection point for tests;
+ *   defaults to node:child_process.execFile. Must have the same signature.
+ * @param {number} [options.timeoutMs] exec timeout, default 10 minutes.
+ * @returns {{ kind: string, runRenewal: Function }}
+ */
+function createAcmeAdapter({
+  kind,
+  commandProfile,
+  execFileImpl = childProcess.execFile,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  if (!SUPPORTED_ADAPTER_KINDS.includes(kind)) {
+    throw new Error(
+      `acme: unsupported adapter kind ${JSON.stringify(kind)}; supported: ${SUPPORTED_ADAPTER_KINDS.join(", ")}`,
+    );
+  }
+
+  if (
+    commandProfile === null ||
+    typeof commandProfile !== "object" ||
+    !Array.isArray(commandProfile.argv)
+  ) {
+    throw new Error(
+      'acme: commandProfile must be an object with an "argv" array (as resolved by the policy engine)',
+    );
+  }
+
+  if (commandProfile.argv.length === 0) {
+    throw new Error("acme: commandProfile.argv must not be empty");
+  }
+
+  assertSafeArgvElements("commandProfile.argv", commandProfile.argv);
+
+  if (typeof execFileImpl !== "function") {
+    throw new Error("acme: execFileImpl must be a function");
+  }
+
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `acme: timeoutMs must be a positive integer, got ${JSON.stringify(timeoutMs)}`,
+    );
+  }
+
+  // Freeze a copy so a caller mutating its profile object after adapter
+  // creation cannot alter what actually gets exec'd.
+  const profileArgv = Object.freeze([...commandProfile.argv]);
+
+  /**
+   * Runs one CSR-based renewal via the configured ACME tool.
+   *
+   * Never throws on operational failure (nonzero exit, timeout, spawn
+   * error): those come back as `{ renewed: false, ... }`. Throws only on
+   * programmer error (malformed inputs) and returns the callback's own
+   * rejection object unchanged when the CA endpoint re-check fails.
+   *
+   * @param {object} options
+   * @param {string} options.caEndpoint ACME directory URL. Already
+   *   allowlist-checked by the caller; re-checked here via checkCaEndpoint.
+   * @param {string[]} options.domains non-empty list of domain names.
+   * @param {string} options.csrPath absolute path to the CSR file (produced
+   *   by the keys module; the private key never passes through here).
+   * @param {string} options.outCertPath absolute path where the tool writes
+   *   the issued certificate.
+   * @param {string[]} [options.extraArgs] appended last, after
+   *   metacharacter validation. For per-job tuning (e.g. preferred chain).
+   * @param {(url: string) => { allowed: boolean, rejectionReason?: string, detail?: string }} options.checkCaEndpoint
+   *   defense-in-depth policy re-check (policy engine's checkCaEndpoint).
+   * @param {boolean} [options.dryRun] map to --dry-run (certbot) / --test
+   *   (acme.sh) so no real certificate is issued.
+   * @returns {Promise<
+   *   { renewed: boolean, exitCode: number|null, stdoutExcerpt: string, stderrExcerpt: string, argvUsed: string[] }
+   *   | { allowed: false, rejectionReason: string, detail: string }
+   * >}
+   */
+  async function runRenewal({
+    caEndpoint,
+    domains,
+    csrPath,
+    outCertPath,
+    extraArgs = [],
+    checkCaEndpoint,
+    dryRun = false,
+  } = {}) {
+    // (1) Programmer-error validation: fail loudly before any policy call
+    // or exec. These are bugs in the dispatch wiring, not job outcomes.
+    if (!isNonEmptyString(caEndpoint)) {
+      throw new Error("acme: runRenewal requires a non-empty caEndpoint string");
+    }
+    if (!Array.isArray(domains) || domains.length === 0) {
+      throw new Error("acme: runRenewal requires a non-empty domains array");
+    }
+    domains.forEach((domain, index) => {
+      if (!isNonEmptyString(domain)) {
+        throw new Error(`acme: domains[${index}] must be a non-empty string`);
+      }
+    });
+    if (!isNonEmptyString(csrPath) || !isAbsolutePathLike(csrPath)) {
+      throw new Error(
+        `acme: csrPath must be an absolute path, got ${JSON.stringify(csrPath)}`,
+      );
+    }
+    if (!isNonEmptyString(outCertPath) || !isAbsolutePathLike(outCertPath)) {
+      throw new Error(
+        `acme: outCertPath must be an absolute path, got ${JSON.stringify(outCertPath)}`,
+      );
+    }
+    if (!Array.isArray(extraArgs)) {
+      throw new Error("acme: extraArgs must be an array of strings");
+    }
+    if (typeof checkCaEndpoint !== "function") {
+      throw new Error(
+        "acme: runRenewal requires a checkCaEndpoint callback (policy engine defense-in-depth re-check)",
+      );
+    }
+
+    // Validate every dynamic argv element against the shell-metacharacter
+    // pattern (defense in depth; exec is shell-less regardless).
+    assertSafeArgvElements("domains", domains);
+    assertSafeArgvElements("extraArgs", extraArgs);
+    assertSafeArgvElements("paths", [csrPath, outCertPath]);
+    assertSafeArgvElements("caEndpoint", [caEndpoint]);
+
+    // (2) Defense-in-depth CA endpoint re-check. The caller has already
+    // consulted the allowlist before dispatch; a rejection here is passed
+    // through UNCHANGED so downstream result reporting handles it exactly
+    // like any other policy rejection.
+    const caCheck = checkCaEndpoint(caEndpoint);
+    if (!caCheck || caCheck.allowed !== true) {
+      return caCheck;
+    }
+
+    // (3) Final argv: allowlisted profile ++ adapter mapping ++ extraArgs.
+    const argvUsed = [
+      ...profileArgv,
+      ...buildAdapterArgs(kind, {
+        caEndpoint,
+        domains,
+        csrPath,
+        outCertPath,
+        dryRun,
+      }),
+      ...extraArgs,
+    ];
+
+    // (4) Exec without a shell, with timeout, capturing bounded excerpts.
+    const { exitCode, stdout, stderr } = await execWithoutShell(
+      execFileImpl,
+      argvUsed,
+      timeoutMs,
+    );
+
+    // (5) Result. argvUsed is included for evidence: it contains no secrets
+    // by construction (no key material exists here; DNS credentials live in
+    // the tool's own config files, never in argv).
+    return {
+      renewed: exitCode === 0,
+      exitCode,
+      stdoutExcerpt: boundAndRedactExcerpt(stdout),
+      stderrExcerpt: boundAndRedactExcerpt(stderr),
+      argvUsed,
+    };
+  }
+
+  return { kind, runRenewal };
+}
+
+module.exports = {
+  createAcmeAdapter,
+  listSupportedAdapters,
+  SHELL_METACHARACTER_PATTERN,
+  OUTPUT_EXCERPT_MAX_CHARS,
+  DEFAULT_TIMEOUT_MS,
+};

--- a/packages/agent/src/claimed-job/index.js
+++ b/packages/agent/src/claimed-job/index.js
@@ -3,12 +3,12 @@
 /**
  * Strict claimed-job validation for the bootstrap agent.
  *
- * Jobs are control-plane input, not a trusted instruction stream. M4 does
- * not execute any action, but it still validates the complete public job
- * shape and every policy dimension before handing it to the local policy
- * engine. Action dimensions are carried in the existing public metadata
- * array, keeping this boundary aligned with the frozen job-payload schema
- * without introducing signed-dispatch/PR #88 execution fields.
+ * Jobs are control-plane input, not a trusted instruction stream. The
+ * bootstrap agent does not execute any action, but it still validates the
+ * complete public job shape and every policy dimension before handing it to
+ * the local policy engine. Action dimensions are carried in the existing
+ * public metadata array, keeping this boundary aligned with the frozen
+ * job-payload schema without introducing signed-dispatch execution fields.
  */
 
 const JOB_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;

--- a/packages/agent/src/clock/clock.test.js
+++ b/packages/agent/src/clock/clock.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { DEFAULT_MAX_SAMPLES, createClockOffsetEstimator } = require("./index.js");
+
+const LOCAL_NOW_MS = Date.parse("2026-07-22T12:00:00.000Z");
+
+function httpDate(epochMs) {
+  return new Date(epochMs).toUTCString();
+}
+
+describe("createClockOffsetEstimator", () => {
+  it("returns null from getOffsetMs before any sample", () => {
+    const estimator = createClockOffsetEstimator();
+    assert.equal(estimator.getOffsetMs(), null);
+    assert.equal(estimator.sampleCount(), 0);
+  });
+
+  it("computes serverTime - localTime from one Date header sample", () => {
+    const estimator = createClockOffsetEstimator();
+    // Server 10s ahead of the local clock => positive offset.
+    const sample = estimator.estimateFromResponseDate(
+      httpDate(LOCAL_NOW_MS + 10000),
+      LOCAL_NOW_MS,
+    );
+    assert.equal(sample, 10000);
+    assert.equal(estimator.getOffsetMs(), 10000);
+  });
+
+  it("yields a negative offset when the local clock is ahead of the server", () => {
+    const estimator = createClockOffsetEstimator();
+    estimator.estimateFromResponseDate(
+      httpDate(LOCAL_NOW_MS - 30000),
+      LOCAL_NOW_MS,
+    );
+    assert.equal(estimator.getOffsetMs(), -30000);
+  });
+
+  it("quantizes to seconds via the HTTP Date format (sub-second truth is invisible)", () => {
+    const estimator = createClockOffsetEstimator();
+    // Server time with 750ms sub-second component: toUTCString drops it.
+    const sample = estimator.estimateFromResponseDate(
+      httpDate(LOCAL_NOW_MS + 750),
+      LOCAL_NOW_MS,
+    );
+    assert.equal(sample, 0);
+  });
+
+  it("uses the median of the rolling window to reject latency-spike outliers", () => {
+    const estimator = createClockOffsetEstimator();
+    for (const offset of [2000, 2000, -60000, 2000, 3000]) {
+      estimator.estimateFromResponseDate(
+        httpDate(LOCAL_NOW_MS + offset),
+        LOCAL_NOW_MS,
+      );
+    }
+    assert.equal(estimator.getOffsetMs(), 2000);
+  });
+
+  it("averages the two middle samples for an even-sized window", () => {
+    const estimator = createClockOffsetEstimator();
+    for (const offset of [1000, 2000, 3000, 4000]) {
+      estimator.estimateFromResponseDate(
+        httpDate(LOCAL_NOW_MS + offset),
+        LOCAL_NOW_MS,
+      );
+    }
+    assert.equal(estimator.getOffsetMs(), 2500);
+  });
+
+  it("caps the window at maxSamples, dropping the oldest sample", () => {
+    const estimator = createClockOffsetEstimator({ maxSamples: 3 });
+    for (const offset of [100000, 1000, 1000, 1000]) {
+      estimator.estimateFromResponseDate(
+        httpDate(LOCAL_NOW_MS + offset),
+        LOCAL_NOW_MS,
+      );
+    }
+    assert.equal(estimator.sampleCount(), 3);
+    assert.equal(estimator.getOffsetMs(), 1000);
+  });
+
+  it("defaults the window size to 5 samples", () => {
+    const estimator = createClockOffsetEstimator();
+    for (let i = 0; i < 10; i += 1) {
+      estimator.estimateFromResponseDate(httpDate(LOCAL_NOW_MS), LOCAL_NOW_MS);
+    }
+    assert.equal(estimator.sampleCount(), DEFAULT_MAX_SAMPLES);
+    assert.equal(DEFAULT_MAX_SAMPLES, 5);
+  });
+
+  it("ignores missing or unparseable Date headers without recording a sample", () => {
+    const estimator = createClockOffsetEstimator();
+    assert.equal(estimator.estimateFromResponseDate(undefined, LOCAL_NOW_MS), null);
+    assert.equal(estimator.estimateFromResponseDate("", LOCAL_NOW_MS), null);
+    assert.equal(
+      estimator.estimateFromResponseDate("not-a-date", LOCAL_NOW_MS),
+      null,
+    );
+    assert.equal(estimator.sampleCount(), 0);
+    assert.equal(estimator.getOffsetMs(), null);
+  });
+
+  it("throws on programmer error: non-finite localNowMs or bad maxSamples", () => {
+    const estimator = createClockOffsetEstimator();
+    assert.throws(
+      () => estimator.estimateFromResponseDate(httpDate(LOCAL_NOW_MS), NaN),
+      /localNowMs/,
+    );
+    assert.throws(() => createClockOffsetEstimator({ maxSamples: 0 }), /maxSamples/);
+    assert.throws(
+      () => createClockOffsetEstimator({ maxSamples: 1.5 }),
+      /maxSamples/,
+    );
+  });
+});

--- a/packages/agent/src/clock/index.js
+++ b/packages/agent/src/clock/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Clock-offset estimation from HTTP Date response headers (CertOps Phase 4
+ * Clock-offset estimation from HTTP Date response headers (signed-dispatch
  * runtime, ADR-0003 clock-drift awareness).
  *
  * Every control-plane HTTP response carries a Date header stamped with the

--- a/packages/agent/src/clock/index.js
+++ b/packages/agent/src/clock/index.js
@@ -1,0 +1,128 @@
+"use strict";
+
+/**
+ * Clock-offset estimation from HTTP Date response headers (CertOps Phase 4
+ * runtime, ADR-0003 clock-drift awareness).
+ *
+ * Every control-plane HTTP response carries a Date header stamped with the
+ * server's clock. Comparing it to the local clock at receive time yields an
+ * estimate of `serverTime - localTime` (offsetMs): positive means the local
+ * clock is BEHIND the server. This is the `clockOffsetMs` value the
+ * agent-protocol envelope reports on heartbeat/result messages and the
+ * adjustment checkJobTimeWindow applies when validating a signed job's
+ * [issuedAt, expiresAt] window.
+ *
+ * Accuracy caveat (documented per task spec): the HTTP Date header has
+ * 1-SECOND resolution (RFC 9110 IMF-fixdate), so each individual sample has
+ * up to ~1s of quantization error, plus one-way network latency (the header
+ * is stamped when the server builds the response, and we timestamp on
+ * receipt, so samples skew slightly negative by the response transit time).
+ * This is deliberately a coarse estimator: it exists to catch drift in the
+ * seconds-to-minutes range that would break the signed-job time window (30s
+ * default tolerance), not to be an NTP replacement.
+ *
+ * Smoothing: a small rolling window of the last N samples (default 5) with
+ * a MEDIAN aggregate. Median over mean because individual samples are
+ * contaminated by occasional latency spikes (slow response => one very
+ * negative sample); the median discards such outliers entirely instead of
+ * letting them drag the estimate.
+ *
+ * This module is self-contained (node builtins only, plain-data API) per
+ * the packages/agent module conventions. The protocol client does NOT
+ * import it; the caller wires the client's onServerDate callback to
+ * estimateFromResponseDate (see src/index.js wiring, done separately).
+ */
+
+const DEFAULT_MAX_SAMPLES = 5;
+
+/**
+ * Creates a rolling clock-offset estimator.
+ *
+ * @param {object} [options]
+ * @param {number} [options.maxSamples=5] rolling window size; oldest sample
+ *   is dropped once the window is full
+ * @returns {{
+ *   estimateFromResponseDate: (dateHeaderValue: string, localNowMs: number) => (number|null),
+ *   getOffsetMs: () => (number|null),
+ *   sampleCount: () => number,
+ * }}
+ */
+function createClockOffsetEstimator({ maxSamples = DEFAULT_MAX_SAMPLES } = {}) {
+  if (!Number.isInteger(maxSamples) || maxSamples <= 0) {
+    throw new Error(
+      "clock: createClockOffsetEstimator maxSamples must be a positive integer",
+    );
+  }
+
+  /** @type {number[]} oldest first */
+  const samples = [];
+
+  /**
+   * Ingests one HTTP Date header sample and returns that single sample's
+   * offset (serverTime - localTime, in ms), or null when the header is
+   * missing/unparseable (in which case no sample is recorded -- a bad
+   * header must not poison the rolling window).
+   *
+   * Second-granularity note: Date.parse of an IMF-fixdate yields whole
+   * seconds, so the returned offset inherits up to ~1s quantization error
+   * per sample; consumers should use getOffsetMs() (the median over the
+   * window) rather than trusting any single sample.
+   *
+   * @param {string} dateHeaderValue value of the response's Date header
+   * @param {number} localNowMs local epoch ms captured when the response
+   *   was received
+   * @returns {number|null} this sample's offsetMs, or null if unusable
+   */
+  function estimateFromResponseDate(dateHeaderValue, localNowMs) {
+    if (!Number.isFinite(localNowMs)) {
+      throw new Error(
+        "clock: estimateFromResponseDate requires a finite localNowMs",
+      );
+    }
+    if (typeof dateHeaderValue !== "string" || dateHeaderValue.length === 0) {
+      return null;
+    }
+    const serverMs = Date.parse(dateHeaderValue);
+    if (Number.isNaN(serverMs)) {
+      return null;
+    }
+
+    const offsetMs = serverMs - localNowMs;
+    samples.push(offsetMs);
+    if (samples.length > maxSamples) {
+      samples.shift();
+    }
+    return offsetMs;
+  }
+
+  /**
+   * Current best estimate: the median of the rolling window, rounded to an
+   * integer (the protocol envelope's clockOffsetMs is an integer), or null
+   * when no samples have been ingested yet. Callers must treat null as
+   * "unknown" and skip offset adjustment (checkJobTimeWindow already
+   * ignores non-finite/non-integer offsets).
+   *
+   * @returns {number|null}
+   */
+  function getOffsetMs() {
+    if (samples.length === 0) return null;
+    const sorted = [...samples].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const median =
+      sorted.length % 2 === 1
+        ? sorted[mid]
+        : (sorted[mid - 1] + sorted[mid]) / 2;
+    return Math.round(median);
+  }
+
+  function sampleCount() {
+    return samples.length;
+  }
+
+  return { estimateFromResponseDate, getOffsetMs, sampleCount };
+}
+
+module.exports = {
+  DEFAULT_MAX_SAMPLES,
+  createClockOffsetEstimator,
+};

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -12,6 +12,8 @@ const {
   loadAgentConfig,
   readCaBundle,
   writeAgentIdentity,
+  writeSigningKeyPin,
+  readSigningKeyPin,
   readCredential,
   writeCredential,
   rotateCredential,
@@ -338,6 +340,212 @@ describe("loadAgentConfig", () => {
         /discovery in config\.json must be an object/,
       );
     });
+  });
+
+  it("defaults execution to null when the block is absent", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://control-plane.example.com" }),
+      "utf8",
+    );
+    withEnv({ TOKENTIMER_AGENT_SERVER_URL: undefined }, () => {
+      const config = loadAgentConfig({ configDir: dir });
+      assert.equal(config.execution, null);
+      assert.equal(config.pinnedSigningKey, null);
+    });
+  });
+
+  it("applies execution defaults (disabled, dry-run, config-dir paths, 30s tolerance)", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({
+        serverUrl: "https://control-plane.example.com",
+        execution: {},
+      }),
+      "utf8",
+    );
+    withEnv({ TOKENTIMER_AGENT_SERVER_URL: undefined }, () => {
+      const { execution } = loadAgentConfig({ configDir: dir });
+      assert.deepEqual(execution, {
+        enabled: false,
+        dryRun: true,
+        keysDir: path.join(dir, "keys"),
+        replayStorePath: path.join(dir, "replay-store.json"),
+        clockDriftToleranceMs: 30000,
+      });
+    });
+  });
+
+  it("passes through explicit execution values", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({
+        serverUrl: "https://control-plane.example.com",
+        execution: {
+          enabled: true,
+          dryRun: false,
+          keysDir: "/var/lib/tokentimer-agent/keys",
+          replayStorePath: "/var/lib/tokentimer-agent/replay.json",
+          clockDriftToleranceMs: 5000,
+        },
+      }),
+      "utf8",
+    );
+    withEnv({ TOKENTIMER_AGENT_SERVER_URL: undefined }, () => {
+      const { execution } = loadAgentConfig({ configDir: dir });
+      assert.deepEqual(execution, {
+        enabled: true,
+        dryRun: false,
+        keysDir: "/var/lib/tokentimer-agent/keys",
+        replayStorePath: "/var/lib/tokentimer-agent/replay.json",
+        clockDriftToleranceMs: 5000,
+      });
+    });
+  });
+
+  it("fails loudly on a malformed execution block", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    const configPath = path.join(dir, "config.json");
+    const badBlocks = [
+      { execution: "not-an-object", pattern: /execution in config\.json must be an object/ },
+      { execution: { enabled: "yes" }, pattern: /execution\.enabled must be a boolean/ },
+      { execution: { dryRun: 1 }, pattern: /execution\.dryRun must be a boolean/ },
+      { execution: { keysDir: "" }, pattern: /execution\.keysDir must be a non-empty string/ },
+      {
+        execution: { replayStorePath: 42 },
+        pattern: /execution\.replayStorePath must be a non-empty string/,
+      },
+      {
+        execution: { clockDriftToleranceMs: -1 },
+        pattern: /execution\.clockDriftToleranceMs must be a positive integer/,
+      },
+      {
+        execution: { clockDriftToleranceMs: 1.5 },
+        pattern: /execution\.clockDriftToleranceMs must be a positive integer/,
+      },
+    ];
+    for (const { execution, pattern } of badBlocks) {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ serverUrl: "https://control-plane.example.com", execution }),
+        "utf8",
+      );
+      withEnv({ TOKENTIMER_AGENT_SERVER_URL: undefined }, () => {
+        assert.throws(() => loadAgentConfig({ configDir: dir }), pattern);
+      });
+    }
+  });
+});
+
+describe("signing key pin round trip", () => {
+  const SAMPLE_PUBLIC_KEY_PEM =
+    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfakefakefakefakefakefakefakefake\n-----END PUBLIC KEY-----\n";
+
+  it("returns null from readSigningKeyPin when no pin is stored", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    assert.equal(readSigningKeyPin(dir), null);
+  });
+
+  it("round-trips write/read of the signing key pin", () => {
+    const dir = makeTempConfigDir();
+    writeSigningKeyPin(dir, {
+      signingKeyId: "signing-key-1",
+      signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+
+    const pin = readSigningKeyPin(dir);
+    assert.deepEqual(pin, {
+      signingKeyId: "signing-key-1",
+      publicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+  });
+
+  it("loadAgentConfig exposes the stored pin as pinnedSigningKey", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://control-plane.example.com" }),
+      "utf8",
+    );
+    writeSigningKeyPin(dir, {
+      signingKeyId: "signing-key-1",
+      signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+
+    withEnv({ TOKENTIMER_AGENT_SERVER_URL: undefined }, () => {
+      const config = loadAgentConfig({ configDir: dir });
+      assert.deepEqual(config.pinnedSigningKey, {
+        signingKeyId: "signing-key-1",
+        publicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+      });
+    });
+  });
+
+  it("sets 0600 permissions on the pin file on non-win32 platforms", { skip: IS_WIN32 }, () => {
+    const dir = makeTempConfigDir();
+    writeSigningKeyPin(dir, {
+      signingKeyId: "signing-key-1",
+      signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+    const mode = fs.statSync(path.join(dir, "signing-key-pin.json")).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+
+  it("rejects an empty signingKeyId or non-PEM public key", () => {
+    const dir = makeTempConfigDir();
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "",
+          signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+        }),
+      /signingKeyId must be a non-empty string/,
+    );
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-1",
+          signingPublicKeyPem: "not-a-pem",
+        }),
+      /PEM-encoded PUBLIC key/,
+    );
+  });
+
+  it("refuses to pin anything containing private key material", () => {
+    const dir = makeTempConfigDir();
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-1",
+          signingPublicKeyPem:
+            "-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----\n" +
+            "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+        }),
+      /private key material/,
+    );
+  });
+
+  it("fails loudly on a corrupted pin file instead of silently unpinning", () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    fs.writeFileSync(path.join(dir, "signing-key-pin.json"), "{not json", "utf8");
+    assert.throws(() => readSigningKeyPin(dir), /failed to parse signing key pin/);
+
+    fs.writeFileSync(
+      path.join(dir, "signing-key-pin.json"),
+      JSON.stringify({ signingKeyId: "signing-key-1" }),
+      "utf8",
+    );
+    assert.throws(() => readSigningKeyPin(dir), /corrupted/);
   });
 });
 

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const crypto = require("node:crypto");
 
 const {
   resolveConfigDir,
@@ -445,8 +446,12 @@ describe("loadAgentConfig", () => {
 });
 
 describe("signing key pin round trip", () => {
-  const SAMPLE_PUBLIC_KEY_PEM =
-    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfakefakefakefakefakefakefakefake\n-----END PUBLIC KEY-----\n";
+  // A real Ed25519 public key: writeSigningKeyPin parses the PEM and
+  // enforces the key type at write time (ADR-0003).
+  const SAMPLE_PUBLIC_KEY_PEM = crypto
+    .generateKeyPairSync("ed25519")
+    .publicKey.export({ type: "spki", format: "pem" })
+    .toString();
 
   it("returns null from readSigningKeyPin when no pin is stored", () => {
     const dir = makeTempConfigDir();
@@ -508,7 +513,7 @@ describe("signing key pin round trip", () => {
           signingKeyId: "",
           signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
         }),
-      /signingKeyId must be a non-empty string/,
+      /signingKeyId must be a 1-128 char string/,
     );
     assert.throws(
       () =>
@@ -517,6 +522,87 @@ describe("signing key pin round trip", () => {
           signingPublicKeyPem: "not-a-pem",
         }),
       /PEM-encoded PUBLIC key/,
+    );
+  });
+
+  it("rejects a public key that is not Ed25519", () => {
+    const dir = makeTempConfigDir();
+    const rsaPublicPem = crypto
+      .generateKeyPairSync("rsa", { modulusLength: 2048 })
+      .publicKey.export({ type: "spki", format: "pem" })
+      .toString();
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-1",
+          signingPublicKeyPem: rsaPublicPem,
+        }),
+      /must be an Ed25519 public key/,
+    );
+  });
+
+  it("rejects an unparseable PEM at write time", () => {
+    const dir = makeTempConfigDir();
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-1",
+          signingPublicKeyPem:
+            "-----BEGIN PUBLIC KEY-----\nnot/base64/key/material\n-----END PUBLIC KEY-----\n",
+        }),
+      /does not parse as a public key/,
+    );
+  });
+
+  it("refuses a silent re-pin to a different key without allowRepin", () => {
+    const dir = makeTempConfigDir();
+    writeSigningKeyPin(dir, {
+      signingKeyId: "signing-key-1",
+      signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+
+    const otherKeyPem = crypto
+      .generateKeyPairSync("ed25519")
+      .publicKey.export({ type: "spki", format: "pem" })
+      .toString();
+
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-2",
+          signingPublicKeyPem: otherKeyPem,
+        }),
+      /refusing to silently re-pin/,
+    );
+
+    // Rewriting the identical pin stays allowed (idempotent).
+    writeSigningKeyPin(dir, {
+      signingKeyId: "signing-key-1",
+      signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+    });
+
+    // An explicit re-registration flow may rotate the pin.
+    writeSigningKeyPin(
+      dir,
+      { signingKeyId: "signing-key-2", signingPublicKeyPem: otherKeyPem },
+      { allowRepin: true },
+    );
+    assert.equal(readSigningKeyPin(dir).signingKeyId, "signing-key-2");
+  });
+
+  it("refuses to write the pin through a symlink", { skip: IS_WIN32 }, () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    const decoyPath = path.join(dir, "decoy.json");
+    fs.writeFileSync(decoyPath, "{}", "utf8");
+    fs.symlinkSync(decoyPath, path.join(dir, "signing-key-pin.json"));
+    assert.throws(
+      () =>
+        writeSigningKeyPin(dir, {
+          signingKeyId: "signing-key-1",
+          signingPublicKeyPem: SAMPLE_PUBLIC_KEY_PEM,
+        }),
+      /not a regular file/,
     );
   });
 

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -52,7 +52,7 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
 const DEFAULT_POLL_INTERVAL_MS = 15000;
 // Discovery is an inventory scan, not a control loop; hourly by default.
 const DEFAULT_DISCOVERY_INTERVAL_MS = 60 * 60 * 1000;
-// Execution (M5 signed-job dispatch) defaults: disabled and dry-run by
+// Execution (signed-job dispatch) defaults: disabled and dry-run by
 // default so an upgraded agent never starts executing jobs without an
 // explicit operator opt-in (ADR-0003).
 const DEFAULT_CLOCK_DRIFT_TOLERANCE_MS = 30000;
@@ -346,7 +346,7 @@ function parseBooleanEnv(value, fallback, envName) {
 }
 
 /**
- * Validates the optional "execution" config block (M5 signed-job dispatch).
+ * Validates the optional "execution" config block (signed-job dispatch).
  * Fail-loud like validatePolicyObject/validateDiscoveryObject: a malformed
  * block aborts startup instead of being silently normalized.
  *

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -41,6 +41,11 @@ const PENDING_REGISTRATION_FILE_NAME = "registration.pending.json";
 const SIGNING_KEY_PIN_FILE_NAME = "signing-key-pin.json";
 
 const AGENT_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;
+// Same character/length policy as the protocol validator's key-id bound;
+// enforced locally too so writeSigningKeyPin is safe regardless of caller.
+const SIGNING_KEY_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;
+// Mirrors the protocol validator's registration-response PEM bound.
+const MAX_SIGNING_KEY_PEM_BYTES = 8192;
 const PROTOCOL_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+$/;
 const CREDENTIAL_SHAPE_PATTERN =
   /^ttagent_([A-Za-z0-9_.:-]{1,128})_([A-Za-z0-9._~+\/-]{16,1024})$/;
@@ -589,23 +594,51 @@ function writeAgentIdentity(configDir, { agentId }) {
  * material, not a secret, so storing it on disk is safe; the file still
  * follows the module's 0600-in-0700-dir convention so only the agent user
  * can replace the pin (integrity, not confidentiality).
+ *
+ * Hardening (all fail loudly):
+ *   - the PEM must parse via crypto.createPublicKey AND be Ed25519
+ *     (ADR-0003 mandates Ed25519 job signing; pinning any other key type
+ *     would soft-reject every job as job_integrity_failed, which looks
+ *     like an attack instead of the misconfiguration it is);
+ *   - signingKeyId and PEM sizes are bounded locally (not only by the
+ *     protocol validator upstream);
+ *   - an existing pin path that is a symlink or non-regular file is
+ *     refused (integrity of the pin is the whole point of the file);
+ *   - overwriting an existing pin with a DIFFERENT key requires an
+ *     explicit allowRepin flag (re-registration is the only flow allowed
+ *     to rotate the pin; a silent overwrite would let any code path
+ *     re-pin an attacker-supplied key). Rewriting the identical pin is a
+ *     no-op-equivalent and stays allowed.
+ *
  * @param {string} configDir
  * @param {{signingKeyId: string, signingPublicKeyPem: string}} pin
+ * @param {{allowRepin?: boolean}} [options]
  * @returns {void}
  */
-function writeSigningKeyPin(configDir, { signingKeyId, signingPublicKeyPem }) {
-  if (typeof signingKeyId !== "string" || signingKeyId.length === 0) {
+function writeSigningKeyPin(
+  configDir,
+  { signingKeyId, signingPublicKeyPem },
+  { allowRepin = false } = {},
+) {
+  if (
+    typeof signingKeyId !== "string" ||
+    !SIGNING_KEY_ID_PATTERN.test(signingKeyId)
+  ) {
     throw new Error(
-      "tokentimer-agent: signingKeyId must be a non-empty string, got: " +
+      "tokentimer-agent: signingKeyId must be a 1-128 char string of " +
+        "[A-Za-z0-9_.:-], got: " +
         JSON.stringify(signingKeyId),
     );
   }
   if (
     typeof signingPublicKeyPem !== "string" ||
+    signingPublicKeyPem.length === 0 ||
+    signingPublicKeyPem.length > MAX_SIGNING_KEY_PEM_BYTES ||
     !signingPublicKeyPem.includes("BEGIN PUBLIC KEY")
   ) {
     throw new Error(
       "tokentimer-agent: signingPublicKeyPem must be a PEM-encoded PUBLIC key " +
+        `of at most ${MAX_SIGNING_KEY_PEM_BYTES} bytes ` +
         "(refusing to pin anything that does not look like public key material)",
     );
   }
@@ -615,19 +648,60 @@ function writeSigningKeyPin(configDir, { signingKeyId, signingPublicKeyPem }) {
         "private key material",
     );
   }
+
+  // Parse-and-type check: the pin must be a well-formed Ed25519 public key
+  // NOW, at write time, not when the first job soft-rejects.
+  let parsedKey;
+  try {
+    parsedKey = crypto.createPublicKey(signingPublicKeyPem);
+  } catch (err) {
+    throw new Error(
+      `tokentimer-agent: signingPublicKeyPem does not parse as a public key: ${err.message}`,
+    );
+  }
+  if (parsedKey.asymmetricKeyType !== "ed25519") {
+    throw new Error(
+      "tokentimer-agent: signingPublicKeyPem must be an Ed25519 public key " +
+        `(ADR-0003), got ${JSON.stringify(parsedKey.asymmetricKeyType)}`,
+    );
+  }
+
   ensureConfigDir(configDir);
 
   const pinPath = path.join(configDir, SIGNING_KEY_PIN_FILE_NAME);
-  const payload = { signingKeyId, publicKeyPem: signingPublicKeyPem };
-  fs.writeFileSync(pinPath, `${JSON.stringify(payload, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
+
+  // Refuse symlinked/special pin files and silent re-pins to a different key.
+  let existingStats = null;
   try {
-    fs.chmodSync(pinPath, 0o600);
-  } catch (_err) {
-    // Best-effort on win32; see the comment in ensureConfigDir for rationale.
+    existingStats = fs.lstatSync(pinPath);
+  } catch (err) {
+    if (!err || err.code !== "ENOENT") throw err;
   }
+  if (existingStats !== null) {
+    if (existingStats.isSymbolicLink() || !existingStats.isFile()) {
+      throw new Error(
+        `tokentimer-agent: signing key pin path ${pinPath} exists but is ` +
+          "not a regular file (symlink or special file); refusing to write " +
+          "the pin through it",
+      );
+    }
+    const existingPin = readSigningKeyPin(configDir);
+    const samePin =
+      existingPin !== null &&
+      existingPin.signingKeyId === signingKeyId &&
+      existingPin.publicKeyPem === signingPublicKeyPem;
+    if (!samePin && !allowRepin) {
+      throw new Error(
+        "tokentimer-agent: a different signing key is already pinned " +
+          `(pinned id ${JSON.stringify(existingPin?.signingKeyId)}, new id ` +
+          `${JSON.stringify(signingKeyId)}); refusing to silently re-pin. ` +
+          "Pass allowRepin: true only from an explicit re-registration flow.",
+      );
+    }
+  }
+
+  const payload = { signingKeyId, publicKeyPem: signingPublicKeyPem };
+  writeFileAtomically(pinPath, `${JSON.stringify(payload, null, 2)}\n`, 0o600);
 }
 
 /**

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -34,6 +34,11 @@ const {
 const CONFIG_FILE_NAME = "config.json";
 const CREDENTIAL_FILE_NAME = "credential";
 const PENDING_REGISTRATION_FILE_NAME = "registration.pending.json";
+// Pinned control-plane job-signing key (ADR-0003 trust-on-first-use). The
+// stored PEM is PUBLIC key material only (never a private key), so this file
+// is not a secret; it still gets 0600 in the 0700 config dir purely as an
+// integrity measure (only the agent user may swap the pin).
+const SIGNING_KEY_PIN_FILE_NAME = "signing-key-pin.json";
 
 const AGENT_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;
 const PROTOCOL_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+$/;
@@ -47,6 +52,12 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
 const DEFAULT_POLL_INTERVAL_MS = 15000;
 // Discovery is an inventory scan, not a control loop; hourly by default.
 const DEFAULT_DISCOVERY_INTERVAL_MS = 60 * 60 * 1000;
+// Execution (M5 signed-job dispatch) defaults: disabled and dry-run by
+// default so an upgraded agent never starts executing jobs without an
+// explicit operator opt-in (ADR-0003).
+const DEFAULT_CLOCK_DRIFT_TOLERANCE_MS = 30000;
+const KEYS_DIR_NAME = "keys";
+const REPLAY_STORE_FILE_NAME = "replay-store.json";
 
 const REDACTED_CREDENTIAL_PLACEHOLDER = "[AGENT_CREDENTIAL_REDACTED]";
 
@@ -335,6 +346,101 @@ function parseBooleanEnv(value, fallback, envName) {
 }
 
 /**
+ * Validates the optional "execution" config block (M5 signed-job dispatch).
+ * Fail-loud like validatePolicyObject/validateDiscoveryObject: a malformed
+ * block aborts startup instead of being silently normalized.
+ *
+ * Returned shape (defaults applied, all fields always present):
+ *   {
+ *     enabled: boolean            (default false),
+ *     dryRun: boolean             (default true),
+ *     keysDir: string             (default <configDir>/keys),
+ *     replayStorePath: string     (default <configDir>/replay-store.json),
+ *     clockDriftToleranceMs: int  (default 30000, must be a positive integer)
+ *   }
+ *
+ * Returns null when the block is absent entirely (execution disabled and
+ * not configured; callers treat null like { enabled: false }).
+ *
+ * @param {*} execution raw config.json "execution" value
+ * @param {string} configDir resolved config dir used for path defaults
+ * @returns {{
+ *   enabled: boolean,
+ *   dryRun: boolean,
+ *   keysDir: string,
+ *   replayStorePath: string,
+ *   clockDriftToleranceMs: number,
+ * }|null}
+ */
+function validateExecutionObject(execution, configDir) {
+  if (execution === undefined || execution === null) return null;
+  if (typeof execution !== "object" || Array.isArray(execution)) {
+    throw new Error(
+      "tokentimer-agent: execution in config.json must be an object " +
+        "({ enabled?, dryRun?, keysDir?, replayStorePath?, clockDriftToleranceMs? })",
+    );
+  }
+
+  const enabled = execution.enabled === undefined ? false : execution.enabled;
+  if (typeof enabled !== "boolean") {
+    throw new Error(
+      "tokentimer-agent: execution.enabled must be a boolean, got: " +
+        JSON.stringify(execution.enabled),
+    );
+  }
+
+  const dryRun = execution.dryRun === undefined ? true : execution.dryRun;
+  if (typeof dryRun !== "boolean") {
+    throw new Error(
+      "tokentimer-agent: execution.dryRun must be a boolean, got: " +
+        JSON.stringify(execution.dryRun),
+    );
+  }
+
+  let keysDir = path.join(configDir, KEYS_DIR_NAME);
+  if (execution.keysDir !== undefined) {
+    if (typeof execution.keysDir !== "string" || execution.keysDir.length === 0) {
+      throw new Error(
+        "tokentimer-agent: execution.keysDir must be a non-empty string, got: " +
+          JSON.stringify(execution.keysDir),
+      );
+    }
+    keysDir = execution.keysDir;
+  }
+
+  let replayStorePath = path.join(configDir, REPLAY_STORE_FILE_NAME);
+  if (execution.replayStorePath !== undefined) {
+    if (
+      typeof execution.replayStorePath !== "string" ||
+      execution.replayStorePath.length === 0
+    ) {
+      throw new Error(
+        "tokentimer-agent: execution.replayStorePath must be a non-empty string, got: " +
+          JSON.stringify(execution.replayStorePath),
+      );
+    }
+    replayStorePath = execution.replayStorePath;
+  }
+
+  let clockDriftToleranceMs = DEFAULT_CLOCK_DRIFT_TOLERANCE_MS;
+  if (execution.clockDriftToleranceMs !== undefined) {
+    if (
+      typeof execution.clockDriftToleranceMs !== "number" ||
+      !Number.isInteger(execution.clockDriftToleranceMs) ||
+      execution.clockDriftToleranceMs <= 0
+    ) {
+      throw new Error(
+        "tokentimer-agent: execution.clockDriftToleranceMs must be a positive " +
+          `integer (milliseconds), got: ${JSON.stringify(execution.clockDriftToleranceMs)}`,
+      );
+    }
+    clockDriftToleranceMs = execution.clockDriftToleranceMs;
+  }
+
+  return { enabled, dryRun, keysDir, replayStorePath, clockDriftToleranceMs };
+}
+
+/**
  * Loads and returns the agent runtime config as a plain object.
  * Load order: config.json file (non-secret fields) -> env var overrides ->
  * defaults. The credential itself is never part of this object; use
@@ -352,6 +458,14 @@ function parseBooleanEnv(value, fallback, envName) {
  *   discovery: {directories: string[], intervalMs: number}|null,
  *   caBundlePath: string|null,
  *   allowInsecureLocalHttp: boolean,
+ *   execution: {
+ *     enabled: boolean,
+ *     dryRun: boolean,
+ *     keysDir: string,
+ *     replayStorePath: string,
+ *     clockDriftToleranceMs: number,
+ *   }|null,
+ *   pinnedSigningKey: {signingKeyId: string, publicKeyPem: string}|null,
  * }}
  */
 function loadAgentConfig({ configDir } = {}) {
@@ -426,6 +540,14 @@ function loadAgentConfig({ configDir } = {}) {
     "TOKENTIMER_AGENT_ALLOW_INSECURE_LOCAL_HTTP",
   );
 
+  // Signed-job execution config; null means execution not configured
+  // (treated everywhere as { enabled: false }).
+  const execution = validateExecutionObject(fileConfig.execution, resolvedDir);
+
+  // Pinned control-plane job-signing key, persisted at registration by
+  // writeSigningKeyPin. Public key material only.
+  const pinnedSigningKey = readSigningKeyPin(resolvedDir);
+
   return {
     serverUrl,
     agentId,
@@ -438,6 +560,8 @@ function loadAgentConfig({ configDir } = {}) {
     discovery,
     caBundlePath,
     allowInsecureLocalHttp,
+    execution,
+    pinnedSigningKey,
   };
 }
 
@@ -457,6 +581,93 @@ function writeAgentIdentity(configDir, { agentId }) {
   const existing = readConfigFile(configDir);
   const merged = { ...existing, agentId };
   writeFileAtomically(configPath, `${JSON.stringify(merged, null, 2)}\n`, 0o600);
+}
+
+/**
+ * Persists the control-plane job-signing key pin received at registration
+ * (ADR-0003 trust-on-first-use). The stored publicKeyPem is PUBLIC key
+ * material, not a secret, so storing it on disk is safe; the file still
+ * follows the module's 0600-in-0700-dir convention so only the agent user
+ * can replace the pin (integrity, not confidentiality).
+ * @param {string} configDir
+ * @param {{signingKeyId: string, signingPublicKeyPem: string}} pin
+ * @returns {void}
+ */
+function writeSigningKeyPin(configDir, { signingKeyId, signingPublicKeyPem }) {
+  if (typeof signingKeyId !== "string" || signingKeyId.length === 0) {
+    throw new Error(
+      "tokentimer-agent: signingKeyId must be a non-empty string, got: " +
+        JSON.stringify(signingKeyId),
+    );
+  }
+  if (
+    typeof signingPublicKeyPem !== "string" ||
+    !signingPublicKeyPem.includes("BEGIN PUBLIC KEY")
+  ) {
+    throw new Error(
+      "tokentimer-agent: signingPublicKeyPem must be a PEM-encoded PUBLIC key " +
+        "(refusing to pin anything that does not look like public key material)",
+    );
+  }
+  if (signingPublicKeyPem.includes("PRIVATE KEY")) {
+    throw new Error(
+      "tokentimer-agent: refusing to pin signingPublicKeyPem containing " +
+        "private key material",
+    );
+  }
+  ensureConfigDir(configDir);
+
+  const pinPath = path.join(configDir, SIGNING_KEY_PIN_FILE_NAME);
+  const payload = { signingKeyId, publicKeyPem: signingPublicKeyPem };
+  fs.writeFileSync(pinPath, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    fs.chmodSync(pinPath, 0o600);
+  } catch (_err) {
+    // Best-effort on win32; see the comment in ensureConfigDir for rationale.
+  }
+}
+
+/**
+ * Reads the persisted signing-key pin, returning null when none is stored.
+ * A present-but-corrupted pin file fails loudly (never silently unpinned).
+ * @param {string} configDir
+ * @returns {{signingKeyId: string, publicKeyPem: string}|null}
+ */
+function readSigningKeyPin(configDir) {
+  const pinPath = path.join(configDir, SIGNING_KEY_PIN_FILE_NAME);
+  let raw;
+  try {
+    raw = fs.readFileSync(pinPath, "utf8");
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    throw err;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `tokentimer-agent: failed to parse signing key pin ${pinPath}: ${err.message}`,
+    );
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    typeof parsed.signingKeyId !== "string" ||
+    parsed.signingKeyId.length === 0 ||
+    typeof parsed.publicKeyPem !== "string" ||
+    !parsed.publicKeyPem.includes("BEGIN PUBLIC KEY")
+  ) {
+    throw new Error(
+      `tokentimer-agent: ${pinPath} is corrupted (expected ` +
+        "{ signingKeyId, publicKeyPem } with a PEM public key); refusing to " +
+        "start unsigned. Re-register the agent to re-pin.",
+    );
+  }
+  return { signingKeyId: parsed.signingKeyId, publicKeyPem: parsed.publicKeyPem };
 }
 
 /**
@@ -612,6 +823,9 @@ module.exports = {
   readCaBundle,
   validateCaBundlePath,
   writeAgentIdentity,
+  writeSigningKeyPin,
+  readSigningKeyPin,
+  validateExecutionObject,
   readCredential,
   writeCredential,
   rotateCredential,

--- a/packages/agent/src/deploy/deploy.test.js
+++ b/packages/agent/src/deploy/deploy.test.js
@@ -1,0 +1,518 @@
+"use strict";
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  validateTargetConfig,
+  deployCertificate,
+  getDeployMetrics,
+  resetDeployMetrics,
+} = require("./index.js");
+
+const CERT_PEM =
+  "-----BEGIN CERTIFICATE-----\nMIIBfake-cert-body-for-tests\n-----END CERTIFICATE-----\n";
+const OTHER_CERT_PEM =
+  "-----BEGIN CERTIFICATE-----\nMIIBdifferent-cert-body\n-----END CERTIFICATE-----\n";
+const PRIVATE_KEY_PEM =
+  "-----BEGIN PRIVATE KEY-----\nMIIEfake-key-body\n-----END PRIVATE KEY-----\n";
+
+const tempDirs = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentimer-agent-deploy-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * A checkPath stub that allows anything under `allowedRoot` (segment-aware,
+ * like the real policy engine) and rejects everything else.
+ */
+function makeCheckPath(allowedRoot) {
+  const normalizedRoot = path.normalize(path.resolve(allowedRoot));
+  return (candidate) => {
+    const normalized = path.normalize(path.resolve(candidate));
+    const relative = path.relative(normalizedRoot, normalized);
+    const contained =
+      normalized === normalizedRoot ||
+      (relative !== "" &&
+        !relative.startsWith("..") &&
+        !path.isAbsolute(relative));
+    if (!contained) {
+      return {
+        allowed: false,
+        rejectionReason: "path_not_allowlisted",
+        detail: `test: "${candidate}" outside "${allowedRoot}"`,
+      };
+    }
+    return { allowed: true };
+  };
+}
+
+function makeTarget(dir, overrides = {}) {
+  return {
+    type: "endpoint",
+    reference: "test-endpoint",
+    certPath: path.join(dir, "server.crt"),
+    ...overrides,
+  };
+}
+
+// Symlink creation on win32 requires elevation or Developer Mode; probe
+// once and skip symlink tests when unavailable (same approach as the
+// discovery tests take for openssl availability).
+function canCreateSymlinks() {
+  const dir = makeTempDir();
+  const targetFile = path.join(dir, "probe-target");
+  const linkPath = path.join(dir, "probe-link");
+  fs.writeFileSync(targetFile, "probe", "utf8");
+  try {
+    fs.symlinkSync(targetFile, linkPath);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+const SYMLINKS_AVAILABLE = canCreateSymlinks();
+const SYMLINK_SKIP = SYMLINKS_AVAILABLE
+  ? false
+  : "symlink creation is not permitted on this machine (win32 without privilege)";
+
+beforeEach(() => {
+  resetDeployMetrics();
+});
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (_err) {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe("validateTargetConfig", () => {
+  it("accepts a well-formed target with existing parent dir and allowed path", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(makeTarget(dir), {
+      checkPath: makeCheckPath(dir),
+    });
+    assert.deepEqual(result, { valid: true });
+  });
+
+  it("rejects a non-object target", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(null, { checkPath: makeCheckPath(dir) });
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /must be an object/);
+  });
+
+  it("rejects an unknown target.type", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(
+      makeTarget(dir, { type: "mainframe" }),
+      { checkPath: makeCheckPath(dir) },
+    );
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /target\.type/);
+  });
+
+  it("rejects a relative certPath", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(
+      makeTarget(dir, { certPath: "relative/server.crt" }),
+      { checkPath: makeCheckPath(dir) },
+    );
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /absolute path/);
+  });
+
+  it("rejects a certPath whose parent directory does not exist", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(
+      makeTarget(dir, { certPath: path.join(dir, "missing-subdir", "server.crt") }),
+      { checkPath: makeCheckPath(dir) },
+    );
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /parent directory does not exist/);
+  });
+
+  it("rejects a certPath the checkPath callback disallows", () => {
+    const dir = makeTempDir();
+    const otherDir = makeTempDir();
+    const result = validateTargetConfig(makeTarget(otherDir), {
+      checkPath: makeCheckPath(dir),
+    });
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /rejected by policy/);
+    assert.match(result.detail, /path_not_allowlisted/);
+  });
+
+  it("validates optional backupDir as an existing, policy-allowed directory", () => {
+    const dir = makeTempDir();
+    const result = validateTargetConfig(
+      makeTarget(dir, { backupDir: path.join(dir, "does-not-exist") }),
+      { checkPath: makeCheckPath(dir) },
+    );
+    assert.equal(result.valid, false);
+    assert.match(result.detail, /backupDir/);
+  });
+
+  it("throws (programmer error) when no checkPath callback is provided", () => {
+    const dir = makeTempDir();
+    assert.throws(
+      () => validateTargetConfig(makeTarget(dir), {}),
+      /checkPath callback is required/,
+    );
+  });
+});
+
+describe("deployCertificate", () => {
+  it("happy path: writes content atomically with a restrictive mode", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+
+    const result = await deployCertificate({
+      target,
+      certificatePem: CERT_PEM,
+      checkPath: makeCheckPath(dir),
+    });
+
+    assert.equal(result.deployed, true);
+    assert.equal(result.skipped, false);
+    assert.equal(result.backupPath, null);
+    assert.equal(fs.readFileSync(target.certPath, "utf8"), CERT_PEM);
+
+    if (process.platform !== "win32") {
+      const mode = fs.statSync(target.certPath).mode & 0o777;
+      assert.equal(mode, 0o600);
+    }
+
+    // No temp files may be left behind.
+    const leftovers = fs.readdirSync(dir).filter((name) => name.endsWith(".tmp"));
+    assert.deepEqual(leftovers, []);
+  });
+
+  it("records an idempotent skip when the destination already has identical bytes", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+    const checkPath = makeCheckPath(dir);
+
+    const first = await deployCertificate({ target, certificatePem: CERT_PEM, checkPath });
+    assert.equal(first.deployed, true);
+    const mtimeAfterFirst = fs.statSync(target.certPath).mtimeMs;
+
+    const second = await deployCertificate({ target, certificatePem: CERT_PEM, checkPath });
+
+    assert.equal(second.deployed, false);
+    assert.equal(second.skipped, true);
+    assert.equal(second.reason, "idempotent");
+    // The file must not have been touched at all.
+    assert.equal(fs.statSync(target.certPath).mtimeMs, mtimeAfterFirst);
+    // And no backup may have been created for a skip.
+    const backups = fs.readdirSync(dir).filter((name) => name.endsWith(".bak"));
+    assert.deepEqual(backups, []);
+  });
+
+  it("creates a timestamped backup when overwriting different content", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+    const checkPath = makeCheckPath(dir);
+    const fixedNow = new Date("2026-07-22T05:00:00.000Z");
+
+    await deployCertificate({ target, certificatePem: CERT_PEM, checkPath });
+    const result = await deployCertificate({
+      target,
+      certificatePem: OTHER_CERT_PEM,
+      checkPath,
+      now: () => fixedNow,
+    });
+
+    assert.equal(result.deployed, true);
+    assert.ok(result.backupPath, "expected a backupPath in the result");
+    assert.equal(
+      path.basename(result.backupPath),
+      "server.crt.2026-07-22T05-00-00.000Z.bak",
+    );
+    assert.equal(fs.readFileSync(result.backupPath, "utf8"), CERT_PEM);
+    assert.equal(fs.readFileSync(target.certPath, "utf8"), OTHER_CERT_PEM);
+  });
+
+  it("honors target.backupDir for the backup location", async () => {
+    const dir = makeTempDir();
+    const backupDir = path.join(dir, "backups");
+    fs.mkdirSync(backupDir);
+    const target = makeTarget(dir, { backupDir });
+    const checkPath = makeCheckPath(dir);
+
+    await deployCertificate({ target, certificatePem: CERT_PEM, checkPath });
+    const result = await deployCertificate({
+      target,
+      certificatePem: OTHER_CERT_PEM,
+      checkPath,
+    });
+
+    assert.equal(result.deployed, true);
+    assert.equal(path.dirname(result.backupPath), backupDir);
+  });
+
+  it("rolls back from the backup when the atomic write fails", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+    const checkPath = makeCheckPath(dir);
+
+    await deployCertificate({ target, certificatePem: CERT_PEM, checkPath });
+
+    const result = await deployCertificate({
+      target,
+      certificatePem: OTHER_CERT_PEM,
+      checkPath,
+      // TEST-ONLY fs override: force the final rename to fail after the
+      // backup has been taken, exercising the rollback path.
+      _fsOverrides: {
+        rename: () => Promise.reject(new Error("injected rename failure")),
+      },
+    });
+
+    assert.equal(result.deployed, false);
+    assert.equal(result.rolledBack, true);
+    assert.equal(result.stage, "write");
+    assert.match(result.error, /injected rename failure/);
+    // Original content restored.
+    assert.equal(fs.readFileSync(target.certPath, "utf8"), CERT_PEM);
+  });
+
+  it("refuses (throws) a payload containing a private-key PEM marker", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+
+    await assert.rejects(
+      deployCertificate({
+        target,
+        certificatePem: CERT_PEM + PRIVATE_KEY_PEM,
+        checkPath: makeCheckPath(dir),
+      }),
+      /private-key PEM marker/,
+    );
+    // Nothing may have been written.
+    assert.equal(fs.existsSync(target.certPath), false);
+  });
+
+  it("returns a validate-stage failure (not a throw) for a policy-rejected target", async () => {
+    const dir = makeTempDir();
+    const otherDir = makeTempDir();
+    const target = makeTarget(otherDir);
+
+    const result = await deployCertificate({
+      target,
+      certificatePem: CERT_PEM,
+      checkPath: makeCheckPath(dir),
+    });
+
+    assert.equal(result.deployed, false);
+    assert.equal(result.stage, "validate");
+    assert.match(result.error, /rejected by policy/);
+  });
+
+  it(
+    "rejects a symlinked destination escaping the allowed root (realpath re-check)",
+    { skip: SYMLINK_SKIP },
+    async () => {
+      const allowedRoot = makeTempDir();
+      const outsideDir = makeTempDir();
+      const outsideFile = path.join(outsideDir, "victim.crt");
+      fs.writeFileSync(outsideFile, "outside content\n", "utf8");
+
+      // Lexically inside allowedRoot, but actually a symlink escaping it.
+      const linkPath = path.join(allowedRoot, "server.crt");
+      fs.symlinkSync(outsideFile, linkPath);
+
+      const result = await deployCertificate({
+        target: makeTarget(allowedRoot),
+        certificatePem: CERT_PEM,
+        checkPath: makeCheckPath(allowedRoot),
+      });
+
+      assert.equal(result.deployed, false);
+      assert.equal(result.stage, "realpath-policy");
+      assert.match(result.error, /escapes the allowlisted roots/);
+      // The outside file must be untouched.
+      assert.equal(fs.readFileSync(outsideFile, "utf8"), "outside content\n");
+    },
+  );
+
+  it(
+    "rejects a symlinked parent directory escaping the allowed root",
+    { skip: SYMLINK_SKIP },
+    async () => {
+      const allowedRoot = makeTempDir();
+      const outsideDir = makeTempDir();
+
+      const linkedSubdir = path.join(allowedRoot, "tls");
+      fs.symlinkSync(outsideDir, linkedSubdir, "dir");
+
+      const result = await deployCertificate({
+        target: makeTarget(allowedRoot, {
+          certPath: path.join(linkedSubdir, "server.crt"),
+        }),
+        certificatePem: CERT_PEM,
+        checkPath: makeCheckPath(allowedRoot),
+      });
+
+      assert.equal(result.deployed, false);
+      assert.equal(result.stage, "realpath-policy");
+      assert.deepEqual(fs.readdirSync(outsideDir), []);
+    },
+  );
+});
+
+describe("deployCertificate per-destination mutex", () => {
+  it("serializes two concurrent deploys to the same destination in call order", async () => {
+    const dir = makeTempDir();
+    const target = makeTarget(dir);
+    const checkPath = makeCheckPath(dir);
+    const events = [];
+
+    // Slow down the first deploy's realpath so, without a mutex, the second
+    // deploy would interleave with (and finish before) the first.
+    const realFsp = require("node:fs/promises");
+    let firstCall = true;
+    const slowRealpath = async (p) => {
+      const isFirst = firstCall;
+      firstCall = false;
+      if (isFirst) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return realFsp.realpath(p);
+    };
+
+    const first = deployCertificate({
+      target,
+      certificatePem: CERT_PEM,
+      checkPath,
+      _fsOverrides: { realpath: slowRealpath },
+    }).then((result) => {
+      events.push("first-done");
+      return result;
+    });
+    const second = deployCertificate({
+      target,
+      certificatePem: OTHER_CERT_PEM,
+      checkPath,
+      _fsOverrides: { realpath: slowRealpath },
+    }).then((result) => {
+      events.push("second-done");
+      return result;
+    });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    assert.deepEqual(events, ["first-done", "second-done"]);
+    assert.equal(firstResult.deployed, true);
+    assert.equal(secondResult.deployed, true);
+    // The second deploy ran after the first completed, so it saw the first
+    // deploy's content on disk and backed it up before overwriting.
+    assert.ok(secondResult.backupPath);
+    assert.equal(fs.readFileSync(secondResult.backupPath, "utf8"), CERT_PEM);
+    assert.equal(fs.readFileSync(target.certPath, "utf8"), OTHER_CERT_PEM);
+  });
+
+  it("lets deploys to different destinations proceed independently", async () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+
+    const [resultA, resultB] = await Promise.all([
+      deployCertificate({
+        target: makeTarget(dirA),
+        certificatePem: CERT_PEM,
+        checkPath: makeCheckPath(dirA),
+      }),
+      deployCertificate({
+        target: makeTarget(dirB),
+        certificatePem: OTHER_CERT_PEM,
+        checkPath: makeCheckPath(dirB),
+      }),
+    ]);
+
+    assert.equal(resultA.deployed, true);
+    assert.equal(resultB.deployed, true);
+  });
+});
+
+describe("deploy metrics", () => {
+  it("increments per-target-type counters across outcomes", async () => {
+    const dir = makeTempDir();
+    const checkPath = makeCheckPath(dir);
+    const endpointTarget = makeTarget(dir);
+    const applianceTarget = makeTarget(dir, {
+      type: "appliance",
+      certPath: path.join(dir, "appliance.crt"),
+    });
+
+    // endpoint: success, then idempotent skip, then a rollback failure.
+    await deployCertificate({ target: endpointTarget, certificatePem: CERT_PEM, checkPath });
+    await deployCertificate({ target: endpointTarget, certificatePem: CERT_PEM, checkPath });
+    await deployCertificate({
+      target: endpointTarget,
+      certificatePem: OTHER_CERT_PEM,
+      checkPath,
+      _fsOverrides: {
+        rename: () => Promise.reject(new Error("injected rename failure")),
+      },
+    });
+    // appliance: one success.
+    await deployCertificate({ target: applianceTarget, certificatePem: CERT_PEM, checkPath });
+
+    const metrics = getDeployMetrics();
+
+    assert.deepEqual(metrics.endpoint, {
+      attempts: 3,
+      succeeded: 1,
+      idempotentSkips: 1,
+      rollbacks: 1,
+      failures: 1,
+    });
+    assert.deepEqual(metrics.appliance, {
+      attempts: 1,
+      succeeded: 1,
+      idempotentSkips: 0,
+      rollbacks: 0,
+      failures: 0,
+    });
+  });
+
+  it("resetDeployMetrics clears all counters", async () => {
+    const dir = makeTempDir();
+    await deployCertificate({
+      target: makeTarget(dir),
+      certificatePem: CERT_PEM,
+      checkPath: makeCheckPath(dir),
+    });
+    assert.ok(getDeployMetrics().endpoint);
+
+    resetDeployMetrics();
+
+    assert.deepEqual(getDeployMetrics(), {});
+  });
+
+  it("returns snapshots that do not leak internal state (mutation-safe)", async () => {
+    const dir = makeTempDir();
+    await deployCertificate({
+      target: makeTarget(dir),
+      certificatePem: CERT_PEM,
+      checkPath: makeCheckPath(dir),
+    });
+
+    const snapshot = getDeployMetrics();
+    snapshot.endpoint.attempts = 999;
+
+    assert.equal(getDeployMetrics().endpoint.attempts, 1);
+  });
+});

--- a/packages/agent/src/deploy/index.js
+++ b/packages/agent/src/deploy/index.js
@@ -1,0 +1,569 @@
+"use strict";
+
+/**
+ * Atomic certificate deployment (CertOps M5).
+ *
+ * Deploys PUBLIC certificate PEM material to a target filesystem path with:
+ *   - target-config re-validation before EVERY deploy (validateTargetConfig)
+ *   - fs.realpath containment re-check on the final destination immediately
+ *     before write (the policy module's documented follow-up: policy does
+ *     lexical checks only; symlink-aware realpath checks belong here)
+ *   - idempotency: byte-identical content is never rewritten (recorded as
+ *     an idempotent skip)
+ *   - timestamped backup of any existing file before overwrite
+ *   - atomic write (temp file in the SAME directory + rename, so the rename
+ *     never crosses devices), with fsync of the file and, where the
+ *     platform allows, the containing directory
+ *   - automatic rollback (restore backup) on any failure after backup
+ *   - a per-destination in-process async mutex serializing concurrent
+ *     deploys to the same resolved path
+ *   - per-target-type counters (attempts, succeeded, idempotentSkips,
+ *     rollbacks, failures) exposed via getDeployMetrics() for evidence
+ *     metadata (public, non-secret values only)
+ *
+ * Zero private-key custody (D5, ADR-0001): this module deploys public
+ * certificates ONLY. M5 Dev B scope deploys public certs; cert and key
+ * deploys are separate targets. As defense in depth, deployCertificate
+ * THROWS if the payload contains a PEM private-key marker, regardless of
+ * what the caller claims the payload is.
+ *
+ * Policy decoupling: this module never loads policy config itself. The
+ * caller (dispatch layer) passes a `checkPath(filePath)` callback -- in
+ * production, the policy engine's checkPath -- returning
+ * { allowed, rejectionReason?, detail? }. This module calls it for every
+ * path it is about to touch (destination, chain destination, backup dir),
+ * including once more against the realpath-resolved destination so a
+ * symlink cannot escape the allowlisted roots.
+ *
+ * This module is self-contained: it accepts plain data as function
+ * parameters and does not import sibling agent modules (config, policy,
+ * etc.). Wiring is left to src/index.js.
+ *
+ * Windows note: directory fsync is not supported on win32 (fs.open on a
+ * directory fails with EISDIR/EPERM), so the post-rename directory fsync is
+ * best-effort and skipped there; the file-content fsync before rename still
+ * runs on every platform. Likewise POSIX modes (0o600/0o644) are asserted
+ * best-effort on win32, mirroring the config module's convention.
+ */
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+// Mirrors discovery/index.js's PRIVATE_KEY_PEM_HEADER_PATTERN (which itself
+// mirrors apps/api/utils/secretMaterial.js). Duplicated, not imported, to
+// keep this module self-contained per package convention. Matches PKCS#8,
+// PKCS#1 (RSA), SEC1 (EC), DSA, and ENCRYPTED variants; does NOT match
+// PUBLIC KEY / CERTIFICATE blocks.
+const PRIVATE_KEY_PEM_HEADER_PATTERN = new RegExp(
+  String.raw`-----\s*BEGIN\s+(?:[A-Z0-9]+\s+)*PRIVATE\s+KEY\s*-----`,
+  "i",
+);
+
+// Restrictive mode for deployed certificate files and their backups.
+// Certificates are public material, but 0o600 matches the package's
+// "restrictive by default" convention (config module: 0600 files in 0700
+// dirs); operators can relax modes out-of-band if a consumer needs it.
+const DEPLOYED_FILE_MODE = 0o600;
+
+// Valid target.type values, per
+// packages/contracts/certops/job-payload.schema.json target.type enum.
+const VALID_TARGET_TYPES = Object.freeze([
+  "domain",
+  "endpoint",
+  "kubernetes",
+  "appliance",
+  "load-balancer",
+  "external",
+]);
+
+// --- Per-destination async mutex ------------------------------------------
+
+/**
+ * Map of resolved destination path -> tail promise of the chain. A deploy
+ * to a destination awaits the current tail, then replaces it; concurrent
+ * deploys to the SAME destination therefore serialize in call order, while
+ * deploys to different destinations proceed in parallel. Entries are
+ * removed once the chain drains so the map does not grow unboundedly.
+ * @type {Map<string, Promise<void>>}
+ */
+const destinationLocks = new Map();
+
+/**
+ * Runs `task` under the mutex for `lockKey`. The returned promise settles
+ * with task's outcome; the internal chain never rejects (failures are
+ * swallowed in the chain link only) so one failed deploy cannot poison the
+ * lock for the next caller.
+ *
+ * @param {string} lockKey
+ * @param {() => Promise<T>} task
+ * @returns {Promise<T>}
+ * @template T
+ */
+function withDestinationLock(lockKey, task) {
+  const previousTail = destinationLocks.get(lockKey) || Promise.resolve();
+
+  const run = previousTail.then(task);
+
+  // The chain link must not reject, or every later waiter would see this
+  // deploy's error instead of its own result.
+  const tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  destinationLocks.set(lockKey, tail);
+
+  tail.finally(() => {
+    if (destinationLocks.get(lockKey) === tail) {
+      destinationLocks.delete(lockKey);
+    }
+  });
+
+  return run;
+}
+
+// --- Metrics ---------------------------------------------------------------
+
+/**
+ * Per-target-type deploy counters, suitable for evidence metadata entries.
+ * All values are public, non-secret integers.
+ * @type {Map<string, { attempts: number, succeeded: number, idempotentSkips: number, rollbacks: number, failures: number }>}
+ */
+const metricsByTargetType = new Map();
+
+function metricsFor(targetType) {
+  let entry = metricsByTargetType.get(targetType);
+  if (!entry) {
+    entry = {
+      attempts: 0,
+      succeeded: 0,
+      idempotentSkips: 0,
+      rollbacks: 0,
+      failures: 0,
+    };
+    metricsByTargetType.set(targetType, entry);
+  }
+  return entry;
+}
+
+/**
+ * Returns a deep copy of the per-target-type deploy counters:
+ * { [targetType]: { attempts, succeeded, idempotentSkips, rollbacks, failures } }.
+ * Values are public, non-secret integers intended for evidence metadata.
+ * @returns {Record<string, { attempts: number, succeeded: number, idempotentSkips: number, rollbacks: number, failures: number }>}
+ */
+function getDeployMetrics() {
+  const snapshot = {};
+  for (const [targetType, counters] of metricsByTargetType) {
+    snapshot[targetType] = { ...counters };
+  }
+  return snapshot;
+}
+
+/**
+ * Resets all deploy counters. Test helper.
+ * @returns {void}
+ */
+function resetDeployMetrics() {
+  metricsByTargetType.clear();
+}
+
+// --- Target validation -------------------------------------------------------
+
+function invalid(detail) {
+  return { valid: false, detail };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isExistingDirectory(fsImpl, dirPath) {
+  try {
+    return fsImpl.statSync(dirPath).isDirectory();
+  } catch (_err) {
+    return false;
+  }
+}
+
+/**
+ * Re-validates a deploy target descriptor. Called before EVERY deploy (a
+ * target validated at job-accept time may have gone stale: directories
+ * removed, policy changed), and callable standalone by the dispatch layer.
+ *
+ * Expected shape (job-payload.schema.json target plus deploy fields):
+ *   {
+ *     type: "domain"|"endpoint"|"kubernetes"|"appliance"|"load-balancer"|"external",
+ *     reference: string,           // non-secret target reference
+ *     certPath: string,            // absolute destination for the cert PEM
+ *     chainPath?: string,          // optional absolute destination for the chain PEM
+ *     backupDir?: string,          // optional absolute dir for timestamped backups
+ *   }
+ *
+ * Checks, in order: shape/type, absolute paths, parent directories exist,
+ * and policy allowance via the injected `checkPath` callback for certPath,
+ * chainPath, and backupDir (when present). `checkPath` must return
+ * { allowed: boolean, rejectionReason?: string, detail?: string } -- in
+ * production this is the policy engine's checkPath, keeping this module
+ * decoupled from the policy module.
+ *
+ * @param {object} target
+ * @param {{ checkPath: (filePath: string) => { allowed: boolean, rejectionReason?: string, detail?: string }, _fsOverrides?: object }} options
+ * @returns {{ valid: true } | { valid: false, detail: string }}
+ */
+function validateTargetConfig(target, { checkPath, _fsOverrides } = {}) {
+  const fsImpl = { ...fs, ..._fsOverrides };
+
+  if (target === null || typeof target !== "object" || Array.isArray(target)) {
+    return invalid("deploy: target must be an object");
+  }
+  if (typeof checkPath !== "function") {
+    // Programmer error, not a target problem: wiring without a policy
+    // callback must fail loudly, never silently allow.
+    throw new Error("deploy: a checkPath callback is required");
+  }
+
+  if (!VALID_TARGET_TYPES.includes(target.type)) {
+    return invalid(
+      `deploy: target.type must be one of ${VALID_TARGET_TYPES.join(", ")} (got ${JSON.stringify(target.type)})`,
+    );
+  }
+  if (!isNonEmptyString(target.reference)) {
+    return invalid("deploy: target.reference must be a non-empty string");
+  }
+
+  const pathFields = [["certPath", target.certPath, true]];
+  if (target.chainPath !== undefined && target.chainPath !== null) {
+    pathFields.push(["chainPath", target.chainPath, false]);
+  }
+  if (target.backupDir !== undefined && target.backupDir !== null) {
+    pathFields.push(["backupDir", target.backupDir, false]);
+  }
+
+  for (const [fieldName, fieldValue, required] of pathFields) {
+    if (!isNonEmptyString(fieldValue)) {
+      if (required) {
+        return invalid(`deploy: target.${fieldName} must be a non-empty string`);
+      }
+      continue;
+    }
+    if (!path.isAbsolute(fieldValue)) {
+      return invalid(
+        `deploy: target.${fieldName} must be an absolute path (got ${JSON.stringify(fieldValue)})`,
+      );
+    }
+
+    // backupDir is itself a directory; the file paths' parents must exist.
+    const dirToCheck =
+      fieldName === "backupDir" ? fieldValue : path.dirname(fieldValue);
+    if (!isExistingDirectory(fsImpl, dirToCheck)) {
+      return invalid(
+        `deploy: target.${fieldName} ${fieldName === "backupDir" ? "directory" : "parent directory"} does not exist: ${JSON.stringify(dirToCheck)}`,
+      );
+    }
+
+    const policyResult = checkPath(fieldValue);
+    if (!policyResult || policyResult.allowed !== true) {
+      const reason = policyResult?.rejectionReason || "path_not_allowlisted";
+      const detail = policyResult?.detail || "no detail provided";
+      return invalid(
+        `deploy: target.${fieldName} rejected by policy (${reason}): ${detail}`,
+      );
+    }
+  }
+
+  return { valid: true };
+}
+
+// --- Atomic write helpers ----------------------------------------------------
+
+/**
+ * fsyncs a directory so a preceding rename in it becomes durable. On win32
+ * directories cannot be opened for fsync (EISDIR/EPERM/EACCES), so this is
+ * documented best-effort: it swallows the error there (and on any other
+ * platform quirk) rather than failing an otherwise-complete deploy. The
+ * file-content fsync before rename is NOT best-effort and runs everywhere.
+ *
+ * @param {typeof fsp} fspImpl
+ * @param {string} dirPath
+ * @returns {Promise<void>}
+ */
+async function fsyncDirBestEffort(fspImpl, dirPath) {
+  let handle;
+  try {
+    handle = await fspImpl.open(dirPath, "r");
+    await handle.sync();
+  } catch (_err) {
+    // win32 (and some filesystems) cannot fsync a directory; the rename is
+    // still atomic on the same volume, just not guaranteed durable across
+    // an immediate power loss. Documented platform limitation.
+  } finally {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch (_err) {
+        // best-effort close
+      }
+    }
+  }
+}
+
+/**
+ * Atomically writes `content` to `destinationPath`: temp file created in
+ * the SAME directory (so the final rename never crosses devices/volumes,
+ * which would silently degrade to copy+delete and lose atomicity), written
+ * with the restrictive mode, fsynced, renamed over the destination, then
+ * the directory is fsynced where the platform allows.
+ *
+ * The temp file is unlinked on any failure so no partial write is left
+ * behind.
+ *
+ * @param {typeof fsp} fspImpl
+ * @param {string} destinationPath
+ * @param {string|Buffer} content
+ * @returns {Promise<void>}
+ */
+async function atomicWrite(fspImpl, destinationPath, content) {
+  const dirPath = path.dirname(destinationPath);
+  const tempPath = path.join(
+    dirPath,
+    `.${path.basename(destinationPath)}.${crypto.randomBytes(6).toString("hex")}.tmp`,
+  );
+
+  let handle;
+  try {
+    handle = await fspImpl.open(tempPath, "wx", DEPLOYED_FILE_MODE);
+    await handle.writeFile(content);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fspImpl.rename(tempPath, destinationPath);
+  } catch (err) {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch (_err) {
+        // best-effort close before cleanup
+      }
+    }
+    try {
+      await fspImpl.unlink(tempPath);
+    } catch (_err) {
+      // temp file may never have been created
+    }
+    throw err;
+  }
+
+  await fsyncDirBestEffort(fspImpl, dirPath);
+}
+
+/**
+ * Builds the timestamped backup path for an existing destination file:
+ * `<backupDir>/<basename>.<ISO-ts>.bak`, with colons replaced by "-" so the
+ * name is valid on win32. Defaults backupDir to the destination's own
+ * directory ("alongside destination").
+ *
+ * @param {string} destinationPath
+ * @param {string|undefined} backupDir
+ * @param {Date} now
+ * @returns {string}
+ */
+function backupPathFor(destinationPath, backupDir, now) {
+  const timestamp = now.toISOString().replace(/:/g, "-");
+  const dir = backupDir || path.dirname(destinationPath);
+  return path.join(dir, `${path.basename(destinationPath)}.${timestamp}.bak`);
+}
+
+// --- Deploy ------------------------------------------------------------------
+
+/**
+ * Deploys a public certificate PEM to target.certPath, atomically and with
+ * rollback. See the module docblock for the full step list.
+ *
+ * REFUSES (throws) if `certificatePem` contains a PEM private-key marker:
+ * this module deploys public certificates only (M5 Dev B scope; cert and
+ * key deploys are separate targets), and a key showing up here means an
+ * upstream bug or an attack, either of which must fail loudly (D5 zero
+ * key custody, defense in depth).
+ *
+ * Never throws for operational failures (bad target, policy rejection,
+ * filesystem errors): those come back as { deployed: false, ... } result
+ * shapes. Throws only on programmer error (missing checkPath, key
+ * material in the payload, non-string payload).
+ *
+ * Result shapes:
+ *   { deployed: true,  skipped: false, destination, backupPath|null }
+ *   { deployed: false, skipped: true,  reason: "idempotent", destination }
+ *   { deployed: false, skipped: false, error, stage }                       // failed before touching the file
+ *   { deployed: false, skipped: false, rolledBack: true|false, error, stage } // failed during write
+ *
+ * @param {{
+ *   target: object,           // see validateTargetConfig
+ *   certificatePem: string,   // public certificate PEM (cert or cert+chain)
+ *   checkPath: (filePath: string) => { allowed: boolean, rejectionReason?: string, detail?: string },
+ *   now?: () => Date,         // injectable clock for deterministic backup names
+ *   _fsOverrides?: object,    // TEST-ONLY: shadows node:fs/promises methods
+ *                             // (e.g. { rename: () => Promise.reject(...) })
+ *                             // to inject failures; never use in production.
+ * }} params
+ * @returns {Promise<object>} one of the result shapes above
+ */
+async function deployCertificate({
+  target,
+  certificatePem,
+  checkPath,
+  now = () => new Date(),
+  _fsOverrides,
+} = {}) {
+  if (typeof certificatePem !== "string" || certificatePem.length === 0) {
+    throw new Error("deploy: certificatePem must be a non-empty string");
+  }
+  if (PRIVATE_KEY_PEM_HEADER_PATTERN.test(certificatePem)) {
+    throw new Error(
+      "deploy: payload contains a private-key PEM marker; this module deploys " +
+        "public certificates only and never handles key material (D5 zero key custody)",
+    );
+  }
+  if (typeof checkPath !== "function") {
+    throw new Error("deploy: a checkPath callback is required");
+  }
+
+  const fspImpl = { ...fsp, ..._fsOverrides };
+  const targetType =
+    target && typeof target.type === "string" ? target.type : "unknown";
+  const counters = metricsFor(targetType);
+  counters.attempts += 1;
+
+  function failure(stage, error, rolledBack) {
+    counters.failures += 1;
+    const result = { deployed: false, skipped: false, stage, error };
+    if (rolledBack !== undefined) {
+      result.rolledBack = rolledBack;
+      if (rolledBack) counters.rollbacks += 1;
+    }
+    return result;
+  }
+
+  // (1) Re-validate the target config before EVERY deploy. Validation uses
+  // the real filesystem (sync stat checks); _fsOverrides only shadows the
+  // async fs/promises operations used by the write path below.
+  const validation = validateTargetConfig(target, { checkPath });
+  if (!validation.valid) {
+    return failure("validate", validation.detail);
+  }
+
+  const destination = path.normalize(path.resolve(target.certPath));
+
+  // The mutex key is the resolved destination path so two descriptors
+  // spelling the same file differently still serialize.
+  return await withDestinationLock(destination, async () => {
+    // (2) realpath containment re-check, symlink-aware. The policy module's
+    // checkPath is lexical only; here, immediately before writing, resolve
+    // symlinks on the deepest existing ancestor (the destination file
+    // itself may not exist yet) and re-run the policy callback against the
+    // real path. A symlinked parent dir pointing outside the allowlisted
+    // roots is rejected even though the lexical path looked fine.
+    let realDestination;
+    try {
+      const parentReal = await fspImpl.realpath(path.dirname(destination));
+      realDestination = path.join(parentReal, path.basename(destination));
+      // If the destination itself exists and is a symlink, resolve it too.
+      try {
+        realDestination = await fspImpl.realpath(realDestination);
+      } catch (err) {
+        if (err?.code !== "ENOENT") throw err;
+      }
+    } catch (err) {
+      return failure("realpath", `deploy: could not resolve destination realpath: ${err?.message || err}`);
+    }
+
+    const realPathPolicy = checkPath(realDestination);
+    if (!realPathPolicy || realPathPolicy.allowed !== true) {
+      return failure(
+        "realpath-policy",
+        `deploy: resolved destination ${JSON.stringify(realDestination)} escapes the ` +
+          `allowlisted roots (${realPathPolicy?.rejectionReason || "path_not_allowlisted"}): ` +
+          `${realPathPolicy?.detail || "no detail provided"}`,
+      );
+    }
+
+    // (3) Idempotency: byte-identical content is a recorded no-op.
+    let existingContent = null;
+    try {
+      existingContent = await fspImpl.readFile(realDestination);
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+        return failure("read-existing", `deploy: could not read existing destination: ${err?.message || err}`);
+      }
+    }
+    if (existingContent !== null && existingContent.equals(Buffer.from(certificatePem, "utf8"))) {
+      counters.idempotentSkips += 1;
+      return {
+        deployed: false,
+        skipped: true,
+        reason: "idempotent",
+        destination: realDestination,
+      };
+    }
+
+    // (4) Timestamped backup of the existing file (if any), same
+    // restrictive mode as the deployed file.
+    let backupPath = null;
+    if (existingContent !== null) {
+      backupPath = backupPathFor(realDestination, target.backupDir, now());
+      try {
+        await fspImpl.writeFile(backupPath, existingContent, {
+          mode: DEPLOYED_FILE_MODE,
+        });
+      } catch (err) {
+        return failure("backup", `deploy: could not write backup: ${err?.message || err}`);
+      }
+    }
+
+    // (5) Atomic write; (6) rollback from backup on failure.
+    try {
+      await atomicWrite(fspImpl, realDestination, certificatePem);
+    } catch (err) {
+      let rolledBack = false;
+      if (backupPath !== null) {
+        try {
+          await fspImpl.writeFile(realDestination, existingContent, {
+            mode: DEPLOYED_FILE_MODE,
+          });
+          rolledBack = true;
+        } catch (_rollbackErr) {
+          // Rollback itself failed; surface the original error with
+          // rolledBack: false so the operator knows the backup file still
+          // holds the previous content.
+        }
+      }
+      return failure("write", `deploy: atomic write failed: ${err?.message || err}`, rolledBack);
+    }
+
+    // Re-assert the restrictive mode (best-effort on win32, mirroring the
+    // config module's convention).
+    try {
+      await fspImpl.chmod(realDestination, DEPLOYED_FILE_MODE);
+    } catch (_err) {
+      // best-effort on win32
+    }
+
+    counters.succeeded += 1;
+    return {
+      deployed: true,
+      skipped: false,
+      destination: realDestination,
+      backupPath,
+    };
+  });
+}
+
+module.exports = {
+  validateTargetConfig,
+  deployCertificate,
+  getDeployMetrics,
+  resetDeployMetrics,
+  DEPLOYED_FILE_MODE,
+  VALID_TARGET_TYPES,
+};

--- a/packages/agent/src/deploy/index.js
+++ b/packages/agent/src/deploy/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Atomic certificate deployment (CertOps M5).
+ * Atomic certificate deployment.
  *
  * Deploys PUBLIC certificate PEM material to a target filesystem path with:
  *   - target-config re-validation before EVERY deploy (validateTargetConfig)
@@ -22,7 +22,7 @@
  *     metadata (public, non-secret values only)
  *
  * Zero private-key custody (D5, ADR-0001): this module deploys public
- * certificates ONLY. M5 Dev B scope deploys public certs; cert and key
+ * certificates ONLY. This scope deploys public certs; cert and key
  * deploys are separate targets. As defense in depth, deployCertificate
  * THROWS if the payload contains a PEM private-key marker, regardless of
  * what the caller claims the payload is.
@@ -382,7 +382,7 @@ function backupPathFor(destinationPath, backupDir, now) {
  * rollback. See the module docblock for the full step list.
  *
  * REFUSES (throws) if `certificatePem` contains a PEM private-key marker:
- * this module deploys public certificates only (M5 Dev B scope; cert and
+ * this module deploys public certificates only (cert and
  * key deploys are separate targets), and a key showing up here means an
  * upstream bug or an attack, either of which must fail loudly (D5 zero
  * key custody, defense in depth).

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -9,7 +9,7 @@
  * stores them. Every module here must stay safe to run against an untrusted
  * or compromised control plane (agent-local policy wins, ADR-0002).
  *
- * Bootstrap scope (current): this file wires the landed modules together
+ * M4 bootstrap scope (current): this file wires the landed modules together
  * into a runnable outbound-only process:
  *   - config: config.json + secure credential storage (src/config)
  *   - policy: agent-local allowlist engine, default-deny (src/policy)
@@ -19,24 +19,49 @@
  *   - discovery: observe-only filesystem certificate inventory, reported as
  *     certificate.observed evidence (src/discovery)
  *
- * Job execution is deliberately NOT implemented here. Ed25519 signature
- * verification, the replay cache, and clock-drift handling are runtime
- * runtime work (ADR-0003); until that lands, every policy-allowed job is
- * reported back as "blocked" with an explanatory error message, and every
- * policy-rejected job is reported as "rejected" with evidence. This keeps
- * the full outbound loop (register -> heartbeat -> claim -> result/evidence)
- * exercisable end to end against the fake-agent harness without ever
- * running an unverified job.
+ * M5 signed-job dispatch (current, opt-in via config.execution.enabled):
+ * jobs claimed from the control plane run through the full trust chain
+ * before any execution: Ed25519 signature verification against the pinned
+ * signing key (src/signing) -> replay-cache check (src/replay) -> clock
+ * window check with drift compensation (src/clock) -> agent-local policy
+ * (src/policy) -> replay consume -> execute. Execution modules: src/keys,
+ * src/acme, src/deploy, src/reload, src/verify.
  *
- * Execution scope (future): src/keys, src/x509, src/acme, src/deploy, src/reload,
- * src/connectors become load-bearing; today they are placeholders.
+ * When execution is NOT enabled (config.execution absent or enabled:false),
+ * the M4 bootstrap behavior is preserved exactly: every policy-allowed job
+ * is reported back as "blocked" with an explanatory error message, and
+ * every policy-rejected job is reported as "rejected" with evidence. This
+ * keeps the full outbound loop (register -> heartbeat -> claim ->
+ * result/evidence) exercisable end to end without ever running an
+ * unverified job.
+ *
+ * Known M2-payload deviations (job-payload.schema.json lacks M5 execution
+ * fields; documented for Dev A's Phase 4/5 backend contract):
+ *   - No domains list => the CSR CN and ACME -d domain come from
+ *     job.target.reference.
+ *   - No keyRotation flag => renew reuses an existing key at
+ *     <keysDir>/<certificateId>.key.pem and generates one only when absent;
+ *     keyRotated reports whether a new key was generated. A truthy
+ *     job.keyRotation (forward-compatible) forces regeneration.
+ *   - No certPath field => job.certPath is honored when present; otherwise
+ *     target.reference is used as the deploy destination when it is an
+ *     absolute path. Neither present/absolute => renew deploys nowhere it
+ *     can name, so the job fails with a clear message.
+ *   - "deploy" jobs need certificatePem from the control plane; the M2
+ *     payload has no such field, so deploy without it reports "blocked"
+ *     (awaiting Dev A's M5 job-type contract).
+ *   - "revoke" execution is out of M5 Dev B scope => always "blocked".
  */
 
+const fs = require("node:fs");
 const os = require("node:os");
+const path = require("node:path");
 
 const {
   resolveConfigDir,
   loadAgentConfig,
+  writeSigningKeyPin,
+  readSigningKeyPin,
   readCredential,
   persistRegistration,
   recoverPendingRegistration,
@@ -61,6 +86,17 @@ const {
   hasReportableJobId,
 } = require("./claimed-job");
 const { defaultAgentLogger } = require("./logging");
+const { verifyJobSignature, checkJobTimeWindow } = require("./signing");
+const { createReplayCache } = require("./replay");
+const { createClockOffsetEstimator } = require("./clock");
+const { generateKeyPairToFile, generateCsr } = require("./keys");
+const { createAcmeAdapter } = require("./acme");
+const { deployCertificate, getDeployMetrics } = require("./deploy");
+const { reloadService } = require("./reload");
+const {
+  verifyDeployedCertificate,
+  computeCertificateFingerprint,
+} = require("./verify");
 
 const { version: AGENT_VERSION } = require("../package.json");
 
@@ -70,13 +106,47 @@ const { version: AGENT_VERSION } = require("../package.json");
  *
  * The claimed-job validator checks the full frozen public job shape first.
  * Action-specific policy dimensions are required in public metadata and are
- * never silently omitted. The bootstrap agent still does not execute jobs.
+ * never silently omitted. Signed-dispatch execution fields are additionally
+ * verified by the signing/replay/clock modules before any execution.
  *
  * @param {object} job claimed job payload
  * @returns {object} policy jobDescriptor
  */
 function buildJobPolicyDescriptor(job) {
   return validateClaimedJob(job).policyDescriptor;
+}
+
+/**
+ * Policy descriptor mapping for the signed-dispatch path. Signed jobs carry
+ * execution fields (issuedAt/expiresAt/nonce/signature/commandRef/...) that
+ * the frozen bootstrap job shape does not allow; their full field validation
+ * happens inside verifyJobSignature (findSignedFieldProblem) BEFORE this
+ * mapping runs, so only the policy-dimension projection is done here.
+ *
+ * @param {object} job signature-verified claimed job payload
+ * @returns {object} policy jobDescriptor
+ */
+function buildSignedJobPolicyDescriptor(job) {
+  const descriptor = {};
+  if (job?.target?.reference !== undefined) {
+    descriptor.targetSelector = job.target.reference;
+  }
+  for (const field of ["commandRef", "path", "caEndpoint", "dnsZone", "dnsProvider"]) {
+    if (job?.[field] !== undefined) descriptor[field] = job[field];
+  }
+  // Any custody-shaped intent on a job maps onto the engine's single
+  // unconditional key-export rejection flag. No job payload field is
+  // expected to carry this today (the schema forbids custody fields), but
+  // if a compromised control plane smuggled one in, this is the belt to
+  // the schema's suspenders.
+  if (
+    job?.requestsKeyExport === true ||
+    job?.exportPrivateKey === true ||
+    job?.keyExport === true
+  ) {
+    descriptor.requestsKeyExport = true;
+  }
+  return descriptor;
 }
 
 function emitLog(log, message, details) {
@@ -92,11 +162,123 @@ function localAttemptId(jobId) {
 }
 
 /**
- * Handles a single claimed job in bootstrap mode: evaluate agent-local
- * policy, then report either a policy rejection (with evidence) or a
- * "blocked" result explaining that execution lands with the signed-dispatch
- * runtime. Never throws for per-job failures; errors are reported through
- * the protocol client and logged.
+ * Bound applied to errorMessage strings reported through reportResult so a
+ * failing step can never flood the control plane (and pre-redacted module
+ * excerpts stay small). The evidence module separately enforces its own
+ * summary bounds.
+ */
+const EXECUTION_ERROR_MESSAGE_MAX_CHARS = 512;
+
+/** ACME adapter kinds executeJob accepts from a job payload. */
+const SUPPORTED_ACME_KINDS = ["certbot", "acme.sh"];
+
+/**
+ * POSIX-or-Windows absolute path check (same rationale as the acme
+ * module's isAbsolutePathLike: agents primarily target POSIX hosts but
+ * tests run on Windows too).
+ *
+ * @param {unknown} candidate
+ * @returns {boolean}
+ */
+function isAbsolutePathLike(candidate) {
+  return (
+    typeof candidate === "string" &&
+    (/^\//.test(candidate) ||
+      /^[A-Za-z]:[\\/]/.test(candidate) ||
+      /^\\\\/.test(candidate))
+  );
+}
+
+/**
+ * @param {unknown} message
+ * @returns {string} message bounded to EXECUTION_ERROR_MESSAGE_MAX_CHARS
+ */
+function boundErrorMessage(message) {
+  return String(message).slice(0, EXECUTION_ERROR_MESSAGE_MAX_CHARS);
+}
+
+/**
+ * Resolves the deploy destination for a job. M2-payload deviation
+ * (documented in the module docblock): the payload has no certPath field,
+ * so an explicit job.certPath wins, then target.reference when it is an
+ * absolute path, else null (the caller fails the job with a clear message).
+ *
+ * @param {object} job
+ * @returns {string|null}
+ */
+function resolveJobCertPath(job) {
+  if (isAbsolutePathLike(job?.certPath)) return job.certPath;
+  if (isAbsolutePathLike(job?.target?.reference)) return job.target.reference;
+  return null;
+}
+
+/**
+ * Reports a trust-layer or policy rejection uniformly: policy.checked
+ * evidence built from the { allowed:false, rejectionReason, detail } shape
+ * (shared by signing/replay/clock/policy modules), then a "rejected"
+ * result. Evidence is deep-scanned for key material before every POST.
+ *
+ * @param {object} params
+ * @param {object} params.client
+ * @param {string} params.jobId
+ * @param {string} params.attemptId
+ * @param {{ rejectionReason: string, detail: string }} params.verdict
+ * @param {(msg: string) => void} params.log
+ * @returns {Promise<{ status: "rejected", rejectionReason: string }>}
+ */
+async function reportJobRejection({ client, jobId, attemptId, verdict, log }) {
+  log(
+    `tokentimer-agent: job ${jobId} rejected: ${verdict.rejectionReason}`,
+  );
+  const evidenceBody = buildPolicyRejectionEvidence({
+    rejectionReason: verdict.rejectionReason,
+    detail: verdict.detail,
+    jobId,
+  });
+  assertEvidencePayloadSafe(evidenceBody);
+  await client.reportEvidence(evidenceBody);
+  await client.reportResult({
+    jobId,
+    attemptId,
+    status: "rejected",
+    rejectionReason: verdict.rejectionReason,
+  });
+  return { status: "rejected", rejectionReason: verdict.rejectionReason };
+}
+
+/**
+ * Builds + safety-scans + reports one evidence body of pre-built items.
+ *
+ * @param {object} client
+ * @param {string} jobId
+ * @param {object[]} items evidence items (buildEvidenceItem inputs)
+ * @returns {Promise<void>}
+ */
+async function reportStepEvidence(client, jobId, items) {
+  const body = buildEvidenceBody({ jobId, evidenceItems: items });
+  assertEvidencePayloadSafe(body);
+  await client.reportEvidence(body);
+}
+
+/**
+ * Handles a single claimed job.
+ *
+ * Without an execution context (M4 bootstrap mode, executionContext null or
+ * enabled:false): evaluate agent-local policy, then report either a policy
+ * rejection (with evidence) or a "blocked" result explaining that execution
+ * is not enabled. This branch is byte-for-byte the M4 behavior.
+ *
+ * With an enabled execution context (M5): run the full trust chain in
+ * order -- signature verify -> replay check -> clock window check -> policy
+ * evaluateJob -> replay consume -> executeJob. Any { allowed: false }
+ * verdict reports policy.checked evidence + a "rejected" result with that
+ * rejectionReason. A job missing its signed-dispatch fields is rejected
+ * with job_integrity_failed (unsigned jobs must never execute). If no
+ * signing key is pinned yet, jobs are "blocked" (never executed) until
+ * registration pins one.
+ *
+ * Never throws for per-job failures; errors are reported through the
+ * protocol client and logged.
  *
  * Exported for direct unit testing.
  *
@@ -104,11 +286,44 @@ function localAttemptId(jobId) {
  * @param {object} params.job claimed job payload
  * @param {object} params.policyEngine from createPolicyEngine
  * @param {object} params.client from createProtocolClient
+ * @param {object|null} [params.executionContext] from
+ *   buildExecutionContext; null preserves M4 bootstrap behavior
  * @param {(msg: string) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
-async function handleClaimedJob({ job, policyEngine, client, log = null }) {
+async function handleClaimedJob({
+  job,
+  policyEngine,
+  client,
+  executionContext = null,
+  log = null,
+}) {
   const reportableJobId = hasReportableJobId(job?.jobId) ? job.jobId : null;
+  const executionEnabled =
+    executionContext !== null && executionContext.enabled === true;
+
+  if (executionEnabled) {
+    if (!reportableJobId) {
+      emitLog(log, "claimed job missing a reportable jobId; skipping");
+      return { status: "skipped", rejectionReason: "job_integrity_failed" };
+    }
+    // Signed dispatch assigns attemptId server-side; fall back to a local id
+    // so result reporting stays schema-valid and idempotency-debuggable.
+    const signedAttemptId =
+      typeof job.attemptId === "string" && job.attemptId.length > 0
+        ? job.attemptId
+        : localAttemptId(reportableJobId);
+    return handleSignedJob({
+      job,
+      jobId: reportableJobId,
+      attemptId: signedAttemptId,
+      policyEngine,
+      client,
+      executionContext,
+      log,
+    });
+  }
+
   let validated;
   try {
     validated = validateClaimedJob(job);
@@ -163,19 +378,687 @@ async function handleClaimedJob({ job, policyEngine, client, log = null }) {
       return { status: "rejected", rejectionReason: verdict.rejectionReason };
     }
 
-    // Bootstrap deliberately never executes a job. Signed dispatch and every
-    // execution mechanism remain out of PR #78 scope.
+    // Execution is not configured on this agent: report "blocked" rather
+    // than silently dropping so the control plane sees an explicit
+    // terminal state.
     await client.reportResult({
       jobId: validatedJob.jobId,
       attemptId,
       status: "blocked",
-      errorMessage: "agent runtime does not execute jobs yet",
+      errorMessage: "agent execution is not enabled on this agent",
     });
     return { status: "blocked", rejectionReason: null };
   } catch (err) {
     emitLog(log, `failed while handling claimed job ${validatedJob.jobId}`, err);
     return { status: "failed", rejectionReason: null };
   }
+}
+
+/**
+ * M5 trust chain for a claimed job when execution is enabled. Order per
+ * ADR-0003 (and tests/integration/agent-protocol.test.js
+ * runVerificationChain): signature verify -> replay check -> clock window
+ * check -> policy -> replay consume -> execute. The replay nonce is
+ * consumed only after every gate passed, so a rejected job does not burn
+ * its nonce, but it IS consumed before execution starts, so a crash
+ * mid-execution can never allow a replay.
+ *
+ * @param {object} params see handleClaimedJob
+ * @returns {Promise<{ status: string, rejectionReason: string|null }>}
+ */
+async function handleSignedJob({
+  job,
+  jobId,
+  attemptId,
+  policyEngine,
+  client,
+  executionContext,
+  log,
+}) {
+  const { pinnedSigningKey, replayCache, clockEstimator, execution } =
+    executionContext;
+
+  // No pinned key => integrity of ANY job cannot be established. Blocked,
+  // not rejected: this is an agent-side precondition failure, not a verdict
+  // about the job itself.
+  if (!pinnedSigningKey) {
+    await client.reportResult({
+      jobId,
+      attemptId,
+      status: "blocked",
+      errorMessage:
+        "execution is enabled but no control-plane signing key is pinned " +
+        "yet (the register response did not carry one); unsigned or " +
+        "unverifiable jobs are never executed",
+    });
+    return { status: "blocked", rejectionReason: null };
+  }
+
+  // 1. Signature (covers the M2-payload fallback: a job without signed
+  // fields fails field validation inside verifyJobSignature and is
+  // rejected with job_integrity_failed).
+  const signatureVerdict = verifyJobSignature({
+    job,
+    publicKeyPem: pinnedSigningKey.publicKeyPem,
+    pinnedSigningKeyId: pinnedSigningKey.signingKeyId,
+  });
+  if (!signatureVerdict.allowed) {
+    return reportJobRejection({ client, jobId, attemptId, verdict: signatureVerdict, log });
+  }
+
+  // 2. Replay check (no consume yet).
+  const replayVerdict = replayCache.check({
+    nonce: job.nonce,
+    jobId,
+    expiresAt: job.expiresAt,
+  });
+  if (!replayVerdict.allowed) {
+    return reportJobRejection({ client, jobId, attemptId, verdict: replayVerdict, log });
+  }
+
+  // 3. Clock window with drift compensation.
+  const windowVerdict = checkJobTimeWindow({
+    job,
+    nowMs: Date.now(),
+    clockOffsetMs: clockEstimator.getOffsetMs(),
+    toleranceMs: execution.clockDriftToleranceMs,
+  });
+  if (!windowVerdict.allowed) {
+    return reportJobRejection({ client, jobId, attemptId, verdict: windowVerdict, log });
+  }
+
+  // 4. Agent-local policy (default deny; ADR-0002 local policy wins).
+  const policyVerdict = policyEngine.evaluateJob(buildSignedJobPolicyDescriptor(job));
+  if (!policyVerdict.allowed) {
+    return reportJobRejection({ client, jobId, attemptId, verdict: policyVerdict, log });
+  }
+
+  // 5. Consume the nonce before executing (see function doc comment).
+  const consumeVerdict = replayCache.consume({
+    nonce: job.nonce,
+    jobId,
+    expiresAt: job.expiresAt,
+  });
+  if (!consumeVerdict.allowed) {
+    return reportJobRejection({ client, jobId, attemptId, verdict: consumeVerdict, log });
+  }
+
+  // 6. Execute. executeJob owns per-step evidence and returns the terminal
+  // result fields; failures inside it are converted to a "failed" result
+  // here so a step crash never kills the claim loop.
+  try {
+    const outcome = await executeJob({
+      job,
+      jobId,
+      policyEngine,
+      client,
+      executionContext,
+      log,
+    });
+    await client.reportResult({
+      jobId,
+      attemptId,
+      status: outcome.status,
+      rejectionReason: outcome.rejectionReason ?? null,
+      keyRotated: outcome.keyRotated ?? null,
+      errorMessage: outcome.errorMessage ?? null,
+      clockOffsetMs: clockEstimator.getOffsetMs(),
+    });
+    return { status: outcome.status, rejectionReason: outcome.rejectionReason ?? null };
+  } catch (err) {
+    log(`tokentimer-agent: job ${jobId} execution error: ${err.message}`);
+    await client.reportResult({
+      jobId,
+      attemptId,
+      status: "failed",
+      errorMessage: boundErrorMessage(`job execution failed: ${err.message}`),
+      clockOffsetMs: clockEstimator.getOffsetMs(),
+    });
+    return { status: "failed", rejectionReason: null };
+  }
+}
+
+/**
+ * Executes a fully verified + policy-approved job. Never reports the
+ * terminal result itself (handleSignedJob does); it DOES report per-step
+ * evidence. Returns the fields for reportResult.
+ *
+ * Dry-run (execution.dryRun true, the default): every gate has already
+ * run; this produces a policy.checked "plan" evidence item per step that
+ * WOULD run, with zero filesystem/exec side effects (keys/acme/deploy/
+ * reload/verify modules are never called), then returns "succeeded" with
+ * keyRotated null and a dry-run marker in the evidence metadata.
+ *
+ * Exported for direct unit testing.
+ *
+ * @param {object} params
+ * @param {object} params.job verified job payload
+ * @param {string} params.jobId
+ * @param {object} params.policyEngine
+ * @param {object} params.client
+ * @param {object} params.executionContext from buildExecutionContext
+ * @param {(msg: string) => void} [params.log]
+ * @returns {Promise<{ status: string, rejectionReason?: string|null, keyRotated?: boolean|null, errorMessage?: string|null }>}
+ */
+async function executeJob({
+  job,
+  jobId,
+  policyEngine,
+  client,
+  executionContext,
+  log = console.error,
+}) {
+  const { execution } = executionContext;
+  const action = job.action;
+  const observedAt = new Date().toISOString();
+
+  if (action === "noop") {
+    await reportStepEvidence(client, jobId, [
+      buildEvidenceItem({
+        eventType: "validation.passed",
+        observedAt,
+        summary: `Noop job ${jobId} executed: signature, replay, clock window, and policy gates all passed; no side effects requested.`,
+        metadata: [{ name: "action", value: "noop" }],
+      }),
+    ]);
+    return { status: "succeeded", keyRotated: null };
+  }
+
+  if (action === "revoke") {
+    // M5 Dev B scope does not include revocation execution.
+    return {
+      status: "blocked",
+      errorMessage:
+        "revoke jobs are not executable by this agent version (revocation " +
+        "execution is out of M5 scope)",
+    };
+  }
+
+  if (action === "deploy" && typeof job.certificatePem !== "string") {
+    // M2-payload deviation: deploy needs certificate bytes from the control
+    // plane and the M2 payload has no such field (awaiting Dev A's M5
+    // job-type contract).
+    return {
+      status: "blocked",
+      errorMessage:
+        "deploy job carries no certificatePem field; the M2 job payload " +
+        "does not define one yet (awaiting the M5 deploy job contract), so " +
+        "there is nothing to deploy",
+    };
+  }
+
+  if (action !== "renew" && action !== "deploy" && action !== "reload") {
+    return {
+      status: "blocked",
+      errorMessage: `unsupported job action "${String(action)}"`,
+    };
+  }
+
+  if (execution.dryRun) {
+    return executeDryRunPlan({ jobId, action, client, observedAt });
+  }
+
+  if (action === "renew") {
+    return executeRenewJob({ job, jobId, policyEngine, client, executionContext, log });
+  }
+  if (action === "deploy") {
+    return executeDeployJob({ job, jobId, policyEngine, client, log });
+  }
+  return executeReloadJob({ job, jobId, policyEngine, client, log });
+}
+
+/**
+ * Dry-run "plan" reporting: one policy.checked evidence item per step the
+ * action WOULD run, public fields only, zero side effects. Returns a
+ * succeeded result (the agent-protocol resultBody allows "succeeded" with
+ * keyRotated/errorMessage null, so a plan-only run is schema-valid).
+ *
+ * @param {object} params
+ * @returns {Promise<{ status: "succeeded", keyRotated: null, errorMessage: null }>}
+ */
+async function executeDryRunPlan({ jobId, action, client, observedAt }) {
+  const plannedSteps = {
+    renew: [
+      "keys: reuse or generate the certificate key under the configured keysDir",
+      "csr: build a CSR with CN from target.reference",
+      "acme: run the allowlisted ACME command against job.caEndpoint",
+      "deploy: atomically install the renewed certificate at the resolved certPath",
+      "reload: validate-then-reload the target service when the job requests it",
+      "verify: fingerprint the deployed certificate",
+    ],
+    deploy: [
+      "deploy: atomically install the job-supplied certificate at the resolved certPath",
+      "reload: validate-then-reload the target service when the job requests it",
+      "verify: fingerprint the deployed certificate",
+    ],
+    reload: [
+      "reload: validate-then-reload the target service via allowlisted command profiles",
+    ],
+  }[action];
+
+  const items = plannedSteps.map((description, index) =>
+    buildEvidenceItem({
+      eventType: "policy.checked",
+      observedAt,
+      summary: `Dry run plan for ${action} job ${jobId}, step ${index + 1}/${plannedSteps.length}: ${description}. No side effects were performed.`,
+      metadata: [
+        { name: "dryRun", value: true },
+        { name: "action", value: action },
+        { name: "planStep", value: index + 1 },
+      ],
+    }),
+  );
+  await reportStepEvidence(client, jobId, items);
+  return { status: "succeeded", keyRotated: null, errorMessage: null };
+}
+
+/**
+ * Full renew chain: keys -> csr -> acme -> deploy -> reload (optional) ->
+ * verify. Semantics documented in the module docblock (M2-payload
+ * deviations: CN from target.reference, key reuse unless job.keyRotation
+ * is truthy, certPath from job.certPath else absolute target.reference).
+ *
+ * @param {object} params
+ * @returns {Promise<object>} reportResult fields
+ */
+async function executeRenewJob({ job, jobId, policyEngine, client, executionContext, log }) {
+  const { execution } = executionContext;
+  const commonName = job?.target?.reference;
+  if (typeof commonName !== "string" || commonName.length === 0) {
+    return {
+      status: "failed",
+      errorMessage: "renew job has no target.reference to use as the certificate CN",
+    };
+  }
+
+  const certPath = resolveJobCertPath(job);
+  if (certPath === null) {
+    return {
+      status: "failed",
+      errorMessage:
+        "renew job names no deploy destination: neither job.certPath nor an " +
+        "absolute-path target.reference is present",
+    };
+  }
+
+  if (typeof job.commandRef !== "string" || job.commandRef.length === 0) {
+    return {
+      status: "failed",
+      errorMessage: "renew job carries no commandRef naming an allowlisted ACME command",
+    };
+  }
+  const commandVerdict = policyEngine.checkCommandRef(job.commandRef);
+  if (!commandVerdict.allowed) {
+    return {
+      status: "rejected",
+      rejectionReason: commandVerdict.rejectionReason,
+      errorMessage: boundErrorMessage(commandVerdict.detail),
+    };
+  }
+
+  if (typeof job.caEndpoint !== "string" || job.caEndpoint.length === 0) {
+    return {
+      status: "failed",
+      errorMessage: "renew job carries no caEndpoint",
+    };
+  }
+
+  const acmeKind = SUPPORTED_ACME_KINDS.includes(job.acmeKind) ? job.acmeKind : "certbot";
+
+  // Step 1: keys. Reuse-if-exists unless job.keyRotation is truthy
+  // (forward-compatible field, absent from the M2 schema).
+  fs.mkdirSync(execution.keysDir, { recursive: true });
+  const keyPath = path.join(execution.keysDir, `${job.certificateId}.key.pem`);
+  const forceRotation = job.keyRotation === true;
+  const keyExisted = fs.existsSync(keyPath);
+  const keyRotated = forceRotation || !keyExisted;
+  if (keyRotated) {
+    generateKeyPairToFile({ keyPath, overwrite: forceRotation });
+  }
+
+  // Step 2: CSR, written to a job-scoped temp path under keysDir (0600).
+  const { csrPem } = generateCsr({
+    keyPath,
+    subject: { commonName },
+    altNames: [commonName],
+  });
+  const csrPath = path.join(execution.keysDir, `${jobId}.csr.pem`);
+  fs.writeFileSync(csrPath, csrPem, { mode: 0o600 });
+
+  // The ACME client writes to a job-scoped staging path; the deploy module
+  // then owns the atomic install (with backup/rollback) to certPath.
+  const stagedCertPath = path.join(execution.keysDir, `${jobId}.cert.pem`);
+
+  try {
+    // Step 3: ACME renewal via the policy-resolved command profile.
+    const adapter = createAcmeAdapter({
+      kind: acmeKind,
+      commandProfile: { argv: commandVerdict.argv },
+      execFileImpl: executionContext.acmeExecFileImpl,
+    });
+    const renewal = await adapter.runRenewal({
+      caEndpoint: job.caEndpoint,
+      domains: [commonName],
+      csrPath,
+      outCertPath: stagedCertPath,
+      checkCaEndpoint: (endpoint) => policyEngine.checkCaEndpoint(endpoint),
+    });
+    if (renewal.allowed === false) {
+      return {
+        status: "rejected",
+        rejectionReason: renewal.rejectionReason,
+        errorMessage: boundErrorMessage(renewal.detail),
+      };
+    }
+    if (renewal.renewed !== true) {
+      await reportStepEvidence(client, jobId, [
+        buildEvidenceItem({
+          eventType: "validation.failed",
+          observedAt: new Date().toISOString(),
+          summary: `ACME renewal step failed for job ${jobId} (exit code ${renewal.exitCode}).`,
+          metadata: [{ name: "step", value: "acme" }, { name: "exitCode", value: renewal.exitCode }],
+        }),
+      ]);
+      return {
+        status: "failed",
+        keyRotated,
+        errorMessage: boundErrorMessage(
+          `acme step failed with exit code ${renewal.exitCode}: ${renewal.stderrExcerpt || "no stderr"}`,
+        ),
+      };
+    }
+    await reportStepEvidence(client, jobId, [
+      buildEvidenceItem({
+        eventType: "validation.passed",
+        observedAt: new Date().toISOString(),
+        summary: `ACME renewal step succeeded for job ${jobId}.`,
+        metadata: [{ name: "step", value: "acme" }, { name: "exitCode", value: renewal.exitCode }],
+      }),
+    ]);
+  } finally {
+    // The CSR is public material, but it is job-scoped scratch: remove it.
+    fs.rmSync(csrPath, { force: true });
+  }
+
+  // Steps 4-6 are shared with the deploy action.
+  let certificatePem;
+  try {
+    certificatePem = fs.readFileSync(stagedCertPath, "utf8");
+  } catch (err) {
+    return {
+      status: "failed",
+      keyRotated,
+      errorMessage: boundErrorMessage(
+        `acme step reported success but produced no certificate file: ${err.message}`,
+      ),
+    };
+  } finally {
+    fs.rmSync(stagedCertPath, { force: true });
+  }
+  const tail = await runDeployReloadVerify({
+    job,
+    jobId,
+    policyEngine,
+    client,
+    certificatePem,
+    certPath,
+    log,
+  });
+  return { ...tail, keyRotated };
+}
+
+/**
+ * Shared deploy -> optional reload -> verify tail used by both renew and
+ * deploy actions. Reports per-step evidence (deployment.updated with the
+ * deploy module's metrics counters, validation.passed/failed for reload
+ * and fingerprint verification). Returns reportResult fields (without
+ * keyRotated, which only renew owns).
+ *
+ * @param {object} params
+ * @returns {Promise<object>}
+ */
+async function runDeployReloadVerify({
+  job,
+  jobId,
+  policyEngine,
+  client,
+  certificatePem,
+  certPath,
+  log,
+}) {
+  // Deploy step (atomic install with backup/rollback; path re-checked
+  // against agent-local policy inside the module via checkPath). The
+  // target type/reference pass through from the job's schema-valid target.
+  const deployResult = await deployCertificate({
+    target: {
+      type: job?.target?.type ?? "endpoint",
+      reference: job?.target?.reference ?? certPath,
+      certPath,
+    },
+    certificatePem,
+    checkPath: (candidate) => policyEngine.checkPath(candidate),
+  });
+
+  if (deployResult.deployed !== true && deployResult.skipped !== true) {
+    await reportStepEvidence(client, jobId, [
+      buildEvidenceItem({
+        eventType: "validation.failed",
+        observedAt: new Date().toISOString(),
+        summary: `Deploy step failed for job ${jobId} at stage ${deployResult.stage} (rolledBack: ${deployResult.rolledBack === true}).`,
+        metadata: [
+          { name: "step", value: "deploy" },
+          { name: "stage", value: String(deployResult.stage) },
+          { name: "rolledBack", value: deployResult.rolledBack === true },
+        ],
+      }),
+    ]);
+    return {
+      status: "failed",
+      errorMessage: boundErrorMessage(
+        `deploy step failed at stage ${deployResult.stage}: ${deployResult.error}`,
+      ),
+    };
+  }
+
+  // Deploy metrics counters for this job's target type, flattened to
+  // numeric publicMetadataEntry items (the evidence module only accepts
+  // scalar values).
+  const targetTypeForMetrics =
+    typeof job?.target?.type === "string" ? job.target.type : "unknown";
+  const metricsForType = getDeployMetrics()[targetTypeForMetrics] || {};
+  await reportStepEvidence(client, jobId, [
+    buildEvidenceItem({
+      eventType: "deployment.updated",
+      observedAt: new Date().toISOString(),
+      summary:
+        deployResult.skipped === true
+          ? `Deploy step skipped for job ${jobId}: destination already holds this certificate (idempotent).`
+          : `Deploy step succeeded for job ${jobId}: certificate installed atomically.`,
+      metadata: [
+        { name: "step", value: "deploy" },
+        { name: "idempotentSkip", value: deployResult.skipped === true },
+        ...Object.entries(metricsForType)
+          .filter(([, value]) => typeof value === "number")
+          .map(([name, value]) => ({ name: `deployMetric_${name}`, value })),
+      ],
+    }),
+  ]);
+
+  // Optional reload step: only when the job names a service AND both
+  // command profile refs resolve through the agent-local allowlist.
+  const reloadOutcome = await maybeReloadForJob({ job, jobId, policyEngine, client, log });
+  if (reloadOutcome !== null && reloadOutcome.status !== "succeeded") {
+    return reloadOutcome;
+  }
+
+  // Verify step: always fingerprint the deployed PEM; probe the live
+  // endpoint only when the job provides a host (job.verifyHost).
+  const deployedPem = fs.readFileSync(certPath, "utf8");
+  const fingerprint = computeCertificateFingerprint(deployedPem);
+  let verifySummary = `Verified deployed certificate fingerprint for job ${jobId}.`;
+  if (typeof job.verifyHost === "string" && job.verifyHost.length > 0) {
+    const probe = await verifyDeployedCertificate({
+      host: job.verifyHost,
+      port: typeof job.verifyPort === "number" ? job.verifyPort : undefined,
+      expectedFingerprintSha256: fingerprint,
+    });
+    if (probe.verified !== true) {
+      await reportStepEvidence(client, jobId, [
+        buildEvidenceItem({
+          eventType: "validation.failed",
+          observedAt: new Date().toISOString(),
+          fingerprintSha256: fingerprint,
+          summary: `Live endpoint verification failed for job ${jobId}: the served certificate does not match the deployed one.`,
+          metadata: [{ name: "step", value: "verify" }],
+        }),
+      ]);
+      return {
+        status: "failed",
+        errorMessage: boundErrorMessage(
+          "verify step failed: live endpoint does not serve the deployed certificate",
+        ),
+      };
+    }
+    verifySummary = `Verified deployed certificate fingerprint for job ${jobId} against live endpoint.`;
+  }
+  await reportStepEvidence(client, jobId, [
+    buildEvidenceItem({
+      eventType: "validation.passed",
+      observedAt: new Date().toISOString(),
+      fingerprintSha256: fingerprint,
+      summary: verifySummary,
+      metadata: [{ name: "step", value: "verify" }],
+    }),
+  ]);
+
+  return { status: "succeeded", errorMessage: null };
+}
+
+/**
+ * Runs the reload step when the job requests one. Returns null when the
+ * job carries no reloadService (step skipped), otherwise reportResult
+ * fields for the step outcome.
+ *
+ * @param {object} params
+ * @returns {Promise<object|null>}
+ */
+async function maybeReloadForJob({ job, jobId, policyEngine, client, log }) {
+  if (typeof job.reloadService !== "string" || job.reloadService.length === 0) {
+    return null;
+  }
+  const refs = job.reloadCommandRefs;
+  if (
+    refs === null ||
+    typeof refs !== "object" ||
+    typeof refs.validate !== "string" ||
+    typeof refs.reload !== "string"
+  ) {
+    return {
+      status: "failed",
+      errorMessage:
+        "job requests a service reload but reloadCommandRefs.validate/.reload " +
+        "command references are missing",
+    };
+  }
+  const validateVerdict = policyEngine.checkCommandRef(refs.validate);
+  if (!validateVerdict.allowed) {
+    return {
+      status: "rejected",
+      rejectionReason: validateVerdict.rejectionReason,
+      errorMessage: boundErrorMessage(validateVerdict.detail),
+    };
+  }
+  const reloadVerdict = policyEngine.checkCommandRef(refs.reload);
+  if (!reloadVerdict.allowed) {
+    return {
+      status: "rejected",
+      rejectionReason: reloadVerdict.rejectionReason,
+      errorMessage: boundErrorMessage(reloadVerdict.detail),
+    };
+  }
+
+  const outcome = await reloadService({
+    service: job.reloadService,
+    commandProfiles: {
+      validateArgv: validateVerdict.argv,
+      reloadArgv: reloadVerdict.argv,
+    },
+  });
+  if (outcome.reloaded !== true) {
+    log(`tokentimer-agent: reload step failed for job ${jobId}`);
+    await reportStepEvidence(client, jobId, [
+      buildEvidenceItem({
+        eventType: "validation.failed",
+        observedAt: new Date().toISOString(),
+        summary: `Reload step failed for job ${jobId} at stage ${outcome.stage}.`,
+        metadata: [
+          { name: "step", value: "reload" },
+          { name: "stage", value: String(outcome.stage) },
+        ],
+      }),
+    ]);
+    return {
+      status: "failed",
+      errorMessage: boundErrorMessage(`reload step failed at stage ${outcome.stage}`),
+    };
+  }
+  await reportStepEvidence(client, jobId, [
+    buildEvidenceItem({
+      eventType: "validation.passed",
+      observedAt: new Date().toISOString(),
+      summary: `Reload step succeeded for job ${jobId} (service validated then reloaded).`,
+      metadata: [{ name: "step", value: "reload" }],
+    }),
+  ]);
+  return { status: "succeeded" };
+}
+
+/**
+ * Deploy action: deploy + optional reload + verify. certificatePem comes
+ * from the job (its presence is checked by executeJob before this runs).
+ *
+ * @param {object} params
+ * @returns {Promise<object>}
+ */
+async function executeDeployJob({ job, jobId, policyEngine, client, log }) {
+  const certPath = resolveJobCertPath(job);
+  if (certPath === null) {
+    return {
+      status: "failed",
+      errorMessage:
+        "deploy job names no destination: neither job.certPath nor an " +
+        "absolute-path target.reference is present",
+    };
+  }
+  return await runDeployReloadVerify({
+    job,
+    jobId,
+    policyEngine,
+    client,
+    certificatePem: job.certificatePem,
+    certPath,
+    log,
+  });
+}
+
+/**
+ * Reload action: reload only. The job must request a reloadService.
+ *
+ * @param {object} params
+ * @returns {Promise<object>}
+ */
+async function executeReloadJob({ job, jobId, policyEngine, client, log }) {
+  const outcome = await maybeReloadForJob({ job, jobId, policyEngine, client, log });
+  if (outcome === null) {
+    return {
+      status: "failed",
+      errorMessage: "reload job carries no reloadService field",
+    };
+  }
+  if (outcome.status === "succeeded") {
+    return { status: "succeeded", errorMessage: null };
+  }
+  return outcome;
 }
 
 /**
@@ -236,7 +1119,7 @@ async function runDiscoveryScan({ directories, client, log = null }) {
  * Performs first-run registration when no credential is stored yet.
  * Requires TOKENTIMER_AGENT_BOOTSTRAP_TOKEN (and optionally
  * TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID) in the environment; the bootstrap
- * token is single-use and never persisted by the agent.
+ * token is single-use and never persisted by the agent (plan section 7.2).
  *
  * @param {object} params
  * @param {object} params.client
@@ -285,6 +1168,15 @@ async function registerIfNeeded({ client, config, configDir, env = process.env }
     agentId: registration.agentId,
     credential: registration.credential,
   });
+  // Trust-on-first-use pinning (ADR-0003): when the register response
+  // carries the control plane's job-signing key info, persist it so every
+  // later run verifies jobs against the same key. Public material only.
+  if (registration.signingKeyId && registration.signingPublicKeyPem) {
+    writeSigningKeyPin(configDir, {
+      signingKeyId: registration.signingKeyId,
+      signingPublicKeyPem: registration.signingPublicKeyPem,
+    });
+  }
   return registration.agentId;
 }
 
@@ -299,10 +1191,61 @@ function createCandidateAgentId(hostname = os.hostname(), pid = process.pid) {
 }
 
 /**
+ * Builds the M5 execution context from a loaded config. Returns null when
+ * execution is not configured or not enabled, which callers treat as "run
+ * in M4 bootstrap mode".
+ *
+ * Startup fail-loud: a corrupted replay store throws here (surfacing as a
+ * startup failure) instead of being silently recreated -- see the replay
+ * module's rationale (a tampered store is a security signal).
+ *
+ * Exported for direct unit testing; tests may inject acmeExecFileImpl to
+ * stub the ACME child process.
+ *
+ * @param {object} params
+ * @param {object} params.config from loadAgentConfig
+ * @param {Function} [params.acmeExecFileImpl] test-only execFile override
+ * @returns {{
+ *   enabled: true,
+ *   execution: object,
+ *   replayCache: object,
+ *   clockEstimator: object,
+ *   pinnedSigningKey: {signingKeyId: string, publicKeyPem: string}|null,
+ *   acmeExecFileImpl: Function|undefined,
+ * }|null}
+ */
+function buildExecutionContext({ config, acmeExecFileImpl } = {}) {
+  if (!config?.execution || config.execution.enabled !== true) {
+    return null;
+  }
+  let replayCache;
+  try {
+    replayCache = createReplayCache({
+      storePath: config.execution.replayStorePath,
+    });
+  } catch (err) {
+    throw new Error(
+      "tokentimer-agent: failed to load the replay store at " +
+        `${config.execution.replayStorePath}: ${err.message}. A corrupted ` +
+        "replay store may indicate tampering; refusing to start execution " +
+        "until an operator inspects it.",
+    );
+  }
+  return {
+    enabled: true,
+    execution: config.execution,
+    replayCache,
+    clockEstimator: createClockOffsetEstimator(),
+    pinnedSigningKey: config.pinnedSigningKey,
+    acmeExecFileImpl,
+  };
+}
+
+/**
  * Runs the agent process: load config, register if needed, then run the
  * heartbeat and claim loops until SIGINT/SIGTERM or until the control plane
  * retires this agent (heartbeat HTTP 410 -> clean exit, no respawn loop,
- * ADR-0002).
+ * ADR-0002 / plan 7.7 item 11).
  *
  * @param {string[]} _argv CLI arguments (none supported yet; configuration
  *   is via config.json and TOKENTIMER_AGENT_* env vars)
@@ -313,6 +1256,11 @@ function createCandidateAgentId(hostname = os.hostname(), pid = process.pid) {
 async function runAgent(_argv, { signal: externalSignal } = {}) {
   const configDir = resolveConfigDir();
   const config = loadAgentConfig({ configDir });
+
+  // Execution context (null in bootstrap/observe-only mode). Built before
+  // any network call so a corrupted replay store fails startup immediately.
+  const executionContext = buildExecutionContext({ config });
+
   const controller = new AbortController();
   const stop = () => controller.abort();
   if (externalSignal) {
@@ -334,6 +1282,14 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
     ? createCaAwareFetch({ caBundlePem: readCaBundle(config.caBundlePath) })
     : undefined;
 
+  const onServerDate = executionContext
+    ? (dateHeaderValue, localNowMs) =>
+        executionContext.clockEstimator.estimateFromResponseDate(
+          dateHeaderValue,
+          localNowMs,
+        )
+    : undefined;
+
   const clientForAgentId = (agentId) =>
     createProtocolClient({
       serverUrl: config.serverUrl,
@@ -343,6 +1299,7 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       signal: controller.signal,
       fetchImpl,
       allowInsecureLocalHttp: config.allowInsecureLocalHttp,
+      onServerDate,
     });
 
   // For a not-yet-registered agent the envelope needs a client-generated
@@ -365,6 +1322,12 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
 
   const client = clientForAgentId(registeredAgentId);
 
+  // Registration may have just pinned the signing key; reload it so a
+  // first-run agent can execute without a restart.
+  if (executionContext && !executionContext.pinnedSigningKey) {
+    executionContext.pinnedSigningKey = readSigningKeyPin(configDir);
+  }
+
   const startedAtMs = Date.now();
 
   const heartbeatLoop = startPollLoop({
@@ -375,9 +1338,16 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       const response = await client.heartbeat({
         agentVersion: AGENT_VERSION,
         uptimeSeconds: Math.floor((Date.now() - startedAtMs) / 1000),
-        // ntpSynced / pinnedSigningKeyId / clockOffsetMs are signed-dispatch
-        // runtime concerns (drift measurement, key pinning); reported as
-        // null until that lands.
+        // With execution enabled, report the measured clock offset and the
+        // pinned signing key id so the control plane can spot drift and
+        // key-rotation lag. In M4 bootstrap mode these stay null.
+        ...(executionContext
+          ? {
+              clockOffsetMs: executionContext.clockEstimator.getOffsetMs(),
+              pinnedSigningKeyId:
+                executionContext.pinnedSigningKey?.signingKeyId ?? null,
+            }
+          : {}),
       });
       if (response && response.retired === true) {
         defaultAgentLogger.error("control plane retired this agent; exiting cleanly");
@@ -394,12 +1364,12 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       const jobs = await client.claim({ maxJobs: 1 });
       for (const job of jobs) {
         if (controller.signal.aborted) break;
-        await handleClaimedJob({ job, policyEngine, client });
+        await handleClaimedJob({ job, policyEngine, client, executionContext });
       }
     },
   });
 
-  // Observe-only discovery loop (filesystem certificate inventory).
+  // Observe-only discovery loop (M4: filesystem certificate inventory).
   // Only started when config.json opts in with a discovery.directories list;
   // scans run immediately on start, then on the configured interval.
   const loops = [heartbeatLoop, claimLoop];
@@ -430,7 +1400,10 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
 module.exports = {
   runAgent,
   handleClaimedJob,
+  executeJob,
+  buildExecutionContext,
   buildJobPolicyDescriptor,
+  resolveJobCertPath,
   runDiscoveryScan,
   registerIfNeeded,
   createCandidateAgentId,

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -86,7 +86,7 @@ const {
   hasReportableJobId,
 } = require("./claimed-job");
 const { defaultAgentLogger } = require("./logging");
-const { verifyJobSignature, checkJobTimeWindow } = require("./signing");
+const { verifyJobSignature, checkJobTimeWindow, DEFAULT_TIME_WINDOW_TOLERANCE_MS } = require("./signing");
 const { createReplayCache } = require("./replay");
 const { createClockOffsetEstimator } = require("./clock");
 const { generateKeyPairToFile, generateCsr } = require("./keys");
@@ -808,6 +808,131 @@ async function executeRenewJob({ job, jobId, policyEngine, client, executionCont
 }
 
 /**
+ * Rolls back a completed deploy after a later tail step (reload or verify)
+ * failed. Without this, a reload/verify failure would leave the NEW
+ * certificate installed while the job reports failure -- the operator sees
+ * "failed" but the destination silently changed.
+ *
+ * Only applies when the deploy actually wrote (deployed: true) AND left a
+ * backup of the previous content (backupPath). An idempotent skip changed
+ * nothing (nothing to roll back), and a first-ever deploy has no previous
+ * certificate to restore (deleting the fresh file would be worse: the
+ * job's failure report plus the deployment.updated evidence trail already
+ * tells the operator exactly what is on disk).
+ *
+ * The restore goes through deployCertificate itself, so it gets the same
+ * policy re-check, atomic write, and metrics as any deploy. After a
+ * successful restore, the service reload (when the job requested one and
+ * the refs resolve) is re-run best-effort so the service picks the old
+ * content back up; its outcome is reported in the rollback evidence but
+ * never changes the job's (already failed) result.
+ *
+ * @param {object} params
+ * @returns {Promise<{ rolledBack: boolean, reason: string|null }>}
+ */
+async function rollbackAfterFailedTail({
+  job,
+  jobId,
+  policyEngine,
+  client,
+  deployResult,
+  failedStep,
+  log,
+}) {
+  if (deployResult?.deployed !== true) {
+    return { rolledBack: false, reason: "deploy step made no change (idempotent skip)" };
+  }
+  if (typeof deployResult.backupPath !== "string" || deployResult.backupPath.length === 0) {
+    return { rolledBack: false, reason: "no previous certificate existed to restore" };
+  }
+
+  let previousPem;
+  try {
+    previousPem = fs.readFileSync(deployResult.backupPath, "utf8");
+  } catch (err) {
+    emitLog(log, `tokentimer-agent: rollback for job ${jobId} could not read the backup: ${err.message}`);
+    return { rolledBack: false, reason: "backup file could not be read" };
+  }
+
+  const restore = await deployCertificate({
+    target: {
+      type: job?.target?.type ?? "endpoint",
+      reference: job?.target?.reference ?? deployResult.destination,
+      certPath: deployResult.destination,
+    },
+    certificatePem: previousPem,
+    checkPath: (candidate) => policyEngine.checkPath(candidate),
+  });
+  const restored = restore.deployed === true || restore.skipped === true;
+  if (!restored) {
+    emitLog(log, `tokentimer-agent: rollback restore failed for job ${jobId} at stage ${restore.stage}`);
+  }
+
+  // Best-effort re-reload so the service serves the restored content again.
+  let reloadNote = "not requested";
+  if (restored && typeof job.reloadService === "string" && job.reloadService.length > 0) {
+    reloadNote = "skipped (command refs unavailable)";
+    const refs = job.reloadCommandRefs;
+    if (refs && typeof refs === "object" && typeof refs.validate === "string" && typeof refs.reload === "string") {
+      const validateVerdict = policyEngine.checkCommandRef(refs.validate);
+      const reloadVerdict = policyEngine.checkCommandRef(refs.reload);
+      if (validateVerdict.allowed && reloadVerdict.allowed) {
+        try {
+          const outcome = await reloadService({
+            service: job.reloadService,
+            commandProfiles: {
+              validateArgv: validateVerdict.argv,
+              reloadArgv: reloadVerdict.argv,
+            },
+          });
+          reloadNote = outcome.reloaded === true ? "reloaded" : `reload failed at stage ${outcome.stage}`;
+        } catch (err) {
+          reloadNote = `reload errored: ${err.message}`;
+        }
+      }
+    }
+  }
+
+  await reportStepEvidence(client, jobId, [
+    buildEvidenceItem({
+      eventType: "deployment.updated",
+      observedAt: new Date().toISOString(),
+      summary: restored
+        ? `Rolled back job ${jobId}: previous certificate restored after the ${failedStep} step failed.`
+        : `Rollback attempted for job ${jobId} after the ${failedStep} step failed, but the restore did not complete; the backup file still holds the previous content.`,
+      metadata: [
+        { name: "step", value: "rollback" },
+        { name: "failedStep", value: String(failedStep) },
+        { name: "restored", value: restored },
+        { name: "reloadAfterRestore", value: reloadNote },
+      ],
+    }),
+  ]);
+
+  return restored
+    ? { rolledBack: true, reason: null }
+    : { rolledBack: false, reason: "restore write failed; backup retained" };
+}
+
+/**
+ * Appends a rollback disposition note to a failed/rejected tail outcome's
+ * errorMessage so the reported result states what is on disk.
+ *
+ * @param {object} outcome reportResult fields
+ * @param {{ rolledBack: boolean, reason: string|null }} rollback
+ * @returns {object}
+ */
+function withRollbackNote(outcome, rollback) {
+  const note = rollback.rolledBack
+    ? "rolled back to the previous certificate"
+    : `not rolled back: ${rollback.reason}`;
+  return {
+    ...outcome,
+    errorMessage: boundErrorMessage(`${outcome.errorMessage} (${note})`),
+  };
+}
+
+/**
  * Shared deploy -> optional reload -> verify tail used by both renew and
  * deploy actions. Reports per-step evidence (deployment.updated with the
  * deploy module's metrics counters, validation.passed/failed for reload
@@ -888,7 +1013,16 @@ async function runDeployReloadVerify({
   // command profile refs resolve through the agent-local allowlist.
   const reloadOutcome = await maybeReloadForJob({ job, jobId, policyEngine, client, log });
   if (reloadOutcome !== null && reloadOutcome.status !== "succeeded") {
-    return reloadOutcome;
+    const rollback = await rollbackAfterFailedTail({
+      job,
+      jobId,
+      policyEngine,
+      client,
+      deployResult,
+      failedStep: "reload",
+      log,
+    });
+    return withRollbackNote(reloadOutcome, rollback);
   }
 
   // Verify step: always fingerprint the deployed PEM; probe the live
@@ -897,6 +1031,41 @@ async function runDeployReloadVerify({
   const fingerprint = computeCertificateFingerprint(deployedPem);
   let verifySummary = `Verified deployed certificate fingerprint for job ${jobId}.`;
   if (typeof job.verifyHost === "string" && job.verifyHost.length > 0) {
+    // Authorization gate: verifyHost/verifyPort are job-controlled and
+    // direct the agent to open a TLS connection, so the destination must
+    // pass agent-local policy (metadata/link-local hard-denied, loopback
+    // and off-target hosts require an explicit allowlist entry).
+    const destinationVerdict = policyEngine.checkVerifyHost(job.verifyHost, {
+      targetReference: job?.target?.reference,
+    });
+    if (!destinationVerdict.allowed) {
+      await reportStepEvidence(client, jobId, [
+        buildEvidenceItem({
+          eventType: "validation.failed",
+          observedAt: new Date().toISOString(),
+          summary: `Verify step rejected for job ${jobId}: the verify destination is not authorized by agent-local policy.`,
+          metadata: [{ name: "step", value: "verify" }],
+        }),
+      ]);
+      const rollback = await rollbackAfterFailedTail({
+        job,
+        jobId,
+        policyEngine,
+        client,
+        deployResult,
+        failedStep: "verify-authorization",
+        log,
+      });
+      return withRollbackNote(
+        {
+          status: "rejected",
+          rejectionReason: destinationVerdict.rejectionReason,
+          errorMessage: boundErrorMessage(destinationVerdict.detail),
+        },
+        rollback,
+      );
+    }
+
     const probe = await verifyDeployedCertificate({
       host: job.verifyHost,
       port: typeof job.verifyPort === "number" ? job.verifyPort : undefined,
@@ -912,12 +1081,24 @@ async function runDeployReloadVerify({
           metadata: [{ name: "step", value: "verify" }],
         }),
       ]);
-      return {
-        status: "failed",
-        errorMessage: boundErrorMessage(
-          "verify step failed: live endpoint does not serve the deployed certificate",
-        ),
-      };
+      const rollback = await rollbackAfterFailedTail({
+        job,
+        jobId,
+        policyEngine,
+        client,
+        deployResult,
+        failedStep: "verify",
+        log,
+      });
+      return withRollbackNote(
+        {
+          status: "failed",
+          errorMessage: boundErrorMessage(
+            "verify step failed: live endpoint does not serve the deployed certificate",
+          ),
+        },
+        rollback,
+      );
     }
     verifySummary = `Verified deployed certificate fingerprint for job ${jobId} against live endpoint.`;
   }
@@ -1171,11 +1352,18 @@ async function registerIfNeeded({ client, config, configDir, env = process.env }
   // Trust-on-first-use pinning (ADR-0003): when the register response
   // carries the control plane's job-signing key info, persist it so every
   // later run verifies jobs against the same key. Public material only.
+  // allowRepin: this IS the explicit registration flow, the only place a
+  // pin rotation is legitimate (a fresh bootstrap token was presented);
+  // writeSigningKeyPin refuses silent re-pins everywhere else.
   if (registration.signingKeyId && registration.signingPublicKeyPem) {
-    writeSigningKeyPin(configDir, {
-      signingKeyId: registration.signingKeyId,
-      signingPublicKeyPem: registration.signingPublicKeyPem,
-    });
+    writeSigningKeyPin(
+      configDir,
+      {
+        signingKeyId: registration.signingKeyId,
+        signingPublicKeyPem: registration.signingPublicKeyPem,
+      },
+      { allowRepin: true },
+    );
   }
   return registration.agentId;
 }
@@ -1218,10 +1406,18 @@ function buildExecutionContext({ config, acmeExecFileImpl } = {}) {
   if (!config?.execution || config.execution.enabled !== true) {
     return null;
   }
+  const clockEstimator = createClockOffsetEstimator();
   let replayCache;
   try {
     replayCache = createReplayCache({
       storePath: config.execution.replayStorePath,
+      // Retention must cover the same tolerance tail checkJobTimeWindow
+      // accepts (expiresAt + tolerance), and the sweep must run on the
+      // same offset-adjusted timeline as the acceptance decision --
+      // otherwise a nonce could be evicted while its job is still
+      // acceptable, reopening the replay window.
+      retentionToleranceMs: DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+      now: () => Date.now() + (clockEstimator.getOffsetMs() ?? 0),
     });
   } catch (err) {
     throw new Error(
@@ -1235,7 +1431,7 @@ function buildExecutionContext({ config, acmeExecFileImpl } = {}) {
     enabled: true,
     execution: config.execution,
     replayCache,
-    clockEstimator: createClockOffsetEstimator(),
+    clockEstimator,
     pinnedSigningKey: config.pinnedSigningKey,
     acmeExecFileImpl,
   };

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -9,7 +9,7 @@
  * stores them. Every module here must stay safe to run against an untrusted
  * or compromised control plane (agent-local policy wins, ADR-0002).
  *
- * M4 bootstrap scope (current): this file wires the landed modules together
+ * Bootstrap scope (current): this file wires the landed modules together
  * into a runnable outbound-only process:
  *   - config: config.json + secure credential storage (src/config)
  *   - policy: agent-local allowlist engine, default-deny (src/policy)
@@ -19,7 +19,7 @@
  *   - discovery: observe-only filesystem certificate inventory, reported as
  *     certificate.observed evidence (src/discovery)
  *
- * M5 signed-job dispatch (current, opt-in via config.execution.enabled):
+ * signed-job dispatch (current, opt-in via config.execution.enabled):
  * jobs claimed from the control plane run through the full trust chain
  * before any execution: Ed25519 signature verification against the pinned
  * signing key (src/signing) -> replay-cache check (src/replay) -> clock
@@ -28,15 +28,15 @@
  * src/acme, src/deploy, src/reload, src/verify.
  *
  * When execution is NOT enabled (config.execution absent or enabled:false),
- * the M4 bootstrap behavior is preserved exactly: every policy-allowed job
+ * the observe-only bootstrap behavior is preserved exactly: every policy-allowed job
  * is reported back as "blocked" with an explanatory error message, and
  * every policy-rejected job is reported as "rejected" with evidence. This
  * keeps the full outbound loop (register -> heartbeat -> claim ->
  * result/evidence) exercisable end to end without ever running an
  * unverified job.
  *
- * Known M2-payload deviations (job-payload.schema.json lacks M5 execution
- * fields; documented for Dev A's Phase 4/5 backend contract):
+ * Known base-payload deviations (job-payload.schema.json lacks signed-job execution
+ * fields; documented for the control-plane backend contract):
  *   - No domains list => the CSR CN and ACME -d domain come from
  *     job.target.reference.
  *   - No keyRotation flag => renew reuses an existing key at
@@ -47,10 +47,10 @@
  *     target.reference is used as the deploy destination when it is an
  *     absolute path. Neither present/absolute => renew deploys nowhere it
  *     can name, so the job fails with a clear message.
- *   - "deploy" jobs need certificatePem from the control plane; the M2
+ *   - "deploy" jobs need certificatePem from the control plane; the base
  *     payload has no such field, so deploy without it reports "blocked"
- *     (awaiting Dev A's M5 job-type contract).
- *   - "revoke" execution is out of M5 Dev B scope => always "blocked".
+ *     (awaiting the deploy job-type contract).
+ *   - "revoke" execution is out of scope for this agent build => always "blocked".
  */
 
 const fs = require("node:fs");
@@ -198,7 +198,7 @@ function boundErrorMessage(message) {
 }
 
 /**
- * Resolves the deploy destination for a job. M2-payload deviation
+ * Resolves the deploy destination for a job. base-payload deviation
  * (documented in the module docblock): the payload has no certPath field,
  * so an explicit job.certPath wins, then target.reference when it is an
  * absolute path, else null (the caller fails the job with a clear message).
@@ -263,12 +263,12 @@ async function reportStepEvidence(client, jobId, items) {
 /**
  * Handles a single claimed job.
  *
- * Without an execution context (M4 bootstrap mode, executionContext null or
+ * Without an execution context (observe-only bootstrap mode, executionContext null or
  * enabled:false): evaluate agent-local policy, then report either a policy
  * rejection (with evidence) or a "blocked" result explaining that execution
- * is not enabled. This branch is byte-for-byte the M4 behavior.
+ * is not enabled. This branch is byte-for-byte the observe-only bootstrap behavior.
  *
- * With an enabled execution context (M5): run the full trust chain in
+ * With an enabled execution context: run the full trust chain in
  * order -- signature verify -> replay check -> clock window check -> policy
  * evaluateJob -> replay consume -> executeJob. Any { allowed: false }
  * verdict reports policy.checked evidence + a "rejected" result with that
@@ -287,7 +287,7 @@ async function reportStepEvidence(client, jobId, items) {
  * @param {object} params.policyEngine from createPolicyEngine
  * @param {object} params.client from createProtocolClient
  * @param {object|null} [params.executionContext] from
- *   buildExecutionContext; null preserves M4 bootstrap behavior
+ *   buildExecutionContext; null preserves observe-only bootstrap behavior
  * @param {(msg: string) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
@@ -395,7 +395,7 @@ async function handleClaimedJob({
 }
 
 /**
- * M5 trust chain for a claimed job when execution is enabled. Order per
+ * Trust chain for a claimed job when execution is enabled. Order per
  * ADR-0003 (and tests/integration/agent-protocol.test.js
  * runVerificationChain): signature verify -> replay check -> clock window
  * check -> policy -> replay consume -> execute. The replay nonce is
@@ -434,7 +434,7 @@ async function handleSignedJob({
     return { status: "blocked", rejectionReason: null };
   }
 
-  // 1. Signature (covers the M2-payload fallback: a job without signed
+  // 1. Signature (covers the base-payload fallback: a job without signed
   // fields fails field validation inside verifyJobSignature and is
   // rejected with job_integrity_failed).
   const signatureVerdict = verifyJobSignature({
@@ -565,24 +565,24 @@ async function executeJob({
   }
 
   if (action === "revoke") {
-    // M5 Dev B scope does not include revocation execution.
+    // Revocation execution is out of scope for this agent build.
     return {
       status: "blocked",
       errorMessage:
         "revoke jobs are not executable by this agent version (revocation " +
-        "execution is out of M5 scope)",
+        "execution is not supported yet)",
     };
   }
 
   if (action === "deploy" && typeof job.certificatePem !== "string") {
-    // M2-payload deviation: deploy needs certificate bytes from the control
-    // plane and the M2 payload has no such field (awaiting Dev A's M5
+    // Base-payload deviation: deploy needs certificate bytes from the control
+    // plane and the base payload has no such field (awaiting the deploy
     // job-type contract).
     return {
       status: "blocked",
       errorMessage:
-        "deploy job carries no certificatePem field; the M2 job payload " +
-        "does not define one yet (awaiting the M5 deploy job contract), so " +
+        "deploy job carries no certificatePem field; the job payload " +
+        "does not define one yet (awaiting the deploy job contract), so " +
         "there is nothing to deploy",
     };
   }
@@ -654,7 +654,7 @@ async function executeDryRunPlan({ jobId, action, client, observedAt }) {
 
 /**
  * Full renew chain: keys -> csr -> acme -> deploy -> reload (optional) ->
- * verify. Semantics documented in the module docblock (M2-payload
+ * verify. Semantics documented in the module docblock (base-payload
  * deviations: CN from target.reference, key reuse unless job.keyRotation
  * is truthy, certPath from job.certPath else absolute target.reference).
  *
@@ -706,7 +706,7 @@ async function executeRenewJob({ job, jobId, policyEngine, client, executionCont
   const acmeKind = SUPPORTED_ACME_KINDS.includes(job.acmeKind) ? job.acmeKind : "certbot";
 
   // Step 1: keys. Reuse-if-exists unless job.keyRotation is truthy
-  // (forward-compatible field, absent from the M2 schema).
+  // (forward-compatible field, absent from the base schema).
   fs.mkdirSync(execution.keysDir, { recursive: true });
   const keyPath = path.join(execution.keysDir, `${job.certificateId}.key.pem`);
   const forceRotation = job.keyRotation === true;
@@ -1191,9 +1191,9 @@ function createCandidateAgentId(hostname = os.hostname(), pid = process.pid) {
 }
 
 /**
- * Builds the M5 execution context from a loaded config. Returns null when
+ * Builds the execution context from a loaded config. Returns null when
  * execution is not configured or not enabled, which callers treat as "run
- * in M4 bootstrap mode".
+ * in observe-only bootstrap mode".
  *
  * Startup fail-loud: a corrupted replay store throws here (surfacing as a
  * startup failure) instead of being silently recreated -- see the replay
@@ -1245,7 +1245,7 @@ function buildExecutionContext({ config, acmeExecFileImpl } = {}) {
  * Runs the agent process: load config, register if needed, then run the
  * heartbeat and claim loops until SIGINT/SIGTERM or until the control plane
  * retires this agent (heartbeat HTTP 410 -> clean exit, no respawn loop,
- * ADR-0002 / plan 7.7 item 11).
+ * ADR-0002).
  *
  * @param {string[]} _argv CLI arguments (none supported yet; configuration
  *   is via config.json and TOKENTIMER_AGENT_* env vars)
@@ -1340,7 +1340,7 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
         uptimeSeconds: Math.floor((Date.now() - startedAtMs) / 1000),
         // With execution enabled, report the measured clock offset and the
         // pinned signing key id so the control plane can spot drift and
-        // key-rotation lag. In M4 bootstrap mode these stay null.
+        // key-rotation lag. in observe-only bootstrap mode these stay null.
         ...(executionContext
           ? {
               clockOffsetMs: executionContext.clockEstimator.getOffsetMs(),
@@ -1369,7 +1369,7 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
     },
   });
 
-  // Observe-only discovery loop (M4: filesystem certificate inventory).
+  // Observe-only discovery loop (filesystem certificate inventory).
   // Only started when config.json opts in with a discovery.directories list;
   // scans run immediately on start, then on the configured interval.
   const loops = [heartbeatLoop, claimLoop];

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -483,7 +483,7 @@ describe("signed-job dispatch chain (handleClaimedJob with executionContext)", (
     );
   }
 
-  it("rejects an unsigned (M2) job with job_integrity_failed while execution is enabled", async () => {
+  it("rejects an unsigned job with job_integrity_failed while execution is enabled", async () => {
     const client = createRecordingClient();
     const job = makeSignedJob();
     delete job.signature;

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -15,7 +15,9 @@ const path = require("node:path");
 
 const {
   handleClaimedJob,
+  buildExecutionContext,
   buildJobPolicyDescriptor,
+  resolveJobCertPath,
   runDiscoveryScan,
   registerIfNeeded,
   createCandidateAgentId,
@@ -23,6 +25,7 @@ const {
 } = require("./index.js");
 const { loadPolicyConfig, createPolicyEngine, REJECTION_REASONS } = require("./policy");
 const { ensureConfigDir, writeCredential, readCredential, loadAgentConfig } = require("./config");
+const { generateSigningKeyPair, signJobPayload } = require("./signing");
 
 function makeTempConfigDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "ttagent-index-test-"));
@@ -144,7 +147,7 @@ describe("handleClaimedJob", () => {
     assert.equal(outcome.rejectionReason, "job_integrity_failed");
   });
 
-  it("reports blocked (not executed) when policy allows the job, until the signed-dispatch runtime lands", async () => {
+  it("reports blocked (not executed) when policy allows the job but execution is not enabled", async () => {
     const client = createRecordingClient();
     const policyEngine = engineWith({}, { declaredTargetSelectors: ["example.com"] });
 
@@ -161,7 +164,7 @@ describe("handleClaimedJob", () => {
     const result = client.calls.reportResult[0];
     assert.equal(result.status, "blocked");
     assert.match(result.attemptId, /^local-job-3-/);
-    assert.match(result.errorMessage, /does not execute jobs yet/);
+    assert.match(result.errorMessage, /execution is not enabled/);
   });
 
   it("skips jobs without a jobId without reporting anything", async () => {
@@ -416,5 +419,318 @@ describe("createCandidateAgentId", () => {
     assert.match(candidate, /^[A-Za-z0-9_.:-]{1,128}$/);
     assert.ok(candidate.length <= 128);
     assert.match(candidate, /^candidate-/);
+  });
+});
+
+describe("signed-job dispatch chain (handleClaimedJob with executionContext)", () => {
+  let workDir;
+  let signingKey;
+
+  beforeEach(() => {
+    workDir = makeTempConfigDir();
+    signingKey = generateSigningKeyPair();
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function makeExecutionContext({ dryRun = true, pinned = true } = {}) {
+    const keysDir = path.join(workDir, "keys");
+    const config = {
+      execution: {
+        enabled: true,
+        dryRun,
+        keysDir,
+        replayStorePath: path.join(workDir, "replay-store.json"),
+        clockDriftToleranceMs: 30000,
+      },
+      pinnedSigningKey: pinned
+        ? {
+            signingKeyId: signingKey.signingKeyId,
+            publicKeyPem: signingKey.publicKeyPem,
+          }
+        : null,
+    };
+    return buildExecutionContext({ config });
+  }
+
+  function makeSignedJob(overrides = {}) {
+    const nowMs = Date.now();
+    const job = {
+      schemaVersion: 1,
+      jobId: overrides.jobId || "job-m5-1",
+      workspaceId: "11111111-2222-3333-4444-555555555555",
+      certificateId: "cert-1",
+      action: "noop",
+      target: { type: "domain", reference: "example.com" },
+      keyMode: "agent-local",
+      requestedAt: new Date(nowMs).toISOString(),
+      issuedAt: new Date(nowMs - 1000).toISOString(),
+      expiresAt: new Date(nowMs + 5 * 60 * 1000).toISOString(),
+      nonce: `nonce-${Math.random().toString(36).slice(2)}-0123456789abcdef`,
+      signingKeyId: signingKey.signingKeyId,
+      ...overrides,
+    };
+    job.signature = signJobPayload({ job, privateKeyPem: signingKey.privateKeyPem });
+    return job;
+  }
+
+  function permissiveEngine() {
+    return engineWith(
+      { allowedPaths: [workDir] },
+      { declaredTargetSelectors: ["example.com"] },
+    );
+  }
+
+  it("rejects an unsigned (M2) job with job_integrity_failed while execution is enabled", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJob();
+    delete job.signature;
+    delete job.nonce;
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "rejected");
+    assert.equal(outcome.rejectionReason, "job_integrity_failed");
+    assert.equal(client.calls.reportResult[0].status, "rejected");
+    assert.equal(client.calls.reportEvidence.length, 1);
+  });
+
+  it("rejects a tampered job with job_integrity_failed", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJob();
+    job.action = "renew"; // mutate after signing
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "rejected");
+    assert.equal(outcome.rejectionReason, "job_integrity_failed");
+  });
+
+  it("rejects a replayed job with job_replay_rejected on the second dispatch", async () => {
+    const client = createRecordingClient();
+    const executionContext = makeExecutionContext();
+    const policyEngine = permissiveEngine();
+    const job = makeSignedJob();
+
+    const first = await handleClaimedJob({
+      job,
+      policyEngine,
+      client,
+      executionContext,
+      log: silentLog,
+    });
+    assert.equal(first.status, "succeeded");
+
+    const second = await handleClaimedJob({
+      job,
+      policyEngine,
+      client,
+      executionContext,
+      log: silentLog,
+    });
+    assert.equal(second.status, "rejected");
+    assert.equal(second.rejectionReason, "job_replay_rejected");
+  });
+
+  it("rejects a stale job with clock_drift_suspected", async () => {
+    const client = createRecordingClient();
+    const nowMs = Date.now();
+    const job = makeSignedJob({
+      issuedAt: new Date(nowMs - 10 * 60 * 1000).toISOString(),
+      expiresAt: new Date(nowMs - 5 * 60 * 1000).toISOString(),
+    });
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "rejected");
+    assert.equal(outcome.rejectionReason, "clock_drift_suspected");
+  });
+
+  it("reports blocked (never executes) when execution is enabled but no key is pinned", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJob();
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext({ pinned: false }),
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "blocked");
+    assert.equal(client.calls.reportResult.length, 1);
+    assert.match(client.calls.reportResult[0].errorMessage, /no control-plane signing key is pinned/);
+    assert.equal(client.calls.reportEvidence.length, 0);
+  });
+
+  it("executes a verified noop job with validation.passed evidence", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJob();
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "succeeded");
+    assert.equal(client.calls.reportResult[0].status, "succeeded");
+    assert.equal(client.calls.reportEvidence.length, 1);
+    assert.equal(
+      client.calls.reportEvidence[0].evidenceItems[0].eventType,
+      "validation.passed",
+    );
+  });
+
+  it("dry-run renew succeeds with a plan and performs zero filesystem side effects", async () => {
+    const client = createRecordingClient();
+    const executionContext = makeExecutionContext({ dryRun: true });
+    const job = makeSignedJob({
+      action: "renew",
+      commandRef: "certbot-renew",
+      caEndpoint: "https://acme.example/dir",
+      certPath: path.join(workDir, "deployed", "cert.pem"),
+    });
+    const policyEngine = engineWith(
+      {
+        allowedPaths: [workDir],
+        allowedCommands: { "certbot-renew": { argv: ["certbot"] } },
+        allowedCaEndpoints: ["https://acme.example/dir"],
+      },
+      { declaredTargetSelectors: ["example.com"] },
+    );
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine,
+      client,
+      executionContext,
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "succeeded");
+    const result = client.calls.reportResult[0];
+    assert.equal(result.status, "succeeded");
+    assert.equal(result.keyRotated, null);
+    assert.equal(result.errorMessage, null);
+
+    // Plan evidence: policy.checked items flagged dryRun.
+    assert.equal(client.calls.reportEvidence.length, 1);
+    const items = client.calls.reportEvidence[0].evidenceItems;
+    assert.ok(items.length >= 4);
+    for (const item of items) {
+      assert.equal(item.eventType, "policy.checked");
+      assert.ok(item.metadata.some((m) => m.name === "dryRun" && m.value === true));
+      assert.match(item.summary, /No side effects were performed/);
+    }
+
+    // Zero side effects: keysDir was never created, no cert deployed.
+    assert.equal(fs.existsSync(executionContext.execution.keysDir), false);
+    assert.equal(fs.existsSync(path.join(workDir, "deployed")), false);
+  });
+
+  it("blocks revoke jobs and deploy jobs without certificatePem", async () => {
+    const client = createRecordingClient();
+    const executionContext = makeExecutionContext({ dryRun: false });
+    const policyEngine = permissiveEngine();
+
+    const revokeOutcome = await handleClaimedJob({
+      job: makeSignedJob({ jobId: "job-revoke", action: "revoke" }),
+      policyEngine,
+      client,
+      executionContext,
+      log: silentLog,
+    });
+    assert.equal(revokeOutcome.status, "blocked");
+
+    const deployOutcome = await handleClaimedJob({
+      job: makeSignedJob({ jobId: "job-deploy", action: "deploy" }),
+      policyEngine,
+      client,
+      executionContext,
+      log: silentLog,
+    });
+    assert.equal(deployOutcome.status, "blocked");
+    const deployResult = client.calls.reportResult.find((r) => r.jobId === "job-deploy");
+    assert.match(deployResult.errorMessage, /certificatePem/);
+  });
+
+  it("strictly rejects a signed-dispatch job when executionContext is null", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJob(); // signed-dispatch fields are not valid bootstrap input
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: null,
+      log: silentLog,
+    });
+
+    // Without execution enabled the strict bootstrap validator rejects the
+    // unknown signed-dispatch fields outright; the job is never executed.
+    assert.equal(outcome.status, "rejected");
+    assert.equal(outcome.rejectionReason, "job_integrity_failed");
+    assert.equal(client.calls.reportResult[0].status, "rejected");
+  });
+
+  it("buildExecutionContext returns null when execution is absent or disabled and throws on a corrupted replay store", () => {
+    assert.equal(buildExecutionContext({ config: {} }), null);
+    assert.equal(
+      buildExecutionContext({
+        config: { execution: { enabled: false } },
+      }),
+      null,
+    );
+
+    const storePath = path.join(workDir, "replay-store.json");
+    fs.writeFileSync(storePath, "{corrupted", "utf8");
+    assert.throws(
+      () =>
+        buildExecutionContext({
+          config: {
+            execution: {
+              enabled: true,
+              dryRun: true,
+              keysDir: path.join(workDir, "keys"),
+              replayStorePath: storePath,
+              clockDriftToleranceMs: 30000,
+            },
+            pinnedSigningKey: null,
+          },
+        }),
+      /replay store/,
+    );
+  });
+
+  it("resolveJobCertPath prefers job.certPath, falls back to absolute target.reference, else null", () => {
+    const abs = process.platform === "win32" ? "C:\\certs\\a.pem" : "/certs/a.pem";
+    const abs2 = process.platform === "win32" ? "C:\\certs\\b.pem" : "/certs/b.pem";
+    assert.equal(resolveJobCertPath({ certPath: abs, target: { reference: abs2 } }), abs);
+    assert.equal(resolveJobCertPath({ target: { reference: abs2 } }), abs2);
+    assert.equal(resolveJobCertPath({ target: { reference: "example.com" } }), null);
   });
 });

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -678,6 +678,67 @@ describe("signed-job dispatch chain (handleClaimedJob with executionContext)", (
     assert.match(deployResult.errorMessage, /certificatePem/);
   });
 
+  it("rejects an unauthorized verify destination after deploy and rolls back to the previous certificate", async () => {
+    const client = createRecordingClient();
+    const executionContext = makeExecutionContext({ dryRun: false });
+    const fakeCertPem = (seed) => {
+      const body = Buffer.from(`fake-der-${seed}`).toString("base64");
+      return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----\n`;
+    };
+    const certPath = path.join(workDir, "tls", "cert.pem");
+    fs.mkdirSync(path.dirname(certPath), { recursive: true });
+    const previousPem = fakeCertPem("previous");
+    const newPem = fakeCertPem("new");
+    fs.writeFileSync(certPath, previousPem);
+
+    const job = makeSignedJob({
+      jobId: "job-verify-gate",
+      action: "deploy",
+      certificatePem: newPem,
+      certPath,
+      // Metadata-endpoint class destination: hard-denied by policy no
+      // matter what the allowlist says.
+      verifyHost: "169.254.169.254",
+    });
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext,
+      log: silentLog,
+    });
+
+    assert.equal(outcome.status, "rejected");
+    assert.equal(outcome.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+
+    // The deploy happened first, then the verify gate rejected and the
+    // previous certificate was restored on disk.
+    assert.equal(fs.readFileSync(certPath, "utf8"), previousPem);
+
+    const result = client.calls.reportResult.find((r) => r.jobId === "job-verify-gate");
+    assert.match(result.errorMessage, /rolled back to the previous certificate/);
+
+    const allItems = client.calls.reportEvidence.flatMap((c) => c.evidenceItems);
+    assert.ok(
+      allItems.some(
+        (item) =>
+          item.eventType === "validation.failed" &&
+          item.metadata.some((m) => m.name === "step" && m.value === "verify"),
+      ),
+      "expected a validation.failed verify-step evidence item",
+    );
+    assert.ok(
+      allItems.some(
+        (item) =>
+          item.eventType === "deployment.updated" &&
+          item.metadata.some((m) => m.name === "step" && m.value === "rollback") &&
+          item.metadata.some((m) => m.name === "restored" && m.value === true),
+      ),
+      "expected a rollback evidence item with restored=true",
+    );
+  });
+
   it("strictly rejects a signed-dispatch job when executionContext is null", async () => {
     const client = createRecordingClient();
     const job = makeSignedJob(); // signed-dispatch fields are not valid bootstrap input

--- a/packages/agent/src/keys/index.js
+++ b/packages/agent/src/keys/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Agent-local key generation and CSR building (CertOps M5).
+ * Agent-local key generation and CSR building.
  *
  * Zero private-key custody (TOKENTIMER_CERTOPS_PLAN section 9.3, ADR-0001):
  * private keys are generated locally on the agent host, written 0600 inside
@@ -12,7 +12,7 @@
  * before it is handed back to the caller (mirroring
  * evidence/assertEvidencePayloadSafe).
  *
- * Memory hygiene note (plan 7.7): JavaScript cannot guarantee zeroization.
+ * Memory hygiene note: JavaScript cannot guarantee zeroization.
  * Strings are immutable and copied freely by the engine, and node:crypto
  * KeyObject internal memory is owned by OpenSSL and not reachable from JS.
  * What this module *can* do, it does: private key PEM is exported into a

--- a/packages/agent/src/keys/index.js
+++ b/packages/agent/src/keys/index.js
@@ -98,8 +98,46 @@ function ensureKeyDir(keyPath) {
 }
 
 /**
+ * Inspects keyPath without following symlinks. Returns "absent" when the
+ * path does not exist. Throws when the path exists but is a symlink or any
+ * non-regular file: a symlink at the key path is a classic
+ * swap-the-destination attack (write 0600 key bytes through a link into an
+ * attacker-chosen location), so it is refused outright rather than
+ * followed or silently replaced.
+ * @param {string} keyPath
+ * @returns {"absent"|"regular"}
+ */
+function classifyExistingKeyPath(keyPath) {
+  let stats;
+  try {
+    stats = fs.lstatSync(keyPath);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return "absent";
+    throw buildError(
+      `tokentimer-agent keys: could not inspect key path ${keyPath}: ${err.message}`,
+    );
+  }
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw buildError(
+      `tokentimer-agent keys: key path ${keyPath} exists but is not a ` +
+        "regular file (symlink or special file); refusing to write key " +
+        "material through it",
+    );
+  }
+  return "regular";
+}
+
+/**
  * Generates a keypair, writes the private key PEM (PKCS#8) to keyPath with
  * mode 0600 (parent dir 0700), and returns ONLY public material.
+ *
+ * Write discipline:
+ *   - fresh key: exclusive create (flag "wx"), so a file (or symlink)
+ *     racing into existence between the existence check and the write
+ *     fails the write instead of being followed/clobbered;
+ *   - rotation (overwrite: true): written to a 0600 temp file in the same
+ *     directory and renamed over the destination, so a crash mid-rotation
+ *     can never leave a truncated key file.
  *
  * The private key PEM is exported into a Buffer, written from that Buffer,
  * and the Buffer is zeroized (fill(0)) immediately after the write. See the
@@ -123,7 +161,10 @@ function generateKeyPairToFile({ keyPath, algorithm = "ec-p256", overwrite = fal
     );
   }
 
-  if (!overwrite && fs.existsSync(keyPath)) {
+  // lstat-based classification: throws on symlinks/special files whether or
+  // not overwrite was requested (see classifyExistingKeyPath).
+  const existing = classifyExistingKeyPath(keyPath);
+  if (!overwrite && existing === "regular") {
     throw buildError(
       `tokentimer-agent keys: refusing to overwrite existing key file at ${keyPath} ` +
         "(pass overwrite: true only when a rekey is explicitly intended)",
@@ -141,7 +182,39 @@ function generateKeyPairToFile({ keyPath, algorithm = "ec-p256", overwrite = fal
     privateKey.export({ type: "pkcs8", format: "pem" }),
   );
   try {
-    fs.writeFileSync(keyPath, privatePemBuffer, { mode: 0o600 });
+    if (existing === "regular") {
+      // Rotation: atomic replace via same-directory temp file + rename.
+      const tempPath = path.join(
+        path.dirname(keyPath),
+        `.${path.basename(keyPath)}.${process.pid}.${crypto.randomBytes(6).toString("hex")}.tmp`,
+      );
+      let fd;
+      try {
+        fd = fs.openSync(tempPath, "wx", 0o600);
+        fs.writeFileSync(fd, privatePemBuffer);
+        fs.fsyncSync(fd);
+        fs.closeSync(fd);
+        fd = undefined;
+        fs.renameSync(tempPath, keyPath);
+      } catch (err) {
+        if (fd !== undefined) {
+          try {
+            fs.closeSync(fd);
+          } catch (_err) {
+            // Best-effort close before cleanup.
+          }
+        }
+        try {
+          fs.unlinkSync(tempPath);
+        } catch (_err) {
+          // The temp file may already have been renamed or never created.
+        }
+        throw err;
+      }
+    } else {
+      // Fresh key: exclusive create; never follows a racing symlink.
+      fs.writeFileSync(keyPath, privatePemBuffer, { mode: 0o600, flag: "wx" });
+    }
     try {
       fs.chmodSync(keyPath, 0o600);
     } catch (_err) {

--- a/packages/agent/src/keys/index.js
+++ b/packages/agent/src/keys/index.js
@@ -1,0 +1,537 @@
+"use strict";
+
+/**
+ * Agent-local key generation and CSR building (CertOps M5).
+ *
+ * Zero private-key custody (TOKENTIMER_CERTOPS_PLAN section 9.3, ADR-0001):
+ * private keys are generated locally on the agent host, written 0600 inside
+ * 0700 directories, and NEVER returned from any exported function. Return
+ * values contain only file paths, fingerprints, and public material (public
+ * key PEM, CSR PEM). Every exported function's return value is passed
+ * through the shared private-key-material detector as a last-resort guard
+ * before it is handed back to the caller (mirroring
+ * evidence/assertEvidencePayloadSafe).
+ *
+ * Memory hygiene note (plan 7.7): JavaScript cannot guarantee zeroization.
+ * Strings are immutable and copied freely by the engine, and node:crypto
+ * KeyObject internal memory is owned by OpenSSL and not reachable from JS.
+ * What this module *can* do, it does: private key PEM is exported into a
+ * Buffer, written to disk from that Buffer, and the Buffer is fill(0)-ed
+ * immediately after the write. The KeyObject itself and any transient
+ * copies made inside OpenSSL/V8 are beyond zeroization from JS; this is a
+ * documented platform limit, not an oversight.
+ *
+ * Module style follows the sibling policy/evidence modules: CommonJS,
+ * node builtins only (node:crypto, node:fs, node:path), self-contained
+ * plain-data functions with no sibling-module imports beyond the shared
+ * detector seam already used by ../evidence.
+ */
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Single source of truth for content-based private-key-material detection,
+// required through the same compatibility seam ../evidence/index.js uses
+// (apps/api/utils/secretMaterial.js -> packages/log-scrub/secret-material).
+const {
+  assertNoPrivateKeyMaterial,
+} = require("../../../../apps/api/utils/secretMaterial.js");
+
+/**
+ * Supported key algorithms. Each entry maps the public algorithm name to
+ * the node:crypto generateKeyPairSync type/options pair.
+ */
+const SUPPORTED_ALGORITHMS = Object.freeze({
+  "ec-p256": Object.freeze({ type: "ec", options: Object.freeze({ namedCurve: "P-256" }) }),
+  "rsa-2048": Object.freeze({ type: "rsa", options: Object.freeze({ modulusLength: 2048 }) }),
+  "rsa-3072": Object.freeze({ type: "rsa", options: Object.freeze({ modulusLength: 3072 }) }),
+  ed25519: Object.freeze({ type: "ed25519", options: Object.freeze({}) }),
+});
+
+const SUPPORTED_ALGORITHM_NAMES = Object.freeze(Object.keys(SUPPORTED_ALGORITHMS));
+
+function buildError(message, code) {
+  const error = new Error(message);
+  if (code) error.code = code;
+  return error;
+}
+
+/**
+ * Last-resort custody guard: deep-scans a return value for private key
+ * material immediately before it leaves this module. Same spirit (and same
+ * shared detector) as evidence/assertEvidencePayloadSafe.
+ *
+ * Content-only scan, deliberately: the shared detector's *field-name*
+ * heuristic bans any name containing "keyPem", which would reject this
+ * module's own `publicKeyPem` field even though it holds public material
+ * by construction. Field-name policy belongs to evidence/protocol payload
+ * builders; the custody boundary here is the content check, applied to
+ * every value in the return object. Throws with code
+ * PRIVATE_KEY_MATERIAL_REJECTED if anything key-like is found.
+ * @param {Record<string, *>} value flat plain-object return value
+ * @returns {Record<string, *>} the value, unchanged, when safe
+ */
+function guardReturnValue(value) {
+  for (const item of Object.values(value)) {
+    assertNoPrivateKeyMaterial(item);
+  }
+  return value;
+}
+
+/**
+ * Ensures the parent directory of keyPath exists with 0700 permissions,
+ * re-asserting the mode on every call (same defense-in-depth discipline as
+ * config/ensureConfigDir; best-effort on win32 where POSIX modes are not
+ * meaningful).
+ * @param {string} keyPath
+ * @returns {void}
+ */
+function ensureKeyDir(keyPath) {
+  const dir = path.dirname(keyPath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch (_err) {
+    // Best-effort on win32; see config/ensureConfigDir for rationale.
+  }
+}
+
+/**
+ * Generates a keypair, writes the private key PEM (PKCS#8) to keyPath with
+ * mode 0600 (parent dir 0700), and returns ONLY public material.
+ *
+ * The private key PEM is exported into a Buffer, written from that Buffer,
+ * and the Buffer is zeroized (fill(0)) immediately after the write. See the
+ * module doc comment for the documented limits of zeroization in JS.
+ *
+ * @param {object} input
+ * @param {string} input.keyPath absolute or relative path for the private key file
+ * @param {"ec-p256"|"rsa-2048"|"rsa-3072"|"ed25519"} [input.algorithm]
+ * @param {boolean} [input.overwrite] refuse to clobber an existing file unless true
+ * @returns {{ keyPath: string, publicKeyPem: string, algorithm: string }}
+ */
+function generateKeyPairToFile({ keyPath, algorithm = "ec-p256", overwrite = false } = {}) {
+  if (typeof keyPath !== "string" || keyPath.length === 0) {
+    throw buildError("tokentimer-agent keys: keyPath must be a non-empty string");
+  }
+  const spec = SUPPORTED_ALGORITHMS[algorithm];
+  if (!spec) {
+    throw buildError(
+      `tokentimer-agent keys: unsupported algorithm ${JSON.stringify(algorithm)}; ` +
+        `supported: ${SUPPORTED_ALGORITHM_NAMES.join(", ")}`,
+    );
+  }
+
+  if (!overwrite && fs.existsSync(keyPath)) {
+    throw buildError(
+      `tokentimer-agent keys: refusing to overwrite existing key file at ${keyPath} ` +
+        "(pass overwrite: true only when a rekey is explicitly intended)",
+    );
+  }
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync(spec.type, spec.options);
+
+  ensureKeyDir(keyPath);
+
+  // Export into a Buffer (not a string) so the bytes can be zeroized after
+  // the write. KeyObject.export returns a Buffer when no encoding is given
+  // beyond format: "pem" -- force Buffer via Buffer.from to be explicit.
+  const privatePemBuffer = Buffer.from(
+    privateKey.export({ type: "pkcs8", format: "pem" }),
+  );
+  try {
+    fs.writeFileSync(keyPath, privatePemBuffer, { mode: 0o600 });
+    try {
+      fs.chmodSync(keyPath, 0o600);
+    } catch (_err) {
+      // Best-effort on win32; see ensureKeyDir.
+    }
+  } finally {
+    // Zeroize what we can: the exported PEM bytes. The KeyObject's internal
+    // OpenSSL memory and any engine-internal copies cannot be zeroized from
+    // JS (documented limit, see module doc comment).
+    privatePemBuffer.fill(0);
+  }
+
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+
+  return guardReturnValue({ keyPath, publicKeyPem, algorithm });
+}
+
+/**
+ * Computes the sha256 hex fingerprint of the public key DER (SPKI) for the
+ * key stored at keyPath, for correlation/evidence purposes.
+ * @param {object} input
+ * @param {string} input.keyPath
+ * @returns {{ fingerprintSha256: string }}
+ */
+function getPublicKeyFingerprint({ keyPath } = {}) {
+  if (typeof keyPath !== "string" || keyPath.length === 0) {
+    throw buildError("tokentimer-agent keys: keyPath must be a non-empty string");
+  }
+
+  const keyBuffer = fs.readFileSync(keyPath);
+  let spkiDer;
+  try {
+    const privateKey = crypto.createPrivateKey(keyBuffer);
+    const publicKey = crypto.createPublicKey(privateKey);
+    spkiDer = publicKey.export({ type: "spki", format: "der" });
+  } finally {
+    keyBuffer.fill(0);
+  }
+
+  const fingerprintSha256 = crypto.createHash("sha256").update(spkiDer).digest("hex");
+  return guardReturnValue({ fingerprintSha256 });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ASN.1 DER encoding helpers for PKCS#10 CSR construction.
+//
+// Node has no built-in CSR API, so the CertificationRequest structure
+// (RFC 2986) is assembled by hand from small, well-tested DER primitives.
+// Only what a CSR needs is implemented: definite-length TLVs, SEQUENCE/SET,
+// OID, UTF8String/PrintableString, BIT STRING, OCTET STRING, INTEGER 0,
+// context tags, and BOOLEAN-free extension bodies. This is an *encoder*
+// only; it never parses untrusted input.
+// ---------------------------------------------------------------------------
+
+/**
+ * Encodes a DER definite length.
+ * @param {number} length
+ * @returns {Buffer}
+ */
+function derLength(length) {
+  if (length < 0x80) return Buffer.from([length]);
+  const bytes = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining >>>= 8;
+  }
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+/**
+ * Encodes one DER TLV.
+ * @param {number} tag
+ * @param {Buffer} value
+ * @returns {Buffer}
+ */
+function derTlv(tag, value) {
+  return Buffer.concat([Buffer.from([tag]), derLength(value.length), value]);
+}
+
+/** @param {Buffer[]} children @returns {Buffer} SEQUENCE (0x30) */
+function derSequence(children) {
+  return derTlv(0x30, Buffer.concat(children));
+}
+
+/** @param {Buffer[]} children @returns {Buffer} SET (0x31) */
+function derSet(children) {
+  return derTlv(0x31, Buffer.concat(children));
+}
+
+/**
+ * Encodes an OBJECT IDENTIFIER from dotted-decimal notation.
+ * @param {string} oid e.g. "2.5.4.3"
+ * @returns {Buffer}
+ */
+function derOid(oid) {
+  const parts = oid.split(".").map(Number);
+  if (parts.length < 2 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw buildError(`tokentimer-agent keys: invalid OID ${JSON.stringify(oid)}`);
+  }
+  const bytes = [40 * parts[0] + parts[1]];
+  for (const part of parts.slice(2)) {
+    // Base-128 with high bit as continuation, per X.690.
+    const stack = [part & 0x7f];
+    let remaining = part >>> 7;
+    while (remaining > 0) {
+      stack.unshift((remaining & 0x7f) | 0x80);
+      remaining >>>= 7;
+    }
+    bytes.push(...stack);
+  }
+  return derTlv(0x06, Buffer.from(bytes));
+}
+
+/** @param {string} value @returns {Buffer} UTF8String (0x0c) */
+function derUtf8String(value) {
+  return derTlv(0x0c, Buffer.from(value, "utf8"));
+}
+
+/** @param {string} value @returns {Buffer} PrintableString (0x13) */
+function derPrintableString(value) {
+  return derTlv(0x13, Buffer.from(value, "ascii"));
+}
+
+/**
+ * BIT STRING (0x03) with zero unused bits, as used for signatures and
+ * public keys in X.509 structures.
+ * @param {Buffer} value
+ * @returns {Buffer}
+ */
+function derBitString(value) {
+  return derTlv(0x03, Buffer.concat([Buffer.from([0x00]), value]));
+}
+
+/** @param {Buffer} value @returns {Buffer} OCTET STRING (0x04) */
+function derOctetString(value) {
+  return derTlv(0x04, value);
+}
+
+/** INTEGER 0 (CSR version). @returns {Buffer} */
+function derIntegerZero() {
+  return Buffer.from([0x02, 0x01, 0x00]);
+}
+
+/**
+ * Context-specific constructed tag [n], e.g. [0] for CSR attributes.
+ * @param {number} tagNumber
+ * @param {Buffer} value
+ * @returns {Buffer}
+ */
+function derContextConstructed(tagNumber, value) {
+  return derTlv(0xa0 | tagNumber, value);
+}
+
+// ---------------------------------------------------------------------------
+// CSR structure building (RFC 2986 / RFC 5280)
+// ---------------------------------------------------------------------------
+
+// X.500 attribute type OIDs for the subject DN fields this module supports.
+const DN_ATTRIBUTE_OIDS = Object.freeze({
+  commonName: "2.5.4.3",
+  organization: "2.5.4.10",
+  organizationalUnit: "2.5.4.11",
+  country: "2.5.4.6",
+  state: "2.5.4.8",
+  locality: "2.5.4.7",
+});
+
+// Fixed DN encoding order (matches conventional C, ST, L, O, OU, CN order).
+const DN_FIELD_ORDER = Object.freeze([
+  "country",
+  "state",
+  "locality",
+  "organization",
+  "organizationalUnit",
+  "commonName",
+]);
+
+const OID_EXTENSION_REQUEST = "1.2.840.113549.1.9.14"; // pkcs-9-at-extensionRequest
+const OID_SUBJECT_ALT_NAME = "2.5.29.17";
+const OID_ECDSA_WITH_SHA256 = "1.2.840.10045.4.3.2";
+const OID_SHA256_WITH_RSA = "1.2.840.113549.1.1.11";
+
+/**
+ * Encodes one DN RelativeDistinguishedName:
+ * SET { SEQUENCE { OID, string } }. country uses PrintableString per
+ * RFC 5280's expectation for countryName; all other fields use UTF8String.
+ * @param {string} fieldName
+ * @param {string} value
+ * @returns {Buffer}
+ */
+function derRdn(fieldName, value) {
+  const oid = DN_ATTRIBUTE_OIDS[fieldName];
+  const encodedValue =
+    fieldName === "country" ? derPrintableString(value) : derUtf8String(value);
+  return derSet([derSequence([derOid(oid), encodedValue])]);
+}
+
+/**
+ * Encodes the subject Name (RDNSequence) from a plain subject object.
+ * @param {{commonName: string, organization?: string, organizationalUnit?: string, country?: string, state?: string, locality?: string}} subject
+ * @returns {Buffer}
+ */
+function derSubjectName(subject) {
+  if (subject === null || typeof subject !== "object" || Array.isArray(subject)) {
+    throw buildError("tokentimer-agent keys: subject must be an object with a commonName");
+  }
+  if (typeof subject.commonName !== "string" || subject.commonName.length === 0) {
+    throw buildError("tokentimer-agent keys: subject.commonName must be a non-empty string");
+  }
+  if (subject.country !== undefined) {
+    if (typeof subject.country !== "string" || !/^[A-Z]{2}$/.test(subject.country)) {
+      throw buildError(
+        "tokentimer-agent keys: subject.country must be a 2-letter uppercase ISO 3166 code",
+      );
+    }
+  }
+
+  const rdns = [];
+  for (const fieldName of DN_FIELD_ORDER) {
+    const value = subject[fieldName];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== "string" || value.length === 0) {
+      throw buildError(
+        `tokentimer-agent keys: subject.${fieldName} must be a non-empty string`,
+      );
+    }
+    rdns.push(derRdn(fieldName, value));
+  }
+  return derSequence(rdns);
+}
+
+/**
+ * Encodes a subjectAltName extension value: SEQUENCE of GeneralName
+ * dNSName ([2] IMPLICIT IA5String) entries.
+ * @param {string[]} altNames
+ * @returns {Buffer} the SAN extension inner value (not yet OCTET STRING wrapped)
+ */
+function derSubjectAltNameValue(altNames) {
+  const generalNames = altNames.map((name) =>
+    // GeneralName dNSName is context tag [2], primitive (0x82), IA5String body.
+    derTlv(0x82, Buffer.from(name, "ascii")),
+  );
+  return derSequence(generalNames);
+}
+
+/**
+ * Encodes the CSR attributes [0] block containing an extensionRequest with
+ * a subjectAltName extension. When altNames is empty, returns an empty
+ * attributes block ([0] with zero length), which RFC 2986 permits.
+ * @param {string[]} altNames
+ * @returns {Buffer}
+ */
+function derCsrAttributes(altNames) {
+  if (altNames.length === 0) {
+    return derContextConstructed(0, Buffer.alloc(0));
+  }
+
+  const sanExtension = derSequence([
+    derOid(OID_SUBJECT_ALT_NAME),
+    derOctetString(derSubjectAltNameValue(altNames)),
+  ]);
+  const extensions = derSequence([sanExtension]);
+  const extensionRequestAttribute = derSequence([
+    derOid(OID_EXTENSION_REQUEST),
+    derSet([extensions]),
+  ]);
+  return derContextConstructed(0, extensionRequestAttribute);
+}
+
+/**
+ * Returns the DER-encoded AlgorithmIdentifier and node:crypto sign options
+ * for a private KeyObject's type. Ed25519 CSRs are intentionally not
+ * supported (documented deviation): a hand-rolled Ed25519 CSR would add a
+ * third signature path for a curve no target CA in scope currently issues
+ * against, so it throws a clear error instead.
+ * @param {crypto.KeyObject} privateKey
+ * @returns {{ signatureAlgorithm: Buffer, signOptions: object|null, hash: string|null }}
+ */
+function resolveSignatureAlgorithm(privateKey) {
+  const keyType = privateKey.asymmetricKeyType;
+  if (keyType === "ec") {
+    // ecdsa-with-SHA256; parameters MUST be absent for ECDSA.
+    return {
+      signatureAlgorithm: derSequence([derOid(OID_ECDSA_WITH_SHA256)]),
+      hash: "sha256",
+    };
+  }
+  if (keyType === "rsa") {
+    // sha256WithRSAEncryption; parameters are explicit NULL for RSA.
+    return {
+      signatureAlgorithm: derSequence([
+        derOid(OID_SHA256_WITH_RSA),
+        Buffer.from([0x05, 0x00]),
+      ]),
+      hash: "sha256",
+    };
+  }
+  if (keyType === "ed25519") {
+    throw buildError(
+      "tokentimer-agent keys: Ed25519 CSR generation is not supported " +
+        "(documented deviation; generate the key as ec-p256 or rsa-* when a CSR is needed)",
+    );
+  }
+  throw buildError(
+    `tokentimer-agent keys: unsupported private key type ${JSON.stringify(keyType)} for CSR signing`,
+  );
+}
+
+/**
+ * Wraps DER bytes in a PEM envelope with the given label.
+ * @param {Buffer} der
+ * @param {string} label e.g. "CERTIFICATE REQUEST"
+ * @returns {string}
+ */
+function derToPem(der, label) {
+  const base64 = der.toString("base64");
+  const lines = base64.match(/.{1,64}/g) || [];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----\n`;
+}
+
+/**
+ * Builds a PKCS#10 CSR signed with the private key stored at keyPath.
+ *
+ * The private key is read from disk only inside this function, used for a
+ * single sign operation, and never cached; the read buffer is zeroized
+ * after the KeyObject is created (KeyObject internals cannot be zeroized
+ * from JS, see module doc comment).
+ *
+ * Supported signature algorithms: ECDSA-with-SHA256 (EC P-256 keys) and
+ * sha256WithRSAEncryption (RSA keys). Ed25519 throws a clear "not
+ * supported" error (documented deviation).
+ *
+ * @param {object} input
+ * @param {string} input.keyPath path to the PKCS#8 private key PEM on disk
+ * @param {{commonName: string, organization?: string, organizationalUnit?: string, country?: string, state?: string, locality?: string}} input.subject
+ * @param {string[]} [input.altNames] dNSName SAN entries
+ * @returns {{ csrPem: string, publicKeyPem: string }}
+ */
+function generateCsr({ keyPath, subject, altNames = [] } = {}) {
+  if (typeof keyPath !== "string" || keyPath.length === 0) {
+    throw buildError("tokentimer-agent keys: keyPath must be a non-empty string");
+  }
+  if (!Array.isArray(altNames) || !altNames.every((n) => typeof n === "string" && n.length > 0)) {
+    throw buildError("tokentimer-agent keys: altNames must be an array of non-empty strings");
+  }
+
+  const subjectName = derSubjectName(subject);
+
+  const keyBuffer = fs.readFileSync(keyPath);
+  let privateKey;
+  try {
+    privateKey = crypto.createPrivateKey(keyBuffer);
+  } finally {
+    keyBuffer.fill(0);
+  }
+
+  const publicKey = crypto.createPublicKey(privateKey);
+  const spkiDer = publicKey.export({ type: "spki", format: "der" });
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+
+  const { signatureAlgorithm, hash } = resolveSignatureAlgorithm(privateKey);
+
+  // CertificationRequestInfo ::= SEQUENCE {
+  //   version INTEGER 0, subject Name, subjectPKInfo SPKI,
+  //   attributes [0] IMPLICIT Attributes }
+  const certificationRequestInfo = derSequence([
+    derIntegerZero(),
+    subjectName,
+    spkiDer,
+    derCsrAttributes(altNames),
+  ]);
+
+  // ECDSA signatures from crypto.sign default to DER format, which is what
+  // X.509 structures require. RSA PKCS#1 v1.5 is the default padding.
+  const signature = crypto.sign(hash, certificationRequestInfo, privateKey);
+
+  const certificationRequest = derSequence([
+    certificationRequestInfo,
+    signatureAlgorithm,
+    derBitString(signature),
+  ]);
+
+  const csrPem = derToPem(certificationRequest, "CERTIFICATE REQUEST");
+  return guardReturnValue({ csrPem, publicKeyPem });
+}
+
+module.exports = {
+  SUPPORTED_ALGORITHM_NAMES,
+  generateKeyPairToFile,
+  generateCsr,
+  getPublicKeyFingerprint,
+};

--- a/packages/agent/src/keys/keys.test.js
+++ b/packages/agent/src/keys/keys.test.js
@@ -1,0 +1,404 @@
+"use strict";
+
+/**
+ * Tests for packages/agent/src/keys/index.js.
+ *
+ * CSR validation strategy: the generated CSR is round-tripped without
+ * openssl by (a) parsing the DER with a tiny TLV reader, (b) recreating the
+ * public key from the embedded SPKI via crypto.createPublicKey, and
+ * (c) verifying the CSR self-signature with crypto.verify over the
+ * CertificationRequestInfo DER. When openssl is available on PATH the CSR
+ * is additionally verified with `openssl req -verify -noout`; that check
+ * skips gracefully when openssl is unavailable.
+ */
+
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  SUPPORTED_ALGORITHM_NAMES,
+  generateKeyPairToFile,
+  generateCsr,
+  getPublicKeyFingerprint,
+} = require("./index.js");
+
+const IS_WIN32 = process.platform === "win32";
+
+const tempDirs = [];
+
+function makeTempKeyDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentimer-agent-keys-test-"));
+  tempDirs.push(dir);
+  // Nested, not-yet-existing subdirectory so tests also cover recursive
+  // parent-dir creation with 0700.
+  return path.join(dir, "keys");
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (_err) {
+      // best-effort cleanup
+    }
+  }
+});
+
+/**
+ * Minimal DER TLV reader for test-side CSR parsing (decode-only; the module
+ * under test owns encoding).
+ * @param {Buffer} buf
+ * @param {number} offset
+ * @returns {{tag: number, start: number, headerLength: number, length: number, valueStart: number, valueEnd: number}}
+ */
+function readTlv(buf, offset) {
+  const tag = buf[offset];
+  let length = buf[offset + 1];
+  let headerLength = 2;
+  if (length & 0x80) {
+    const lengthBytes = length & 0x7f;
+    length = 0;
+    for (let i = 0; i < lengthBytes; i += 1) {
+      length = length * 256 + buf[offset + 2 + i];
+    }
+    headerLength += lengthBytes;
+  }
+  const valueStart = offset + headerLength;
+  return {
+    tag,
+    start: offset,
+    headerLength,
+    length,
+    valueStart,
+    valueEnd: valueStart + length,
+  };
+}
+
+function pemToDer(pem, label) {
+  const match = pem.match(
+    new RegExp(`-----BEGIN ${label}-----([\\s\\S]*?)-----END ${label}-----`),
+  );
+  assert.ok(match, `PEM must contain a ${label} block`);
+  return Buffer.from(match[1].replace(/\s+/g, ""), "base64");
+}
+
+/**
+ * Parses a CSR DER into its three top-level parts plus the embedded SPKI.
+ * @param {Buffer} csrDer
+ */
+function parseCsr(csrDer) {
+  const outer = readTlv(csrDer, 0);
+  assert.equal(outer.tag, 0x30, "CSR outer tag must be SEQUENCE");
+  assert.equal(outer.valueEnd, csrDer.length, "CSR outer length must span the whole DER");
+
+  const cri = readTlv(csrDer, outer.valueStart);
+  assert.equal(cri.tag, 0x30, "CertificationRequestInfo must be SEQUENCE");
+  const criDer = csrDer.subarray(cri.start, cri.valueEnd);
+
+  const sigAlg = readTlv(csrDer, cri.valueEnd);
+  assert.equal(sigAlg.tag, 0x30, "signatureAlgorithm must be SEQUENCE");
+
+  const sigBits = readTlv(csrDer, sigAlg.valueEnd);
+  assert.equal(sigBits.tag, 0x03, "signature must be BIT STRING");
+  assert.equal(csrDer[sigBits.valueStart], 0x00, "BIT STRING must have 0 unused bits");
+  const signature = csrDer.subarray(sigBits.valueStart + 1, sigBits.valueEnd);
+
+  // Inside CRI: INTEGER version, subject Name, SPKI, [0] attributes.
+  const version = readTlv(csrDer, cri.valueStart);
+  assert.equal(version.tag, 0x02, "CSR version must be INTEGER");
+  assert.equal(csrDer[version.valueStart], 0x00, "CSR version must be 0");
+  const subject = readTlv(csrDer, version.valueEnd);
+  assert.equal(subject.tag, 0x30, "subject Name must be SEQUENCE");
+  const spki = readTlv(csrDer, subject.valueEnd);
+  assert.equal(spki.tag, 0x30, "SubjectPublicKeyInfo must be SEQUENCE");
+  const spkiDer = csrDer.subarray(spki.start, spki.valueEnd);
+  const attributes = readTlv(csrDer, spki.valueEnd);
+  assert.equal(attributes.tag, 0xa0, "attributes must be context [0]");
+
+  return { criDer, signature, spkiDer };
+}
+
+function opensslAvailable() {
+  try {
+    const probe = spawnSync("openssl", ["version"], { encoding: "utf8" });
+    return probe.status === 0;
+  } catch (_err) {
+    return false;
+  }
+}
+
+describe("generateKeyPairToFile", () => {
+  for (const algorithm of SUPPORTED_ALGORITHM_NAMES) {
+    it(`generates a ${algorithm} keypair, writes the file, and returns only public material`, () => {
+      const keyPath = path.join(makeTempKeyDir(), `${algorithm}.key.pem`);
+      const result = generateKeyPairToFile({ keyPath, algorithm });
+
+      assert.deepEqual(Object.keys(result).sort(), ["algorithm", "keyPath", "publicKeyPem"]);
+      assert.equal(result.keyPath, keyPath);
+      assert.equal(result.algorithm, algorithm);
+      assert.ok(result.publicKeyPem.includes("-----BEGIN PUBLIC KEY-----"));
+      assert.ok(!JSON.stringify(result).includes("PRIVATE KEY"));
+
+      // The file on disk is a loadable PKCS#8 private key whose public half
+      // matches the returned publicKeyPem.
+      const onDisk = fs.readFileSync(keyPath, "utf8");
+      assert.ok(onDisk.includes("-----BEGIN PRIVATE KEY-----"));
+      const derivedPublic = crypto
+        .createPublicKey(crypto.createPrivateKey(onDisk))
+        .export({ type: "spki", format: "pem" })
+        .toString();
+      assert.equal(derivedPublic, result.publicKeyPem);
+    });
+  }
+
+  it("rejects an unsupported algorithm with a clear error", () => {
+    const keyPath = path.join(makeTempKeyDir(), "bad.key.pem");
+    assert.throws(
+      () => generateKeyPairToFile({ keyPath, algorithm: "dsa-1024" }),
+      /unsupported algorithm/,
+    );
+  });
+
+  it("rejects a missing keyPath", () => {
+    assert.throws(() => generateKeyPairToFile({}), /keyPath must be a non-empty string/);
+  });
+
+  it("sets 0600 on the key file and 0700 on the parent dir on non-win32", { skip: IS_WIN32 }, () => {
+    const dir = makeTempKeyDir();
+    const keyPath = path.join(dir, "perm.key.pem");
+    generateKeyPairToFile({ keyPath });
+    assert.equal(fs.statSync(keyPath).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(dir).mode & 0o777, 0o700);
+  });
+
+  it("refuses to overwrite an existing key file unless overwrite is true", () => {
+    const keyPath = path.join(makeTempKeyDir(), "overwrite.key.pem");
+    const first = generateKeyPairToFile({ keyPath });
+    assert.throws(
+      () => generateKeyPairToFile({ keyPath }),
+      /refusing to overwrite existing key file/,
+    );
+    const second = generateKeyPairToFile({ keyPath, overwrite: true });
+    assert.notEqual(second.publicKeyPem, first.publicKeyPem);
+  });
+
+  it("never includes 'PRIVATE KEY' in a thrown error message", () => {
+    const keyPath = path.join(makeTempKeyDir(), "err.key.pem");
+    generateKeyPairToFile({ keyPath });
+    for (const throwing of [
+      () => generateKeyPairToFile({ keyPath }),
+      () => generateKeyPairToFile({ keyPath: "", algorithm: "ec-p256" }),
+      () => generateKeyPairToFile({ keyPath: `${keyPath}.other`, algorithm: "nope" }),
+    ]) {
+      try {
+        throwing();
+        assert.fail("expected the call to throw");
+      } catch (err) {
+        assert.ok(!String(err.message).includes("PRIVATE KEY"));
+      }
+    }
+  });
+});
+
+describe("getPublicKeyFingerprint", () => {
+  it("returns the sha256 hex of the SPKI DER", () => {
+    const keyPath = path.join(makeTempKeyDir(), "fp.key.pem");
+    const { publicKeyPem } = generateKeyPairToFile({ keyPath });
+    const { fingerprintSha256 } = getPublicKeyFingerprint({ keyPath });
+
+    assert.match(fingerprintSha256, /^[a-f0-9]{64}$/);
+    const expected = crypto
+      .createHash("sha256")
+      .update(crypto.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" }))
+      .digest("hex");
+    assert.equal(fingerprintSha256, expected);
+  });
+
+  it("is stable across calls and distinct across keys", () => {
+    const dir = makeTempKeyDir();
+    const keyPathA = path.join(dir, "a.key.pem");
+    const keyPathB = path.join(dir, "b.key.pem");
+    generateKeyPairToFile({ keyPath: keyPathA });
+    generateKeyPairToFile({ keyPath: keyPathB });
+
+    const fpA1 = getPublicKeyFingerprint({ keyPath: keyPathA }).fingerprintSha256;
+    const fpA2 = getPublicKeyFingerprint({ keyPath: keyPathA }).fingerprintSha256;
+    const fpB = getPublicKeyFingerprint({ keyPath: keyPathB }).fingerprintSha256;
+    assert.equal(fpA1, fpA2);
+    assert.notEqual(fpA1, fpB);
+  });
+
+  it("rejects a missing keyPath", () => {
+    assert.throws(() => getPublicKeyFingerprint({}), /keyPath must be a non-empty string/);
+  });
+});
+
+describe("generateCsr", () => {
+  for (const algorithm of ["ec-p256", "rsa-2048"]) {
+    it(`builds a parseable, self-signature-valid CSR for ${algorithm}`, () => {
+      const keyPath = path.join(makeTempKeyDir(), `${algorithm}-csr.key.pem`);
+      const generated = generateKeyPairToFile({ keyPath, algorithm });
+
+      const altNames = ["example.com", "www.example.com"];
+      const { csrPem, publicKeyPem } = generateCsr({
+        keyPath,
+        subject: { commonName: "example.com", organization: "TokenTimer Test" },
+        altNames,
+      });
+
+      assert.ok(csrPem.startsWith("-----BEGIN CERTIFICATE REQUEST-----"));
+      assert.equal(publicKeyPem, generated.publicKeyPem);
+      assert.ok(!csrPem.includes("PRIVATE KEY"));
+
+      const csrDer = pemToDer(csrPem, "CERTIFICATE REQUEST");
+      const { criDer, signature, spkiDer } = parseCsr(csrDer);
+
+      // Round-trip: the embedded SPKI must load via createPublicKey and
+      // match the returned public key.
+      const embeddedPublic = crypto.createPublicKey({
+        key: spkiDer,
+        format: "der",
+        type: "spki",
+      });
+      assert.equal(
+        embeddedPublic.export({ type: "spki", format: "pem" }).toString(),
+        publicKeyPem,
+      );
+
+      // Manual self-signature verification over the CertificationRequestInfo DER.
+      assert.equal(crypto.verify("sha256", criDer, embeddedPublic, signature), true);
+
+      // CN and each SAN must appear as encoded strings in the DER bytes.
+      assert.ok(criDer.includes(Buffer.from("example.com", "utf8")));
+      for (const san of altNames) {
+        assert.ok(criDer.includes(Buffer.from(san, "ascii")), `SAN ${san} missing from DER`);
+      }
+    });
+  }
+
+  it("supports rsa-3072 keys with the same RSA signature path", () => {
+    const keyPath = path.join(makeTempKeyDir(), "rsa3072-csr.key.pem");
+    generateKeyPairToFile({ keyPath, algorithm: "rsa-3072" });
+    const { csrPem } = generateCsr({ keyPath, subject: { commonName: "rsa3072.example.com" } });
+    const csrDer = pemToDer(csrPem, "CERTIFICATE REQUEST");
+    const { criDer, signature, spkiDer } = parseCsr(csrDer);
+    const embeddedPublic = crypto.createPublicKey({ key: spkiDer, format: "der", type: "spki" });
+    assert.equal(crypto.verify("sha256", criDer, embeddedPublic, signature), true);
+  });
+
+  it("encodes optional O/OU/C subject fields into the DER", () => {
+    const keyPath = path.join(makeTempKeyDir(), "dn.key.pem");
+    generateKeyPairToFile({ keyPath });
+    const { csrPem } = generateCsr({
+      keyPath,
+      subject: {
+        commonName: "dn.example.com",
+        organization: "TokenTimer GmbH",
+        organizationalUnit: "CertOps",
+        country: "DE",
+      },
+    });
+    const csrDer = pemToDer(csrPem, "CERTIFICATE REQUEST");
+    assert.ok(csrDer.includes(Buffer.from("dn.example.com", "utf8")));
+    assert.ok(csrDer.includes(Buffer.from("TokenTimer GmbH", "utf8")));
+    assert.ok(csrDer.includes(Buffer.from("CertOps", "utf8")));
+    assert.ok(csrDer.includes(Buffer.from("DE", "ascii")));
+  });
+
+  it("builds a CSR with no SANs (empty attributes block)", () => {
+    const keyPath = path.join(makeTempKeyDir(), "nosan.key.pem");
+    generateKeyPairToFile({ keyPath });
+    const { csrPem } = generateCsr({ keyPath, subject: { commonName: "nosan.example.com" } });
+    const csrDer = pemToDer(csrPem, "CERTIFICATE REQUEST");
+    const { criDer, signature, spkiDer } = parseCsr(csrDer);
+    const embeddedPublic = crypto.createPublicKey({ key: spkiDer, format: "der", type: "spki" });
+    assert.equal(crypto.verify("sha256", criDer, embeddedPublic, signature), true);
+  });
+
+  it("throws a clear 'not supported' error for Ed25519 CSRs (documented deviation)", () => {
+    const keyPath = path.join(makeTempKeyDir(), "ed.key.pem");
+    generateKeyPairToFile({ keyPath, algorithm: "ed25519" });
+    assert.throws(
+      () => generateCsr({ keyPath, subject: { commonName: "ed.example.com" } }),
+      /Ed25519 CSR generation is not supported/,
+    );
+  });
+
+  it("validates subject and altNames shapes with clear errors", () => {
+    const keyPath = path.join(makeTempKeyDir(), "shape.key.pem");
+    generateKeyPairToFile({ keyPath });
+    assert.throws(() => generateCsr({ keyPath }), /subject must be an object/);
+    assert.throws(
+      () => generateCsr({ keyPath, subject: {} }),
+      /commonName must be a non-empty string/,
+    );
+    assert.throws(
+      () => generateCsr({ keyPath, subject: { commonName: "x", country: "Germany" } }),
+      /country must be a 2-letter uppercase/,
+    );
+    assert.throws(
+      () => generateCsr({ keyPath, subject: { commonName: "x" }, altNames: [42] }),
+      /altNames must be an array of non-empty strings/,
+    );
+  });
+
+  it("never includes 'PRIVATE KEY' in any thrown error message", () => {
+    const keyPath = path.join(makeTempKeyDir(), "csr-err.key.pem");
+    generateKeyPairToFile({ keyPath, algorithm: "ed25519" });
+    for (const throwing of [
+      () => generateCsr({ keyPath, subject: { commonName: "x" } }),
+      () => generateCsr({ keyPath: "", subject: { commonName: "x" } }),
+      () => generateCsr({ keyPath, subject: null }),
+    ]) {
+      try {
+        throwing();
+        assert.fail("expected the call to throw");
+      } catch (err) {
+        assert.ok(!String(err.message).includes("PRIVATE KEY"));
+      }
+    }
+  });
+
+  it("verifies the CSR with openssl when available", { skip: !opensslAvailable() }, () => {
+    const dir = makeTempKeyDir();
+    const keyPath = path.join(dir, "openssl.key.pem");
+    generateKeyPairToFile({ keyPath });
+    const { csrPem } = generateCsr({
+      keyPath,
+      subject: { commonName: "openssl.example.com" },
+      altNames: ["openssl.example.com"],
+    });
+
+    const csrPath = path.join(dir, "openssl.csr.pem");
+    fs.writeFileSync(csrPath, csrPem, "utf8");
+    const result = spawnSync(
+      "openssl",
+      ["req", "-verify", "-noout", "-in", csrPath],
+      { encoding: "utf8" },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `openssl req -verify failed: ${result.stderr || result.stdout}`,
+    );
+  });
+});
+
+describe("zero-custody return-value guard", () => {
+  it("no exported function return value contains a PRIVATE KEY marker", () => {
+    const keyPath = path.join(makeTempKeyDir(), "guard.key.pem");
+    const genResult = generateKeyPairToFile({ keyPath });
+    const csrResult = generateCsr({ keyPath, subject: { commonName: "guard.example.com" } });
+    const fpResult = getPublicKeyFingerprint({ keyPath });
+
+    for (const result of [genResult, csrResult, fpResult]) {
+      assert.ok(!JSON.stringify(result).includes("PRIVATE KEY"));
+    }
+  });
+});

--- a/packages/agent/src/keys/keys.test.js
+++ b/packages/agent/src/keys/keys.test.js
@@ -188,6 +188,42 @@ describe("generateKeyPairToFile", () => {
     assert.notEqual(second.publicKeyPem, first.publicKeyPem);
   });
 
+  it("refuses to write through a symlink at the key path", { skip: IS_WIN32 }, () => {
+    const dir = makeTempKeyDir();
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const realTarget = path.join(dir, "attacker-target.pem");
+    fs.writeFileSync(realTarget, "sentinel", { mode: 0o600 });
+    const linkPath = path.join(dir, "linked.key.pem");
+    fs.symlinkSync(realTarget, linkPath);
+
+    for (const overwrite of [false, true]) {
+      assert.throws(
+        () => generateKeyPairToFile({ keyPath: linkPath, overwrite }),
+        /not a\s+regular file|refusing to write key/,
+      );
+    }
+    // The symlink target was never clobbered with key material.
+    assert.equal(fs.readFileSync(realTarget, "utf8"), "sentinel");
+  });
+
+  it("rotation replaces the key atomically and leaves no temp files behind", () => {
+    const dir = makeTempKeyDir();
+    const keyPath = path.join(dir, "rotate.key.pem");
+    const first = generateKeyPairToFile({ keyPath });
+    const second = generateKeyPairToFile({ keyPath, overwrite: true });
+    assert.notEqual(second.publicKeyPem, first.publicKeyPem);
+
+    // The on-disk key is complete and matches the returned public half.
+    const derivedPublic = crypto
+      .createPublicKey(crypto.createPrivateKey(fs.readFileSync(keyPath, "utf8")))
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    assert.equal(derivedPublic, second.publicKeyPem);
+
+    const leftovers = fs.readdirSync(dir).filter((name) => name.endsWith(".tmp"));
+    assert.deepEqual(leftovers, []);
+  });
+
   it("never includes 'PRIVATE KEY' in a thrown error message", () => {
     const keyPath = path.join(makeTempKeyDir(), "err.key.pem");
     generateKeyPairToFile({ keyPath });

--- a/packages/agent/src/policy/index.js
+++ b/packages/agent/src/policy/index.js
@@ -39,6 +39,7 @@
  */
 
 const path = require("node:path");
+const net = require("node:net");
 
 /**
  * Shell metacharacters disallowed in any argv element of an allowlisted
@@ -218,12 +219,18 @@ function loadPolicyConfig(rawConfigObject) {
     rawConfigObject.allowedDnsProviders,
   );
 
+  const allowedVerifyHosts = validateStringList(
+    "allowedVerifyHosts",
+    rawConfigObject.allowedVerifyHosts,
+  );
+
   return {
     allowedCommands,
     allowedPaths,
     allowedCaEndpoints,
     allowedDnsZones,
     allowedDnsProviders,
+    allowedVerifyHosts,
   };
 }
 
@@ -294,6 +301,59 @@ function isZoneCoveredBy(zone, allowedZone) {
     normalizedZone === normalizedAllowed ||
     normalizedZone.endsWith(`.${normalizedAllowed}`)
   );
+}
+
+/**
+ * Classifies a verify destination host for the checkVerifyHost dimension.
+ *
+ * Returns one of:
+ *   "denied"    -- never probeable, regardless of any allowlist: the
+ *                  unspecified addresses, IPv4/IPv6 link-local (which
+ *                  includes every cloud metadata endpoint such as
+ *                  169.254.169.254), multicast, and broadcast. There is no
+ *                  legitimate TLS certificate deployment on these.
+ *   "loopback"  -- 127.0.0.0/8, ::1, and localhost names. Probing the
+ *                  agent's own host CAN be legitimate (a local nginx), but
+ *                  only when the operator explicitly allowlists it.
+ *   "ordinary"  -- everything else (public/private IPs and hostnames).
+ *
+ * IPv4-mapped IPv6 (::ffff:a.b.c.d) is unwrapped and classified as its
+ * embedded IPv4 address so the mapping cannot bypass the deny list.
+ *
+ * @param {string} host
+ * @returns {"denied"|"loopback"|"ordinary"}
+ */
+function classifyVerifyHost(host) {
+  // Bare IPv6 in URL-style brackets: strip for classification.
+  const bare = host.startsWith("[") && host.endsWith("]")
+    ? host.slice(1, -1)
+    : host;
+  const lowered = bare.toLowerCase();
+
+  const ipVersion = net.isIP(lowered);
+  if (ipVersion === 4) {
+    const octets = lowered.split(".").map(Number);
+    if (octets[0] === 127) return "loopback";
+    if (octets[0] === 0) return "denied"; // 0.0.0.0/8 unspecified
+    if (octets[0] === 169 && octets[1] === 254) return "denied"; // link-local / metadata
+    if (octets[0] >= 224) return "denied"; // multicast + reserved + broadcast
+    return "ordinary";
+  }
+  if (ipVersion === 6) {
+    // IPv4-mapped: classify the embedded IPv4 address.
+    const mappedMatch = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(lowered);
+    if (mappedMatch) return classifyVerifyHost(mappedMatch[1]);
+    if (lowered === "::" || lowered === "0:0:0:0:0:0:0:0") return "denied";
+    if (lowered === "::1" || lowered === "0:0:0:0:0:0:0:1") return "loopback";
+    if (/^fe[89ab]/.test(lowered)) return "denied"; // fe80::/10 link-local
+    if (lowered.startsWith("ff")) return "denied"; // ff00::/8 multicast
+    return "ordinary";
+  }
+
+  if (lowered === "localhost" || lowered.endsWith(".localhost")) {
+    return "loopback";
+  }
+  return "ordinary";
 }
 
 /**
@@ -429,6 +489,88 @@ function createPolicyEngine(policyConfig, { declaredTargetSelectors = [] } = {})
   }
 
   /**
+   * Verify-destination authorization for the post-deploy live probe.
+   *
+   * A signed job's verifyHost/verifyPort direct the agent to open a TLS
+   * connection, so the destination must be authorized agent-locally like
+   * every other job-controlled reference (ADR-0002: agent-local policy
+   * always wins over control-plane intent). Decision order:
+   *
+   *   1. hard deny (never probeable, regardless of allowlists): the
+   *      unspecified addresses, IPv4/IPv6 link-local (including cloud
+   *      metadata endpoints such as 169.254.169.254), multicast/broadcast;
+   *   2. loopback (127/8, ::1, localhost): allowed only when explicitly
+   *      present in allowedVerifyHosts;
+   *   3. otherwise allowed when the host equals the job's own
+   *      target.reference (case-insensitive; verifying the domain being
+   *      renewed is the normal case and needs no extra config), or when it
+   *      is covered by allowedVerifyHosts (exact match for IPs,
+   *      dot-boundary suffix match for hostnames, same semantics as DNS
+   *      zone coverage).
+   *
+   * Uses the target_out_of_scope rejection reason: the destination is
+   * outside this agent's authorized verification scope.
+   *
+   * @param {string} host verify destination from the job
+   * @param {{ targetReference?: string }} [context]
+   * @returns {{ allowed: true } | ReturnType<typeof reject>}
+   */
+  function checkVerifyHost(host, { targetReference } = {}) {
+    if (!isNonEmptyString(host) || host.length > 255) {
+      return reject(
+        REJECTION_REASONS.TARGET_OUT_OF_SCOPE,
+        "Verify destination host must be a non-empty string of at most 255 characters.",
+      );
+    }
+
+    const classification = classifyVerifyHost(host);
+    if (classification === "denied") {
+      return reject(
+        REJECTION_REASONS.TARGET_OUT_OF_SCOPE,
+        `Verify destination "${host}" is a link-local, unspecified, or ` +
+          "multicast address and can never be probed (metadata-endpoint " +
+          "class destinations are always denied).",
+      );
+    }
+
+    const loweredHost = host.toLowerCase();
+    const allowlisted = policyConfig.allowedVerifyHosts.some((allowedHost) => {
+      const loweredAllowed = allowedHost.toLowerCase();
+      if (loweredAllowed === loweredHost) return true;
+      // Hostname entries also cover subdomains at a dot boundary; IP
+      // entries only ever match exactly (net.isIP guards the suffix rule).
+      return (
+        net.isIP(loweredAllowed) === 0 &&
+        net.isIP(loweredHost) === 0 &&
+        isZoneCoveredBy(loweredHost, loweredAllowed)
+      );
+    });
+
+    if (classification === "loopback") {
+      if (allowlisted) return { allowed: true };
+      return reject(
+        REJECTION_REASONS.TARGET_OUT_OF_SCOPE,
+        `Verify destination "${host}" is a loopback address, which is only ` +
+          "probeable when explicitly present in allowedVerifyHosts.",
+      );
+    }
+
+    if (
+      isNonEmptyString(targetReference) &&
+      targetReference.toLowerCase() === loweredHost
+    ) {
+      return { allowed: true };
+    }
+    if (allowlisted) return { allowed: true };
+
+    return reject(
+      REJECTION_REASONS.TARGET_OUT_OF_SCOPE,
+      `Verify destination "${host}" neither matches the job's target ` +
+        "reference nor any allowedVerifyHosts entry.",
+    );
+  }
+
+  /**
    * Exact-match check against the declared target selectors. Selector
    * *pattern* matching (globs, wildcards, etc.), if ever needed, is out of
    * scope for the agent bootstrap and is left as a future extension.
@@ -558,6 +700,7 @@ function createPolicyEngine(policyConfig, { declaredTargetSelectors = [] } = {})
     checkCaEndpoint,
     checkDnsZone,
     checkDnsProvider,
+    checkVerifyHost,
     checkTargetScope,
     checkNoKeyExport,
     evaluateJob,

--- a/packages/agent/src/policy/policy.test.js
+++ b/packages/agent/src/policy/policy.test.js
@@ -414,3 +414,105 @@ test("evaluateJob falls through to path rejection when command passes", () => {
   });
   assert.equal(result.rejectionReason, REJECTION_REASONS.PATH_NOT_ALLOWLISTED);
 });
+
+// ---------------------------------------------------------------------------
+// checkVerifyHost
+// ---------------------------------------------------------------------------
+
+function verifyEngine(allowedVerifyHosts = []) {
+  const config = loadPolicyConfig({
+    ...baseRawConfig(),
+    allowedVerifyHosts,
+  });
+  return createPolicyEngine(config, {
+    declaredTargetSelectors: ["host:web-01"],
+  });
+}
+
+test("checkVerifyHost allows the job's own target reference without extra config", () => {
+  const engine = verifyEngine();
+  assert.deepEqual(
+    engine.checkVerifyHost("web.example.com", { targetReference: "web.example.com" }),
+    { allowed: true },
+  );
+  // Case-insensitive match.
+  assert.deepEqual(
+    engine.checkVerifyHost("WEB.Example.COM", { targetReference: "web.example.com" }),
+    { allowed: true },
+  );
+});
+
+test("checkVerifyHost rejects a host matching neither target reference nor allowlist", () => {
+  const engine = verifyEngine();
+  const result = engine.checkVerifyHost("internal-service.corp", {
+    targetReference: "web.example.com",
+  });
+  assert.equal(result.allowed, false);
+  assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+});
+
+test("checkVerifyHost hard-denies metadata/link-local/unspecified/multicast destinations even when allowlisted", () => {
+  const engine = verifyEngine([
+    "169.254.169.254",
+    "0.0.0.0",
+    "::",
+    "fe80::1",
+    "ff02::1",
+    "::ffff:169.254.169.254",
+  ]);
+  for (const host of [
+    "169.254.169.254",
+    "0.0.0.0",
+    "::",
+    "fe80::1",
+    "ff02::1",
+    "::ffff:169.254.169.254",
+    "[fe80::1]",
+  ]) {
+    const result = engine.checkVerifyHost(host, { targetReference: host });
+    assert.equal(result.allowed, false, `expected ${host} to be denied`);
+    assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+  }
+});
+
+test("checkVerifyHost allows loopback only when explicitly allowlisted", () => {
+  const closed = verifyEngine();
+  for (const host of ["127.0.0.1", "::1", "localhost"]) {
+    const result = closed.checkVerifyHost(host, { targetReference: host });
+    assert.equal(result.allowed, false, `expected ${host} to be rejected`);
+    assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+  }
+
+  const open = verifyEngine(["127.0.0.1", "::1", "localhost"]);
+  for (const host of ["127.0.0.1", "::1", "localhost"]) {
+    assert.deepEqual(open.checkVerifyHost(host), { allowed: true });
+  }
+});
+
+test("checkVerifyHost hostname allowlist covers subdomains at a dot boundary only", () => {
+  const engine = verifyEngine(["example.com"]);
+  assert.deepEqual(engine.checkVerifyHost("example.com"), { allowed: true });
+  assert.deepEqual(engine.checkVerifyHost("web.example.com"), { allowed: true });
+
+  const result = engine.checkVerifyHost("evilexample.com");
+  assert.equal(result.allowed, false);
+  assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+});
+
+test("checkVerifyHost IP allowlist entries match exactly, never as suffixes", () => {
+  const engine = verifyEngine(["10.0.0.5"]);
+  assert.deepEqual(engine.checkVerifyHost("10.0.0.5"), { allowed: true });
+
+  const result = engine.checkVerifyHost("110.0.0.5");
+  assert.equal(result.allowed, false);
+  assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+});
+
+test("checkVerifyHost rejects empty, non-string, and oversized hosts", () => {
+  const engine = verifyEngine(["example.com"]);
+  for (const host of ["", undefined, null, 42, "a".repeat(256)]) {
+    const result = engine.checkVerifyHost(host);
+    assert.equal(result.allowed, false);
+    assert.equal(result.rejectionReason, REJECTION_REASONS.TARGET_OUT_OF_SCOPE);
+  }
+});

--- a/packages/agent/src/protocol/index.js
+++ b/packages/agent/src/protocol/index.js
@@ -476,7 +476,7 @@ async function readBoundedResponseJson(response) {
   }
 }
 
-async function postJson(url, { token, envelope, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch }) {
+async function postJson(url, { token, envelope, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch, onServerDate = null }) {
   const { envelope: safeEnvelope, serialized } = prepareOutboundEnvelope(envelope);
   const headers = { "content-type": "application/json" };
   if (token) headers.authorization = `Bearer ${token}`;
@@ -495,6 +495,17 @@ async function postJson(url, { token, envelope, signal, requestTimeoutMs = REQUE
   if (response.status >= 300 && response.status < 400) {
     throw new AgentProtocolError("control-plane redirect was refused", AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status: response.status });
   }
+  if (response.ok && typeof onServerDate === "function") {
+    const dateHeaderValue = response.headers?.get?.("date");
+    if (dateHeaderValue) {
+      try {
+        onServerDate(dateHeaderValue, Date.now());
+      } catch (_err) {
+        // A clock-sampling callback failure must never fail the protocol
+        // request itself; the sample is simply lost.
+      }
+    }
+  }
   const json = await readBoundedResponseJson(response);
   return { status: response.status, ok: response.ok, json, envelope: safeEnvelope };
 }
@@ -503,9 +514,13 @@ function validateRegistrationResponse(json, expectedProtocolVersion) {
   if (!isPlainObject(json)) {
     throw new AgentProtocolError("registration response must be an object", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
   }
-  const expectedKeys = new Set(["agentId", "credential", "protocolVersion"]);
+  // signingKeyId/signingPublicKeyPem carry the control plane's job-signing
+  // key pin (ADR-0003 trust-on-first-use); optional so a server that does
+  // not sign dispatch yet still registers cleanly.
+  const requiredKeys = new Set(["agentId", "credential", "protocolVersion"]);
+  const optionalKeys = new Set(["signingKeyId", "signingPublicKeyPem"]);
   const keys = Object.keys(json);
-  if (keys.length !== expectedKeys.size || keys.some((key) => !expectedKeys.has(key))) {
+  if (keys.some((key) => !requiredKeys.has(key) && !optionalKeys.has(key)) || [...requiredKeys].some((key) => !keys.includes(key))) {
     throw new AgentProtocolError("registration response contains unknown or missing fields", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
   }
   if (typeof json.agentId !== "string" || !AGENT_ID_PATTERN.test(json.agentId)) {
@@ -518,20 +533,43 @@ function validateRegistrationResponse(json, expectedProtocolVersion) {
   if (typeof json.protocolVersion !== "string" || !PROTOCOL_VERSION_PATTERN.test(json.protocolVersion) || json.protocolVersion !== expectedProtocolVersion) {
     throw new AgentProtocolError("registration response contains an unsupported protocolVersion", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
   }
-  return { agentId: json.agentId, credential: json.credential, protocolVersion: json.protocolVersion };
+  let signingKeyId = null;
+  let signingPublicKeyPem = null;
+  if (json.signingKeyId !== undefined && json.signingKeyId !== null) {
+    if (typeof json.signingKeyId !== "string" || !AGENT_ID_PATTERN.test(json.signingKeyId)) {
+      throw new AgentProtocolError("registration response contains an invalid signingKeyId", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
+    }
+    signingKeyId = json.signingKeyId;
+  }
+  if (json.signingPublicKeyPem !== undefined && json.signingPublicKeyPem !== null) {
+    if (
+      typeof json.signingPublicKeyPem !== "string" ||
+      json.signingPublicKeyPem.length === 0 ||
+      json.signingPublicKeyPem.length > 8192 ||
+      !json.signingPublicKeyPem.includes("BEGIN PUBLIC KEY") ||
+      json.signingPublicKeyPem.includes("PRIVATE KEY")
+    ) {
+      throw new AgentProtocolError("registration response contains an invalid signingPublicKeyPem", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
+    }
+    signingPublicKeyPem = json.signingPublicKeyPem;
+  }
+  if ((signingKeyId === null) !== (signingPublicKeyPem === null)) {
+    throw new AgentProtocolError("registration response must provide signingKeyId and signingPublicKeyPem together", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
+  }
+  return { agentId: json.agentId, credential: json.credential, protocolVersion: json.protocolVersion, signingKeyId, signingPublicKeyPem };
 }
 
 async function resolveCredential(getCredential) {
   return typeof getCredential === "function" ? await getCredential() : null;
 }
 
-function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredential, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch, allowInsecureLocalHttp = false } = {}) {
+function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredential, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch, allowInsecureLocalHttp = false, onServerDate = null } = {}) {
   const baseUrl = parseServerUrl(serverUrl, { allowInsecureLocalHttp });
   if (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs < 1 || requestTimeoutMs > 120_000) {
     throw new AgentProtocolError("requestTimeoutMs must be an integer between 1 and 120000", AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE);
   }
   const routeUrl = (route) => `${baseUrl}${route}`;
-  const send = (route, token, envelope) => postJson(routeUrl(route), { token, envelope, signal, requestTimeoutMs, fetchImpl });
+  const send = (route, token, envelope) => postJson(routeUrl(route), { token, envelope, signal, requestTimeoutMs, fetchImpl, onServerDate });
 
   async function register({ bootstrapToken, bootstrapTokenId, agentVersion, hostname = null, platform = null, nodeVersion = null, declaredTargetSelectors = [], declaredCommandProfileNames = [] } = {}) {
     if (typeof bootstrapToken !== "string" || bootstrapToken.length === 0) {

--- a/packages/agent/src/protocol/protocol.test.js
+++ b/packages/agent/src/protocol/protocol.test.js
@@ -557,3 +557,204 @@ test("startPollLoop: startImmediately true invokes the first tick without waitin
   });
   assert.equal(tickCount, 1);
 });
+
+/**
+ * Like stubFetch but the queued entries may carry a dateHeader that is
+ * exposed through response.headers.get("date"), for clock-sampling tests.
+ */
+function stubFetchWithHeaders(responses) {
+  const calls = [];
+  let index = 0;
+  global.fetch = (url, init) => {
+    const entry = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    calls.push({ url, init, parsedBody: init?.body ? JSON.parse(init.body) : null });
+    return Promise.resolve({
+      ok: entry.status >= 200 && entry.status < 300,
+      status: entry.status,
+      headers: {
+        get: (name) =>
+          String(name).toLowerCase() === "date" && entry.dateHeader ? entry.dateHeader : null,
+      },
+      json: () => Promise.resolve(entry.json ?? {}),
+    });
+  };
+  return calls;
+}
+
+test("register: returns null signing-key fields when the response omits them", async () => {
+  stubFetch([
+    {
+      status: 201,
+      json: { agentId: "agent-1", credential: CREDENTIAL, protocolVersion: "1.0.0" },
+    },
+  ]);
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "candidate-agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => null,
+  });
+  const result = await client.register({
+    bootstrapToken: "raw-bootstrap-token",
+    bootstrapTokenId: "bst_abc123",
+    agentVersion: "0.1.0",
+  });
+  assert.equal(result.signingKeyId, null);
+  assert.equal(result.signingPublicKeyPem, null);
+});
+
+test("register: passes through signingKeyId and signingPublicKeyPem when the response carries them", async () => {
+  const signingPublicKeyPem =
+    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfake\n-----END PUBLIC KEY-----\n";
+  stubFetch([
+    {
+      status: 201,
+      json: {
+        agentId: "agent-1",
+        credential: CREDENTIAL,
+        protocolVersion: "1.0.0",
+        signingKeyId: "signing-key-1",
+        signingPublicKeyPem,
+      },
+    },
+  ]);
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "candidate-agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => null,
+  });
+  const result = await client.register({
+    bootstrapToken: "raw-bootstrap-token",
+    bootstrapTokenId: "bst_abc123",
+    agentVersion: "0.1.0",
+  });
+  assert.equal(result.signingKeyId, "signing-key-1");
+  assert.equal(result.signingPublicKeyPem, signingPublicKeyPem);
+});
+
+test("register: rejects a signingKeyId without its public key (and vice versa)", async () => {
+  stubFetch([
+    {
+      status: 201,
+      json: {
+        agentId: "agent-1",
+        credential: CREDENTIAL,
+        protocolVersion: "1.0.0",
+        signingKeyId: "signing-key-1",
+      },
+    },
+  ]);
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "candidate-agent-1",
+    protocolVersion: "1.0.0",
+  });
+  await assert.rejects(
+    () => client.register({ bootstrapToken: "bootstrap-token", bootstrapTokenId: "bst_1", agentVersion: "0.1.0" }),
+    (err) => {
+      assert.equal(err.code, AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
+      return true;
+    },
+  );
+});
+
+test("register: rejects a signingPublicKeyPem containing private key material", async () => {
+  stubFetch([
+    {
+      status: 201,
+      json: {
+        agentId: "agent-1",
+        credential: CREDENTIAL,
+        protocolVersion: "1.0.0",
+        signingKeyId: "signing-key-1",
+        signingPublicKeyPem:
+          "-----BEGIN PUBLIC KEY-----\nx\n-----END PUBLIC KEY-----\n-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+      },
+    },
+  ]);
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "candidate-agent-1",
+    protocolVersion: "1.0.0",
+  });
+  await assert.rejects(
+    () => client.register({ bootstrapToken: "bootstrap-token", bootstrapTokenId: "bst_1", agentVersion: "0.1.0" }),
+    (err) => {
+      assert.equal(err.code, AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
+      return true;
+    },
+  );
+});
+
+test("onServerDate: fires with the Date header and a local timestamp on successful requests", async () => {
+  const dateHeader = "Wed, 22 Jul 2026 12:00:00 GMT";
+  stubFetchWithHeaders([
+    { status: 200, dateHeader, json: {} },
+    { status: 200, dateHeader, json: { jobs: [] } },
+  ]);
+
+  const samples = [];
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => CREDENTIAL,
+    onServerDate: (dateHeaderValue, localNowMs) => {
+      samples.push({ dateHeaderValue, localNowMs });
+    },
+  });
+
+  const before = Date.now();
+  await client.heartbeat({ agentVersion: "0.1.0" });
+  await client.claim({ maxJobs: 1 });
+  const after = Date.now();
+
+  assert.equal(samples.length, 2);
+  for (const sample of samples) {
+    assert.equal(sample.dateHeaderValue, dateHeader);
+    assert.ok(sample.localNowMs >= before && sample.localNowMs <= after);
+  }
+});
+
+test("onServerDate: not fired on non-2xx responses or when the Date header is absent", async () => {
+  stubFetchWithHeaders([
+    { status: 500, dateHeader: "Wed, 22 Jul 2026 12:00:00 GMT", json: {} },
+    { status: 200, json: {} },
+  ]);
+
+  const samples = [];
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => CREDENTIAL,
+    onServerDate: (dateHeaderValue, localNowMs) => {
+      samples.push({ dateHeaderValue, localNowMs });
+    },
+  });
+
+  await assert.rejects(() => client.heartbeat({ agentVersion: "0.1.0" }));
+  await client.heartbeat({ agentVersion: "0.1.0" });
+  assert.equal(samples.length, 0);
+});
+
+test("onServerDate: a throwing callback never fails the protocol request", async () => {
+  stubFetchWithHeaders([
+    { status: 200, dateHeader: "Wed, 22 Jul 2026 12:00:00 GMT", json: {} },
+  ]);
+
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => CREDENTIAL,
+    onServerDate: () => {
+      throw new Error("clock sampling exploded");
+    },
+  });
+
+  const result = await client.heartbeat({ agentVersion: "0.1.0" });
+  assert.deepEqual(result, {});
+});

--- a/packages/agent/src/reload/index.js
+++ b/packages/agent/src/reload/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Validate-then-reload service helpers (CertOps M5).
+ * Validate-then-reload service helpers.
  *
  * After a certificate deploy, the consuming service (nginx, apache/httpd,
  * haproxy) must reload its configuration. The safe sequence is always

--- a/packages/agent/src/reload/index.js
+++ b/packages/agent/src/reload/index.js
@@ -1,0 +1,242 @@
+"use strict";
+
+/**
+ * Validate-then-reload service helpers (CertOps M5).
+ *
+ * After a certificate deploy, the consuming service (nginx, apache/httpd,
+ * haproxy) must reload its configuration. The safe sequence is always
+ * validate-then-reload: run the service's config-check command first
+ * (e.g. `nginx -t`), and only if it exits 0 run the reload command
+ * (e.g. `systemctl reload nginx`). A broken config must never be reloaded
+ * into a running service.
+ *
+ * Command custody (7.5/7.7, ADR-0002): this module NEVER constructs argv
+ * itself and NEVER uses a shell. The dispatch layer resolves command
+ * profile names via the agent-local policy engine (policy module's
+ * checkCommandRef) and passes the concrete argv arrays here as
+ * `commandProfiles: { validateArgv, reloadArgv }`. Commands are exec'd via
+ * child_process.execFile(argv[0], argv.slice(1), { shell: false, timeout }),
+ * so no shell interpretation ever happens. As defense in depth this module
+ * re-rejects argv elements containing the same shell metacharacter set the
+ * policy module uses (a profile that looks like shell syntax is a config
+ * bug that must fail loudly).
+ *
+ * Output hygiene: stderr/stdout excerpts returned in results are bounded
+ * (max STDERR_EXCERPT_MAX_CHARS) and passed through a scrubber that
+ * replaces the WHOLE excerpt with "[redacted]" if it contains a
+ * private-key marker ("PRIVATE KEY"), in the spirit of the evidence
+ * module's redaction: better to lose a diagnostic line than to ever leak
+ * key material into results/evidence (D5).
+ *
+ * Error model: command failures (nonzero exit, timeout, spawn error) are
+ * RESULTS, not exceptions -- { reloaded: false, stage, exitCode, ... }.
+ * This module throws only on programmer error: unknown service name,
+ * malformed commandProfiles/argv, or shell metacharacters in argv.
+ *
+ * This module is self-contained: it accepts plain data as parameters and
+ * does not import sibling agent modules. Wiring is left to src/index.js.
+ */
+
+const { execFile } = require("node:child_process");
+
+/**
+ * Same set as the policy module's SHELL_METACHARACTER_PATTERN, duplicated
+ * (not imported) to keep this module self-contained per package
+ * convention: ; | & $ ` > < and newlines (CR or LF).
+ */
+const SHELL_METACHARACTER_PATTERN = /[;|&$`><\r\n]/;
+
+/** Services this module knows how to validate-then-reload. */
+const SUPPORTED_SERVICES = Object.freeze(["nginx", "apache", "haproxy"]);
+
+/** Default per-command timeout (30s). */
+const DEFAULT_COMMAND_TIMEOUT_MS = 30000;
+
+/** Hard bound on stderr/stdout excerpts included in results. */
+const STDERR_EXCERPT_MAX_CHARS = 512;
+
+const REDACTED_PLACEHOLDER = "[redacted]";
+
+/**
+ * Bounds and scrubs command output before it may appear in a result shape.
+ * If the output contains a private-key marker anywhere, the whole excerpt
+ * is replaced with "[redacted]" (simple and safe beats clever partial
+ * redaction, per the evidence module's approach). Otherwise the output is
+ * truncated to STDERR_EXCERPT_MAX_CHARS.
+ *
+ * @param {string|Buffer|undefined|null} output
+ * @returns {string}
+ */
+function scrubExcerpt(output) {
+  const text = output === undefined || output === null ? "" : String(output);
+  if (/PRIVATE KEY/i.test(text)) {
+    return REDACTED_PLACEHOLDER;
+  }
+  return text.slice(0, STDERR_EXCERPT_MAX_CHARS);
+}
+
+/**
+ * Validates one argv array from a command profile. Throws on programmer
+ * error (the dispatch layer handed us something the policy module should
+ * never have produced).
+ *
+ * @param {string} label e.g. "commandProfiles.validateArgv"
+ * @param {unknown} argv
+ * @returns {string[]} shallow copy of argv
+ */
+function assertValidArgv(label, argv) {
+  if (!Array.isArray(argv) || argv.length === 0) {
+    throw new Error(`reload: ${label} must be a non-empty array of strings`);
+  }
+  argv.forEach((element, index) => {
+    if (typeof element !== "string" || element.length === 0) {
+      throw new Error(`reload: ${label}[${index}] must be a non-empty string`);
+    }
+    if (SHELL_METACHARACTER_PATTERN.test(element)) {
+      throw new Error(
+        `reload: ${label}[${index}] contains a disallowed shell metacharacter: ${JSON.stringify(element)}`,
+      );
+    }
+  });
+  return [...argv];
+}
+
+/**
+ * Runs one argv without a shell, returning a settled outcome object (never
+ * rejects for command failure). Timeout kills the process and surfaces as
+ * a failure outcome.
+ *
+ * @param {typeof execFile} execFileImpl
+ * @param {string[]} argv
+ * @param {number} timeoutMs
+ * @returns {Promise<{ ok: boolean, exitCode: number|null, stderr: string, stdout: string, timedOut: boolean, errorMessage: string|null }>}
+ */
+function runCommand(execFileImpl, argv, timeoutMs) {
+  return new Promise((resolve) => {
+    execFileImpl(
+      argv[0],
+      argv.slice(1),
+      // shell: false is execFile's default, but it is set explicitly so
+      // the no-shell invariant is visible at the call site and assertable
+      // in tests via execFileImpl stubs.
+      { shell: false, timeout: timeoutMs },
+      (error, stdout, stderr) => {
+        if (!error) {
+          resolve({
+            ok: true,
+            exitCode: 0,
+            stdout: String(stdout ?? ""),
+            stderr: String(stderr ?? ""),
+            timedOut: false,
+            errorMessage: null,
+          });
+          return;
+        }
+        // execFile sets error.killed/error.signal on timeout kills and
+        // error.code to the numeric exit code for nonzero exits (or a
+        // string like "ENOENT" for spawn failures).
+        const timedOut =
+          error.killed === true ||
+          error.signal === "SIGTERM" ||
+          error.code === "ETIMEDOUT";
+        resolve({
+          ok: false,
+          exitCode: typeof error.code === "number" ? error.code : null,
+          stdout: String(stdout ?? ""),
+          stderr: String(stderr ?? ""),
+          timedOut,
+          errorMessage: error.message || String(error),
+        });
+      },
+    );
+  });
+}
+
+/**
+ * Validate-then-reload for a supported service.
+ *
+ * @param {{
+ *   service: "nginx"|"apache"|"haproxy",
+ *   commandProfiles: { validateArgv: string[], reloadArgv: string[] },
+ *     // Resolved by the dispatch layer from the agent-local policy
+ *     // allowlist (policy checkCommandRef); NEVER constructed here.
+ *   timeoutMs?: number,       // per-command timeout, default 30000
+ *   execFileImpl?: typeof execFile, // injectable for tests
+ * }} params
+ * @returns {Promise<
+ *   | { reloaded: true, service: string, stages: Array<{ stage: string, exitCode: number }> }
+ *   | { reloaded: false, service: string, stage: "validate"|"reload", exitCode: number|null, timedOut: boolean, stderrExcerpt: string, error: string|null }
+ * >}
+ */
+async function reloadService({
+  service,
+  commandProfiles,
+  timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
+  execFileImpl = execFile,
+} = {}) {
+  if (!SUPPORTED_SERVICES.includes(service)) {
+    throw new Error(
+      `reload: service must be one of ${SUPPORTED_SERVICES.join(", ")} (got ${JSON.stringify(service)})`,
+    );
+  }
+  if (
+    commandProfiles === null ||
+    typeof commandProfiles !== "object" ||
+    Array.isArray(commandProfiles)
+  ) {
+    throw new Error(
+      "reload: commandProfiles must be an object with validateArgv and reloadArgv " +
+        "(resolved from the agent-local policy allowlist by the dispatch layer)",
+    );
+  }
+
+  const validateArgv = assertValidArgv(
+    "commandProfiles.validateArgv",
+    commandProfiles.validateArgv,
+  );
+  const reloadArgv = assertValidArgv(
+    "commandProfiles.reloadArgv",
+    commandProfiles.reloadArgv,
+  );
+
+  const stages = [];
+
+  const validateOutcome = await runCommand(execFileImpl, validateArgv, timeoutMs);
+  if (!validateOutcome.ok) {
+    return {
+      reloaded: false,
+      service,
+      stage: "validate",
+      exitCode: validateOutcome.exitCode,
+      timedOut: validateOutcome.timedOut,
+      stderrExcerpt: scrubExcerpt(validateOutcome.stderr || validateOutcome.stdout),
+      error: validateOutcome.errorMessage,
+    };
+  }
+  stages.push({ stage: "validate", exitCode: 0 });
+
+  const reloadOutcome = await runCommand(execFileImpl, reloadArgv, timeoutMs);
+  if (!reloadOutcome.ok) {
+    return {
+      reloaded: false,
+      service,
+      stage: "reload",
+      exitCode: reloadOutcome.exitCode,
+      timedOut: reloadOutcome.timedOut,
+      stderrExcerpt: scrubExcerpt(reloadOutcome.stderr || reloadOutcome.stdout),
+      error: reloadOutcome.errorMessage,
+    };
+  }
+  stages.push({ stage: "reload", exitCode: 0 });
+
+  return { reloaded: true, service, stages };
+}
+
+module.exports = {
+  reloadService,
+  scrubExcerpt,
+  SUPPORTED_SERVICES,
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  STDERR_EXCERPT_MAX_CHARS,
+  SHELL_METACHARACTER_PATTERN,
+};

--- a/packages/agent/src/reload/reload.test.js
+++ b/packages/agent/src/reload/reload.test.js
@@ -1,0 +1,304 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  reloadService,
+  scrubExcerpt,
+  SUPPORTED_SERVICES,
+  STDERR_EXCERPT_MAX_CHARS,
+} = require("./index.js");
+
+const NGINX_PROFILES = Object.freeze({
+  validateArgv: ["nginx", "-t"],
+  reloadArgv: ["systemctl", "reload", "nginx"],
+});
+
+/**
+ * Builds an execFile stub. `plan` maps the command binary (argv[0] as
+ * passed to execFile) to an outcome:
+ *   { exitCode?: number, stdout?: string, stderr?: string, timeout?: boolean, delayMs?: number }
+ * Records every call (file, args, options) in `calls`.
+ */
+function makeExecFileStub(plan) {
+  const calls = [];
+
+  function execFileStub(file, args, options, callback) {
+    calls.push({ file, args, options });
+    const outcome = plan[file] || {};
+    const stdout = outcome.stdout || "";
+    const stderr = outcome.stderr || "";
+
+    const finish = () => {
+      if (outcome.timeout) {
+        const error = new Error(`Command timed out: ${file}`);
+        error.killed = true;
+        error.signal = "SIGTERM";
+        callback(error, stdout, stderr);
+        return;
+      }
+      const exitCode = outcome.exitCode ?? 0;
+      if (exitCode === 0) {
+        callback(null, stdout, stderr);
+      } else {
+        const error = new Error(`Command failed: ${file} (exit ${exitCode})`);
+        error.code = exitCode;
+        callback(error, stdout, stderr);
+      }
+    };
+
+    if (outcome.delayMs) {
+      setTimeout(finish, outcome.delayMs);
+    } else {
+      setImmediate(finish);
+    }
+  }
+
+  execFileStub.calls = calls;
+  return execFileStub;
+}
+
+describe("reloadService", () => {
+  it("runs validate then reload on success and reports both stages", async () => {
+    const stub = makeExecFileStub({});
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.deepEqual(result, {
+      reloaded: true,
+      service: "nginx",
+      stages: [
+        { stage: "validate", exitCode: 0 },
+        { stage: "reload", exitCode: 0 },
+      ],
+    });
+    assert.equal(stub.calls.length, 2);
+    assert.deepEqual(stub.calls[0], {
+      file: "nginx",
+      args: ["-t"],
+      options: stub.calls[0].options,
+    });
+    assert.deepEqual(stub.calls[1].file, "systemctl");
+    assert.deepEqual(stub.calls[1].args, ["reload", "nginx"]);
+  });
+
+  it("short-circuits on validate failure: reload is never invoked", async () => {
+    const stub = makeExecFileStub({
+      nginx: { exitCode: 1, stderr: "nginx: configuration file test failed" },
+    });
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.equal(result.reloaded, false);
+    assert.equal(result.stage, "validate");
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderrExcerpt, /configuration file test failed/);
+    // The reload command must never have been run.
+    assert.equal(stub.calls.length, 1);
+    assert.equal(stub.calls[0].file, "nginx");
+  });
+
+  it("reports a reload-stage failure when validate passes but reload fails", async () => {
+    const stub = makeExecFileStub({
+      systemctl: { exitCode: 5, stderr: "Failed to reload nginx.service" },
+    });
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.equal(result.reloaded, false);
+    assert.equal(result.stage, "reload");
+    assert.equal(result.exitCode, 5);
+    assert.match(result.stderrExcerpt, /Failed to reload/);
+    assert.equal(stub.calls.length, 2);
+  });
+
+  it("surfaces a timeout as a failure result, never a throw", async () => {
+    const stub = makeExecFileStub({
+      nginx: { timeout: true },
+    });
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.equal(result.reloaded, false);
+    assert.equal(result.stage, "validate");
+    assert.equal(result.timedOut, true);
+    assert.equal(stub.calls.length, 1);
+  });
+
+  it("passes the timeout option through to execFile", async () => {
+    const stub = makeExecFileStub({});
+
+    await reloadService({
+      service: "haproxy",
+      commandProfiles: {
+        validateArgv: ["haproxy", "-c", "-f", "/etc/haproxy/haproxy.cfg"],
+        reloadArgv: ["systemctl", "reload", "haproxy"],
+      },
+      timeoutMs: 1234,
+      execFileImpl: stub,
+    });
+
+    assert.equal(stub.calls[0].options.timeout, 1234);
+    assert.equal(stub.calls[1].options.timeout, 1234);
+  });
+
+  it("never uses a shell: every call passes shell:false explicitly", async () => {
+    const stub = makeExecFileStub({});
+
+    await reloadService({
+      service: "apache",
+      commandProfiles: {
+        validateArgv: ["apachectl", "configtest"],
+        reloadArgv: ["systemctl", "reload", "httpd"],
+      },
+      execFileImpl: stub,
+    });
+
+    assert.equal(stub.calls.length, 2);
+    for (const call of stub.calls) {
+      assert.equal(call.options.shell, false);
+    }
+  });
+
+  it("bounds the stderr excerpt to the documented maximum", async () => {
+    const longStderr = "e".repeat(STDERR_EXCERPT_MAX_CHARS * 4);
+    const stub = makeExecFileStub({
+      nginx: { exitCode: 1, stderr: longStderr },
+    });
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.equal(result.stderrExcerpt.length, STDERR_EXCERPT_MAX_CHARS);
+  });
+
+  it("redacts the whole excerpt when output contains a PRIVATE KEY marker", async () => {
+    const stub = makeExecFileStub({
+      nginx: {
+        exitCode: 1,
+        stderr:
+          "error near -----BEGIN PRIVATE KEY----- MIIEsecretbytes -----END PRIVATE KEY-----",
+      },
+    });
+
+    const result = await reloadService({
+      service: "nginx",
+      commandProfiles: NGINX_PROFILES,
+      execFileImpl: stub,
+    });
+
+    assert.equal(result.stderrExcerpt, "[redacted]");
+    assert.ok(!JSON.stringify(result).includes("MIIEsecretbytes"));
+  });
+
+  it("throws on an unsupported service name", async () => {
+    const stub = makeExecFileStub({});
+    await assert.rejects(
+      reloadService({
+        service: "postgres",
+        commandProfiles: NGINX_PROFILES,
+        execFileImpl: stub,
+      }),
+      /service must be one of/,
+    );
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("throws on argv elements containing shell metacharacters", async () => {
+    const stub = makeExecFileStub({});
+    const badProfiles = {
+      validateArgv: ["nginx", "-t; rm -rf /"],
+      reloadArgv: ["systemctl", "reload", "nginx"],
+    };
+
+    await assert.rejects(
+      reloadService({
+        service: "nginx",
+        commandProfiles: badProfiles,
+        execFileImpl: stub,
+      }),
+      /disallowed shell metacharacter/,
+    );
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("throws on empty or malformed argv (programmer error)", async () => {
+    const stub = makeExecFileStub({});
+
+    await assert.rejects(
+      reloadService({
+        service: "nginx",
+        commandProfiles: { validateArgv: [], reloadArgv: ["systemctl"] },
+        execFileImpl: stub,
+      }),
+      /must be a non-empty array/,
+    );
+    await assert.rejects(
+      reloadService({
+        service: "nginx",
+        commandProfiles: { validateArgv: ["nginx", 42], reloadArgv: ["systemctl"] },
+        execFileImpl: stub,
+      }),
+      /must be a non-empty string/,
+    );
+    await assert.rejects(
+      reloadService({
+        service: "nginx",
+        commandProfiles: null,
+        execFileImpl: stub,
+      }),
+      /commandProfiles must be an object/,
+    );
+    assert.equal(stub.calls.length, 0);
+  });
+});
+
+describe("scrubExcerpt", () => {
+  it("passes short, clean output through unchanged", () => {
+    assert.equal(scrubExcerpt("syntax is ok"), "syntax is ok");
+  });
+
+  it("truncates output beyond the maximum", () => {
+    const long = "x".repeat(STDERR_EXCERPT_MAX_CHARS + 100);
+    assert.equal(scrubExcerpt(long).length, STDERR_EXCERPT_MAX_CHARS);
+  });
+
+  it("replaces the entire excerpt when a private-key marker appears anywhere", () => {
+    assert.equal(
+      scrubExcerpt("prefix -----BEGIN RSA PRIVATE KEY----- suffix"),
+      "[redacted]",
+    );
+    assert.equal(scrubExcerpt("mentions private key material"), "[redacted]");
+  });
+
+  it("handles null/undefined defensively", () => {
+    assert.equal(scrubExcerpt(null), "");
+    assert.equal(scrubExcerpt(undefined), "");
+  });
+});
+
+describe("SUPPORTED_SERVICES", () => {
+  it("covers exactly nginx, apache, haproxy", () => {
+    assert.deepEqual([...SUPPORTED_SERVICES].sort(), ["apache", "haproxy", "nginx"]);
+  });
+});

--- a/packages/agent/src/replay/index.js
+++ b/packages/agent/src/replay/index.js
@@ -41,11 +41,23 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const crypto = require("node:crypto");
 
 const REPLAY_REJECTION_REASON = "job_replay_rejected";
 
 const STORE_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_ENTRIES = 5000;
+
+/**
+ * Default retention slack past an entry's expiresAt, mirroring the signing
+ * module's DEFAULT_TIME_WINDOW_TOLERANCE_MS. checkJobTimeWindow accepts a
+ * job until expiresAt + tolerance, so the replay cache must retain a
+ * consumed nonce for at least that same tolerance: evicting at bare
+ * expiresAt would open a real replay window during (expiresAt,
+ * expiresAt + tolerance]. Wiring (src/index.js) passes the signing module's
+ * constant explicitly; this default only guards direct constructions.
+ */
+const DEFAULT_RETENTION_TOLERANCE_MS = 30000;
 
 /**
  * @param {string} detail
@@ -166,8 +178,14 @@ function loadStore(storePath) {
  * @param {number} [params.maxEntries=5000] hard bound on stored entries;
  *   when reached (after sweeping expired entries), new jobs are rejected
  *   rather than evicting unexpired nonces (see module doc for why)
- * @param {() => number} [params.now] clock injection for tests; defaults to
- *   Date.now
+ * @param {number} [params.retentionToleranceMs=30000] extra retention past
+ *   an entry's expiresAt before the sweep may evict it; MUST be >= the
+ *   signing module's time-window tolerance (see
+ *   DEFAULT_RETENTION_TOLERANCE_MS for why)
+ * @param {() => number} [params.now] clock injection; defaults to Date.now.
+ *   Wiring should pass an offset-adjusted clock (local time + the clock
+ *   module's estimated server offset) so sweep eviction uses the same
+ *   timeline as checkJobTimeWindow's acceptance decision.
  * @returns {{
  *   check: (entry: { nonce: string, jobId: string, expiresAt: number|string }) =>
  *     ({ allowed: true } | { allowed: false, rejectionReason: string, detail: string }),
@@ -180,6 +198,7 @@ function loadStore(storePath) {
 function createReplayCache({
   storePath,
   maxEntries = DEFAULT_MAX_ENTRIES,
+  retentionToleranceMs = DEFAULT_RETENTION_TOLERANCE_MS,
   now = Date.now,
 } = {}) {
   if (typeof storePath !== "string" || storePath.length === 0) {
@@ -188,6 +207,12 @@ function createReplayCache({
   if (!Number.isInteger(maxEntries) || maxEntries <= 0) {
     throw new Error(
       "replay: createReplayCache maxEntries must be a positive integer",
+    );
+  }
+  if (!Number.isFinite(retentionToleranceMs) || retentionToleranceMs < 0) {
+    throw new Error(
+      "replay: createReplayCache retentionToleranceMs must be a " +
+        "non-negative finite number",
     );
   }
   if (typeof now !== "function") {
@@ -206,10 +231,36 @@ function createReplayCache({
       schemaVersion: STORE_SCHEMA_VERSION,
       entries: [...entries.values()],
     });
-    fs.writeFileSync(storePath, `${serialized}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
+    // Atomic write (temp file + rename in the same directory, content
+    // fsynced before the rename): a crash mid-write must never leave a
+    // torn store file, because the fail-loud loader would then refuse to
+    // start the agent until an operator intervenes.
+    const tempPath = `${storePath}.${process.pid}.${crypto
+      .randomBytes(8)
+      .toString("hex")}.tmp`;
+    let fd;
+    try {
+      fd = fs.openSync(tempPath, "wx", 0o600);
+      fs.writeFileSync(fd, `${serialized}\n`, "utf8");
+      fs.fsyncSync(fd);
+      fs.closeSync(fd);
+      fd = undefined;
+      fs.renameSync(tempPath, storePath);
+    } catch (err) {
+      if (fd !== undefined) {
+        try {
+          fs.closeSync(fd);
+        } catch (_err) {
+          // Best-effort close before cleanup.
+        }
+      }
+      try {
+        fs.unlinkSync(tempPath);
+      } catch (_err) {
+        // The temp file may already have been renamed or never created.
+      }
+      throw err;
+    }
     try {
       fs.chmodSync(storePath, 0o600);
     } catch (_err) {
@@ -218,13 +269,15 @@ function createReplayCache({
   }
 
   /**
-   * Drops entries whose expiresAt has passed. Expired nonces are safe to
-   * forget: checkJobTimeWindow independently rejects any job past its
-   * expiresAt (plus tolerance), so an expired nonce can never be replayed
-   * successfully anyway. This is what keeps the store's growth bounded in
-   * normal operation.
+   * Drops entries whose expiresAt has passed by MORE than the retention
+   * tolerance. The tolerance matters: checkJobTimeWindow accepts jobs
+   * until expiresAt + tolerance, so an entry evicted at bare expiresAt
+   * could be replayed during the tolerance tail. Only entries the signing
+   * module could no longer accept under ANY circumstance are forgotten.
+   * This is what keeps the store's growth bounded in normal operation.
    *
-   * @param {number} [nowMs] defaults to the injected clock
+   * @param {number} [nowMs] defaults to the injected clock (which wiring
+   *   makes offset-adjusted; see createReplayCache's now param)
    * @returns {number} number of entries removed
    */
   function sweep(nowMs = now()) {
@@ -233,7 +286,7 @@ function createReplayCache({
     }
     let removed = 0;
     for (const [key, entry] of entries) {
-      if (entry.expiresAtMs < nowMs) {
+      if (entry.expiresAtMs + retentionToleranceMs < nowMs) {
         entries.delete(key);
         removed += 1;
       }
@@ -308,5 +361,6 @@ function createReplayCache({
 module.exports = {
   REPLAY_REJECTION_REASON,
   DEFAULT_MAX_ENTRIES,
+  DEFAULT_RETENTION_TOLERANCE_MS,
   createReplayCache,
 };

--- a/packages/agent/src/replay/index.js
+++ b/packages/agent/src/replay/index.js
@@ -1,0 +1,312 @@
+"use strict";
+
+/**
+ * Persisted consumed-nonce replay cache (CertOps Phase 4 runtime, ADR-0003).
+ *
+ * ADR-0003: "Agents keep a bounded replay cache keyed by nonce + jobId and
+ * reject jobs outside [issuedAt, expiresAt]". This module owns the
+ * nonce+jobId half; the time-window half lives in the signing module
+ * (checkJobTimeWindow) so each can be tested in isolation.
+ *
+ * Persistence: the store is a JSON file written with mode 0o600, following
+ * the config module's permission conventions (mode asserted at write time
+ * and re-asserted via chmod; best-effort on win32, where POSIX modes are not
+ * meaningful -- see packages/agent/src/config/index.js for the same caveat).
+ * Persisting across restarts matters because a job's validity window can
+ * outlive an agent process: without persistence, restarting the agent would
+ * reopen the replay window for every not-yet-expired captured job.
+ *
+ * Fail-loud choices (documented per task spec):
+ *   - A corrupted/unreadable store file throws at load. A tampered replay
+ *     store is a security signal (someone may be trying to reset the cache
+ *     to enable a replay), not a recoverable glitch, so it must surface to
+ *     the operator instead of being silently recreated. A missing file is
+ *     fine: that is simply a fresh store.
+ *   - When the cache is full (after sweeping expired entries) new jobs are
+ *     REJECTED with job_replay_rejected rather than evicting the oldest
+ *     unexpired nonces. Silently evicting an unexpired nonce would reopen
+ *     the replay window for exactly the job whose nonce was evicted: an
+ *     attacker who can flood the agent with jobs could push a captured
+ *     job's nonce out of the cache and then replay it. Refusing new work is
+ *     the safe failure mode; the bound exists only to keep the store's disk
+ *     and memory footprint predictable.
+ *
+ * Rejection results use the exact shape the policy module produces
+ * ({ allowed: false, rejectionReason, detail }) so downstream evidence/
+ * result reporting handles them uniformly.
+ *
+ * This module is self-contained (node builtins only, plain-data API) per
+ * the packages/agent module conventions.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPLAY_REJECTION_REASON = "job_replay_rejected";
+
+const STORE_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_ENTRIES = 5000;
+
+/**
+ * @param {string} detail
+ * @returns {{ allowed: false, rejectionReason: string, detail: string }}
+ */
+function rejectReplay(detail) {
+  return { allowed: false, rejectionReason: REPLAY_REJECTION_REASON, detail };
+}
+
+/**
+ * Composite cache key per ADR-0003 (nonce + jobId). Both components are
+ * length-delimited so distinct pairs can never collide via concatenation
+ * ambiguity (e.g. nonce "a:b" + jobId "c" vs nonce "a" + jobId "b:c").
+ *
+ * @param {string} nonce
+ * @param {string} jobId
+ * @returns {string}
+ */
+function cacheKey(nonce, jobId) {
+  return `${nonce.length}:${nonce}|${jobId.length}:${jobId}`;
+}
+
+function assertEntryInput({ nonce, jobId, expiresAt }, methodName) {
+  if (typeof nonce !== "string" || nonce.length === 0) {
+    throw new Error(`replay: ${methodName} requires a non-empty nonce string`);
+  }
+  if (typeof jobId !== "string" || jobId.length === 0) {
+    throw new Error(`replay: ${methodName} requires a non-empty jobId string`);
+  }
+  const expiresAtMs =
+    typeof expiresAt === "number" ? expiresAt : Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    throw new Error(
+      `replay: ${methodName} requires expiresAt as epoch ms or a parseable date-time string`,
+    );
+  }
+  return expiresAtMs;
+}
+
+/**
+ * Loads the persisted store file. Missing file => fresh empty store.
+ * Anything else that prevents a well-formed load (unreadable file, invalid
+ * JSON, wrong shape, wrong schema version) throws with a clear message --
+ * see the module doc comment for why corruption is treated as a security
+ * signal rather than silently recreated.
+ *
+ * @param {string} storePath
+ * @returns {Map<string, { nonce: string, jobId: string, expiresAtMs: number }>}
+ */
+function loadStore(storePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(storePath, "utf8");
+  } catch (err) {
+    if (err && err.code === "ENOENT") return new Map();
+    throw new Error(
+      `replay: replay store at ${storePath} exists but could not be read ` +
+        `(${err.message}). Refusing to start with an unreadable replay ` +
+        "store: silently recreating it would reopen the replay window. " +
+        "Investigate before deleting the file manually.",
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `replay: replay store at ${storePath} contains invalid JSON ` +
+        `(${err.message}). A corrupted replay store is a tamper signal; ` +
+        "refusing to silently recreate it.",
+    );
+  }
+
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    parsed.schemaVersion !== STORE_SCHEMA_VERSION ||
+    !Array.isArray(parsed.entries)
+  ) {
+    throw new Error(
+      `replay: replay store at ${storePath} has an unexpected shape ` +
+        `(expected { schemaVersion: ${STORE_SCHEMA_VERSION}, entries: [] }). ` +
+        "A malformed replay store is a tamper signal; refusing to silently recreate it.",
+    );
+  }
+
+  const entries = new Map();
+  parsed.entries.forEach((entry, index) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.nonce !== "string" ||
+      typeof entry.jobId !== "string" ||
+      !Number.isFinite(entry.expiresAtMs)
+    ) {
+      throw new Error(
+        `replay: replay store at ${storePath} has a malformed entry at ` +
+          `index ${index}; refusing to load a partially corrupted store.`,
+      );
+    }
+    entries.set(cacheKey(entry.nonce, entry.jobId), {
+      nonce: entry.nonce,
+      jobId: entry.jobId,
+      expiresAtMs: entry.expiresAtMs,
+    });
+  });
+  return entries;
+}
+
+/**
+ * Creates a persisted replay cache.
+ *
+ * @param {object} params
+ * @param {string} params.storePath JSON file path for the persisted store;
+ *   written with mode 0o600 (config-module convention; best-effort on win32)
+ * @param {number} [params.maxEntries=5000] hard bound on stored entries;
+ *   when reached (after sweeping expired entries), new jobs are rejected
+ *   rather than evicting unexpired nonces (see module doc for why)
+ * @param {() => number} [params.now] clock injection for tests; defaults to
+ *   Date.now
+ * @returns {{
+ *   check: (entry: { nonce: string, jobId: string, expiresAt: number|string }) =>
+ *     ({ allowed: true } | { allowed: false, rejectionReason: string, detail: string }),
+ *   consume: (entry: { nonce: string, jobId: string, expiresAt: number|string }) =>
+ *     ({ allowed: true } | { allowed: false, rejectionReason: string, detail: string }),
+ *   sweep: (nowMs?: number) => number,
+ *   size: () => number,
+ * }}
+ */
+function createReplayCache({
+  storePath,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  now = Date.now,
+} = {}) {
+  if (typeof storePath !== "string" || storePath.length === 0) {
+    throw new Error("replay: createReplayCache requires a storePath string");
+  }
+  if (!Number.isInteger(maxEntries) || maxEntries <= 0) {
+    throw new Error(
+      "replay: createReplayCache maxEntries must be a positive integer",
+    );
+  }
+  if (typeof now !== "function") {
+    throw new Error("replay: createReplayCache now must be a function");
+  }
+
+  // Fail-loud load: throws on corruption, tolerates only ENOENT.
+  const entries = loadStore(storePath);
+
+  function persist() {
+    const dir = path.dirname(storePath);
+    // 0700 dir / 0600 file per the config module's conventions; chmod is
+    // best-effort on win32 (no POSIX mode semantics there).
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const serialized = JSON.stringify({
+      schemaVersion: STORE_SCHEMA_VERSION,
+      entries: [...entries.values()],
+    });
+    fs.writeFileSync(storePath, `${serialized}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    try {
+      fs.chmodSync(storePath, 0o600);
+    } catch (_err) {
+      // Best-effort on win32; see packages/agent/src/config/index.js.
+    }
+  }
+
+  /**
+   * Drops entries whose expiresAt has passed. Expired nonces are safe to
+   * forget: checkJobTimeWindow independently rejects any job past its
+   * expiresAt (plus tolerance), so an expired nonce can never be replayed
+   * successfully anyway. This is what keeps the store's growth bounded in
+   * normal operation.
+   *
+   * @param {number} [nowMs] defaults to the injected clock
+   * @returns {number} number of entries removed
+   */
+  function sweep(nowMs = now()) {
+    if (!Number.isFinite(nowMs)) {
+      throw new Error("replay: sweep requires a finite nowMs");
+    }
+    let removed = 0;
+    for (const [key, entry] of entries) {
+      if (entry.expiresAtMs < nowMs) {
+        entries.delete(key);
+        removed += 1;
+      }
+    }
+    if (removed > 0) persist();
+    return removed;
+  }
+
+  /**
+   * Read-only replay check: has this nonce+jobId pair been consumed before?
+   * Does not record anything; call consume() after all other verification
+   * gates pass and immediately before execution.
+   *
+   * @param {{ nonce: string, jobId: string, expiresAt: number|string }} entry
+   * @returns {{ allowed: true } | { allowed: false, rejectionReason: string, detail: string }}
+   */
+  function check({ nonce, jobId, expiresAt }) {
+    assertEntryInput({ nonce, jobId, expiresAt }, "check");
+    if (entries.has(cacheKey(nonce, jobId))) {
+      return rejectReplay(
+        `Job ${jobId} presented an already-consumed nonce; replay rejected.`,
+      );
+    }
+    return { allowed: true };
+  }
+
+  /**
+   * Records the nonce+jobId pair as consumed and persists the store.
+   * A duplicate consume (same pair already recorded) is itself a replay and
+   * is rejected, making the check+consume sequence safe even if a caller
+   * skips check(). Capacity is enforced here fail-loud: when the store is
+   * still full after sweeping expired entries, the NEW job is rejected with
+   * job_replay_rejected; unexpired nonces are never evicted (see module doc
+   * for why silent eviction would reopen the replay window).
+   *
+   * @param {{ nonce: string, jobId: string, expiresAt: number|string }} entry
+   * @returns {{ allowed: true } | { allowed: false, rejectionReason: string, detail: string }}
+   */
+  function consume({ nonce, jobId, expiresAt }) {
+    const expiresAtMs = assertEntryInput({ nonce, jobId, expiresAt }, "consume");
+    const key = cacheKey(nonce, jobId);
+
+    if (entries.has(key)) {
+      return rejectReplay(
+        `Job ${jobId} presented an already-consumed nonce; replay rejected.`,
+      );
+    }
+
+    if (entries.size >= maxEntries) {
+      sweep();
+      if (entries.size >= maxEntries) {
+        return rejectReplay(
+          `Replay cache is full (${entries.size}/${maxEntries} unexpired ` +
+            "entries); rejecting new job rather than evicting unexpired " +
+            "nonces, which would reopen the replay window.",
+        );
+      }
+    }
+
+    entries.set(key, { nonce, jobId, expiresAtMs });
+    persist();
+    return { allowed: true };
+  }
+
+  function size() {
+    return entries.size;
+  }
+
+  return { check, consume, sweep, size };
+}
+
+module.exports = {
+  REPLAY_REJECTION_REASON,
+  DEFAULT_MAX_ENTRIES,
+  createReplayCache,
+};

--- a/packages/agent/src/replay/index.js
+++ b/packages/agent/src/replay/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Persisted consumed-nonce replay cache (CertOps Phase 4 runtime, ADR-0003).
+ * Persisted consumed-nonce replay cache (signed-dispatch runtime, ADR-0003).
  *
  * ADR-0003: "Agents keep a bounded replay cache keyed by nonce + jobId and
  * reject jobs outside [issuedAt, expiresAt]". This module owns the

--- a/packages/agent/src/replay/replay.test.js
+++ b/packages/agent/src/replay/replay.test.js
@@ -192,7 +192,13 @@ describe("persistence", () => {
 });
 
 describe("sweep and bounded growth", () => {
-  it("sweep drops entries whose expiresAt has passed and reports the count", () => {
+  // Sweep eviction happens at expiresAt + retention tolerance (default
+  // 30000 ms, mirroring the signing module's clock tolerance), never at
+  // bare expiresAt: checkJobTimeWindow still accepts a job inside the
+  // tolerance tail, so its nonce must still be remembered there.
+  const RETENTION_TOLERANCE_MS = 30000;
+
+  it("sweep drops entries whose expiresAt+tolerance has passed and reports the count", () => {
     const storePath = makeStorePath();
     const cache = createReplayCache({ storePath, now: () => NOW_MS });
 
@@ -202,23 +208,60 @@ describe("sweep and bounded growth", () => {
     cache.consume(alive);
     assert.equal(cache.size(), 2);
 
-    const removed = cache.sweep(NOW_MS + 2000);
+    const removed = cache.sweep(NOW_MS + 1000 + RETENTION_TOLERANCE_MS + 1);
     assert.equal(removed, 1);
     assert.equal(cache.size(), 1);
 
-    // The expired pair is forgettable: window checks reject it anyway.
+    // The fully expired pair is forgettable: even with maximum tolerance,
+    // window checks reject it anyway.
     assert.deepEqual(cache.check(expired), { allowed: true });
     assert.equal(cache.check(alive).allowed, false);
+  });
+
+  it("retains a consumed nonce through the clock-tolerance tail after expiresAt", () => {
+    const storePath = makeStorePath();
+    const cache = createReplayCache({ storePath, now: () => NOW_MS });
+
+    const job = entry({ expiresAt: NOW_MS + 1000 });
+    cache.consume(job);
+
+    // Inside (expiresAt, expiresAt + tolerance]: checkJobTimeWindow would
+    // still accept a replayed copy, so the sweep must NOT evict it.
+    const withinTail = cache.sweep(NOW_MS + 1000 + RETENTION_TOLERANCE_MS - 1);
+    assert.equal(withinTail, 0);
+    assert.equal(cache.check(job).allowed, false);
+
+    // Past the tail the entry is unreplayable and may be forgotten.
+    const pastTail = cache.sweep(NOW_MS + 1000 + RETENTION_TOLERANCE_MS + 1);
+    assert.equal(pastTail, 1);
   });
 
   it("sweep persists the pruned store", () => {
     const storePath = makeStorePath();
     const cache = createReplayCache({ storePath, now: () => NOW_MS });
     cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
-    cache.sweep(NOW_MS + 2000);
+    cache.sweep(NOW_MS + 1000 + RETENTION_TOLERANCE_MS + 1);
 
     const reloaded = createReplayCache({ storePath, now: () => NOW_MS });
     assert.equal(reloaded.size(), 0);
+  });
+
+  it("persists atomically: no temp files linger and the store stays loadable", () => {
+    const storePath = makeStorePath();
+    const cache = createReplayCache({ storePath, now: () => NOW_MS });
+    for (let i = 0; i < 5; i += 1) {
+      cache.consume(entry({ expiresAt: FUTURE_MS }));
+    }
+
+    const siblings = fs.readdirSync(path.dirname(storePath));
+    assert.equal(
+      siblings.some((name) => name.endsWith(".tmp")),
+      false,
+      "no temp file may remain after persists",
+    );
+
+    const reloaded = createReplayCache({ storePath, now: () => NOW_MS });
+    assert.equal(reloaded.size(), 5);
   });
 
   it("rejects new jobs with job_replay_rejected when full after sweep, never evicting unexpired nonces", () => {
@@ -244,7 +287,7 @@ describe("sweep and bounded growth", () => {
     assert.equal(cache.check(second).allowed, false);
   });
 
-  it("frees capacity via sweep when full entries have expired", () => {
+  it("frees capacity via sweep when full entries have fully expired", () => {
     let clock = NOW_MS;
     const cache = createReplayCache({
       storePath: makeStorePath(),
@@ -255,8 +298,9 @@ describe("sweep and bounded growth", () => {
     cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
     cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
 
-    // Advance past expiry: the internal sweep during consume frees room.
-    clock = NOW_MS + 5000;
+    // Advance past expiry AND the retention tolerance: the internal sweep
+    // during consume frees room.
+    clock = NOW_MS + 1000 + RETENTION_TOLERANCE_MS + 1;
     assert.deepEqual(cache.consume(entry({ expiresAt: clock + 60000 })), {
       allowed: true,
     });

--- a/packages/agent/src/replay/replay.test.js
+++ b/packages/agent/src/replay/replay.test.js
@@ -1,0 +1,269 @@
+"use strict";
+
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  REPLAY_REJECTION_REASON,
+  DEFAULT_MAX_ENTRIES,
+  createReplayCache,
+} = require("./index.js");
+
+const IS_WIN32 = process.platform === "win32";
+
+const tempDirs = [];
+
+function makeStorePath() {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tokentimer-agent-replay-test-"),
+  );
+  tempDirs.push(dir);
+  return path.join(dir, "nested", "replay-store.json");
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (_err) {
+      // best-effort cleanup
+    }
+  }
+});
+
+const NOW_MS = Date.parse("2026-07-22T12:00:00.000Z");
+const FUTURE_MS = NOW_MS + 5 * 60 * 1000;
+
+function entry(overrides = {}) {
+  return {
+    nonce: crypto.randomUUID(),
+    jobId: `job-${crypto.randomUUID()}`,
+    expiresAt: FUTURE_MS,
+    ...overrides,
+  };
+}
+
+describe("createReplayCache basics", () => {
+  it("allows a fresh nonce+jobId via check, then rejects after consume", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    const job = entry();
+
+    assert.deepEqual(cache.check(job), { allowed: true });
+    assert.deepEqual(cache.consume(job), { allowed: true });
+
+    const rechecked = cache.check(job);
+    assert.equal(rechecked.allowed, false);
+    assert.equal(rechecked.rejectionReason, REPLAY_REJECTION_REASON);
+    assert.match(rechecked.detail, /replay rejected/i);
+  });
+
+  it("treats a duplicate consume as a replay (idempotent-reject)", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    const job = entry();
+
+    assert.deepEqual(cache.consume(job), { allowed: true });
+    const second = cache.consume(job);
+    assert.equal(second.allowed, false);
+    assert.equal(second.rejectionReason, REPLAY_REJECTION_REASON);
+  });
+
+  it("keys by nonce + jobId: same nonce with a different jobId is distinct", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    const nonce = crypto.randomUUID();
+
+    assert.deepEqual(
+      cache.consume(entry({ nonce, jobId: "job-a" })),
+      { allowed: true },
+    );
+    assert.deepEqual(
+      cache.consume(entry({ nonce, jobId: "job-b" })),
+      { allowed: true },
+    );
+    assert.equal(cache.consume(entry({ nonce, jobId: "job-a" })).allowed, false);
+  });
+
+  it("does not confuse composite keys via concatenation ambiguity", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    assert.deepEqual(
+      cache.consume(entry({ nonce: "aaaabbbbccccdddd:x", jobId: "y" })),
+      { allowed: true },
+    );
+    assert.deepEqual(
+      cache.consume(entry({ nonce: "aaaabbbbccccdddd", jobId: "x:y" })),
+      { allowed: true },
+    );
+  });
+
+  it("accepts expiresAt as an ISO string or epoch ms", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    assert.deepEqual(
+      cache.consume(entry({ expiresAt: new Date(FUTURE_MS).toISOString() })),
+      { allowed: true },
+    );
+    assert.deepEqual(cache.consume(entry({ expiresAt: FUTURE_MS })), {
+      allowed: true,
+    });
+  });
+
+  it("throws on programmer error: bad inputs to check/consume/factory", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    assert.throws(() => cache.check({ jobId: "j", expiresAt: FUTURE_MS }), /nonce/);
+    assert.throws(() => cache.consume({ nonce: "n", expiresAt: FUTURE_MS }), /jobId/);
+    assert.throws(
+      () => cache.consume({ nonce: "n", jobId: "j", expiresAt: "garbage" }),
+      /expiresAt/,
+    );
+    assert.throws(() => createReplayCache({}), /storePath/);
+    assert.throws(
+      () => createReplayCache({ storePath: makeStorePath(), maxEntries: 0 }),
+      /maxEntries/,
+    );
+  });
+});
+
+describe("persistence", () => {
+  it("persists consumed nonces across cache instances (restart survival)", () => {
+    const storePath = makeStorePath();
+    const job = entry();
+
+    const first = createReplayCache({ storePath, now: () => NOW_MS });
+    assert.deepEqual(first.consume(job), { allowed: true });
+
+    const second = createReplayCache({ storePath, now: () => NOW_MS });
+    const replayed = second.check(job);
+    assert.equal(replayed.allowed, false);
+    assert.equal(replayed.rejectionReason, REPLAY_REJECTION_REASON);
+  });
+
+  it("writes the store file with 0600 permissions on non-win32", { skip: IS_WIN32 }, () => {
+    const storePath = makeStorePath();
+    const cache = createReplayCache({ storePath, now: () => NOW_MS });
+    cache.consume(entry());
+    const mode = fs.statSync(storePath).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+
+  it("starts fresh when the store file does not exist", () => {
+    const cache = createReplayCache({ storePath: makeStorePath(), now: () => NOW_MS });
+    assert.equal(cache.size(), 0);
+  });
+
+  it("fails loud on invalid JSON in the store file", () => {
+    const storePath = makeStorePath();
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(storePath, "{not json", "utf8");
+    assert.throws(
+      () => createReplayCache({ storePath, now: () => NOW_MS }),
+      /invalid JSON.*tamper signal/s,
+    );
+  });
+
+  it("fails loud on an unexpected store shape", () => {
+    const storePath = makeStorePath();
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(storePath, JSON.stringify({ schemaVersion: 99 }), "utf8");
+    assert.throws(
+      () => createReplayCache({ storePath, now: () => NOW_MS }),
+      /unexpected shape/,
+    );
+  });
+
+  it("fails loud on a malformed entry inside an otherwise valid store", () => {
+    const storePath = makeStorePath();
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [{ nonce: "n", jobId: 42, expiresAtMs: FUTURE_MS }],
+      }),
+      "utf8",
+    );
+    assert.throws(
+      () => createReplayCache({ storePath, now: () => NOW_MS }),
+      /malformed entry at index 0/,
+    );
+  });
+});
+
+describe("sweep and bounded growth", () => {
+  it("sweep drops entries whose expiresAt has passed and reports the count", () => {
+    const storePath = makeStorePath();
+    const cache = createReplayCache({ storePath, now: () => NOW_MS });
+
+    const expired = entry({ expiresAt: NOW_MS + 1000 });
+    const alive = entry({ expiresAt: FUTURE_MS });
+    cache.consume(expired);
+    cache.consume(alive);
+    assert.equal(cache.size(), 2);
+
+    const removed = cache.sweep(NOW_MS + 2000);
+    assert.equal(removed, 1);
+    assert.equal(cache.size(), 1);
+
+    // The expired pair is forgettable: window checks reject it anyway.
+    assert.deepEqual(cache.check(expired), { allowed: true });
+    assert.equal(cache.check(alive).allowed, false);
+  });
+
+  it("sweep persists the pruned store", () => {
+    const storePath = makeStorePath();
+    const cache = createReplayCache({ storePath, now: () => NOW_MS });
+    cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
+    cache.sweep(NOW_MS + 2000);
+
+    const reloaded = createReplayCache({ storePath, now: () => NOW_MS });
+    assert.equal(reloaded.size(), 0);
+  });
+
+  it("rejects new jobs with job_replay_rejected when full after sweep, never evicting unexpired nonces", () => {
+    const cache = createReplayCache({
+      storePath: makeStorePath(),
+      maxEntries: 2,
+      now: () => NOW_MS,
+    });
+
+    const first = entry();
+    const second = entry();
+    assert.deepEqual(cache.consume(first), { allowed: true });
+    assert.deepEqual(cache.consume(second), { allowed: true });
+
+    const overflow = cache.consume(entry());
+    assert.equal(overflow.allowed, false);
+    assert.equal(overflow.rejectionReason, REPLAY_REJECTION_REASON);
+    assert.match(overflow.detail, /full/i);
+    assert.match(overflow.detail, /reopen the replay window/i);
+
+    // The previously consumed nonces must still be present (no eviction).
+    assert.equal(cache.check(first).allowed, false);
+    assert.equal(cache.check(second).allowed, false);
+  });
+
+  it("frees capacity via sweep when full entries have expired", () => {
+    let clock = NOW_MS;
+    const cache = createReplayCache({
+      storePath: makeStorePath(),
+      maxEntries: 2,
+      now: () => clock,
+    });
+
+    cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
+    cache.consume(entry({ expiresAt: NOW_MS + 1000 }));
+
+    // Advance past expiry: the internal sweep during consume frees room.
+    clock = NOW_MS + 5000;
+    assert.deepEqual(cache.consume(entry({ expiresAt: clock + 60000 })), {
+      allowed: true,
+    });
+    assert.equal(cache.size(), 1);
+  });
+
+  it("exposes the documented default bound", () => {
+    assert.equal(DEFAULT_MAX_ENTRIES, 5000);
+  });
+});

--- a/packages/agent/src/signing/index.js
+++ b/packages/agent/src/signing/index.js
@@ -1,0 +1,467 @@
+"use strict";
+
+/**
+ * Job signature verification and canonicalization (CertOps Phase 4 runtime,
+ * ADR-0003).
+ *
+ * Jobs dispatched by the control plane are signed with an Ed25519 platform
+ * operational signing key. The agent pins the corresponding public key
+ * (`signingKeyId` + PEM) and verifies every job's signature before any other
+ * processing. HMAC is explicitly rejected by ADR-0003 (a shared symmetric
+ * secret would let any agent forge jobs for any other agent); only
+ * node:crypto Ed25519 is used here.
+ *
+ * This module is intentionally self-contained: it accepts plain data as
+ * function parameters and does not import sibling modules (config, protocol,
+ * replay, ...). Wiring is left to src/index.js (dispatch-wiring work, done
+ * separately).
+ *
+ * Rejection results use the exact shape the policy module produces
+ * ({ allowed: false, rejectionReason, detail }) so downstream evidence/result
+ * reporting handles policy and integrity rejections uniformly.
+ *
+ * Custody invariant: no function in this module ever places private key
+ * material (or the public key PEM) into a returned detail string, error
+ * message, or log line. Details reference key IDs and field names only.
+ */
+
+const crypto = require("node:crypto");
+
+/**
+ * Rejection reasons owned by the Phase 4 signature/time-window runtime,
+ * mirroring the subset of agent-protocol.schema.json's
+ * resultBody.rejectionReason enum not owned by the policy module.
+ * (job_replay_rejected is owned by the sibling replay module.)
+ */
+const SIGNING_REJECTION_REASONS = Object.freeze({
+  JOB_INTEGRITY_FAILED: "job_integrity_failed",
+  CLOCK_DRIFT_SUSPECTED: "clock_drift_suspected",
+});
+
+/**
+ * Default clock tolerance applied to the [issuedAt, expiresAt] window.
+ *
+ * Why 30000 ms: HTTP Date-based offset estimation (see the clock module) has
+ * 1-second granularity, NTP-synced hosts are typically within tens of
+ * milliseconds, and non-NTP hosts commonly drift by seconds, not minutes.
+ * 30s absorbs realistic residual drift plus network latency between the
+ * control plane stamping issuedAt and the agent validating it, while staying
+ * far below the 5-minute dispatch validity window, so it never effectively
+ * disables expiry.
+ */
+const DEFAULT_TIME_WINDOW_TOLERANCE_MS = 30000;
+
+// job-payload.schema.json bounds: signature is base64, 64-1024 chars.
+const SIGNATURE_LENGTH_MIN = 64;
+const SIGNATURE_LENGTH_MAX = 1024;
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+const SIGNING_KEY_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;
+const NONCE_PATTERN = /^[A-Za-z0-9_.:-]{16,128}$/;
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}
+
+/**
+ * @param {string} rejectionReason
+ * @param {string} detail
+ * @returns {{ allowed: false, rejectionReason: string, detail: string }}
+ */
+function reject(rejectionReason, detail) {
+  return { allowed: false, rejectionReason, detail };
+}
+
+/**
+ * Recursive canonical JSON serializer shared by canonicalizeJobPayload.
+ * Kept separate so the top-level signature exclusion (which applies ONLY at
+ * depth 0 per ADR-0003) does not leak into nested levels.
+ *
+ * @param {*} value
+ * @param {string} pathLabel JSON-path-ish label for error messages
+ * @returns {string}
+ */
+function serializeCanonical(value, pathLabel) {
+  if (value === undefined) {
+    throw new Error(
+      `signing: canonicalizeJobPayload found an undefined value at ${pathLabel}; ` +
+        "undefined is not representable in JSON and would silently diverge " +
+        "between implementations, so it is rejected",
+    );
+  }
+  if (value === null) return "null";
+  const valueType = typeof value;
+  if (valueType === "boolean") return value ? "true" : "false";
+  if (valueType === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(
+        `signing: canonicalizeJobPayload found a non-finite number at ${pathLabel}`,
+      );
+    }
+    return JSON.stringify(value);
+  }
+  if (valueType === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    const items = value.map((item, index) =>
+      serializeCanonical(item, `${pathLabel}[${index}]`),
+    );
+    return `[${items.join(",")}]`;
+  }
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value).sort();
+    const entries = keys.map((key) => {
+      const serialized = serializeCanonical(value[key], `${pathLabel}.${key}`);
+      return `${JSON.stringify(key)}:${serialized}`;
+    });
+    return `{${entries.join(",")}}`;
+  }
+  throw new Error(
+    `signing: canonicalizeJobPayload cannot serialize value of type ` +
+      `${valueType} at ${pathLabel} (only plain objects, arrays, strings, ` +
+      "finite numbers, booleans, and null are allowed)",
+  );
+}
+
+/**
+ * Deterministic canonical JSON serialization of a job payload, EXCLUDING the
+ * top-level "signature" property. This is the exact byte sequence the
+ * control plane signs and the agent verifies (ADR-0003: "the signature must
+ * cover a canonical serialization excluding the signature field").
+ *
+ * CANONICALIZATION ALGORITHM (the control plane MUST implement this
+ * identically, byte for byte):
+ *
+ *   1. Input must be a plain object (prototype Object.prototype or null).
+ *      Anything else (array, class instance, Map, primitive, null) throws.
+ *   2. The TOP-LEVEL property named "signature" is omitted. Properties named
+ *      "signature" at any deeper nesting level are KEPT and serialized
+ *      normally; per ADR-0003 only the envelope's own signature field is
+ *      excluded from the signed bytes.
+ *   3. Object keys are sorted lexicographically by UTF-16 code unit
+ *      (JavaScript's default Array.prototype.sort() on strings), recursively
+ *      at every nesting level.
+ *   4. Arrays keep their original element order.
+ *   5. No whitespace anywhere: `{"a":1,"b":[2,3]}` style.
+ *   6. Strings and keys are encoded with JSON.stringify's standard JSON
+ *      string escaping. Numbers use JSON.stringify's shortest round-trip
+ *      form; non-finite numbers (NaN, Infinity) throw.
+ *   7. `undefined` anywhere in the tree throws (it is not representable in
+ *      JSON and dropping it silently would let two implementations sign
+ *      different bytes for the "same" object).
+ *   8. The resulting string is UTF-8 encoded to produce the bytes to
+ *      sign/verify (Node string -> Buffer.from(str, "utf8")).
+ *
+ * @param {object} job the job payload (may include the signature field,
+ *   which is excluded from the output)
+ * @returns {string} canonical JSON string (UTF-8 encode it for signing)
+ * @throws {Error} on non-plain-object input or unserializable values
+ */
+function canonicalizeJobPayload(job) {
+  if (!isPlainObject(job)) {
+    throw new Error(
+      "signing: canonicalizeJobPayload requires a plain object job payload",
+    );
+  }
+  const withoutSignature = {};
+  for (const key of Object.keys(job)) {
+    if (key === "signature") continue;
+    withoutSignature[key] = job[key];
+  }
+  return serializeCanonical(withoutSignature, "$");
+}
+
+/**
+ * Structural checks on the signed-dispatch fields of an untrusted job.
+ * Returns a human-readable problem string, or null when well-formed.
+ * Bounds mirror job-payload.schema.json (nonce 16-128 chars, signingKeyId
+ * 1-128 chars, signature base64 64-1024 chars, issuedAt/expiresAt ISO
+ * date-time).
+ *
+ * @param {object} job
+ * @returns {string|null}
+ */
+function findSignedFieldProblem(job) {
+  if (!isPlainObject(job)) {
+    return "job payload must be a plain object";
+  }
+  if (
+    typeof job.signature !== "string" ||
+    job.signature.length < SIGNATURE_LENGTH_MIN ||
+    job.signature.length > SIGNATURE_LENGTH_MAX ||
+    !BASE64_PATTERN.test(job.signature)
+  ) {
+    return "job signature is missing or not a well-formed base64 string (64-1024 chars)";
+  }
+  if (
+    typeof job.signingKeyId !== "string" ||
+    !SIGNING_KEY_ID_PATTERN.test(job.signingKeyId)
+  ) {
+    return "job signingKeyId is missing or malformed";
+  }
+  if (typeof job.nonce !== "string" || !NONCE_PATTERN.test(job.nonce)) {
+    return "job nonce is missing or malformed (16-128 chars, [A-Za-z0-9_.:-])";
+  }
+  if (
+    typeof job.issuedAt !== "string" ||
+    Number.isNaN(Date.parse(job.issuedAt))
+  ) {
+    return "job issuedAt is missing or not a parseable date-time";
+  }
+  if (
+    typeof job.expiresAt !== "string" ||
+    Number.isNaN(Date.parse(job.expiresAt))
+  ) {
+    return "job expiresAt is missing or not a parseable date-time";
+  }
+  return null;
+}
+
+/**
+ * Verifies an untrusted job's Ed25519 signature against the pinned
+ * control-plane public key.
+ *
+ * Checks, in order (first failure wins):
+ *   1. signature / signingKeyId / nonce / issuedAt / expiresAt present and
+ *      well-formed per job-payload.schema.json bounds.
+ *   2. job.signingKeyId === pinnedSigningKeyId (a mismatch means the job was
+ *      signed by a key this agent does not pin -- possibly a rotation the
+ *      agent has not picked up, possibly forgery; either way integrity
+ *      cannot be established).
+ *   3. crypto.verify(null, utf8(canonicalizeJobPayload(job)), publicKeyPem,
+ *      base64(job.signature)) -- algorithm null selects Ed25519's intrinsic
+ *      signing scheme per Node's crypto API.
+ *
+ * Never throws on untrusted (job) input: any malformed or forged job
+ * produces { allowed: false, rejectionReason: "job_integrity_failed",
+ * detail }. Throws only on programmer error (missing/invalid publicKeyPem
+ * or pinnedSigningKeyId), because running without a pinned verification key
+ * is a misconfiguration that must fail loudly, not soft-reject jobs.
+ *
+ * @param {object} params
+ * @param {object} params.job untrusted job payload from a claim response
+ * @param {string} params.publicKeyPem pinned Ed25519 public key (SPKI PEM)
+ * @param {string} params.pinnedSigningKeyId pinned signing key id
+ * @returns {{ allowed: true } | { allowed: false, rejectionReason: string, detail: string }}
+ */
+function verifyJobSignature({ job, publicKeyPem, pinnedSigningKeyId }) {
+  if (typeof publicKeyPem !== "string" || publicKeyPem.length === 0) {
+    throw new Error(
+      "signing: verifyJobSignature requires a publicKeyPem string (pinned " +
+        "control-plane signing public key); refusing to run without one",
+    );
+  }
+  if (
+    typeof pinnedSigningKeyId !== "string" ||
+    pinnedSigningKeyId.length === 0
+  ) {
+    throw new Error(
+      "signing: verifyJobSignature requires a pinnedSigningKeyId string",
+    );
+  }
+
+  const fieldProblem = findSignedFieldProblem(job);
+  if (fieldProblem !== null) {
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      `Signed job field validation failed: ${fieldProblem}.`,
+    );
+  }
+
+  if (job.signingKeyId !== pinnedSigningKeyId) {
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      `Signing key id mismatch: job was signed with key id ` +
+        `"${job.signingKeyId}" but this agent pins key id ` +
+        `"${pinnedSigningKeyId}".`,
+    );
+  }
+
+  // Parsing the *pinned* public key is trusted-local-config territory: a
+  // malformed pinned key is operator/programmer error and must fail loudly,
+  // not soft-reject every job (which would look like an attack signal).
+  let publicKey;
+  try {
+    publicKey = crypto.createPublicKey(publicKeyPem);
+  } catch (err) {
+    throw new Error(
+      `signing: verifyJobSignature was given an unparseable publicKeyPem: ${err.message}`,
+    );
+  }
+
+  let verified = false;
+  try {
+    const canonicalBytes = Buffer.from(canonicalizeJobPayload(job), "utf8");
+    const signatureBytes = Buffer.from(job.signature, "base64");
+    verified = crypto.verify(null, canonicalBytes, publicKey, signatureBytes);
+  } catch (err) {
+    // Everything inside this try operates on untrusted job data
+    // (canonicalization of a structurally hostile job with undefined values,
+    // or a signature buffer crypto.verify cannot process): integrity cannot
+    // be established, so soft-reject. Never echo raw job content here.
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      "Job payload could not be canonically serialized or verified " +
+        `(${err.message}).`,
+    );
+  }
+
+  if (!verified) {
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      "Job signature verification failed: the Ed25519 signature does not " +
+        "match the canonical job payload under the pinned signing key.",
+    );
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Validates that the current time falls inside the job's signed validity
+ * window [issuedAt - toleranceMs, expiresAt + toleranceMs].
+ *
+ * The comparison time is `nowMs + clockOffsetMs` when clockOffsetMs is a
+ * finite integer (the clock module's serverTime - localTime estimate, so
+ * adding it converts local time to estimated server time -- the same clock
+ * that stamped issuedAt/expiresAt). When clockOffsetMs is null/undefined/
+ * non-finite, nowMs is used unadjusted.
+ *
+ * Rejection semantics (documented choice):
+ *   - expiresAt < issuedAt: the window is malformed regardless of any clock;
+ *     no drift could explain it => "job_integrity_failed".
+ *   - adjusted now < issuedAt - toleranceMs (job "from the future") or
+ *     adjusted now > expiresAt + toleranceMs (job expired): both are
+ *     plausibly clock-related -- a skewed agent clock makes fresh jobs look
+ *     future-dated or valid jobs look expired -- so both reject with
+ *     "clock_drift_suspected". A genuinely replayed old job is also caught
+ *     independently by the replay cache, so classifying window failures as
+ *     drift keeps the operator signal actionable (check NTP) without
+ *     weakening replay defense.
+ *
+ * @param {object} params
+ * @param {object} params.job untrusted job payload (issuedAt/expiresAt)
+ * @param {number} params.nowMs current local epoch milliseconds
+ * @param {number|null} [params.clockOffsetMs] estimated serverTime - localTime
+ * @param {number} [params.toleranceMs] window slack, default 30000 (see
+ *   DEFAULT_TIME_WINDOW_TOLERANCE_MS for rationale)
+ * @returns {{ allowed: true } | { allowed: false, rejectionReason: string, detail: string }}
+ */
+function checkJobTimeWindow({
+  job,
+  nowMs,
+  clockOffsetMs = null,
+  toleranceMs = DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+}) {
+  if (!Number.isFinite(nowMs)) {
+    throw new Error("signing: checkJobTimeWindow requires a finite nowMs");
+  }
+  if (!Number.isFinite(toleranceMs) || toleranceMs < 0) {
+    throw new Error(
+      "signing: checkJobTimeWindow toleranceMs must be a non-negative finite number",
+    );
+  }
+
+  if (
+    !isPlainObject(job) ||
+    typeof job.issuedAt !== "string" ||
+    Number.isNaN(Date.parse(job.issuedAt)) ||
+    typeof job.expiresAt !== "string" ||
+    Number.isNaN(Date.parse(job.expiresAt))
+  ) {
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      "Job issuedAt/expiresAt missing or unparseable; cannot establish a validity window.",
+    );
+  }
+
+  const issuedAtMs = Date.parse(job.issuedAt);
+  const expiresAtMs = Date.parse(job.expiresAt);
+
+  if (expiresAtMs < issuedAtMs) {
+    return reject(
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      "Job validity window is malformed: expiresAt precedes issuedAt.",
+    );
+  }
+
+  const offsetApplies =
+    typeof clockOffsetMs === "number" &&
+    Number.isFinite(clockOffsetMs) &&
+    Number.isInteger(clockOffsetMs);
+  const adjustedNowMs = offsetApplies ? nowMs + clockOffsetMs : nowMs;
+
+  if (adjustedNowMs < issuedAtMs - toleranceMs) {
+    return reject(
+      SIGNING_REJECTION_REASONS.CLOCK_DRIFT_SUSPECTED,
+      `Job issuedAt is ${issuedAtMs - adjustedNowMs}ms in the future ` +
+        `(tolerance ${toleranceMs}ms); local clock drift suspected.`,
+    );
+  }
+
+  if (adjustedNowMs > expiresAtMs + toleranceMs) {
+    return reject(
+      SIGNING_REJECTION_REASONS.CLOCK_DRIFT_SUSPECTED,
+      `Job expired ${adjustedNowMs - expiresAtMs}ms ago ` +
+        `(tolerance ${toleranceMs}ms); stale dispatch or local clock drift.`,
+    );
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * TEST / CONTROL-PLANE-SIDE UTILITY ONLY. The agent itself never generates
+ * or holds a signing private key; the private key lives exclusively in the
+ * control plane (ADR-0003). This helper exists so the fake control-plane
+ * harness (tests/integration/fake-agent.js) and control-plane code can
+ * produce keypairs that interoperate with verifyJobSignature.
+ *
+ * @returns {{ publicKeyPem: string, privateKeyPem: string, signingKeyId: string }}
+ */
+function generateSigningKeyPair() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  return {
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    privateKeyPem: privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString(),
+    signingKeyId: `signing-key-${crypto.randomUUID()}`,
+  };
+}
+
+/**
+ * TEST / CONTROL-PLANE-SIDE UTILITY ONLY (see generateSigningKeyPair).
+ * Signs canonicalizeJobPayload(job) with Ed25519 and returns the base64
+ * signature. Using this together with verifyJobSignature guarantees both
+ * sides run the identical canonicalization algorithm.
+ *
+ * @param {object} params
+ * @param {object} params.job job payload (any existing top-level signature
+ *   field is ignored/excluded by canonicalization)
+ * @param {string} params.privateKeyPem Ed25519 private key (PKCS8 PEM)
+ * @returns {string} base64 signature
+ */
+function signJobPayload({ job, privateKeyPem }) {
+  if (typeof privateKeyPem !== "string" || privateKeyPem.length === 0) {
+    throw new Error("signing: signJobPayload requires a privateKeyPem string");
+  }
+  const canonicalBytes = Buffer.from(canonicalizeJobPayload(job), "utf8");
+  return crypto
+    .sign(null, canonicalBytes, crypto.createPrivateKey(privateKeyPem))
+    .toString("base64");
+}
+
+module.exports = {
+  SIGNING_REJECTION_REASONS,
+  DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+  canonicalizeJobPayload,
+  verifyJobSignature,
+  checkJobTimeWindow,
+  generateSigningKeyPair,
+  signJobPayload,
+};

--- a/packages/agent/src/signing/index.js
+++ b/packages/agent/src/signing/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Job signature verification and canonicalization (CertOps Phase 4 runtime,
+ * Job signature verification and canonicalization (signed-dispatch runtime,
  * ADR-0003).
  *
  * Jobs dispatched by the control plane are signed with an Ed25519 platform
@@ -28,7 +28,7 @@
 const crypto = require("node:crypto");
 
 /**
- * Rejection reasons owned by the Phase 4 signature/time-window runtime,
+ * Rejection reasons owned by the signature/time-window runtime,
  * mirroring the subset of agent-protocol.schema.json's
  * resultBody.rejectionReason enum not owned by the policy module.
  * (job_replay_rejected is owned by the sibling replay module.)

--- a/packages/agent/src/signing/signing.test.js
+++ b/packages/agent/src/signing/signing.test.js
@@ -1,0 +1,437 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+
+const {
+  SIGNING_REJECTION_REASONS,
+  DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+  canonicalizeJobPayload,
+  verifyJobSignature,
+  checkJobTimeWindow,
+  generateSigningKeyPair,
+  signJobPayload,
+} = require("./index.js");
+
+const NOW_MS = Date.parse("2026-07-22T12:00:00.000Z");
+
+function buildSignedJob({ privateKeyPem, signingKeyId, overrides = {} }) {
+  const job = {
+    schemaVersion: 1,
+    jobId: `job-${crypto.randomUUID()}`,
+    workspaceId: "11111111-1111-4111-8111-111111111111",
+    certificateId: "cert-1",
+    action: "renew",
+    target: { type: "domain", reference: "example.com" },
+    keyMode: "agent-local",
+    requestedAt: new Date(NOW_MS).toISOString(),
+    nonce: crypto.randomUUID(),
+    signingKeyId,
+    issuedAt: new Date(NOW_MS).toISOString(),
+    expiresAt: new Date(NOW_MS + 5 * 60 * 1000).toISOString(),
+    ...overrides,
+  };
+  job.signature = signJobPayload({ job, privateKeyPem });
+  return job;
+}
+
+describe("canonicalizeJobPayload", () => {
+  it("sorts object keys lexicographically at every level, no whitespace", () => {
+    const canonical = canonicalizeJobPayload({
+      b: 1,
+      a: { z: true, m: null, a: "x" },
+    });
+    assert.equal(canonical, '{"a":{"a":"x","m":null,"z":true},"b":1}');
+  });
+
+  it("excludes only the TOP-LEVEL signature property", () => {
+    const canonical = canonicalizeJobPayload({
+      signature: "should-be-dropped",
+      nested: { signature: "kept" },
+    });
+    assert.equal(canonical, '{"nested":{"signature":"kept"}}');
+  });
+
+  it("keeps array element order", () => {
+    assert.equal(
+      canonicalizeJobPayload({ list: [3, 1, 2, ["b", "a"]] }),
+      '{"list":[3,1,2,["b","a"]]}',
+    );
+  });
+
+  it("is insensitive to property insertion order", () => {
+    const one = canonicalizeJobPayload({ a: 1, b: { d: 4, c: 3 } });
+    const two = canonicalizeJobPayload({ b: { c: 3, d: 4 }, a: 1 });
+    assert.equal(one, two);
+  });
+
+  it("escapes strings using standard JSON escaping", () => {
+    assert.equal(
+      canonicalizeJobPayload({ s: 'quote " and \n newline and ünïcödé' }),
+      '{"s":"quote \\" and \\n newline and ünïcödé"}',
+    );
+  });
+
+  it("throws on non-plain-object input", () => {
+    for (const bad of [null, undefined, "str", 42, [], new Map(), new Date()]) {
+      assert.throws(() => canonicalizeJobPayload(bad), /plain object/);
+    }
+  });
+
+  it("throws on undefined values anywhere in the tree", () => {
+    assert.throws(
+      () => canonicalizeJobPayload({ a: { b: undefined } }),
+      /undefined value at \$\.a\.b/,
+    );
+    assert.throws(
+      () => canonicalizeJobPayload({ list: [1, undefined] }),
+      /undefined value at \$\.list\[1\]/,
+    );
+  });
+
+  it("throws on non-finite numbers and non-JSON values", () => {
+    assert.throws(() => canonicalizeJobPayload({ n: NaN }), /non-finite/);
+    assert.throws(() => canonicalizeJobPayload({ n: Infinity }), /non-finite/);
+    assert.throws(
+      () => canonicalizeJobPayload({ d: new Date() }),
+      /cannot serialize/,
+    );
+  });
+});
+
+describe("verifyJobSignature", () => {
+  const keys = generateSigningKeyPair();
+
+  it("accepts a validly signed job (sign/verify interop via shared canonicalization)", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    const result = verifyJobSignature({
+      job,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    assert.deepEqual(result, { allowed: true });
+  });
+
+  it("accepts a job whose properties arrive in a different order", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    const reordered = {};
+    for (const key of Object.keys(job).reverse()) reordered[key] = job[key];
+    const result = verifyJobSignature({
+      job: reordered,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    assert.deepEqual(result, { allowed: true });
+  });
+
+  it("rejects a tampered payload with job_integrity_failed", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    job.action = "revoke";
+    const result = verifyJobSignature({
+      job,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+    );
+    assert.ok(typeof result.detail === "string" && result.detail.length > 0);
+  });
+
+  it("rejects a signingKeyId mismatch with a detail mentioning the key id mismatch", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: "signing-key-other",
+    });
+    const result = verifyJobSignature({
+      job,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+    );
+    assert.match(result.detail, /key id mismatch/i);
+  });
+
+  it("rejects a job signed with a different keypair but the pinned signingKeyId", () => {
+    const otherKeys = generateSigningKeyPair();
+    const job = buildSignedJob({
+      privateKeyPem: otherKeys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    const result = verifyJobSignature({
+      job,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+    );
+  });
+
+  it("rejects missing or malformed signed fields without throwing", () => {
+    const base = () =>
+      buildSignedJob({
+        privateKeyPem: keys.privateKeyPem,
+        signingKeyId: keys.signingKeyId,
+      });
+
+    const cases = [
+      (job) => delete job.signature,
+      (job) => (job.signature = "too-short"),
+      (job) => (job.signature = "!!!not-base64###".repeat(8)),
+      (job) => delete job.signingKeyId,
+      (job) => delete job.nonce,
+      (job) => (job.nonce = "short"),
+      (job) => delete job.issuedAt,
+      (job) => (job.issuedAt = "not-a-date"),
+      (job) => delete job.expiresAt,
+    ];
+
+    for (const mutate of cases) {
+      const job = base();
+      mutate(job);
+      const result = verifyJobSignature({
+        job,
+        publicKeyPem: keys.publicKeyPem,
+        pinnedSigningKeyId: keys.signingKeyId,
+      });
+      assert.equal(result.allowed, false);
+      assert.equal(
+        result.rejectionReason,
+        SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      );
+    }
+  });
+
+  it("never throws on hostile untrusted job inputs", () => {
+    for (const hostile of [null, undefined, "job", 7, [], { nested: [] }]) {
+      const result = verifyJobSignature({
+        job: hostile,
+        publicKeyPem: keys.publicKeyPem,
+        pinnedSigningKeyId: keys.signingKeyId,
+      });
+      assert.equal(result.allowed, false);
+    }
+  });
+
+  it("throws on programmer error: missing publicKeyPem or pinnedSigningKeyId", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    assert.throws(
+      () => verifyJobSignature({ job, pinnedSigningKeyId: keys.signingKeyId }),
+      /publicKeyPem/,
+    );
+    assert.throws(
+      () => verifyJobSignature({ job, publicKeyPem: keys.publicKeyPem }),
+      /pinnedSigningKeyId/,
+    );
+    assert.throws(
+      () =>
+        verifyJobSignature({
+          job,
+          publicKeyPem: "garbage-not-pem",
+          pinnedSigningKeyId: keys.signingKeyId,
+        }),
+      /unparseable publicKeyPem/,
+    );
+  });
+
+  it("never leaks private key material into rejection details", () => {
+    const job = buildSignedJob({
+      privateKeyPem: keys.privateKeyPem,
+      signingKeyId: keys.signingKeyId,
+    });
+    job.certificateId = "tampered";
+    const result = verifyJobSignature({
+      job,
+      publicKeyPem: keys.publicKeyPem,
+      pinnedSigningKeyId: keys.signingKeyId,
+    });
+    const serialized = JSON.stringify(result);
+    assert.ok(!serialized.includes("PRIVATE KEY"));
+    assert.ok(!serialized.includes(keys.privateKeyPem.slice(30, 60)));
+  });
+});
+
+describe("checkJobTimeWindow", () => {
+  const window = {
+    issuedAt: new Date(NOW_MS).toISOString(),
+    expiresAt: new Date(NOW_MS + 5 * 60 * 1000).toISOString(),
+  };
+
+  it("allows a job whose window contains now", () => {
+    assert.deepEqual(
+      checkJobTimeWindow({ job: { ...window }, nowMs: NOW_MS + 1000 }),
+      { allowed: true },
+    );
+  });
+
+  it("allows edge times within the default tolerance", () => {
+    assert.deepEqual(
+      checkJobTimeWindow({
+        job: { ...window },
+        nowMs: NOW_MS - DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+      }),
+      { allowed: true },
+    );
+    assert.deepEqual(
+      checkJobTimeWindow({
+        job: { ...window },
+        nowMs: NOW_MS + 5 * 60 * 1000 + DEFAULT_TIME_WINDOW_TOLERANCE_MS,
+      }),
+      { allowed: true },
+    );
+  });
+
+  it("rejects a future-issued job with clock_drift_suspected", () => {
+    const result = checkJobTimeWindow({
+      job: { ...window },
+      nowMs: NOW_MS - DEFAULT_TIME_WINDOW_TOLERANCE_MS - 1,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.CLOCK_DRIFT_SUSPECTED,
+    );
+    assert.match(result.detail, /future/);
+  });
+
+  it("rejects an expired job with clock_drift_suspected", () => {
+    const result = checkJobTimeWindow({
+      job: { ...window },
+      nowMs: NOW_MS + 10 * 60 * 1000,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.CLOCK_DRIFT_SUSPECTED,
+    );
+    assert.match(result.detail, /expired/i);
+  });
+
+  it("rejects expiresAt < issuedAt as job_integrity_failed (malformed, not drift)", () => {
+    const result = checkJobTimeWindow({
+      job: {
+        issuedAt: new Date(NOW_MS).toISOString(),
+        expiresAt: new Date(NOW_MS - 1000).toISOString(),
+      },
+      nowMs: NOW_MS,
+    });
+    assert.equal(result.allowed, false);
+    assert.equal(
+      result.rejectionReason,
+      SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+    );
+  });
+
+  it("applies a finite integer clockOffsetMs (serverTime - localTime) to now", () => {
+    // Local clock 2 minutes behind the server: without the offset the job
+    // (issued "now" in server time) would look future-dated beyond tolerance.
+    const skewMs = 2 * 60 * 1000;
+    const localNowMs = NOW_MS - skewMs;
+
+    const withoutOffset = checkJobTimeWindow({
+      job: { ...window },
+      nowMs: localNowMs,
+    });
+    assert.equal(withoutOffset.allowed, false);
+
+    const withOffset = checkJobTimeWindow({
+      job: { ...window },
+      nowMs: localNowMs,
+      clockOffsetMs: skewMs,
+    });
+    assert.deepEqual(withOffset, { allowed: true });
+  });
+
+  it("ignores null/undefined/non-finite clockOffsetMs", () => {
+    for (const offset of [null, undefined, NaN, Infinity, 0.5]) {
+      assert.deepEqual(
+        checkJobTimeWindow({
+          job: { ...window },
+          nowMs: NOW_MS + 1000,
+          clockOffsetMs: offset,
+        }),
+        { allowed: true },
+      );
+    }
+  });
+
+  it("rejects missing/unparseable window fields as job_integrity_failed", () => {
+    for (const job of [
+      {},
+      { issuedAt: "bad", expiresAt: window.expiresAt },
+      { issuedAt: window.issuedAt },
+      null,
+    ]) {
+      const result = checkJobTimeWindow({ job, nowMs: NOW_MS });
+      assert.equal(result.allowed, false);
+      assert.equal(
+        result.rejectionReason,
+        SIGNING_REJECTION_REASONS.JOB_INTEGRITY_FAILED,
+      );
+    }
+  });
+
+  it("throws on programmer error: non-finite nowMs or negative tolerance", () => {
+    assert.throws(
+      () => checkJobTimeWindow({ job: { ...window }, nowMs: NaN }),
+      /finite nowMs/,
+    );
+    assert.throws(
+      () =>
+        checkJobTimeWindow({
+          job: { ...window },
+          nowMs: NOW_MS,
+          toleranceMs: -1,
+        }),
+      /toleranceMs/,
+    );
+  });
+});
+
+describe("generateSigningKeyPair / signJobPayload (test-side utilities)", () => {
+  it("generates a usable Ed25519 keypair with PEM material and a key id", () => {
+    const keys = generateSigningKeyPair();
+    assert.match(keys.publicKeyPem, /-----BEGIN PUBLIC KEY-----/);
+    assert.match(keys.privateKeyPem, /-----BEGIN PRIVATE KEY-----/);
+    assert.match(keys.signingKeyId, /^signing-key-/);
+  });
+
+  it("produces base64 signatures within the schema's 64-1024 char bounds", () => {
+    const keys = generateSigningKeyPair();
+    const signature = signJobPayload({
+      job: { jobId: "job-1", nonce: crypto.randomUUID() },
+      privateKeyPem: keys.privateKeyPem,
+    });
+    assert.ok(signature.length >= 64 && signature.length <= 1024);
+    assert.match(signature, /^[A-Za-z0-9+/]+={0,2}$/);
+  });
+
+  it("signJobPayload throws on programmer error (missing privateKeyPem)", () => {
+    assert.throws(
+      () => signJobPayload({ job: { jobId: "job-1" } }),
+      /privateKeyPem/,
+    );
+  });
+});

--- a/packages/agent/src/verify/index.js
+++ b/packages/agent/src/verify/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Post-deploy certificate verification (CertOps M5).
+ * Post-deploy certificate verification.
  *
  * After the deploy module writes a renewed certificate and the target
  * service reloads, dispatch must confirm the endpoint is actually serving

--- a/packages/agent/src/verify/index.js
+++ b/packages/agent/src/verify/index.js
@@ -1,0 +1,267 @@
+"use strict";
+
+/**
+ * Post-deploy certificate verification (CertOps M5).
+ *
+ * After the deploy module writes a renewed certificate and the target
+ * service reloads, dispatch must confirm the endpoint is actually serving
+ * the certificate that was deployed. This module does that by fingerprint
+ * pinning: connect, take the peer certificate's DER bytes, sha256 them, and
+ * compare against the expected fingerprint computed from the deployed PEM.
+ *
+ * Why rejectUnauthorized: false -- this is deliberate, not an oversight.
+ * Chain validation against the local trust store is the wrong check here:
+ * a freshly deployed certificate may carry a chain the agent host's local
+ * store does not trust (yet), private CAs are a normal CertOps deployment
+ * scenario, and staging/--dry-run CAs are untrusted by design. The
+ * fingerprint comparison IS the verification: it proves byte-identity
+ * between the certificate the endpoint serves and the certificate that was
+ * deployed, which is strictly stronger evidence of "the deploy took" than
+ * chain trust would be.
+ *
+ * Error discipline: network problems (refused, timeout, reset, DNS) are
+ * expected operational outcomes and yield { verified: false, ... } -- this
+ * function never throws for those. It throws only on programmer error
+ * (missing/malformed host, port, or expected fingerprint).
+ *
+ * Fingerprint form: lowercase, no colons, 64 hex chars -- identical
+ * semantics to the discovery module's normalizeFingerprint (which is
+ * exported there but deliberately not imported here; modules in this
+ * package are self-contained and accept plain data only).
+ *
+ * This module handles only public certificate material (DER/PEM of certs).
+ * No private key is ever read, transmitted, or accepted by any function
+ * here (D5 / ADR-0001 zero key custody).
+ */
+
+const crypto = require("node:crypto");
+const tls = require("node:tls");
+
+const DEFAULT_TLS_PORT = 443;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+/** Lowercase-hex sha256, optionally colon-separated, case-insensitive. */
+const FINGERPRINT_INPUT_PATTERN = /^(?:[0-9a-f]{2}:){31}[0-9a-f]{2}$|^[0-9a-f]{64}$/i;
+
+const PEM_CERTIFICATE_PATTERN =
+  /-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\s]+)-----END CERTIFICATE-----/;
+
+/**
+ * Normalizes a sha256 fingerprint to the schema form: strip colons,
+ * lowercase. Mirrors discovery's normalizeFingerprint semantics exactly
+ * (duplicated rather than imported; see module header).
+ *
+ * @param {string} fingerprint
+ * @returns {string}
+ */
+function normalizeFingerprint(fingerprint) {
+  return String(fingerprint || "")
+    .replace(/:/g, "")
+    .toLowerCase();
+}
+
+/**
+ * @param {Buffer} derBytes
+ * @returns {string} lowercase 64-hex-char sha256 of the DER bytes
+ */
+function sha256HexOfDer(derBytes) {
+  return crypto.createHash("sha256").update(derBytes).digest("hex");
+}
+
+/**
+ * Computes the sha256 fingerprint (lowercase hex, no colons) of the DER
+ * encoding of the FIRST certificate block in a PEM string. Dispatch uses
+ * this to derive the expected fingerprint from the deployed PEM file (which
+ * may be a fullchain file; the leaf certificate comes first by convention,
+ * and the leaf is what the peer presents as its own certificate).
+ *
+ * @param {string} certPem PEM text containing at least one CERTIFICATE block
+ * @returns {string}
+ */
+function computeCertificateFingerprint(certPem) {
+  if (typeof certPem !== "string" || certPem.length === 0) {
+    throw new Error(
+      "verify: computeCertificateFingerprint requires a non-empty PEM string",
+    );
+  }
+
+  const match = PEM_CERTIFICATE_PATTERN.exec(certPem);
+  if (!match) {
+    throw new Error(
+      "verify: computeCertificateFingerprint found no CERTIFICATE block in the provided PEM",
+    );
+  }
+
+  const base64Body = match[1].replace(/\s+/g, "");
+  let der;
+  try {
+    der = Buffer.from(base64Body, "base64");
+  } catch {
+    der = null;
+  }
+  if (!der || der.length === 0) {
+    throw new Error(
+      "verify: computeCertificateFingerprint could not decode the CERTIFICATE block as base64",
+    );
+  }
+
+  return sha256HexOfDer(der);
+}
+
+/**
+ * Verifies that the certificate served at host:port matches an expected
+ * sha256 fingerprint.
+ *
+ * Comparison is case-insensitive and colon-tolerant on the expected value
+ * (normalized to lowercase no-colon hex before comparing). The actual
+ * fingerprint is always reported in the normalized form so it can be reused
+ * directly in evidence.
+ *
+ * @param {object} options
+ * @param {string} options.host hostname or IP to connect to.
+ * @param {number} [options.port] TCP port, default 443.
+ * @param {string} [options.servername] SNI name; defaults to `host` (node's
+ *   tls.connect default), pass explicitly when verifying by IP against an
+ *   SNI-routed endpoint.
+ * @param {string} options.expectedFingerprintSha256 sha256 fingerprint of
+ *   the deployed certificate's DER, hex, with or without colons, any case
+ *   (e.g. from computeCertificateFingerprint or discovery's
+ *   fingerprintSha256).
+ * @param {number} [options.timeoutMs] connection/handshake budget, default
+ *   10000 ms.
+ * @param {Function} [options.connectImpl] injection point for tests; must
+ *   mimic tls.connect(options) => socket (an EventEmitter with
+ *   getPeerCertificate/end/destroy/setTimeout).
+ * @returns {Promise<
+ *   { verified: true, actualFingerprintSha256: string }
+ *   | { verified: false, actualFingerprintSha256: string|null, detail: string }
+ * >}
+ */
+function verifyDeployedCertificate({
+  host,
+  port = DEFAULT_TLS_PORT,
+  servername,
+  expectedFingerprintSha256,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  connectImpl = tls.connect,
+} = {}) {
+  // Programmer-error validation: these throw synchronously, they are bugs
+  // in the caller, not network outcomes.
+  if (typeof host !== "string" || host.length === 0) {
+    throw new Error("verify: verifyDeployedCertificate requires a non-empty host");
+  }
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(
+      `verify: port must be an integer in [1, 65535], got ${JSON.stringify(port)}`,
+    );
+  }
+  if (
+    typeof expectedFingerprintSha256 !== "string" ||
+    !FINGERPRINT_INPUT_PATTERN.test(expectedFingerprintSha256)
+  ) {
+    throw new Error(
+      "verify: expectedFingerprintSha256 must be a sha256 hex fingerprint " +
+        `(64 hex chars, colons optional), got ${JSON.stringify(expectedFingerprintSha256)}`,
+    );
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `verify: timeoutMs must be a positive integer, got ${JSON.stringify(timeoutMs)}`,
+    );
+  }
+  if (typeof connectImpl !== "function") {
+    throw new Error("verify: connectImpl must be a function");
+  }
+
+  const expected = normalizeFingerprint(expectedFingerprintSha256);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let socket = null;
+    let timer = null;
+
+    function settle(result) {
+      if (settled) return;
+      settled = true;
+      if (timer !== null) clearTimeout(timer);
+      if (socket) {
+        try {
+          socket.destroy();
+        } catch {
+          // Best-effort teardown; the result has already been decided.
+        }
+      }
+      resolve(result);
+    }
+
+    function fail(detail) {
+      settle({ verified: false, actualFingerprintSha256: null, detail });
+    }
+
+    // One overall wall-clock budget covering connect + handshake, enforced
+    // locally instead of relying on socket idle timeouts (which reset on
+    // activity and would not bound a slow-loris handshake).
+    timer = setTimeout(() => {
+      fail(`Connection to ${host}:${port} timed out after ${timeoutMs} ms.`);
+    }, timeoutMs);
+
+    try {
+      socket = connectImpl({
+        host,
+        port,
+        ...(servername !== undefined ? { servername } : {}),
+        // Deliberate: fingerprint pinning, not chain validation. See the
+        // module header for the full rationale (fresh deploys, private CAs,
+        // staging endpoints). The sha256 comparison below is the actual
+        // verification.
+        rejectUnauthorized: false,
+      });
+    } catch (err) {
+      fail(`TLS connect to ${host}:${port} failed: ${err?.message || err}`);
+      return;
+    }
+
+    socket.on("secureConnect", () => {
+      let peerCert;
+      try {
+        peerCert = socket.getPeerCertificate();
+      } catch (err) {
+        fail(
+          `Could not obtain peer certificate from ${host}:${port}: ${err?.message || err}`,
+        );
+        return;
+      }
+
+      const der = peerCert && peerCert.raw;
+      if (!Buffer.isBuffer(der) || der.length === 0) {
+        fail(
+          `Peer at ${host}:${port} presented no certificate (or an empty one).`,
+        );
+        return;
+      }
+
+      const actual = sha256HexOfDer(der);
+      if (actual === expected) {
+        settle({ verified: true, actualFingerprintSha256: actual });
+      } else {
+        settle({
+          verified: false,
+          actualFingerprintSha256: actual,
+          detail:
+            `Fingerprint mismatch at ${host}:${port}: expected ${expected}, ` +
+            `endpoint presented ${actual}.`,
+        });
+      }
+    });
+
+    socket.on("error", (err) => {
+      fail(`TLS connection to ${host}:${port} failed: ${err?.message || err}`);
+    });
+  });
+}
+
+module.exports = {
+  verifyDeployedCertificate,
+  computeCertificateFingerprint,
+  normalizeFingerprint,
+};

--- a/packages/agent/src/verify/verify.test.js
+++ b/packages/agent/src/verify/verify.test.js
@@ -1,0 +1,319 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const net = require("node:net");
+const { EventEmitter } = require("node:events");
+const { X509Certificate } = require("node:crypto");
+
+const {
+  verifyDeployedCertificate,
+  computeCertificateFingerprint,
+  normalizeFingerprint,
+} = require("./index.js");
+
+/**
+ * Static PUBLIC certificate fixture (self-signed, CN
+ * certops-verify-fixture.test, generated once for this test file). Public
+ * material only -- per the zero key custody invariant, NO private key
+ * fixture exists anywhere in the repo, so this cert can never be used to
+ * serve traffic; it exists purely as parse/fingerprint input.
+ *
+ * Test-strategy note (documented choice): generating a fresh self-signed
+ * certificate at runtime without dependencies is not possible with
+ * node:crypto alone (it can create keypairs and parse X.509, but has no
+ * certificate-signing API), and vendoring a private key fixture to run a
+ * real tls.createServer is forbidden. The happy/mismatch handshake paths
+ * are therefore exercised through a connectImpl stub that mimics
+ * tls.connect, while the connection-error path uses a REAL socket against
+ * a port with no listener (no certificate needed for that).
+ */
+const FIXTURE_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIDLTCCAhWgAwIBAgIUNNNJnkEUxHbRL7iDNJAUsL9ldbAwDQYJKoZIhvcNAQEL
+BQAwJjEkMCIGA1UEAwwbY2VydG9wcy12ZXJpZnktZml4dHVyZS50ZXN0MB4XDTI2
+MDcyMjA1MjUzNVoXDTM2MDcxOTA1MjUzNVowJjEkMCIGA1UEAwwbY2VydG9wcy12
+ZXJpZnktZml4dHVyZS50ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEA2ukFK8Np/lO9PUjkTZ0LUtHPH7SRyfJMgMks9XMlyIfn2vsMI4YpbLh1WD82
+A2b08wxlaxbilElqtuoPOWtUgk99SNLW170tAzKf3X/Yvf/sh8MJp7bJTjQY2o5x
+LgU1HoFb/HtcMvB6xjsJZppn9cwNk1qWRvBb8cL8VDiseg1h8RTUNCoDWTlDpiUf
+04+BFImTRNky8j/SmhlHmtrOoHwYu3bul+OuYmbFH+Sxm+/ZGK6LbdnqEAfugBHg
+UNtbiaFLFiceU2+CHF2+tMROqxj2wefVX9dQzyXLlTOPhgbEAk86jwe5UKJNREKT
+vkn3ibR5bxc992fLSGPQ3oziDQIDAQABo1MwUTAdBgNVHQ4EFgQU4YR1yo0mQmDa
+NCGg2i28Vace8UYwHwYDVR0jBBgwFoAU4YR1yo0mQmDaNCGg2i28Vace8UYwDwYD
+VR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAJcsjXHpAOzi4Fwi6wSWZ
+aacLB76johdLGTXK1FGbN8+2PVISXUJ/wsNhoYSu9qtYyuVdxsAiiUBT1xupD0ca
+MG85NmVqKVLN2WzT9OFSWSsA4HlIc37kUamApq7VZ2VMylCpQI1A9fhfb5ZbRYhM
+1Gfhfx1UaAnWcs0AAsGjxeCrNKizZfBRUsmap0V+yeXLIOBE/tJxwaHu14qLx+Ws
+Uw7sRZcMXBIEmaNAi4EEX6eJ0zUcKLUI0glUsEpNId3VaKR63L2IXOxxEXvlYrXs
+rDRLsqd2zwJUBZ5zeUp3Ji++P4IM/DBkbrbtr8PX9Rj2U5ZRxQQ4ZE+ifMJqDeKy
+Cw==
+-----END CERTIFICATE-----
+`;
+
+const fixtureX509 = new X509Certificate(FIXTURE_CERT_PEM);
+const FIXTURE_DER = fixtureX509.raw;
+const FIXTURE_FINGERPRINT = normalizeFingerprint(fixtureX509.fingerprint256);
+
+const OTHER_FINGERPRINT = "0".repeat(64);
+
+/**
+ * connectImpl stub mimicking tls.connect: returns a socket-like
+ * EventEmitter and emits the configured outcome asynchronously.
+ *
+ * @param {object} outcome
+ * @param {Buffer|null} [outcome.peerDer] DER to present on secureConnect
+ * @param {Error} [outcome.error] error to emit instead of secureConnect
+ * @param {boolean} [outcome.hang] never emit anything (timeout path)
+ * @param {object|undefined} [outcome.peerCertOverride] raw value returned by
+ *   getPeerCertificate (to simulate a missing/empty peer certificate)
+ */
+function makeConnectStub(outcome) {
+  const seenOptions = [];
+
+  function connectStub(options) {
+    seenOptions.push(options);
+    const socket = new EventEmitter();
+    socket.destroyed = false;
+    socket.destroy = () => {
+      socket.destroyed = true;
+    };
+    socket.getPeerCertificate = () => {
+      if ("peerCertOverride" in outcome) return outcome.peerCertOverride;
+      return { raw: outcome.peerDer };
+    };
+
+    process.nextTick(() => {
+      if (outcome.hang) return;
+      if (outcome.error) {
+        socket.emit("error", outcome.error);
+      } else {
+        socket.emit("secureConnect");
+      }
+    });
+
+    return socket;
+  }
+
+  connectStub.seenOptions = seenOptions;
+  return connectStub;
+}
+
+function baseVerifyInputs(connectImpl, overrides = {}) {
+  return {
+    host: "web-01.example.com",
+    port: 8443,
+    expectedFingerprintSha256: FIXTURE_FINGERPRINT,
+    connectImpl,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeCertificateFingerprint
+// ---------------------------------------------------------------------------
+
+test("computeCertificateFingerprint matches node:crypto's fingerprint256 for the fixture", () => {
+  const computed = computeCertificateFingerprint(FIXTURE_CERT_PEM);
+  assert.equal(computed, FIXTURE_FINGERPRINT);
+  assert.match(computed, /^[a-f0-9]{64}$/);
+});
+
+test("computeCertificateFingerprint uses the FIRST cert of a fullchain-style PEM", () => {
+  const fullchainLike = `${FIXTURE_CERT_PEM}\n${FIXTURE_CERT_PEM}`;
+  assert.equal(
+    computeCertificateFingerprint(fullchainLike),
+    FIXTURE_FINGERPRINT,
+  );
+});
+
+test("computeCertificateFingerprint throws on empty / non-PEM input", () => {
+  assert.throws(() => computeCertificateFingerprint(""), /non-empty PEM/);
+  assert.throws(
+    () => computeCertificateFingerprint("not a pem at all"),
+    /no CERTIFICATE block/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// normalizeFingerprint
+// ---------------------------------------------------------------------------
+
+test("normalizeFingerprint strips colons and lowercases (discovery semantics)", () => {
+  assert.equal(normalizeFingerprint("AA:BB:cc:DD"), "aabbccdd");
+  assert.equal(normalizeFingerprint(""), "");
+});
+
+// ---------------------------------------------------------------------------
+// verifyDeployedCertificate: happy / mismatch paths (connectImpl stub)
+// ---------------------------------------------------------------------------
+
+test("matching fingerprint => verified: true with normalized actual", async () => {
+  const connectImpl = makeConnectStub({ peerDer: FIXTURE_DER });
+  const result = await verifyDeployedCertificate(baseVerifyInputs(connectImpl));
+
+  assert.deepEqual(result, {
+    verified: true,
+    actualFingerprintSha256: FIXTURE_FINGERPRINT,
+  });
+});
+
+test("expected fingerprint with colons and uppercase still matches", async () => {
+  const colonUpper = FIXTURE_FINGERPRINT.toUpperCase()
+    .match(/.{2}/g)
+    .join(":");
+  const connectImpl = makeConnectStub({ peerDer: FIXTURE_DER });
+
+  const result = await verifyDeployedCertificate(
+    baseVerifyInputs(connectImpl, { expectedFingerprintSha256: colonUpper }),
+  );
+
+  assert.equal(result.verified, true);
+  assert.equal(result.actualFingerprintSha256, FIXTURE_FINGERPRINT);
+});
+
+test("mismatched fingerprint => verified: false, reports actual fingerprint", async () => {
+  const connectImpl = makeConnectStub({ peerDer: FIXTURE_DER });
+  const result = await verifyDeployedCertificate(
+    baseVerifyInputs(connectImpl, { expectedFingerprintSha256: OTHER_FINGERPRINT }),
+  );
+
+  assert.equal(result.verified, false);
+  assert.equal(result.actualFingerprintSha256, FIXTURE_FINGERPRINT);
+  assert.match(result.detail, /Fingerprint mismatch/);
+  assert.match(result.detail, new RegExp(OTHER_FINGERPRINT));
+});
+
+test("peer presenting no certificate => verified: false with detail", async () => {
+  const connectImpl = makeConnectStub({ peerCertOverride: {} });
+  const result = await verifyDeployedCertificate(baseVerifyInputs(connectImpl));
+
+  assert.equal(result.verified, false);
+  assert.equal(result.actualFingerprintSha256, null);
+  assert.match(result.detail, /no certificate/);
+});
+
+test("connect options: rejectUnauthorized false, servername passthrough", async () => {
+  const connectImpl = makeConnectStub({ peerDer: FIXTURE_DER });
+  await verifyDeployedCertificate(
+    baseVerifyInputs(connectImpl, { servername: "sni.example.com" }),
+  );
+
+  assert.equal(connectImpl.seenOptions.length, 1);
+  const options = connectImpl.seenOptions[0];
+  assert.equal(options.rejectUnauthorized, false);
+  assert.equal(options.host, "web-01.example.com");
+  assert.equal(options.port, 8443);
+  assert.equal(options.servername, "sni.example.com");
+});
+
+// ---------------------------------------------------------------------------
+// verifyDeployedCertificate: error / timeout paths
+// ---------------------------------------------------------------------------
+
+test("socket error => verified: false with detail, never throws", async () => {
+  const connectImpl = makeConnectStub({
+    error: new Error("connect ECONNREFUSED 127.0.0.1:8443"),
+  });
+  const result = await verifyDeployedCertificate(baseVerifyInputs(connectImpl));
+
+  assert.equal(result.verified, false);
+  assert.equal(result.actualFingerprintSha256, null);
+  assert.match(result.detail, /ECONNREFUSED/);
+});
+
+test("handshake that never completes => verified: false via timeout", async () => {
+  const connectImpl = makeConnectStub({ hang: true });
+  const result = await verifyDeployedCertificate(
+    baseVerifyInputs(connectImpl, { timeoutMs: 50 }),
+  );
+
+  assert.equal(result.verified, false);
+  assert.equal(result.actualFingerprintSha256, null);
+  assert.match(result.detail, /timed out after 50 ms/);
+});
+
+test("connectImpl throwing synchronously => verified: false, never throws", async () => {
+  const connectImpl = () => {
+    throw new Error("synchronous connect explosion");
+  };
+  const result = await verifyDeployedCertificate(baseVerifyInputs(connectImpl));
+
+  assert.equal(result.verified, false);
+  assert.match(result.detail, /synchronous connect explosion/);
+});
+
+test("real connection against a closed port => verified: false with detail", async () => {
+  // Reserve an ephemeral port, then close the listener so nothing is
+  // listening there: the real tls.connect (default connectImpl) must fail
+  // with a connection error, not a throw. This is the one path that needs
+  // no certificate, so it can use a real socket (see the fixture comment
+  // for why the handshake paths are stub-based).
+  const port = await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const claimed = server.address().port;
+      server.close((err) => (err ? reject(err) : resolve(claimed)));
+    });
+    server.on("error", reject);
+  });
+
+  const result = await verifyDeployedCertificate({
+    host: "127.0.0.1",
+    port,
+    expectedFingerprintSha256: FIXTURE_FINGERPRINT,
+    timeoutMs: 5000,
+  });
+
+  assert.equal(result.verified, false);
+  assert.equal(result.actualFingerprintSha256, null);
+  assert.match(result.detail, /failed|timed out/);
+});
+
+// ---------------------------------------------------------------------------
+// programmer-error validation (throws)
+// ---------------------------------------------------------------------------
+
+test("missing host throws", () => {
+  assert.throws(
+    () =>
+      verifyDeployedCertificate({
+        expectedFingerprintSha256: FIXTURE_FINGERPRINT,
+      }),
+    /non-empty host/,
+  );
+});
+
+test("missing or malformed expected fingerprint throws", () => {
+  assert.throws(
+    () => verifyDeployedCertificate({ host: "example.com" }),
+    /expectedFingerprintSha256/,
+  );
+  assert.throws(
+    () =>
+      verifyDeployedCertificate({
+        host: "example.com",
+        expectedFingerprintSha256: "zz".repeat(32),
+      }),
+    /expectedFingerprintSha256/,
+  );
+  assert.throws(
+    () =>
+      verifyDeployedCertificate({
+        host: "example.com",
+        expectedFingerprintSha256: "abc123",
+      }),
+    /expectedFingerprintSha256/,
+  );
+});
+
+test("invalid port throws", () => {
+  assert.throws(
+    () =>
+      verifyDeployedCertificate({
+        host: "example.com",
+        port: 70000,
+        expectedFingerprintSha256: FIXTURE_FINGERPRINT,
+      }),
+    /port/,
+  );
+});

--- a/tests/integration/agent-protocol.test.js
+++ b/tests/integration/agent-protocol.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// Phase 4 agent runtime trust layer, end-to-end against the fake control
+// agent runtime trust layer, end-to-end against the fake control
 // plane (tests/integration/fake-agent.js in signed-dispatch mode). No DB.
 //
 // Exercises the agent-side verification chain DIRECTLY
@@ -122,7 +122,7 @@ function runVerificationChain({ job, publicKeyPem, pinnedSigningKeyId, replayCac
   });
 }
 
-describe("agent protocol trust layer (signed dispatch, Phase 4)", function () {
+describe("agent protocol trust layer (signed dispatch)", function () {
   this.timeout(30000);
 
   after(() => {

--- a/tests/integration/agent-protocol.test.js
+++ b/tests/integration/agent-protocol.test.js
@@ -1,0 +1,374 @@
+"use strict";
+
+// Phase 4 agent runtime trust layer, end-to-end against the fake control
+// plane (tests/integration/fake-agent.js in signed-dispatch mode). No DB.
+//
+// Exercises the agent-side verification chain DIRECTLY
+// (signing.verifyJobSignature -> replay cache -> signing.checkJobTimeWindow)
+// rather than via packages/agent/src/index.js, which is not yet wired for
+// dispatch (that wiring is a separate work item). The chain order mirrors
+// what the wiring must do: integrity first (never trust an unverified
+// payload's fields), then replay, then time window, and consume() only
+// after every gate passes.
+//
+// Also asserts the custody invariant: no private-key-shaped content ever
+// appears in any protocol message the harness records (field-name ban
+// approach reused from tests/unit/certops-agent-protocol-contracts.test.js).
+
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+
+const { expect } = require("./setup");
+const {
+  buildFakeAgentControlPlaneApp,
+  createFakeAgent,
+} = require("./fake-agent");
+const {
+  verifyJobSignature,
+  checkJobTimeWindow,
+} = require("../../packages/agent/src/signing");
+const {
+  createReplayCache,
+} = require("../../packages/agent/src/replay");
+
+// Same custody vocabulary as certops-agent-protocol-contracts.test.js.
+const FORBIDDEN_FIELD_FRAGMENTS = [
+  "privatekey",
+  "privatekeypem",
+  "encryptedprivatekey",
+  "keymaterial",
+  "pfxblob",
+  "jksblob",
+  "tlskey",
+  "caprivatekey",
+  "keystorepassword",
+  "privatekeypassword",
+  "keypassword",
+  "password",
+  "secret",
+  "rawsecret",
+  "rawprivatekey",
+  "keypem",
+];
+
+// Non-secret reference names legitimately present in the protocol.
+const ALLOWED_CREDENTIAL_ADJACENT_NAMES = new Set(["bootstrapTokenId"]);
+
+function normalizeFieldName(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function collectFieldNames(value, names = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectFieldNames(item, names);
+    return names;
+  }
+  if (value === null || typeof value !== "object") return names;
+  for (const [key, child] of Object.entries(value)) {
+    names.push(key);
+    collectFieldNames(child, names);
+  }
+  return names;
+}
+
+function assertNoCustodyShapedContent(payload, label) {
+  for (const fieldName of collectFieldNames(payload)) {
+    if (ALLOWED_CREDENTIAL_ADJACENT_NAMES.has(fieldName)) continue;
+    const normalized = normalizeFieldName(fieldName);
+    const hit = FORBIDDEN_FIELD_FRAGMENTS.find((fragment) =>
+      normalized.includes(fragment),
+    );
+    expect(hit, `${label} carries custody-shaped field "${fieldName}"`).to.equal(
+      undefined,
+    );
+  }
+  // Belt and braces beyond field names: no PEM private-key block anywhere
+  // in the serialized payload either.
+  expect(JSON.stringify(payload)).to.not.match(/-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+}
+
+const tempDirs = [];
+
+function makeReplayStorePath() {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tokentimer-agent-protocol-test-"),
+  );
+  tempDirs.push(dir);
+  return path.join(dir, "replay-store.json");
+}
+
+// The full agent-side verification chain in dispatch-wiring order.
+function runVerificationChain({ job, publicKeyPem, pinnedSigningKeyId, replayCache }) {
+  const integrity = verifyJobSignature({ job, publicKeyPem, pinnedSigningKeyId });
+  if (!integrity.allowed) return integrity;
+
+  const replay = replayCache.check({
+    nonce: job.nonce,
+    jobId: job.jobId,
+    expiresAt: job.expiresAt,
+  });
+  if (!replay.allowed) return replay;
+
+  const window = checkJobTimeWindow({ job, nowMs: Date.now() });
+  if (!window.allowed) return window;
+
+  return replayCache.consume({
+    nonce: job.nonce,
+    jobId: job.jobId,
+    expiresAt: job.expiresAt,
+  });
+}
+
+describe("agent protocol trust layer (signed dispatch, Phase 4)", function () {
+  this.timeout(30000);
+
+  after(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (_err) {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  async function setupSignedWorld() {
+    const app = buildFakeAgentControlPlaneApp({ signedJobDispatch: true });
+    const agent = createFakeAgent({ app });
+
+    const registerResponse = await agent.register({ agentVersion: "1.0.0" });
+    expect(registerResponse.status).to.equal(201);
+    // The register response advertises the pinning info in signed mode.
+    expect(registerResponse.body.signingKeyId).to.be.a("string");
+    expect(registerResponse.body.signingPublicKeyPem).to.match(
+      /-----BEGIN PUBLIC KEY-----/,
+    );
+    expect(registerResponse.body.signingKeyId).to.equal(
+      app.getSigningKeyInfo().signingKeyId,
+    );
+
+    const replayCache = createReplayCache({ storePath: makeReplayStorePath() });
+
+    return {
+      app,
+      agent,
+      replayCache,
+      publicKeyPem: registerResponse.body.signingPublicKeyPem,
+      pinnedSigningKeyId: registerResponse.body.signingKeyId,
+    };
+  }
+
+  async function claimOneJob(agent) {
+    const response = await agent.claim({ maxJobs: 1 });
+    expect(response.status).to.equal(200);
+    expect(response.body.jobs).to.have.length(1);
+    return response.body.jobs[0];
+  }
+
+  it("happy path: a valid signed job passes integrity, replay, and time-window checks", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchSignedJob();
+
+    const job = await claimOneJob(world.agent);
+    expect(job.signature).to.be.a("string");
+    expect(job.signingKeyId).to.equal(world.pinnedSigningKeyId);
+    expect(job.nonce).to.be.a("string");
+
+    const result = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(result).to.deep.equal({ allowed: true });
+  });
+
+  it("tampered payload => job_integrity_failed", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchTamperedJob({ tamperField: "action", tamperValue: "revoke" });
+
+    const job = await claimOneJob(world.agent);
+    const result = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(result.allowed).to.equal(false);
+    expect(result.rejectionReason).to.equal("job_integrity_failed");
+    expect(result.detail).to.be.a("string").that.is.not.empty;
+  });
+
+  it("replayed nonce+jobId => second delivery rejected with job_replay_rejected", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchReplayedJob();
+
+    const firstDelivery = await claimOneJob(world.agent);
+    const firstResult = runVerificationChain({
+      job: firstDelivery,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(firstResult).to.deep.equal({ allowed: true });
+
+    const secondDelivery = await claimOneJob(world.agent);
+    expect(secondDelivery.nonce).to.equal(firstDelivery.nonce);
+    expect(secondDelivery.jobId).to.equal(firstDelivery.jobId);
+
+    const secondResult = runVerificationChain({
+      job: secondDelivery,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(secondResult.allowed).to.equal(false);
+    expect(secondResult.rejectionReason).to.equal("job_replay_rejected");
+  });
+
+  it("expired window => clock_drift_suspected (documented semantics: window failures read as drift)", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchExpiredJob();
+
+    const job = await claimOneJob(world.agent);
+    const result = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(result.allowed).to.equal(false);
+    // Per the signing module's documented semantics, an expired-but-well-
+    // formed window rejects as clock_drift_suspected (a genuinely stale
+    // replay is independently caught by the replay cache).
+    expect(result.rejectionReason).to.equal("clock_drift_suspected");
+    // An expired rejection must NOT consume the nonce (the chain stops
+    // before consume), so state stays clean.
+    expect(world.replayCache.size()).to.equal(0);
+  });
+
+  it("wrong key, variant wrong-signature (rogue key claims pinned key id) => job_integrity_failed", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchWrongKeyJob({ variant: "wrong-signature" });
+
+    const job = await claimOneJob(world.agent);
+    expect(job.signingKeyId).to.equal(world.pinnedSigningKeyId);
+
+    const result = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(result.allowed).to.equal(false);
+    expect(result.rejectionReason).to.equal("job_integrity_failed");
+  });
+
+  it("wrong key, variant wrong-key-id (unpinned key id) => job_integrity_failed mentioning the mismatch", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchWrongKeyJob({ variant: "wrong-key-id" });
+
+    const job = await claimOneJob(world.agent);
+    expect(job.signingKeyId).to.not.equal(world.pinnedSigningKeyId);
+
+    const result = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    expect(result.allowed).to.equal(false);
+    expect(result.rejectionReason).to.equal("job_integrity_failed");
+    expect(result.detail).to.match(/key id mismatch/i);
+  });
+
+  it("rejections report uniformly through the result path with the policy-compatible shape", async () => {
+    const world = await setupSignedWorld();
+    world.app.dispatchTamperedJob();
+    const job = await claimOneJob(world.agent);
+
+    const rejection = runVerificationChain({
+      job,
+      publicKeyPem: world.publicKeyPem,
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+      replayCache: world.replayCache,
+    });
+    // Shape parity with the policy module's rejection results, so the
+    // downstream evidence/result reporting handles both uniformly.
+    expect(Object.keys(rejection).sort()).to.deep.equal([
+      "allowed",
+      "detail",
+      "rejectionReason",
+    ]);
+
+    const resultResponse = await world.agent.reportResult({
+      jobId: job.jobId,
+      attemptId: `attempt-${crypto.randomUUID()}`,
+      status: "rejected",
+      rejectionReason: rejection.rejectionReason,
+    });
+    expect(resultResponse.status).to.equal(202);
+    expect(world.app.state.results).to.have.length(1);
+    expect(world.app.state.results[0].body.rejectionReason).to.equal(
+      "job_integrity_failed",
+    );
+  });
+
+  it("no private-key-shaped content appears in any recorded protocol message or dispatched job", async () => {
+    const world = await setupSignedWorld();
+
+    world.app.dispatchSignedJob();
+    world.app.dispatchTamperedJob();
+    world.app.dispatchExpiredJob();
+    world.app.dispatchWrongKeyJob({ variant: "wrong-signature" });
+    world.app.dispatchWrongKeyJob({ variant: "wrong-key-id" });
+
+    await world.agent.heartbeat({
+      agentVersion: "1.0.0",
+      pinnedSigningKeyId: world.pinnedSigningKeyId,
+    });
+    const claimResponse = await world.agent.claim({ maxJobs: 16 });
+    expect(claimResponse.body.jobs.length).to.be.greaterThan(0);
+    await world.agent.reportResult({
+      jobId: claimResponse.body.jobs[0].jobId,
+      attemptId: `attempt-${crypto.randomUUID()}`,
+      status: "rejected",
+      rejectionReason: "job_integrity_failed",
+    });
+
+    const { state } = world.app;
+    for (const [label, payloads] of Object.entries({
+      heartbeats: state.heartbeats,
+      claims: state.claims,
+      results: state.results,
+      evidence: state.evidence,
+      dispatchedJobs: claimResponse.body.jobs,
+    })) {
+      for (const payload of payloads) {
+        assertNoCustodyShapedContent(payload, `state.${label}`);
+      }
+    }
+
+    // The register response itself carries the PUBLIC pinning material only.
+    assertNoCustodyShapedContent(
+      { signingKeyId: world.pinnedSigningKeyId },
+      "register pinning info",
+    );
+    expect(world.publicKeyPem).to.match(/-----BEGIN PUBLIC KEY-----/);
+    expect(world.publicKeyPem).to.not.match(/PRIVATE KEY/);
+  });
+
+  it("keeps unsigned mode untouched: default app still returns empty job lists", async () => {
+    const app = buildFakeAgentControlPlaneApp();
+    expect(app.dispatchSignedJob).to.equal(undefined);
+    expect(app.getSigningKeyInfo).to.equal(undefined);
+
+    const agent = createFakeAgent({ app });
+    await agent.register({ agentVersion: "1.0.0" });
+    const response = await agent.claim({ maxJobs: 5 });
+    expect(response.body.jobs).to.deep.equal([]);
+  });
+});

--- a/tests/integration/agent-protocol.test.js
+++ b/tests/integration/agent-protocol.test.js
@@ -5,9 +5,10 @@
 //
 // Exercises the agent-side verification chain DIRECTLY
 // (signing.verifyJobSignature -> replay cache -> signing.checkJobTimeWindow)
-// rather than via packages/agent/src/index.js, which is not yet wired for
-// dispatch (that wiring is a separate work item). The chain order mirrors
-// what the wiring must do: integrity first (never trust an unverified
+// rather than via packages/agent/src/index.js. The full dispatch wiring in
+// src/index.js is exercised end to end by agent-renewal.test.js; this suite
+// keeps direct coverage of the chain order the wiring must preserve:
+// integrity first (never trust an unverified
 // payload's fields), then replay, then time window, and consume() only
 // after every gate passes.
 //

--- a/tests/integration/agent-renewal.test.js
+++ b/tests/integration/agent-renewal.test.js
@@ -1,0 +1,405 @@
+"use strict";
+
+// M5 signed renew job, end to end: the REAL dispatch wiring
+// (packages/agent/src/index.js handleClaimedJob -> executeJob) driven
+// against the fake control plane (fake-agent.js in signed-dispatch mode).
+// No DB. The ACME child process is the ONLY stubbed execution dependency
+// (an execFileImpl that fakes certbot by writing a runtime-generated
+// certificate PEM to --cert-path); keys and deploy run for real against
+// temp directories, reload is skipped (no reloadService on the job), and
+// verification uses computeCertificateFingerprint against the deployed
+// file (no network probe: the job carries no verifyHost).
+//
+// Also asserts the custody invariant from agent-protocol.test.js: no
+// private-key-shaped content in any protocol message the harness records.
+
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+
+const { expect } = require("./setup");
+const {
+  buildFakeAgentControlPlaneApp,
+  createFakeAgent,
+} = require("./fake-agent");
+const {
+  handleClaimedJob,
+  buildExecutionContext,
+} = require("../../packages/agent/src/index.js");
+const {
+  loadPolicyConfig,
+  createPolicyEngine,
+} = require("../../packages/agent/src/policy");
+const {
+  computeCertificateFingerprint,
+} = require("../../packages/agent/src/verify");
+
+// --- custody assertion (reused from agent-protocol.test.js) -----------------
+
+const FORBIDDEN_FIELD_FRAGMENTS = [
+  "privatekey",
+  "privatekeypem",
+  "encryptedprivatekey",
+  "keymaterial",
+  "pfxblob",
+  "jksblob",
+  "tlskey",
+  "caprivatekey",
+  "keystorepassword",
+  "privatekeypassword",
+  "keypassword",
+  "password",
+  "secret",
+  "rawsecret",
+  "rawprivatekey",
+  "keypem",
+];
+
+const ALLOWED_CREDENTIAL_ADJACENT_NAMES = new Set(["bootstrapTokenId"]);
+
+function normalizeFieldName(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function collectFieldNames(value, names = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectFieldNames(item, names);
+    return names;
+  }
+  if (value === null || typeof value !== "object") return names;
+  for (const [key, child] of Object.entries(value)) {
+    names.push(key);
+    collectFieldNames(child, names);
+  }
+  return names;
+}
+
+function assertNoCustodyShapedContent(payload, label) {
+  for (const fieldName of collectFieldNames(payload)) {
+    if (ALLOWED_CREDENTIAL_ADJACENT_NAMES.has(fieldName)) continue;
+    const normalized = normalizeFieldName(fieldName);
+    const hit = FORBIDDEN_FIELD_FRAGMENTS.find((fragment) =>
+      normalized.includes(fragment),
+    );
+    expect(hit, `${label} carries custody-shaped field "${fieldName}"`).to.equal(
+      undefined,
+    );
+  }
+  expect(JSON.stringify(payload)).to.not.match(
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  );
+}
+
+// --- fixtures ----------------------------------------------------------------
+
+const tempDirs = [];
+
+function makeTempDir(label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ttagent-renewal-${label}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// Runtime-generated certificate-shaped PEM. Never a committed fixture: the
+// body is a fresh Ed25519 PUBLIC key DER (real, valid base64 DER bytes, no
+// key custody risk) wrapped in CERTIFICATE markers. Both the deploy module
+// (opaque public payload) and computeCertificateFingerprint (base64 DER
+// digest) accept it without parsing X.509 internals.
+function generateRuntimeCertificatePem() {
+  const { publicKey } = crypto.generateKeyPairSync("ed25519");
+  const der = publicKey.export({ type: "spki", format: "der" });
+  const body = der.toString("base64").replace(/(.{64})/g, "$1\n").trim();
+  return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----\n`;
+}
+
+// Fake certbot: an execFile-shaped stub that writes `certificatePem` to the
+// path following --cert-path in the argv and exits 0. Anything else about
+// the argv is recorded for assertions.
+function makeFakeCertbotExecFile(certificatePem, recordedInvocations) {
+  return (file, args, _options, callback) => {
+    recordedInvocations.push({ file, args: [...args] });
+    const flagIndex = args.indexOf("--cert-path");
+    if (flagIndex === -1 || flagIndex + 1 >= args.length) {
+      callback(new Error("fake certbot: no --cert-path in argv"), "", "");
+      return;
+    }
+    fs.writeFileSync(args[flagIndex + 1], certificatePem, "utf8");
+    callback(null, "fake certbot: certificate issued\n", "");
+  };
+}
+
+// Bridges the src/index.js client contract onto the harness fake agent so
+// every result/evidence the dispatch layer emits becomes a REAL protocol
+// message the harness records (and the custody assertion can inspect).
+function makeHarnessBackedClient(agent) {
+  return {
+    reportResult: async ({ jobId, attemptId, status, rejectionReason, keyRotated, errorMessage }) => {
+      const response = await agent.reportResult({
+        jobId,
+        attemptId,
+        status,
+        ...(rejectionReason !== undefined && rejectionReason !== null
+          ? { rejectionReason }
+          : {}),
+        ...(keyRotated !== undefined ? { keyRotated } : {}),
+        ...(errorMessage !== undefined ? { errorMessage } : {}),
+      });
+      expect(response.status).to.equal(202);
+      return response.body;
+    },
+    reportEvidence: async (body) => {
+      const response = await agent.reportEvidence({
+        jobId: body.jobId,
+        evidenceItems: body.evidenceItems,
+      });
+      expect(response.status).to.equal(202);
+      return response.body;
+    },
+  };
+}
+
+describe("agent renewal execution (M5 signed dispatch, end to end)", function () {
+  this.timeout(30000);
+
+  after(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (_err) {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  async function setupRenewalWorld({ dryRun }) {
+    const app = buildFakeAgentControlPlaneApp({ signedJobDispatch: true });
+    const agent = createFakeAgent({ app });
+
+    const registerResponse = await agent.register({ agentVersion: "1.0.0" });
+    expect(registerResponse.status).to.equal(201);
+    const pinnedSigningKey = {
+      signingKeyId: registerResponse.body.signingKeyId,
+      publicKeyPem: registerResponse.body.signingPublicKeyPem,
+    };
+
+    const workDir = makeTempDir(dryRun ? "dry" : "real");
+    const keysDir = path.join(workDir, "keys");
+    const deployDir = path.join(workDir, "deployed");
+    fs.mkdirSync(deployDir, { recursive: true });
+    const certPath = path.join(deployDir, "cert.pem");
+
+    const caEndpoint = "https://acme.example.test/directory";
+    const policyEngine = createPolicyEngine(
+      loadPolicyConfig({
+        allowedPaths: [workDir],
+        allowedCommands: { "certbot-renew": { argv: ["certbot"] } },
+        allowedCaEndpoints: [caEndpoint],
+      }),
+      { declaredTargetSelectors: ["renewal.example.com"] },
+    );
+
+    const certificatePem = generateRuntimeCertificatePem();
+    const acmeInvocations = [];
+    const executionContext = buildExecutionContext({
+      config: {
+        execution: {
+          enabled: true,
+          dryRun,
+          keysDir,
+          replayStorePath: path.join(workDir, "replay-store.json"),
+          clockDriftToleranceMs: 30000,
+        },
+        pinnedSigningKey,
+      },
+      acmeExecFileImpl: makeFakeCertbotExecFile(certificatePem, acmeInvocations),
+    });
+
+    app.dispatchSignedJob({
+      action: "renew",
+      target: { type: "domain", reference: "renewal.example.com" },
+      commandRef: "certbot-renew",
+      caEndpoint,
+      certPath,
+    });
+
+    const claimResponse = await agent.claim({ maxJobs: 1 });
+    expect(claimResponse.status).to.equal(200);
+    expect(claimResponse.body.jobs).to.have.length(1);
+    const job = claimResponse.body.jobs[0];
+
+    return {
+      app,
+      agent,
+      job,
+      policyEngine,
+      executionContext,
+      client: makeHarnessBackedClient(agent),
+      certificatePem,
+      acmeInvocations,
+      keysDir,
+      deployDir,
+      certPath,
+    };
+  }
+
+  const silentLog = () => {};
+
+  it("runs a signed renew job through keys -> acme -> deploy -> verify and reports success", async () => {
+    const world = await setupRenewalWorld({ dryRun: false });
+
+    const outcome = await handleClaimedJob({
+      job: world.job,
+      policyEngine: world.policyEngine,
+      client: world.client,
+      executionContext: world.executionContext,
+      log: silentLog,
+    });
+    expect(outcome.status).to.equal("succeeded");
+
+    // Terminal result: succeeded, keyRotated true (no pre-existing key, so
+    // a new one was generated on this first renewal).
+    const results = world.app.state.results;
+    expect(results).to.have.length(1);
+    expect(results[0].body.status).to.equal("succeeded");
+    expect(results[0].body.keyRotated).to.equal(true);
+    expect(results[0].body.jobId).to.equal(world.job.jobId);
+
+    // Deployed file exists with exactly the PEM the fake certbot issued.
+    expect(fs.existsSync(world.certPath)).to.equal(true);
+    expect(fs.readFileSync(world.certPath, "utf8")).to.equal(
+      world.certificatePem,
+    );
+
+    // The private key stayed local, under keysDir, and never left.
+    const keyPath = path.join(
+      world.keysDir,
+      `${world.job.certificateId}.key.pem`,
+    );
+    expect(fs.existsSync(keyPath)).to.equal(true);
+
+    // The fake certbot ran exactly once, with the allowlisted profile argv
+    // head and the policy-approved CA endpoint.
+    expect(world.acmeInvocations).to.have.length(1);
+    expect(world.acmeInvocations[0].file).to.equal("certbot");
+    expect(world.acmeInvocations[0].args).to.include(
+      "https://acme.example.test/directory",
+    );
+
+    // Per-step evidence: acme pass, deploy update, verify pass (with the
+    // deployed certificate's actual fingerprint).
+    const evidenceItems = world.app.state.evidence.flatMap(
+      (envelope) => envelope.body.evidenceItems,
+    );
+    const steps = evidenceItems.flatMap((item) =>
+      (item.metadata || [])
+        .filter((entry) => entry.name === "step")
+        .map((entry) => entry.value),
+    );
+    expect(steps).to.include("acme");
+    expect(steps).to.include("deploy");
+    expect(steps).to.include("verify");
+
+    const verifyItem = evidenceItems.find((item) =>
+      (item.metadata || []).some(
+        (entry) => entry.name === "step" && entry.value === "verify",
+      ),
+    );
+    expect(verifyItem.eventType).to.equal("validation.passed");
+    expect(verifyItem.fingerprintSha256).to.equal(
+      computeCertificateFingerprint(fs.readFileSync(world.certPath, "utf8")),
+    );
+
+    const deployItem = evidenceItems.find((item) =>
+      (item.metadata || []).some(
+        (entry) => entry.name === "step" && entry.value === "deploy",
+      ),
+    );
+    expect(deployItem.eventType).to.equal("deployment.updated");
+    // Deploy metrics counters travel as flattened numeric metadata.
+    expect(
+      deployItem.metadata.some(
+        (entry) =>
+          entry.name === "deployMetric_attempts" &&
+          typeof entry.value === "number",
+      ),
+    ).to.equal(true);
+
+    // Replay defense: dispatching the SAME signed job again is rejected by
+    // the replay cache before any execution.
+    const replayOutcome = await handleClaimedJob({
+      job: world.job,
+      policyEngine: world.policyEngine,
+      client: world.client,
+      executionContext: world.executionContext,
+      log: silentLog,
+    });
+    expect(replayOutcome.status).to.equal("rejected");
+    expect(replayOutcome.rejectionReason).to.equal("job_replay_rejected");
+    expect(world.acmeInvocations).to.have.length(1); // still exactly one exec
+    const replayResult = world.app.state.results.at(-1);
+    expect(replayResult.body.status).to.equal("rejected");
+    expect(replayResult.body.rejectionReason).to.equal("job_replay_rejected");
+
+    // Custody invariant: no private-key-shaped content in ANY protocol
+    // message the harness recorded during the whole flow.
+    const { state } = world.app;
+    for (const [label, payloads] of Object.entries({
+      heartbeats: state.heartbeats,
+      claims: state.claims,
+      results: state.results,
+      evidence: state.evidence,
+    })) {
+      for (const payload of payloads) {
+        assertNoCustodyShapedContent(payload, `state.${label}`);
+      }
+    }
+  });
+
+  it("dry-run renew reports a plan and succeeds with zero side effects", async () => {
+    const world = await setupRenewalWorld({ dryRun: true });
+
+    const outcome = await handleClaimedJob({
+      job: world.job,
+      policyEngine: world.policyEngine,
+      client: world.client,
+      executionContext: world.executionContext,
+      log: silentLog,
+    });
+    expect(outcome.status).to.equal("succeeded");
+
+    const results = world.app.state.results;
+    expect(results).to.have.length(1);
+    expect(results[0].body.status).to.equal("succeeded");
+    // No key was generated or rotated in a dry run.
+    expect(results[0].body.keyRotated).to.equal(null);
+
+    // Plan evidence only: every item is policy.checked and dry-run-flagged.
+    const evidenceItems = world.app.state.evidence.flatMap(
+      (envelope) => envelope.body.evidenceItems,
+    );
+    expect(evidenceItems.length).to.be.greaterThan(0);
+    for (const item of evidenceItems) {
+      expect(item.eventType).to.equal("policy.checked");
+      expect(
+        item.metadata.some(
+          (entry) => entry.name === "dryRun" && entry.value === true,
+        ),
+      ).to.equal(true);
+    }
+
+    // Zero side effects: no ACME exec, no keysDir, no deployed file.
+    expect(world.acmeInvocations).to.have.length(0);
+    expect(fs.existsSync(world.keysDir)).to.equal(false);
+    expect(fs.existsSync(world.certPath)).to.equal(false);
+
+    // Custody invariant holds in dry-run mode too.
+    for (const payload of [
+      ...world.app.state.results,
+      ...world.app.state.evidence,
+    ]) {
+      assertNoCustodyShapedContent(payload, "dry-run protocol message");
+    }
+  });
+});

--- a/tests/integration/agent-renewal.test.js
+++ b/tests/integration/agent-renewal.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// M5 signed renew job, end to end: the REAL dispatch wiring
+// Signed renew job, end to end: the REAL dispatch wiring
 // (packages/agent/src/index.js handleClaimedJob -> executeJob) driven
 // against the fake control plane (fake-agent.js in signed-dispatch mode).
 // No DB. The ACME child process is the ONLY stubbed execution dependency
@@ -159,7 +159,7 @@ function makeHarnessBackedClient(agent) {
   };
 }
 
-describe("agent renewal execution (M5 signed dispatch, end to end)", function () {
+describe("agent renewal execution (signed dispatch, end to end)", function () {
   this.timeout(30000);
 
   after(() => {

--- a/tests/integration/fake-agent.js
+++ b/tests/integration/fake-agent.js
@@ -237,7 +237,7 @@ function dispatchResultOrEvidence(state, resultHandler, evidenceHandler) {
 // handler can be overridden per-test, e.g. a test wants heartbeat to return
 // 410 to exercise agent retirement handling once that lands server-side.
 //
-// Signed job dispatch (Phase 4, ADR-0003) is OPT-IN via
+// Signed job dispatch (ADR-0003) is OPT-IN via
 // `signedJobDispatch: true` so all existing unsigned-mode tests keep
 // working unchanged. When enabled, the app:
 //   - generates an Ed25519 keypair (packages/agent signing module) at build
@@ -303,7 +303,7 @@ function buildFakeAgentControlPlaneApp({
   app.state = state;
 
   if (signedJobDispatch) {
-    // Base job payload per job-payload.schema.json plus the M4 signed
+    // Base job payload per job-payload.schema.json plus the signed
     // dispatch fields (nonce/issuedAt/expiresAt/signingKeyId/signature).
     const buildJobPayload = (overrides = {}) => {
       const nowMs = Date.now();

--- a/tests/integration/fake-agent.js
+++ b/tests/integration/fake-agent.js
@@ -42,6 +42,13 @@ const { createRequire } = require("module");
 const supertest = require("supertest");
 
 const { TestUtils } = require("./setup");
+// Signing utilities shared with the real agent runtime so harness-signed
+// jobs are guaranteed to interoperate with the agent-side verification
+// chain (identical canonicalization on both sides, per ADR-0003).
+const {
+  generateSigningKeyPair,
+  signJobPayload,
+} = require("../../packages/agent/src/signing");
 
 const apiRequire = createRequire(
   require.resolve("../../apps/api/package.json"),
@@ -105,6 +112,10 @@ function createInMemoryAgentControlPlaneState() {
     claims: [],
     results: [],
     evidence: [],
+    // Signed-dispatch queue: only populated via the dispatch* helpers when
+    // buildFakeAgentControlPlaneApp is created with signedJobDispatch: true.
+    // Harmless (always empty) in unsigned mode.
+    pendingJobs: [],
   };
 }
 
@@ -128,6 +139,34 @@ function defaultRegisterHandler(state) {
   };
 }
 
+// Register handler used when signed job dispatch is enabled: same as the
+// default, but the response additionally carries the control plane's job
+// signing PUBLIC key (PEM) + signingKeyId, mirroring how a real agent will
+// learn/pin the verification key at registration time (7.4 key pinning).
+// The PRIVATE key never appears in any response or recorded message; it
+// stays inside the harness closure.
+function signedRegisterHandler(state, signingKeys) {
+  return (req, res) => {
+    const envelope = req.body || {};
+    const agentId = envelope.agentId || `agent-${crypto.randomUUID()}`;
+    const credential = issueFakeAgentCredential(agentId);
+    state.registeredAgents.set(agentId, {
+      agentId,
+      credential,
+      registeredAt: new Date().toISOString(),
+      body: envelope.body || null,
+    });
+    return res.status(201).json({
+      ok: true,
+      agentId,
+      credential,
+      protocolVersion: envelope.protocolVersion || DEFAULT_PROTOCOL_VERSION,
+      signingKeyId: signingKeys.signingKeyId,
+      signingPublicKeyPem: signingKeys.publicKeyPem,
+    });
+  };
+}
+
 function defaultHeartbeatHandler(state) {
   return (req, res) => {
     const envelope = req.body || {};
@@ -141,6 +180,20 @@ function defaultClaimHandler(state) {
     const envelope = req.body || {};
     state.claims.push(envelope);
     return res.status(200).json({ ok: true, jobs: [] });
+  };
+}
+
+// Claim handler used when signed job dispatch is enabled: drains the
+// harness-side pendingJobs queue (populated by the dispatch* helpers on the
+// app) up to the agent's requested maxJobs. Unsigned mode keeps
+// defaultClaimHandler's fixed `jobs: []` so existing tests are unaffected.
+function signedDispatchClaimHandler(state) {
+  return (req, res) => {
+    const envelope = req.body || {};
+    state.claims.push(envelope);
+    const maxJobs = envelope.body?.maxJobs || 1;
+    const jobs = state.pendingJobs.splice(0, maxJobs);
+    return res.status(200).json({ ok: true, jobs });
   };
 }
 
@@ -183,6 +236,21 @@ function dispatchResultOrEvidence(state, resultHandler, evidenceHandler) {
 // agent-protocol.schema.json and ADR-0002/0003, with in-memory state. Every
 // handler can be overridden per-test, e.g. a test wants heartbeat to return
 // 410 to exercise agent retirement handling once that lands server-side.
+//
+// Signed job dispatch (Phase 4, ADR-0003) is OPT-IN via
+// `signedJobDispatch: true` so all existing unsigned-mode tests keep
+// working unchanged. When enabled, the app:
+//   - generates an Ed25519 keypair (packages/agent signing module) at build
+//     time; the private key never leaves the app closure and never appears
+//     in any HTTP response or recorded state,
+//   - returns signingKeyId + signingPublicKeyPem from the register response
+//     (also exposed via app.getSigningKeyInfo() for tests that skip
+//     registration),
+//   - queues signed jobs via app.dispatchSignedJob(...) which the (now
+//     queue-draining) claim handler hands to the next claim, and
+//   - offers tamper helpers (dispatchTamperedJob / dispatchReplayedJob /
+//     dispatchExpiredJob / dispatchWrongKeyJob) that produce the exact
+//     attack shapes the agent-side verification chain must reject.
 function buildFakeAgentControlPlaneApp({
   registerHandler,
   heartbeatHandler,
@@ -190,20 +258,35 @@ function buildFakeAgentControlPlaneApp({
   resultHandler,
   evidenceHandler,
   state: providedState,
+  signedJobDispatch = false,
 } = {}) {
   const state = providedState || createInMemoryAgentControlPlaneState();
+  if (!Array.isArray(state.pendingJobs)) {
+    state.pendingJobs = [];
+  }
   const app = express();
   app.use(express.json());
 
-  app.post(
-    AGENT_REGISTER_ROUTE,
-    registerHandler || defaultRegisterHandler(state),
-  );
+  // Only generated in signed mode; keys.privateKeyPem stays in this closure.
+  const signingKeys = signedJobDispatch ? generateSigningKeyPair() : null;
+
+  const effectiveRegisterHandler =
+    registerHandler ||
+    (signedJobDispatch
+      ? signedRegisterHandler(state, signingKeys)
+      : defaultRegisterHandler(state));
+  const effectiveClaimHandler =
+    claimHandler ||
+    (signedJobDispatch
+      ? signedDispatchClaimHandler(state)
+      : defaultClaimHandler(state));
+
+  app.post(AGENT_REGISTER_ROUTE, effectiveRegisterHandler);
   app.post(
     AGENT_HEARTBEAT_ROUTE,
     heartbeatHandler || defaultHeartbeatHandler(state),
   );
-  app.post(AGENT_CLAIM_ROUTE, claimHandler || defaultClaimHandler(state));
+  app.post(AGENT_CLAIM_ROUTE, effectiveClaimHandler);
   app.post(
     AGENT_RESULT_ROUTE,
     dispatchResultOrEvidence(state, resultHandler, evidenceHandler),
@@ -218,6 +301,108 @@ function buildFakeAgentControlPlaneApp({
   });
 
   app.state = state;
+
+  if (signedJobDispatch) {
+    // Base job payload per job-payload.schema.json plus the M4 signed
+    // dispatch fields (nonce/issuedAt/expiresAt/signingKeyId/signature).
+    const buildJobPayload = (overrides = {}) => {
+      const nowMs = Date.now();
+      return {
+        schemaVersion: 1,
+        jobId: `job-${crypto.randomUUID()}`,
+        workspaceId: crypto.randomUUID(),
+        certificateId: `cert-${crypto.randomUUID()}`,
+        action: "renew",
+        target: { type: "domain", reference: "example.com" },
+        keyMode: "agent-local",
+        requestedAt: new Date(nowMs).toISOString(),
+        nonce: crypto.randomUUID(),
+        issuedAt: new Date(nowMs).toISOString(),
+        expiresAt: new Date(nowMs + 5 * 60 * 1000).toISOString(),
+        signingKeyId: signingKeys.signingKeyId,
+        ...overrides,
+      };
+    };
+
+    const signAndQueue = (job, privateKeyPem = signingKeys.privateKeyPem) => {
+      const signed = {
+        ...job,
+        signature: signJobPayload({ job, privateKeyPem }),
+      };
+      state.pendingJobs.push(signed);
+      return signed;
+    };
+
+    // Non-secret pinning info, mirroring what the register response carries.
+    app.getSigningKeyInfo = () => ({
+      signingKeyId: signingKeys.signingKeyId,
+      publicKeyPem: signingKeys.publicKeyPem,
+    });
+
+    // Queues a correctly signed job for the next claim. `overrides` merge
+    // into the job payload BEFORE signing (so the signature stays valid).
+    app.dispatchSignedJob = (overrides = {}) =>
+      signAndQueue(buildJobPayload(overrides));
+
+    // Valid signature, then a field mutated AFTER signing => the agent must
+    // reject with job_integrity_failed.
+    app.dispatchTamperedJob = ({
+      tamperField = "action",
+      tamperValue = "revoke",
+      ...overrides
+    } = {}) => {
+      const signed = signAndQueue(buildJobPayload(overrides));
+      signed[tamperField] = tamperValue;
+      return signed;
+    };
+
+    // Queues the SAME signed job (same nonce + jobId) twice => the second
+    // claim must be rejected by the replay cache (job_replay_rejected).
+    app.dispatchReplayedJob = (overrides = {}) => {
+      const signed = signAndQueue(buildJobPayload(overrides));
+      state.pendingJobs.push({ ...signed });
+      return signed;
+    };
+
+    // Correctly signed but with expiresAt already in the past (window
+    // checked by checkJobTimeWindow, signature itself stays valid).
+    app.dispatchExpiredJob = (overrides = {}) => {
+      const nowMs = Date.now();
+      return signAndQueue(
+        buildJobPayload({
+          issuedAt: new Date(nowMs - 10 * 60 * 1000).toISOString(),
+          expiresAt: new Date(nowMs - 5 * 60 * 1000).toISOString(),
+          ...overrides,
+        }),
+      );
+    };
+
+    // Two wrong-key variants (both must fail as job_integrity_failed):
+    //   variant: "wrong-signature" (default) -- signed with a DIFFERENT
+    //     keypair while claiming the pinned signingKeyId, i.e. a forgery.
+    //   variant: "wrong-key-id" -- correctly signed by a rogue keypair that
+    //     also advertises its own (unpinned) signingKeyId; rejected at the
+    //     key-id pinning check before signature verification.
+    app.dispatchWrongKeyJob = ({
+      variant = "wrong-signature",
+      ...overrides
+    } = {}) => {
+      const rogueKeys = generateSigningKeyPair();
+      if (variant === "wrong-key-id") {
+        return signAndQueue(
+          buildJobPayload({ signingKeyId: rogueKeys.signingKeyId, ...overrides }),
+          rogueKeys.privateKeyPem,
+        );
+      }
+      if (variant !== "wrong-signature") {
+        throw new Error(
+          `dispatchWrongKeyJob: unknown variant "${variant}" (use "wrong-signature" or "wrong-key-id")`,
+        );
+      }
+      return signAndQueue(buildJobPayload(overrides), rogueKeys.privateKeyPem);
+    };
+  }
+
   return app;
 }
 

--- a/tests/unit/certops-agent-protocol-contracts.test.js
+++ b/tests/unit/certops-agent-protocol-contracts.test.js
@@ -5,7 +5,7 @@
 // the packages/agent modules (protocol client routes, policy rejection
 // reasons, evidence event types / metadata name pattern), the route-compat
 // contract, the OpenAPI document, and the executor schemas it is derived from.
-// Follows the conventions of certops-m2-contracts.test.js.
+// Follows the conventions of certops-contracts.test.js.
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");


### PR DESCRIPTION
## Summary

The agent moves from bootstrap (report-only) to signed-job execution. Stacked on PR #78 (agent bootstrap), which stacks on PR #75 (cert-manager controller).

- **Trust layer**: Ed25519 job signature verification with trust-on-first-use key pinning (`signing-key-pin.json`, 0600), canonical JSON payload (reference signer included for the control plane), persisted replay cache with consume-after-gates semantics and reject-when-full, and Date-header clock offset estimation feeding drift-compensated job validity window checks.
- **Execution modules**: local keygen + PKCS#10 CSR (`keys`), certbot/acme.sh no-shell exec adapters (`acme`), atomic deploy with backup/rollback and realpath containment re-check (`deploy`), validate-then-reload helpers for nginx/apache/haproxy (`reload`), post-deploy fingerprint verification with optional live TLS probe (`verify`).
- **Dispatch wiring** in `src/index.js`: fixed chain `signature -> replay check -> clock window -> policy -> replay consume -> execute`, opt-in via the new `execution` config block (`enabled: false`, `dryRun: true` defaults; observe-only bootstrap behavior preserved exactly when absent). Unsigned jobs are rejected whenever execution is enabled. Heartbeats now carry `clockOffsetMs` and `pinnedSigningKeyId`.
- **Zero-custody invariant** enforced at every layer: key material never leaves the host, every module deep-scans its outputs, ACME/reload output is redacted wholesale on any private-key marker, and `checkNoKeyExport` remains unconditional.
- **Docs**: `docs/certops/agent.md` operator reference (config, protocol, security model, renewal chain, troubleshooting).
- Also fixes the `packages/contracts/package.json` version regression (0.9.0 -> 0.10.0) introduced by a rebase resolution; main ships 0.10.0 and both variants pin `^0.10.0`.

## Design notes

- CSR CN/SAN derived from `target.reference` when the payload carries no domains list.
- `certPath`: explicit `job.certPath` wins, else absolute `target.reference`, else the job fails clearly.
- `deploy` without `certificatePem` and all `revoke` jobs report `blocked` (revocation execution is out of scope for this agent build).
- Execution fields honored when present: `keyRotation`, `verifyHost`/`verifyPort`, `reloadService`/`reloadCommandRefs`, `acmeKind`. The server-side job contract blessing these fields lands in #91.
- Ed25519 CSR generation unsupported (`node:crypto` limitation); use `ec-p256`/`rsa-*`.

## Control-plane counterpart (see #91)

1. Register response returns `signingKeyId` + `signingPublicKeyPem` for TOFU pinning.
2. The job contract blesses `certificatePem` (deploy), `certPath`, `keyRotation`, `reloadService`/`reloadCommandRefs`, `verifyHost`, `acmeKind`.
3. `revoke` jobs are never dispatched to agents.
4. Heartbeat `clockOffsetMs`/`pinnedSigningKeyId` are available server-side for drift and pin-mismatch monitoring.

## Test evidence (win32, Node 22)

| Gate | Result |
|---|---|
| `pnpm run lint:agent` | 0 errors |
| `pnpm --filter @tokentimer/agent test` | 318 pass, 0 fail, 9 win32 skips |
| `pnpm run test:unit` | 607 pass, 0 fail |
| `pnpm run test:contracts` | 25 pass |
| fake-agent harness self-test | 8 passing |
| signed-dispatch protocol integration | 9 passing (tamper, replay, expiry, wrong-key, wrong-key-id, custody scan) |
| end-to-end renewal integration | 2 passing (real chain keys->acme->deploy->verify, zero-side-effect dry-run) |

## Manual test plan

1. Start the fake control plane in signed-dispatch mode and a real agent process with `execution.enabled: true`, `dryRun: true`; dispatch a signed renew job and confirm a `succeeded` result with per-step dry-run evidence and no filesystem writes.
2. Flip `dryRun: false` with a stub certbot on PATH; confirm key generation under `keys/` (0600), staged cert cleanup, atomic deploy to `certPath`, backup file creation, and fingerprint evidence.
3. Tamper one payload byte after signing; confirm `rejected` with `job_integrity_failed` and no execution.
4. Redispatch the same nonce+jobId; confirm `job_replay_rejected` on the second delivery only.
5. Dispatch with `expiresAt` in the past; confirm `clock_drift_suspected`.
6. Remove `signing-key-pin.json` and restart; confirm jobs report `blocked` until re-registration pins a key.
7. Corrupt `replay-store.json`; confirm loud startup failure (tamper signal), not silent recovery.
8. Confirm heartbeats show `clockOffsetMs` and `pinnedSigningKeyId` when execution is enabled, null in observe-only mode.
