### PR TITLE
Release TokenTimer Core v0.10.1 with Location Filter Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-22
+
 ### Added
 
+- **Filter rules on the "location" field** — import filter rules can now include/exclude on `location` (exact or regex), the provider-side path every integration scan builds (e.g. `gitlab:projects/42/access_tokens/7`, `vault:secret/data/ci`, `aws:secretsmanager:eu-west-1:arn`). This makes it possible to scope imports to specific projects, groups, mounts, or regions without relying on naming conventions. Unlike `description`, `location` has no name fallback: an item without a location matches nothing, so provider-path rules never accidentally match token names.
 - **Helm CSRF port-forward warning** — `deploy/helm/templates/NOTES.txt` now warns (when `config.nodeEnv` resolves to `production`, the default) that CSRF protection and Secure session cookies will reject plain-HTTP `kubectl port-forward` logins, and documents the `SESSION_COOKIE_SECURE_LOCALHOST_OVERRIDE=true` / `config.nodeEnv=development` workarounds for local testing. The chart README's existing TLS warning section was extended with the same guidance.
 
 ### Changed
 
 - **CertOps enabled by default in Helm and Compose** — new `config.certopsEnabled` Helm value (default `true`, explicit `false` correctly honored via a ternary that distinguishes "unset" from "false") wires `CERTOPS_ENABLED` into the shared ConfigMap consumed by the API and worker pods. Compose (`docker-compose.yml`, `docker-compose.dev.yml`) now defaults `CERTOPS_ENABLED` to `true` for the `api` and `worker-endpoint-check` services instead of leaving it unset (previously the app-level default was `false` when unset). `docs/CONFIGURATION.md` documents the app-level default alongside the Helm/Compose deployment defaults.
+- Version metadata bumped to 0.10.1 across all manifests, contracts, and Helm chart.
 
 ## [0.10.0] - 2026-07-21
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/services/importFilterRules.js
+++ b/apps/api/services/importFilterRules.js
@@ -4,7 +4,7 @@
  * Ordered list of rules applied uniformly to provider scan results and to
  * the shared import pipeline. Each rule:
  *   { action: "include"|"exclude", matchType: "regex"|"exact",
- *     field: "name"|"description", value: string }
+ *     field: "name"|"description"|"location", value: string }
  *
  * `value` for matchType "regex" uses JavaScript (ECMAScript) regex syntax,
  * evaluated case-sensitively unless wrapped as a full JS regex literal
@@ -35,7 +35,7 @@ const MAX_REGEX_GROUPS = 10;
 
 const VALID_ACTIONS = new Set(["include", "exclude"]);
 const VALID_MATCH_TYPES = new Set(["regex", "exact"]);
-const VALID_FIELDS = new Set(["name", "description"]);
+const VALID_FIELDS = new Set(["name", "description", "location"]);
 
 /**
  * Accepts a regex value either as a bare pattern (`^foo`) or as a full
@@ -200,7 +200,7 @@ function validateFilterRules(rules) {
       return `${label}.matchType must be "regex" or "exact"`;
     }
     if (!VALID_FIELDS.has(rule.field)) {
-      return `${label}.field must be "name" or "description"`;
+      return `${label}.field must be "name", "description" or "location"`;
     }
     if (typeof rule.value !== "string" || rule.value.length === 0) {
       return `${label}.value must be a non-empty string`;
@@ -228,6 +228,14 @@ function getItemField(item, field) {
   if (!item || typeof item !== "object") return "";
   if (field === "name") {
     return typeof item.name === "string" ? item.name : "";
+  }
+  // Location is the provider-side path built by every integration scan
+  // (e.g. `gitlab:projects/42/access_tokens/7`, `vault:secret/data/ci`,
+  // `aws:secretsmanager:eu-west-1:arn`). Unlike description there is no
+  // sensible fallback: an item without a location simply matches nothing,
+  // so rules stay predictable across providers.
+  if (field === "location") {
+    return typeof item.location === "string" ? item.location : "";
   }
   // Description-like field: scan items and import payloads may carry the
   // provider description under `description` or `notes`. GitLab personal

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/dashboard/src/components/FilterRulesEditor.jsx
+++ b/apps/dashboard/src/components/FilterRulesEditor.jsx
@@ -166,7 +166,7 @@ export function sanitizeFilterRules(rules) {
 /**
  * Ordered include/exclude rule editor (issue #69).
  * Rules: { action: 'include'|'exclude', matchType: 'regex'|'exact',
- *          field: 'name'|'description', value: string }
+ *          field: 'name'|'description'|'location', value: string }
  * Exclude rules win; if any include rule exists, items must match one.
  */
 export default function FilterRulesEditor({
@@ -236,6 +236,9 @@ export default function FilterRulesEditor({
         {
           ' The description field falls back to the item name when the source has no separate description.'
         }
+        {
+          ' The location field matches the provider-side path shown in the preview table, e.g. gitlab:projects/42/access_tokens/7.'
+        }
       </Text>
       {rules.length > 0 && (
         <VStack align='stretch' spacing={2}>
@@ -261,6 +264,7 @@ export default function FilterRulesEditor({
                   >
                     <option value='name'>Name</option>
                     <option value='description'>Description</option>
+                    <option value='location'>Location</option>
                   </Select>
                   <Select
                     size='xs'

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.10.0
-appVersion: "0.10.0"
+version: 0.10.1
+appVersion: "0.10.1"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.10.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "status": "m2-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes for M1/M2. M1/M2 Core workspace, machine-token executor, job read, job manual-create, evidence, and token-management routes are runtime-stable where implemented and documented in OpenAPI. This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn.",
   "namespacePolicy": {

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.10.0
+  version: 0.10.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/unit/import-filter-rules.unit.test.js
+++ b/tests/unit/import-filter-rules.unit.test.js
@@ -38,7 +38,7 @@ describe("importFilterRules.validateFilterRules", () => {
 
   it("rejects an invalid field", () => {
     const err = validateFilterRules([
-      { action: "include", matchType: "exact", field: "location", value: "x" },
+      { action: "include", matchType: "exact", field: "owner", value: "x" },
     ]);
     assert.match(err, /field/);
   });
@@ -66,6 +66,12 @@ describe("importFilterRules.validateFilterRules", () => {
         value: "^iac-provisioned:.*",
       },
       { action: "exclude", matchType: "exact", field: "name", value: "temp" },
+      {
+        action: "exclude",
+        matchType: "regex",
+        field: "location",
+        value: "^gitlab:projects/42/",
+      },
     ]);
     assert.strictEqual(err, null);
   });
@@ -249,6 +255,72 @@ describe("importFilterRules.evaluateFilterRules", () => {
     );
     assert.strictEqual(
       evaluateFilterRules(rules, { name: "real description" }),
+      true,
+    );
+  });
+
+  it("matches on the location field with regex and exact rules", () => {
+    const regexRules = [
+      {
+        action: "exclude",
+        matchType: "regex",
+        field: "location",
+        value: "^gitlab:projects/42/",
+      },
+    ];
+    assert.strictEqual(
+      evaluateFilterRules(regexRules, {
+        name: "ci-token",
+        location: "gitlab:projects/42/access_tokens/7",
+      }),
+      false,
+    );
+    assert.strictEqual(
+      evaluateFilterRules(regexRules, {
+        name: "ci-token",
+        location: "gitlab:projects/99/access_tokens/7",
+      }),
+      true,
+    );
+
+    const exactRules = [
+      {
+        action: "include",
+        matchType: "exact",
+        field: "location",
+        value: "vault:secret/data/ci",
+      },
+    ];
+    assert.strictEqual(
+      evaluateFilterRules(exactRules, {
+        name: "x",
+        location: "vault:secret/data/ci",
+      }),
+      true,
+    );
+    assert.strictEqual(
+      evaluateFilterRules(exactRules, {
+        name: "x",
+        location: "vault:secret/data/other",
+      }),
+      false,
+    );
+  });
+
+  it("treats a missing location as an empty string with no name fallback", () => {
+    const rules = [
+      {
+        action: "include",
+        matchType: "regex",
+        field: "location",
+        value: "ci-token",
+      },
+    ];
+    // Unlike description, location must not fall back to the item name:
+    // a rule targeting provider paths should never accidentally match names.
+    assert.strictEqual(evaluateFilterRules(rules, { name: "ci-token" }), false);
+    assert.strictEqual(
+      evaluateFilterRules(rules, { name: "x", location: "gitlab:ci-token" }),
       true,
     );
   });


### PR DESCRIPTION
## Summary
Patch release adding a third matchable field to import filter rules: `location`, the provider-side path every integration scan builds (e.g. `gitlab:projects/42/access_tokens/7`, `vault:secret/data/ci`, `aws:secretsmanager:eu-west-1:arn`). Include/exclude rules (exact or regex) can now scope imports to specific projects, groups, mounts, or regions without relying on naming conventions. Also ships the Helm CSRF port-forward warning and CertOps-enabled-by-default deployment changes merged via #87.

## Changes

### API
- `apps/api/services/importFilterRules.js`: `location` added to the valid rule fields; matching reads `item.location` with no name fallback (an item without a location matches nothing), so provider-path rules never accidentally match token names. Validation error message updated.

### Dashboard
- `apps/dashboard/src/components/FilterRulesEditor.jsx`: new Location option in the field selector, plus help text explaining what the location field matches.

### Tests
- `tests/unit/import-filter-rules.unit.test.js`: coverage for location regex/exact matching, missing-location semantics (no name fallback), validation of location rules in a mixed rule set; the invalid-field fixture switched from `location` to `owner`.

### From #87 (merged to main before this release)
- Helm `NOTES.txt` warning that CSRF protection blocks plain-HTTP `kubectl port-forward` logins under the `NODE_ENV=production` default.
- CertOps switched to enabled-by-default in Helm (`config.certopsEnabled`, default `true`) and Compose (`CERTOPS_ENABLED` defaults to `true`).

### Docs / metadata
- Version bumped to 0.10.1 across all manifests, contract artifacts, and Helm chart.
- CHANGELOG: new 0.10.1 section.

## Test plan
- [x] `pnpm audit --prod --audit-level=moderate` — pass (1 low, below threshold)
- [x] Lint (dashboard, worker, api) — 0 errors
- [x] Dashboard Prettier `--write` then `--check` — clean
- [x] `pnpm run test:unit` — 458/458 pass
- [x] `pnpm run check:contracts`, `check:contracts:integrity`, `test:contracts` — all green
- [ ] Main CI run green after squash-merge (core CI runs on push to main, not on PRs)