### PR TITLE
CertOps: agent productization (11 DNS-01 providers, onboarding, sequence enforcement, renewal caps, bulk renew)

### DIFF
--- a/apps/api/routes/certops-agent.js
+++ b/apps/api/routes/certops-agent.js
@@ -46,8 +46,10 @@ const {
   CERTOPS_AGENT_RESULT_NONCE_REJECTED,
   CERTOPS_AGENT_RESULT_STATUS_INVALID,
   CERTOPS_AGENT_RETIRED,
+  CERTOPS_AGENT_SEQUENCE_REGRESSION,
   assertEvidenceClaimOwnership,
   claimJobs,
+  enforceAgentSequence,
   ingestResult,
   recordHeartbeat,
   registerAgent,
@@ -138,6 +140,14 @@ function validateEnvelope(body, expectedMessageType) {
     !Number.isInteger(body.clockOffsetMs)
   ) {
     throw messageError("clockOffsetMs must be an integer or null");
+  }
+  // Optional per-agent monotonic message counter (plain integer in the
+  // schema, never null); enforcement itself lives in agentDispatch.
+  if (
+    body.sequence !== undefined &&
+    (!Number.isInteger(body.sequence) || body.sequence < 1)
+  ) {
+    throw messageError("sequence must be an integer >= 1 when present");
   }
   return body;
 }
@@ -453,6 +463,12 @@ function handleAgentRouteError(res, error) {
         error: "Result nonce was rejected",
         code: CERTOPS_AGENT_RESULT_NONCE_REJECTED,
       });
+    case CERTOPS_AGENT_SEQUENCE_REGRESSION:
+      return res.status(409).json({
+        error:
+          "Message sequence is not greater than the last accepted sequence for this agent",
+        code: CERTOPS_AGENT_SEQUENCE_REGRESSION,
+      });
     case CERTOPS_AGENT_RESULT_STATUS_INVALID:
       return res.status(400).json({
         error: "Result status is invalid",
@@ -521,6 +537,7 @@ async function claimHandler(req, res, options = {}) {
     const result = await (options.claimJobs || claimJobs)({
       dbPool: options.dbPool,
       agent: req.certopsAgent,
+      envelope,
       body,
       env: options.env,
       deps: options.claimDeps,
@@ -545,6 +562,14 @@ async function resultsHandler(req, res, options = {}) {
         // a jobId has no persistence target yet.
         throw messageError("jobId is required for agent evidence messages");
       }
+      // Sequence enforcement (post-auth; evidence carries no dispatch
+      // nonce, so this is the only anti-replay/ordering gate here). Runs
+      // before any evidence row is appended.
+      await (options.enforceAgentSequence || enforceAgentSequence)({
+        client: options.dbPool,
+        agentRowId: req.certopsAgent.id,
+        envelope,
+      });
       // Claim-ownership binding: only the agent that claimed the job may
       // append evidence to it (409 CERTOPS_AGENT_CLAIM_OWNERSHIP_MISMATCH
       // otherwise). Post-result evidence from the same agent stays valid
@@ -589,6 +614,7 @@ async function resultsHandler(req, res, options = {}) {
     const result = await (options.ingestResult || ingestResult)({
       dbPool: options.dbPool,
       agent: req.certopsAgent,
+      envelope,
       body: { ...body, claimId: body.claimId ?? body.attemptId },
       deps: options.resultDeps,
     });

--- a/apps/api/routes/certops-agent.js
+++ b/apps/api/routes/certops-agent.js
@@ -56,6 +56,7 @@ const {
 } = require("../services/certops/agentDispatch");
 const {
   createCertificateEvidence,
+  createControllerObservationEvidence,
 } = require("../services/certops/evidence");
 const { CERTOPS_JOB_NOT_FOUND } = require("../services/certops/jobs");
 
@@ -558,9 +559,49 @@ async function resultsHandler(req, res, options = {}) {
       const envelope = validateEnvelope(req.body, "evidence");
       const body = validateEvidenceBody(envelope);
       if (!body.jobId) {
-        // The evidence store is job-scoped; agent-level evidence without
-        // a jobId has no persistence target yet.
-        throw messageError("jobId is required for agent evidence messages");
+        // Jobless evidence is the discovery path: agents report observed
+        // certificate inventory (certificate.observed) with jobId null.
+        // Only that event type has a jobless persistence target; anything
+        // else without a jobId stays invalid.
+        const onlyObservations = body.evidenceItems.every(
+          (item) => item.eventType === "certificate.observed",
+        );
+        if (!onlyObservations) {
+          throw messageError(
+            "jobId is required for agent evidence messages other than certificate.observed",
+          );
+        }
+        await (options.enforceAgentSequence || enforceAgentSequence)({
+          client: options.dbPool,
+          agentRowId: req.certopsAgent.id,
+          envelope,
+        });
+        const persistObservation =
+          options.createControllerObservationEvidence ||
+          createControllerObservationEvidence;
+        const observations = [];
+        for (const item of body.evidenceItems) {
+          const evidence = await persistObservation({
+            client: options.dbPool,
+            workspaceId: req.certopsAgent.workspaceId,
+            evidenceType: item.eventType,
+            metadata: {
+              summary: item.summary ?? null,
+              fingerprintSha256: item.fingerprintSha256 ?? null,
+              agentId: req.certopsAgent.agentId,
+              ...(Array.isArray(item.metadata)
+                ? Object.fromEntries(
+                    item.metadata.map((entry) => [entry.name, entry.value]),
+                  )
+                : {}),
+            },
+            observedAt: item.observedAt,
+          });
+          observations.push(evidence);
+        }
+        return res
+          .status(200)
+          .json({ ok: true, evidenceCount: observations.length });
       }
       // Sequence enforcement (post-auth; evidence carries no dispatch
       // nonce, so this is the only anti-replay/ordering gate here). Runs

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -65,10 +65,15 @@ const {
   CERTOPS_JOB_OPERATION_INVALID,
   CERTOPS_JOB_SOURCE_INVALID,
   CERTOPS_JOB_STATUS_INVALID,
+  findActiveJobForSubject,
   getCertificateJobById,
   listCertificateJobLog,
   listCertificateJobs,
+  validateJobPayloadForOperation,
 } = require("../services/certops/jobs");
+const {
+  NON_RENEWABLE_CERTIFICATE_STATUSES,
+} = require("../services/certops/renewalScheduler");
 const {
   CERTOPS_EVIDENCE_INVALID,
   CERTOPS_EVIDENCE_TYPE_INVALID,
@@ -105,6 +110,7 @@ const CERTOPS_AGENT_BOOTSTRAP_TOKEN_NOT_FOUND =
   "CERTOPS_AGENT_BOOTSTRAP_TOKEN_NOT_FOUND";
 const CERTOPS_AGENT_NOT_FOUND = "CERTOPS_AGENT_NOT_FOUND";
 const CERTOPS_AGENT_RETIRE_BLOCKED = "CERTOPS_AGENT_RETIRE_BLOCKED";
+const CERTOPS_CERTIFICATE_NOT_RENEWABLE = "CERTOPS_CERTIFICATE_NOT_RENEWABLE";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -489,9 +495,19 @@ const BULK_RENEW_MAX_CERTIFICATES = 100;
 const BULK_RENEW_ALLOWED_BODY_FIELDS = Object.freeze([
   "certificateIds",
   "dryRun",
+  "idempotencyKey",
   "requiresApproval",
   "payload",
 ]);
+// Per-item keys are "bulk-renew:<client key>:<certificate uuid>". Bound the
+// client part so the composed key stays under the service's 128-char
+// short-text limit with room to spare.
+const BULK_RENEW_IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+
+function bulkRenewItemIdempotencyKey(idempotencyKey, certificateId) {
+  if (!idempotencyKey) return undefined;
+  return `bulk-renew:${idempotencyKey}:${certificateId}`;
+}
 
 /**
  * Validates the whole bulk-renew request shape. Shape problems (missing or
@@ -538,6 +554,17 @@ function parseBulkRenewRequest(body) {
   if (body.dryRun !== undefined && typeof body.dryRun !== "boolean") {
     return { error: "dryRun must be a boolean" };
   }
+  if (body.idempotencyKey !== undefined) {
+    if (
+      typeof body.idempotencyKey !== "string" ||
+      !BULK_RENEW_IDEMPOTENCY_KEY_PATTERN.test(body.idempotencyKey)
+    ) {
+      return {
+        error:
+          "idempotencyKey must be 1-64 characters of letters, digits, '.', '_' or '-'",
+      };
+    }
+  }
   if (
     body.requiresApproval !== undefined &&
     typeof body.requiresApproval !== "boolean"
@@ -556,6 +583,7 @@ function parseBulkRenewRequest(body) {
   return {
     certificateIds: normalized,
     dryRun: body.dryRun === true,
+    idempotencyKey: body.idempotencyKey || null,
     requiresApproval: body.requiresApproval === true,
     payload: body.payload || {},
   };
@@ -568,10 +596,21 @@ function parseBulkRenewRequest(body) {
  * single renew job exactly. Item failures never abort the batch; the
  * response is always 200 with per-item outcomes, except whole-request shape
  * problems (400) and the disabled-rollout 404.
+ *
+ * An optional request-level idempotencyKey makes retries safe: each item is
+ * created with a derived "bulk-renew:<key>:<certificateId>" job key, so a
+ * replayed batch returns the already-created jobs (marked replayed: true)
+ * instead of enqueueing duplicates.
+ *
+ * Dry run preflights each certificate without writing: existence, renewable
+ * inventory status, the same payload validation the real run applies, and
+ * whether a non-terminal renew job is already in flight (reported as
+ * activeJobId so callers can spot double-renewals before committing).
  */
 function bulkRenewCertificatesHandler({
   manualJobCreator = createManualCertificateJob,
   certificateLoader = getManagedCertificate,
+  activeJobFinder = findActiveJobForSubject,
 } = {}) {
   return async function bulkRenewCertificatesHandler(req, res) {
     const parsed = parseBulkRenewRequest(req.body);
@@ -580,6 +619,24 @@ function bulkRenewCertificatesHandler({
         error: parsed.error,
         code: CERTOPS_JOB_INVALID,
       });
+    }
+
+    // The payload is a whole-request field; validate it once up front (with
+    // a representative certificateId stamped in, as each item's payload
+    // will be) so a bad payload is a 400 instead of N identical item errors.
+    try {
+      validateJobPayloadForOperation(
+        { ...parsed.payload, certificateId: parsed.certificateIds[0] },
+        "renew",
+      );
+    } catch (err) {
+      if (typeof err?.code === "string" && err.code) {
+        return res.status(400).json({
+          error: err.message || "payload is invalid",
+          code: err.code,
+        });
+      }
+      throw err;
     }
 
     const results = [];
@@ -601,19 +658,43 @@ function bulkRenewCertificatesHandler({
           continue;
         }
 
-        if (parsed.dryRun) {
-          succeeded += 1;
-          results.push({ certificateId, ok: true });
+        if (NON_RENEWABLE_CERTIFICATE_STATUSES.includes(certificate.status)) {
+          results.push({
+            certificateId,
+            ok: false,
+            errorCode: CERTOPS_CERTIFICATE_NOT_RENEWABLE,
+            message: `Certificate status '${certificate.status}' is not renewable`,
+          });
           continue;
         }
 
-        const { job } = await manualJobCreator({
+        if (parsed.dryRun) {
+          const activeJob = await activeJobFinder({
+            workspaceId: req.workspace.id,
+            subjectType: "managed_certificate",
+            subjectId: certificateId,
+            operation: "renew",
+          });
+          succeeded += 1;
+          results.push({
+            certificateId,
+            ok: true,
+            ...(activeJob ? { activeJobId: activeJob.id } : {}),
+          });
+          continue;
+        }
+
+        const { job, created } = await manualJobCreator({
           workspaceId: req.workspace.id,
           operation: "renew",
           subjectType: "managed_certificate",
           subjectId: certificateId,
           payload: { ...parsed.payload, certificateId },
           requiresApproval: parsed.requiresApproval,
+          idempotencyKey: bulkRenewItemIdempotencyKey(
+            parsed.idempotencyKey,
+            certificateId,
+          ),
           // Same session-write source posture as single manual job creation.
           source: "api",
           requestedByUserId: req.user?.id || null,
@@ -621,7 +702,12 @@ function bulkRenewCertificatesHandler({
           subjectUserId: req.user?.id || null,
         });
         succeeded += 1;
-        results.push({ certificateId, ok: true, jobId: job.id });
+        results.push({
+          certificateId,
+          ok: true,
+          jobId: job.id,
+          ...(created === false ? { replayed: true } : {}),
+        });
       } catch (err) {
         // A disabled rollout is a whole-surface condition, not a
         // per-certificate one: keep the same 404 posture as the middleware.

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -485,6 +485,185 @@ function createManualCertificateJobHandler({
   };
 }
 
+const BULK_RENEW_MAX_CERTIFICATES = 100;
+const BULK_RENEW_ALLOWED_BODY_FIELDS = Object.freeze([
+  "certificateIds",
+  "dryRun",
+  "requiresApproval",
+  "payload",
+]);
+
+/**
+ * Validates the whole bulk-renew request shape. Shape problems (missing or
+ * oversized id list, non-UUID or duplicate ids, wrong field types, unknown
+ * fields) fail the entire request with 400; per-certificate problems are
+ * reported in the response envelope instead.
+ */
+function parseBulkRenewRequest(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "Request body must be a JSON object" };
+  }
+
+  const unknownField = Object.keys(body).find(
+    (key) => !BULK_RENEW_ALLOWED_BODY_FIELDS.includes(key),
+  );
+  if (unknownField) {
+    return { error: `Unknown field: ${unknownField}` };
+  }
+
+  const { certificateIds } = body;
+  if (!Array.isArray(certificateIds) || certificateIds.length < 1) {
+    return { error: "certificateIds must be a non-empty array" };
+  }
+  if (certificateIds.length > BULK_RENEW_MAX_CERTIFICATES) {
+    return {
+      error: `certificateIds accepts at most ${BULK_RENEW_MAX_CERTIFICATES} ids per request`,
+    };
+  }
+
+  const normalized = [];
+  const seen = new Set();
+  for (const value of certificateIds) {
+    if (typeof value !== "string" || !UUID_PATTERN.test(value.trim())) {
+      return { error: "certificateIds must contain only UUID strings" };
+    }
+    const id = value.trim().toLowerCase();
+    if (seen.has(id)) {
+      return { error: "certificateIds must not contain duplicates" };
+    }
+    seen.add(id);
+    normalized.push(id);
+  }
+
+  if (body.dryRun !== undefined && typeof body.dryRun !== "boolean") {
+    return { error: "dryRun must be a boolean" };
+  }
+  if (
+    body.requiresApproval !== undefined &&
+    typeof body.requiresApproval !== "boolean"
+  ) {
+    return { error: "requiresApproval must be a boolean" };
+  }
+  if (
+    body.payload !== undefined &&
+    (body.payload === null ||
+      typeof body.payload !== "object" ||
+      Array.isArray(body.payload))
+  ) {
+    return { error: "payload must be an object" };
+  }
+
+  return {
+    certificateIds: normalized,
+    dryRun: body.dryRun === true,
+    requiresApproval: body.requiresApproval === true,
+    payload: body.payload || {},
+  };
+}
+
+/**
+ * Bulk renewal with a partial-failure envelope. Each certificate id goes
+ * through the same manual-creation service path as POST /jobs (kill switch,
+ * approval gate, payload validation), so per-certificate behavior matches a
+ * single renew job exactly. Item failures never abort the batch; the
+ * response is always 200 with per-item outcomes, except whole-request shape
+ * problems (400) and the disabled-rollout 404.
+ */
+function bulkRenewCertificatesHandler({
+  manualJobCreator = createManualCertificateJob,
+  certificateLoader = getManagedCertificate,
+} = {}) {
+  return async function bulkRenewCertificatesHandler(req, res) {
+    const parsed = parseBulkRenewRequest(req.body);
+    if (parsed.error) {
+      return res.status(400).json({
+        error: parsed.error,
+        code: CERTOPS_JOB_INVALID,
+      });
+    }
+
+    const results = [];
+    let succeeded = 0;
+
+    for (const certificateId of parsed.certificateIds) {
+      try {
+        const certificate = await certificateLoader({
+          workspaceId: req.workspace.id,
+          certId: certificateId,
+        });
+        if (!certificate) {
+          results.push({
+            certificateId,
+            ok: false,
+            errorCode: CERTOPS_CERTIFICATE_NOT_FOUND,
+            message: "Certificate not found",
+          });
+          continue;
+        }
+
+        if (parsed.dryRun) {
+          succeeded += 1;
+          results.push({ certificateId, ok: true });
+          continue;
+        }
+
+        const { job } = await manualJobCreator({
+          workspaceId: req.workspace.id,
+          operation: "renew",
+          subjectType: "managed_certificate",
+          subjectId: certificateId,
+          payload: { ...parsed.payload, certificateId },
+          requiresApproval: parsed.requiresApproval,
+          // Same session-write source posture as single manual job creation.
+          source: "api",
+          requestedByUserId: req.user?.id || null,
+          actorUserId: req.user?.id || null,
+          subjectUserId: req.user?.id || null,
+        });
+        succeeded += 1;
+        results.push({ certificateId, ok: true, jobId: job.id });
+      } catch (err) {
+        // A disabled rollout is a whole-surface condition, not a
+        // per-certificate one: keep the same 404 posture as the middleware.
+        if (err?.code === CERTOPS_DISABLED) {
+          return res.status(404).json(NOT_FOUND_RESPONSE);
+        }
+        if (typeof err?.code === "string" && err.code) {
+          results.push({
+            certificateId,
+            ok: false,
+            errorCode: err.code,
+            message: err.message || "CertOps job creation failed",
+          });
+          continue;
+        }
+        logger.error("CertOps bulk renew item failed", {
+          error: err?.message,
+          workspaceId: req.workspace?.id,
+          certificateId,
+          userId: req.user?.id,
+        });
+        results.push({
+          certificateId,
+          ok: false,
+          errorCode: "INTERNAL_ERROR",
+          message: "Failed to create CertOps job",
+        });
+      }
+    }
+
+    return res.status(200).json({
+      summary: {
+        requested: parsed.certificateIds.length,
+        succeeded,
+        failed: parsed.certificateIds.length - succeeded,
+      },
+      ...(parsed.dryRun ? { dryRun: true } : {}),
+      results,
+    });
+  };
+}
+
 function jobApprovalDecisionHandler(decision, {
   approver = approveJob,
   rejecter = rejectJob,
@@ -1386,6 +1565,20 @@ router.post(
   createManualCertificateJobHandler(),
 );
 
+// Bulk renewal shares the exact middleware posture of single manual job
+// creation: each certificate id is queued through the same manual-creation
+// service path, and per-certificate outcomes are reported in a
+// partial-failure envelope instead of aborting the batch.
+router.post(
+  "/api/v1/workspaces/:id/certops/jobs/bulk-renew",
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsWriteRole,
+  requireWorkspaceCertOpsActive,
+  bulkRenewCertificatesHandler(),
+);
+
 router.post(
   "/api/v1/workspaces/:id/certops/provision-intents",
   getApiLimiter(),
@@ -1760,6 +1953,8 @@ router.post(
 module.exports = router;
 module.exports._test = {
   createManualCertificateJobHandler,
+  bulkRenewCertificatesHandler,
+  parseBulkRenewRequest,
   createControllerProvisionIntentHandler,
   requireCertOpsSessionUser,
   handleCertOpsError,

--- a/apps/api/services/certops/agentDispatch.js
+++ b/apps/api/services/certops/agentDispatch.js
@@ -51,6 +51,7 @@ const CERTOPS_AGENT_RESULT_NONCE_REJECTED =
   "CERTOPS_AGENT_RESULT_NONCE_REJECTED";
 const CERTOPS_AGENT_RESULT_STATUS_INVALID =
   "CERTOPS_AGENT_RESULT_STATUS_INVALID";
+const CERTOPS_AGENT_SEQUENCE_REGRESSION = "CERTOPS_AGENT_SEQUENCE_REGRESSION";
 
 const DEFAULT_JOB_LEASE_SECONDS = 900;
 // The dispatch nonce must stay consumable for the whole window the agent is
@@ -108,6 +109,59 @@ function dateToIso(value) {
   return date.toISOString();
 }
 
+// --- Per-agent monotonic sequence enforcement (defense in depth) ---
+
+/**
+ * Extracts a usable sequence value from an envelope. Envelopes without a
+ * `sequence` field are legacy/backward-compatible traffic: enforcement is
+ * skipped entirely and certops_agents.last_sequence is left untouched.
+ */
+function envelopeSequence(envelope) {
+  const sequence = envelope?.sequence;
+  return Number.isInteger(sequence) && sequence >= 1 ? sequence : null;
+}
+
+/**
+ * Atomic compare-and-swap of certops_agents.last_sequence: a single UPDATE
+ * only matches when the incoming sequence strictly exceeds the stored one,
+ * so two concurrent messages can never both pass with the same value (the
+ * row lock serializes them and the loser sees last_sequence >= its own).
+ *
+ * Runs after credential auth (the agent row is known to exist) and after
+ * any nonce replay check, per the agent-route check ordering. A no-match is
+ * therefore always a sequence regression within the current registered
+ * generation and rejects the message with a 409-shaped error; the message
+ * must not be processed.
+ *
+ * No-op when the envelope carries no sequence (legacy agents).
+ *
+ * @param {object} params
+ * @param {object} [params.client] pg client or pool (injectable; defaults
+ *   to the shared pool)
+ * @param {string} params.agentRowId certops_agents.id (NOT the public
+ *   agent_id string)
+ * @param {object} params.envelope validated message envelope
+ */
+async function enforceAgentSequence({ client = pool, agentRowId, envelope }) {
+  const sequence = envelopeSequence(envelope);
+  if (sequence === null) return;
+
+  const result = await client.query(
+    `UPDATE certops_agents
+        SET last_sequence = $2
+      WHERE id = $1
+        AND last_sequence < $2
+      RETURNING id`,
+    [agentRowId, sequence],
+  );
+  if (result.rows.length === 0) {
+    throw serviceError(
+      "Message sequence is not greater than the last accepted sequence for this agent",
+      CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
+  }
+}
+
 // --- Registration (7.2) ---
 
 /**
@@ -152,9 +206,10 @@ async function registerAgent({
          declared_target_selectors,
          declared_command_profile_names,
          status,
-         bootstrap_token_id
+         bootstrap_token_id,
+         last_sequence
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, 'active', $13)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, 'active', $13, $14)
        ON CONFLICT (agent_id) DO NOTHING
        RETURNING id, agent_id, protocol_version`,
       [
@@ -173,6 +228,12 @@ async function registerAgent({
         JSON.stringify(body.declaredTargetSelectors || []),
         JSON.stringify(body.declaredCommandProfileNames || []),
         bootstrapToken.id,
+        // Registration begins a new sequence generation: last_sequence is
+        // seeded from the register envelope's own sequence (or 0 when the
+        // agent does not send one), so an agent whose non-persisted counter
+        // restarted low is only ever compared against its new generation,
+        // never against a previous registration's high-water mark.
+        envelopeSequence(envelope) ?? 0,
       ],
     );
 
@@ -226,6 +287,12 @@ async function recordHeartbeat({
 } = {}) {
   const getSigningKey =
     deps.getActiveSigningKeyPublicInfo || getActiveSigningKeyPublicInfo;
+  const enforceSequence = deps.enforceAgentSequence || enforceAgentSequence;
+
+  // Sequence enforcement runs after auth (route middleware) and before the
+  // heartbeat write; a regression rejects the message with no last_seen_at
+  // (or any other) update.
+  await enforceSequence({ client: dbPool, agentRowId: agent.id, envelope });
 
   const clockOffsetMs = Number.isInteger(envelope.clockOffsetMs)
     ? envelope.clockOffsetMs
@@ -290,6 +357,7 @@ async function recordHeartbeat({
 async function claimJobs({
   dbPool = pool,
   agent,
+  envelope = {},
   body = {},
   env = process.env,
   deps = {},
@@ -299,6 +367,7 @@ async function claimJobs({
   const signJob = deps.signJobForDispatch || signJobForDispatch;
   const invalidateApproval =
     deps.invalidateApprovalForClaim || invalidateApprovalForClaim;
+  const enforceSequence = deps.enforceAgentSequence || enforceAgentSequence;
 
   const maxJobs =
     Number.isInteger(body.maxJobs) && body.maxJobs >= 1 && body.maxJobs <= 16
@@ -310,6 +379,12 @@ async function claimJobs({
   const leaseSeconds = jobLeaseSeconds(env);
 
   return await withTransaction(dbPool, async (client) => {
+    // Sequence enforcement first (post-auth, pre-dispatch): a regression
+    // rejects the poll before any workspace lock or job selection. Inside
+    // the transaction, so a claim that later fails rolls the counter back
+    // with everything else.
+    await enforceSequence({ client, agentRowId: agent.id, envelope });
+
     // Throws CERTOPS_WORKSPACE_PAUSED / CERTOPS_DISABLED; the route maps
     // these to 409 / 404 and no job is claimed.
     await lockWorkspace({ client, workspaceId: agent.workspaceId });
@@ -444,10 +519,12 @@ function safeParseJson(value) {
 async function ingestResult({
   dbPool = pool,
   agent,
+  envelope = {},
   body = {},
   deps = {},
 } = {}) {
   const consume = deps.consumeNonce || consumeNonce;
+  const enforceSequence = deps.enforceAgentSequence || enforceAgentSequence;
   const queueRenewalFailedAlert =
     deps.queueCertRenewalFailedAlert || queueCertRenewalFailedAlert;
   const log = deps.logger || logger;
@@ -525,6 +602,13 @@ async function ingestResult({
       error.replayed = nonceOutcome?.code === CERTOPS_NONCE_REPLAYED;
       throw error;
     }
+
+    // Sequence enforcement after the nonce replay ledger (route-family
+    // check ordering: auth, nonce replay, sequence) and before the status
+    // transition. A regression aborts the transaction, so the nonce
+    // consumption above rolls back with it and the message is not
+    // processed.
+    await enforceSequence({ client, agentRowId: agent.id, envelope });
 
     if (job.status !== "claimed" && job.status !== "running") {
       throw serviceError(
@@ -660,9 +744,11 @@ module.exports = {
   CERTOPS_AGENT_RESULT_NONCE_REJECTED,
   CERTOPS_AGENT_RESULT_STATUS_INVALID,
   CERTOPS_AGENT_RETIRED,
+  CERTOPS_AGENT_SEQUENCE_REGRESSION,
   DEFAULT_JOB_LEASE_SECONDS,
   assertEvidenceClaimOwnership,
   claimJobs,
+  enforceAgentSequence,
   ingestResult,
   jobLeaseSeconds,
   recordHeartbeat,
@@ -671,6 +757,7 @@ module.exports = {
     NONCE_TTL_GRACE_SECONDS,
     RESULT_STATUS_TO_JOB_STATUS,
     dateToIso,
+    envelopeSequence,
     safeParseJson,
     serviceError,
     withTransaction,

--- a/apps/api/services/certops/agentDispatch.js
+++ b/apps/api/services/certops/agentDispatch.js
@@ -113,8 +113,9 @@ function dateToIso(value) {
 
 /**
  * Extracts a usable sequence value from an envelope. Envelopes without a
- * `sequence` field are legacy/backward-compatible traffic: enforcement is
- * skipped entirely and certops_agents.last_sequence is left untouched.
+ * `sequence` field are legacy traffic: they are tolerated only for agents
+ * that have never sent a sequenced message (last_sequence = 0). See the
+ * no-bypass rule in enforceAgentSequence.
  */
 function envelopeSequence(envelope) {
   const sequence = envelope?.sequence;
@@ -128,12 +129,18 @@ function envelopeSequence(envelope) {
  * row lock serializes them and the loser sees last_sequence >= its own).
  *
  * Runs after credential auth (the agent row is known to exist) and after
- * any nonce replay check, per the agent-route check ordering. A no-match is
- * therefore always a sequence regression within the current registered
- * generation and rejects the message with a 409-shaped error; the message
- * must not be processed.
+ * any nonce replay check, per the agent-route check ordering, and always on
+ * the caller's transaction client so a message that later fails rolls the
+ * counter back with everything else. A no-match is a sequence regression
+ * within the current registered generation and rejects the message with a
+ * 409-shaped error; the message must not be processed.
  *
- * No-op when the envelope carries no sequence (legacy agents).
+ * No-bypass rule: an envelope WITHOUT a sequence is accepted only while the
+ * agent has never sent one (last_sequence = 0, pre-sequencing agent
+ * builds). Once any sequenced message has been accepted, unsequenced
+ * traffic is rejected outright; otherwise dropping the field would defeat
+ * the whole regression check (a replayed captured message could simply
+ * omit it).
  *
  * @param {object} params
  * @param {object} [params.client] pg client or pool (injectable; defaults
@@ -144,7 +151,20 @@ function envelopeSequence(envelope) {
  */
 async function enforceAgentSequence({ client = pool, agentRowId, envelope }) {
   const sequence = envelopeSequence(envelope);
-  if (sequence === null) return;
+  if (sequence === null) {
+    const existing = await client.query(
+      `SELECT last_sequence FROM certops_agents WHERE id = $1 FOR UPDATE`,
+      [agentRowId],
+    );
+    const lastSequence = Number(existing.rows[0]?.last_sequence ?? 0);
+    if (lastSequence > 0) {
+      throw serviceError(
+        "Message carries no sequence but this agent already sends sequenced messages",
+        CERTOPS_AGENT_SEQUENCE_REGRESSION,
+      );
+    }
+    return;
+  }
 
   const result = await client.query(
     `UPDATE certops_agents
@@ -277,6 +297,9 @@ async function registerAgent({
  * Steady-state heartbeat write. The route has already rejected retired
  * agents (410, no last_seen_at update). An 'offline' agent that calls in is
  * alive again, so status flips back to 'active'.
+ *
+ * Runs in one transaction so the sequence bump and the heartbeat write
+ * commit or roll back together (a failed write must not burn the sequence).
  */
 async function recordHeartbeat({
   dbPool = pool,
@@ -288,11 +311,6 @@ async function recordHeartbeat({
   const getSigningKey =
     deps.getActiveSigningKeyPublicInfo || getActiveSigningKeyPublicInfo;
   const enforceSequence = deps.enforceAgentSequence || enforceAgentSequence;
-
-  // Sequence enforcement runs after auth (route middleware) and before the
-  // heartbeat write; a regression rejects the message with no last_seen_at
-  // (or any other) update.
-  await enforceSequence({ client: dbPool, agentRowId: agent.id, envelope });
 
   const clockOffsetMs = Number.isInteger(envelope.clockOffsetMs)
     ? envelope.clockOffsetMs
@@ -307,43 +325,50 @@ async function recordHeartbeat({
       ? body.pinnedSigningKeyId
       : null;
 
-  const result = await dbPool.query(
-    `UPDATE certops_agents
-        SET last_seen_at = NOW(),
-            clock_offset_ms = $2,
-            ntp_synced = $3,
-            uptime_seconds = $4,
-            pinned_signing_key_id = COALESCE($5, pinned_signing_key_id),
-            agent_version = $6,
-            status = CASE WHEN status = 'offline' THEN 'active' ELSE status END,
-            updated_at = NOW()
-      WHERE id = $1
-        AND status <> 'retired'
-      RETURNING id, status, last_seen_at`,
-    [
-      agent.id,
-      clockOffsetMs,
-      ntpSynced,
-      uptimeSeconds,
-      pinnedSigningKeyId,
-      body.agentVersion || agent.agentVersion,
-    ],
-  );
+  return await withTransaction(dbPool, async (client) => {
+    // Sequence enforcement runs after auth (route middleware) and before
+    // the heartbeat write; a regression rejects the message with no
+    // last_seen_at (or any other) update.
+    await enforceSequence({ client, agentRowId: agent.id, envelope });
 
-  const row = result.rows[0];
-  if (!row) {
-    // Retired between auth and write: freeze, same as the route-level rule.
-    throw serviceError("Agent is retired", CERTOPS_AGENT_RETIRED);
-  }
+    const result = await client.query(
+      `UPDATE certops_agents
+          SET last_seen_at = NOW(),
+              clock_offset_ms = $2,
+              ntp_synced = $3,
+              uptime_seconds = $4,
+              pinned_signing_key_id = COALESCE($5, pinned_signing_key_id),
+              agent_version = $6,
+              status = CASE WHEN status = 'offline' THEN 'active' ELSE status END,
+              updated_at = NOW()
+        WHERE id = $1
+          AND status <> 'retired'
+        RETURNING id, status, last_seen_at`,
+      [
+        agent.id,
+        clockOffsetMs,
+        ntpSynced,
+        uptimeSeconds,
+        pinnedSigningKeyId,
+        body.agentVersion || agent.agentVersion,
+      ],
+    );
 
-  const signingKey = await getSigningKey({ client: dbPool });
-  return {
-    ok: true,
-    status: row.status,
-    lastSeenAt: dateToIso(row.last_seen_at),
-    signingKeyId: signingKey?.signingKeyId ?? null,
-    signingPublicKeyPem: signingKey?.publicKeyPem ?? null,
-  };
+    const row = result.rows[0];
+    if (!row) {
+      // Retired between auth and write: freeze, same as the route-level rule.
+      throw serviceError("Agent is retired", CERTOPS_AGENT_RETIRED);
+    }
+
+    const signingKey = await getSigningKey({ client });
+    return {
+      ok: true,
+      status: row.status,
+      lastSeenAt: dateToIso(row.last_seen_at),
+      signingKeyId: signingKey?.signingKeyId ?? null,
+      signingPublicKeyPem: signingKey?.publicKeyPem ?? null,
+    };
+  });
 }
 
 // --- Claim (7.3) ---

--- a/apps/api/services/certops/agentRegistry.js
+++ b/apps/api/services/certops/agentRegistry.js
@@ -25,6 +25,8 @@ const AGENT_SAFE_SELECT_FIELDS = `
   status,
   last_seen_at,
   clock_offset_ms,
+  ntp_synced,
+  pinned_signing_key_id,
   created_at,
   retired_at,
   retire_reason
@@ -98,6 +100,8 @@ function agentMetadataFromRow(row) {
     status: row.status,
     lastSeenAt: dateToIso(row.last_seen_at),
     clockOffsetMs: row.clock_offset_ms === null ? null : Number(row.clock_offset_ms),
+    ntpSynced: typeof row.ntp_synced === "boolean" ? row.ntp_synced : null,
+    pinnedSigningKeyId: row.pinned_signing_key_id ?? null,
     createdAt: dateToIso(row.created_at),
     retiredAt: dateToIso(row.retired_at),
     retireReason: row.retire_reason ?? null,

--- a/apps/api/services/certops/evidence.js
+++ b/apps/api/services/certops/evidence.js
@@ -310,9 +310,11 @@ async function createCertificateEvidence(options) {
 }
 
 // This is deliberately narrower than createCertificateEvidence(): controller
-// observations have no certificate job, but still need one bounded,
-// detector-scanned, transaction-owned evidence record. It is not exported to a
-// public route and cannot be used for arbitrary jobless evidence.
+// observations and agent discovery reports have no certificate job, but still
+// need one bounded, detector-scanned, transaction-owned evidence record. It
+// only accepts certificate.observed, so it cannot be used for arbitrary
+// jobless evidence; callers are the controller ingestion path and the
+// credential-authenticated agent evidence route (discovery scans).
 async function createControllerObservationEvidence(options) {
   assertNoPrivateKeyMaterial(options.evidenceType);
   assertNoPrivateKeyMaterial(options.subjectId);

--- a/apps/api/services/certops/jobs.js
+++ b/apps/api/services/certops/jobs.js
@@ -1060,6 +1060,64 @@ function getCertificateJobById(options) {
   );
 }
 
+/**
+ * Runs the exact payload normalization and per-operation execution-field
+ * validation that createCertificateJob applies, without touching the
+ * database. Dry-run preflight uses this so a dry run rejects the same
+ * payloads the real run would.
+ */
+function validateJobPayloadForOperation(payload, operation) {
+  const normalizedOperation = normalizeEnum(
+    operation,
+    JOB_OPERATION_SET,
+    CERTOPS_JOB_OPERATION_INVALID,
+    "operation",
+  );
+  const normalizedPayload = normalizePublicObject(payload, "payload");
+  validateExecutionFields(normalizedPayload, normalizedOperation);
+  return normalizedPayload;
+}
+
+/**
+ * Returns the newest non-terminal job for a subject (optionally scoped to
+ * one operation), or null. Lets preflight surface an in-flight renewal that
+ * a new job would race against.
+ */
+async function findActiveJobForSubject(options) {
+  const db = options.client || pool;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const { subjectType, subjectId } = normalizeSubject(options);
+  const params = [workspaceId, subjectType, subjectId, [...ACTIVE_JOB_STATUSES]];
+  const conditions = [
+    "workspace_id = $1",
+    "subject_type = $2",
+    "subject_id = $3",
+    "status = ANY($4)",
+  ];
+
+  if (options.operation !== undefined && options.operation !== null && options.operation !== "") {
+    const operation = normalizeEnum(
+      options.operation,
+      JOB_OPERATION_SET,
+      CERTOPS_JOB_OPERATION_INVALID,
+      "operation",
+    );
+    params.push(operation);
+    conditions.push(`operation = $${params.length}`);
+  }
+
+  const result = await db.query(
+    `SELECT ${SAFE_JOB_SELECT_FIELDS}
+       FROM certificate_jobs
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY created_at DESC, id ASC
+      LIMIT 1`,
+    params,
+  );
+
+  return result.rows[0] ? jobFromRow(result.rows[0]) : null;
+}
+
 async function listCertificateJobs(options) {
   const db = options.client || pool;
   const workspaceId = normalizeWorkspaceId(options.workspaceId);
@@ -1338,6 +1396,7 @@ module.exports = {
   createCertificateJob,
   dateToIso,
   fieldNameLooksForbidden,
+  findActiveJobForSubject,
   getCertificateJobById,
   isTerminalJobStatus,
   jobCreationRequestFingerprint,
@@ -1352,6 +1411,7 @@ module.exports = {
   normalizeWorkspaceId,
   serviceError,
   updateCertificateJobStatus,
+  validateJobPayloadForOperation,
   _test: {
     assertSafePublicValue,
     fieldNameLooksForbidden,

--- a/apps/api/services/certops/renewalScheduler.js
+++ b/apps/api/services/certops/renewalScheduler.js
@@ -33,6 +33,10 @@ const RENEWAL_PER_CA_CAP_ENV = "CERTOPS_RENEWAL_PER_CA_CAP";
 // of endpoint-less renewals is still capped instead of being unbounded.
 const UNKNOWN_CA_BUCKET = "__unknown-ca__";
 
+// Advisory lock key for the sweep (single-flight across workers). Any
+// constant bigint works; this one is arbitrary but must stay stable.
+const RENEWAL_SCHEDULER_ADVISORY_LOCK_KEY = 7_384_211_257_001n;
+
 // Inventory statuses that never get automated renewal jobs.
 const NON_RENEWABLE_CERTIFICATE_STATUSES = Object.freeze([
   "revoked",
@@ -85,11 +89,53 @@ function isValidCaEndpointUrl(value) {
 }
 
 /**
+ * Canonical form of a CA endpoint for cap bucketing, so the same CA never
+ * lands in two buckets because of representation differences (case in the
+ * scheme/host, default ports, trailing slashes, query/fragment noise).
+ * Non-URL strings are lowercased+trimmed as-is; empty input maps to the
+ * unknown-CA bucket. Used for BOTH sides of the cap comparison (due
+ * certificates and in-flight job counts); the raw (un-normalized but valid)
+ * URL is still what gets stamped on job payloads.
+ */
+function normalizeCaBucket(value) {
+  if (typeof value !== "string") return UNKNOWN_CA_BUCKET;
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed === UNKNOWN_CA_BUCKET) return UNKNOWN_CA_BUCKET;
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (_error) {
+    return trimmed.toLowerCase();
+  }
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  // URL already lowercases protocol/hostname and drops default ports.
+  return `${parsed.protocol}//${parsed.host}${pathname}`;
+}
+
+/**
  * CA bucket for a due certificate: the caEndpoint recorded in the
  * certificate's public metadata, falling back to its profile's public
- * metadata, else the shared unknown-CA bucket.
+ * metadata, else the shared unknown-CA bucket. Normalized for bucketing.
  */
 function certificateCaBucket(certificate) {
+  const candidates = [
+    certificate?.certificate_ca_endpoint,
+    certificate?.profile_ca_endpoint,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim() !== "") {
+      return normalizeCaBucket(candidate);
+    }
+  }
+  return UNKNOWN_CA_BUCKET;
+}
+
+/**
+ * Raw (un-normalized) caEndpoint candidate for stamping on job payloads.
+ * Kept separate from certificateCaBucket so payloads carry the operator's
+ * exact URL while cap accounting uses the canonical bucket.
+ */
+function certificateCaEndpointRaw(certificate) {
   const candidates = [
     certificate?.certificate_ca_endpoint,
     certificate?.profile_ca_endpoint,
@@ -99,33 +145,50 @@ function certificateCaBucket(certificate) {
       return candidate.trim();
     }
   }
-  return UNKNOWN_CA_BUCKET;
+  return null;
 }
 
 /**
- * Best-effort snapshot of in-flight renewal jobs grouped by the caEndpoint
- * recorded in the job payload. Jobs without one land in the unknown-CA
- * bucket. The sweep is single-flight from one worker, so a point-in-time
- * count (plus local increments for jobs the sweep itself creates) is
- * race-tolerant enough: a concurrent manual job at worst delays a renewal
- * by one sweep.
+ * Composite cap-accounting key: caps are per (workspace, CA), never global,
+ * so one tenant's renewal backlog can never starve another tenant sharing
+ * the same public CA.
+ */
+function caCapKey(workspaceId, caBucket) {
+  return `${workspaceId}::${caBucket}`;
+}
+
+/**
+ * Point-in-time snapshot of in-flight renewal jobs keyed by
+ * (workspace, normalized CA bucket). Jobs without a payload caEndpoint land
+ * in the unknown-CA bucket. Normalization happens here in JS with the SAME
+ * normalizeCaBucket used for due certificates, so both sides of the cap
+ * comparison agree. The sweep itself is single-flight (advisory lock in
+ * runRenewalSchedulerSweep) and locally increments this map for jobs it
+ * creates, so the snapshot stays consistent for the duration of a sweep; a
+ * concurrent manual job at worst delays a renewal by one sweep.
  */
 async function countInFlightRenewalJobsByCaEndpoint({
   db = pool,
   terminalStatuses,
 } = {}) {
   const result = await db.query(
-    `SELECT COALESCE(NULLIF(BTRIM(cj.payload->>'caEndpoint'), ''), $2) AS ca_bucket,
+    `SELECT cj.workspace_id,
+            NULLIF(BTRIM(cj.payload->>'caEndpoint'), '') AS ca_endpoint,
             COUNT(*)::int AS in_flight
        FROM certificate_jobs cj
       WHERE cj.operation = 'renew'
         AND NOT (cj.status = ANY($1::text[]))
-      GROUP BY 1`,
-    [terminalStatuses, UNKNOWN_CA_BUCKET],
+      GROUP BY 1, 2`,
+    [terminalStatuses],
   );
   const counts = new Map();
   for (const row of result.rows || []) {
-    counts.set(row.ca_bucket, Number(row.in_flight) || 0);
+    const bucket =
+      row.ca_endpoint == null
+        ? UNKNOWN_CA_BUCKET
+        : normalizeCaBucket(row.ca_endpoint);
+    const key = caCapKey(row.workspace_id, bucket);
+    counts.set(key, (counts.get(key) || 0) + (Number(row.in_flight) || 0));
   }
   return counts;
 }
@@ -217,9 +280,9 @@ async function createRenewalJobForCertificate({
     // Stamp the resolved caEndpoint on the payload when it is a valid
     // execution-field URL, so in-flight counts in later sweeps bucket this
     // job under the same CA the scheduler capped it against.
-    const caBucket = certificateCaBucket(certificate);
-    if (caBucket !== UNKNOWN_CA_BUCKET && isValidCaEndpointUrl(caBucket)) {
-      payload.caEndpoint = caBucket;
+    const rawCaEndpoint = certificateCaEndpointRaw(certificate);
+    if (rawCaEndpoint !== null && isValidCaEndpointUrl(rawCaEndpoint)) {
+      payload.caEndpoint = rawCaEndpoint;
     }
     // The inventory schema records no dedicated keyRotationPolicy column, so
     // the payload keyRotation execution field is only set when key_mode
@@ -268,14 +331,21 @@ async function createRenewalJobForCertificate({
 
 /**
  * One renewal-planning pass. Returns a summary:
- * { thresholdDays, perCaCap, scanned, created, replayed, skippedPaused,
- *   skippedByCaCap, errors }.
+ * { thresholdDays, perCaCap, lockAcquired, scanned, created, replayed,
+ *   skippedPaused, skippedByCaCap, errors }.
  *
- * Per-CA cap: before creating a job the sweep checks how many renew jobs are
- * already in flight for the certificate's CA bucket (point-in-time count
- * taken once per sweep, incremented locally for jobs this sweep creates).
- * Capped certificates are skipped, counted in skippedByCaCap, and picked up
- * by a later sweep once the CA's in-flight jobs drain.
+ * Single-flight: the whole sweep runs under a session advisory lock
+ * (pg_try_advisory_lock). A second worker starting a sweep while one is in
+ * progress returns immediately with lockAcquired: false and does nothing;
+ * without this, two concurrent sweeps would each take a point-in-time
+ * in-flight snapshot and could jointly exceed every per-CA cap.
+ *
+ * Per-CA cap: before creating a job the sweep checks how many renew jobs
+ * are already in flight for the certificate's (workspace, normalized CA)
+ * bucket (snapshot taken once per sweep, incremented locally for jobs this
+ * sweep creates). Capped certificates are skipped, counted in
+ * skippedByCaCap, and picked up by a later sweep once the CA's in-flight
+ * jobs drain.
  */
 async function runRenewalSchedulerSweep({
   dbPool = pool,
@@ -294,22 +364,11 @@ async function runRenewalSchedulerSweep({
     "cancelled",
   ].filter(isTerminalJobStatus);
 
-  const dueCertificates = await findCertificatesDueForRenewal({
-    db: dbPool,
-    thresholdDays,
-    batchSize,
-    terminalStatuses,
-  });
-
-  const inFlightByCa = await countInFlightRenewalJobsByCaEndpoint({
-    db: dbPool,
-    terminalStatuses,
-  });
-
   const summary = {
     thresholdDays,
     perCaCap,
-    scanned: dueCertificates.length,
+    lockAcquired: false,
+    scanned: 0,
     created: 0,
     replayed: 0,
     skippedPaused: 0,
@@ -317,59 +376,106 @@ async function runRenewalSchedulerSweep({
     errors: [],
   };
 
-  for (const certificate of dueCertificates) {
-    const caBucket = certificateCaBucket(certificate);
-    const inFlight = inFlightByCa.get(caBucket) || 0;
-    if (inFlight >= perCaCap) {
-      summary.skippedByCaCap += 1;
-      continue;
+  // Advisory locks are session-scoped: acquire and release on ONE dedicated
+  // connection held for the whole sweep.
+  const lockClient = await dbPool.connect();
+  try {
+    const lockResult = await lockClient.query(
+      "SELECT pg_try_advisory_lock($1) AS acquired",
+      [RENEWAL_SCHEDULER_ADVISORY_LOCK_KEY.toString()],
+    );
+    if (lockResult.rows?.[0]?.acquired !== true) {
+      return summary;
     }
-    try {
-      const { created } = await createRenewalJobForCertificate({
-        dbPool,
-        certificate,
-        jobCreator,
-        env,
-      });
-      if (created) {
-        summary.created += 1;
-        inFlightByCa.set(caBucket, inFlight + 1);
-      } else {
-        summary.replayed += 1;
-      }
-    } catch (error) {
-      if (
-        error?.code === CERTOPS_WORKSPACE_PAUSED ||
-        error?.code === CERTOPS_DISABLED
-      ) {
-        summary.skippedPaused += 1;
+    summary.lockAcquired = true;
+
+    const dueCertificates = await findCertificatesDueForRenewal({
+      db: dbPool,
+      thresholdDays,
+      batchSize,
+      terminalStatuses,
+    });
+
+    const inFlightByCa = await countInFlightRenewalJobsByCaEndpoint({
+      db: dbPool,
+      terminalStatuses,
+    });
+
+    summary.scanned = dueCertificates.length;
+
+    for (const certificate of dueCertificates) {
+      const capKey = caCapKey(
+        certificate.workspace_id,
+        certificateCaBucket(certificate),
+      );
+      const inFlight = inFlightByCa.get(capKey) || 0;
+      if (inFlight >= perCaCap) {
+        summary.skippedByCaCap += 1;
         continue;
       }
-      summary.errors.push({
-        certificateId: String(certificate.id),
-        error: error?.message || String(error),
-      });
-      if (logger?.error) {
-        logger.error("certops-renewal-scheduler-cert-failure", {
-          certificateId: String(certificate.id),
-          error: error?.message,
+      try {
+        const { created } = await createRenewalJobForCertificate({
+          dbPool,
+          certificate,
+          jobCreator,
+          env,
         });
+        if (created) {
+          summary.created += 1;
+          inFlightByCa.set(capKey, inFlight + 1);
+        } else {
+          summary.replayed += 1;
+        }
+      } catch (error) {
+        if (
+          error?.code === CERTOPS_WORKSPACE_PAUSED ||
+          error?.code === CERTOPS_DISABLED
+        ) {
+          summary.skippedPaused += 1;
+          continue;
+        }
+        summary.errors.push({
+          certificateId: String(certificate.id),
+          error: error?.message || String(error),
+        });
+        if (logger?.error) {
+          logger.error("certops-renewal-scheduler-cert-failure", {
+            certificateId: String(certificate.id),
+            error: error?.message,
+          });
+        }
       }
     }
-  }
 
-  return summary;
+    return summary;
+  } finally {
+    if (summary.lockAcquired) {
+      try {
+        await lockClient.query("SELECT pg_advisory_unlock($1)", [
+          RENEWAL_SCHEDULER_ADVISORY_LOCK_KEY.toString(),
+        ]);
+      } catch (_error) {
+        // The session release below frees the lock regardless.
+      }
+    }
+    lockClient.release();
+  }
 }
 
 module.exports = {
   DEFAULT_RENEWAL_PER_CA_CAP,
   DEFAULT_RENEWAL_THRESHOLD_DAYS,
+  NON_RENEWABLE_CERTIFICATE_STATUSES,
   RENEWAL_PER_CA_CAP_ENV,
+  RENEWAL_SCHEDULER_ADVISORY_LOCK_KEY,
   RENEWAL_THRESHOLD_ENV,
   UNKNOWN_CA_BUCKET,
+  caCapKey,
   certificateCaBucket,
+  certificateCaEndpointRaw,
   countInFlightRenewalJobsByCaEndpoint,
   findCertificatesDueForRenewal,
+  normalizeCaBucket,
   renewalIdempotencyKey,
   resolveRenewalPerCaCap,
   resolveRenewalThresholdDays,

--- a/apps/api/services/certops/renewalScheduler.js
+++ b/apps/api/services/certops/renewalScheduler.js
@@ -26,6 +26,12 @@ const { CERTOPS_DISABLED } = require("./settings");
 const DEFAULT_RENEWAL_THRESHOLD_DAYS = 30;
 const DEFAULT_BATCH_SIZE = 200;
 const RENEWAL_THRESHOLD_ENV = "CERTOPS_RENEWAL_THRESHOLD_DAYS";
+const DEFAULT_RENEWAL_PER_CA_CAP = 5;
+const RENEWAL_PER_CA_CAP_ENV = "CERTOPS_RENEWAL_PER_CA_CAP";
+
+// Certificates without a resolvable caEndpoint share this bucket, so a flood
+// of endpoint-less renewals is still capped instead of being unbounded.
+const UNKNOWN_CA_BUCKET = "__unknown-ca__";
 
 // Inventory statuses that never get automated renewal jobs.
 const NON_RENEWABLE_CERTIFICATE_STATUSES = Object.freeze([
@@ -43,6 +49,85 @@ function resolveRenewalThresholdDays(env = process.env) {
     return DEFAULT_RENEWAL_THRESHOLD_DAYS;
   }
   return parsed;
+}
+
+/**
+ * Max renewal jobs that may be in flight per CA endpoint at sweep time.
+ * Same env pattern as resolveRenewalThresholdDays: blank/invalid values fall
+ * back to the default.
+ */
+function resolveRenewalPerCaCap(env = process.env) {
+  const raw = env[RENEWAL_PER_CA_CAP_ENV];
+  if (raw == null || String(raw).trim() === "") {
+    return DEFAULT_RENEWAL_PER_CA_CAP;
+  }
+  const parsed = Number.parseInt(String(raw).trim(), 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_RENEWAL_PER_CA_CAP;
+  }
+  return parsed;
+}
+
+/**
+ * True when a metadata caEndpoint value would pass the execution-field
+ * validation in jobs.js (http/https URL, <= 512 chars). Invalid values are
+ * still used for cap bucketing but never stamped onto job payloads.
+ */
+function isValidCaEndpointUrl(value) {
+  if (typeof value !== "string" || value.length > 512) return false;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (_error) {
+    return false;
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "http:";
+}
+
+/**
+ * CA bucket for a due certificate: the caEndpoint recorded in the
+ * certificate's public metadata, falling back to its profile's public
+ * metadata, else the shared unknown-CA bucket.
+ */
+function certificateCaBucket(certificate) {
+  const candidates = [
+    certificate?.certificate_ca_endpoint,
+    certificate?.profile_ca_endpoint,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim() !== "") {
+      return candidate.trim();
+    }
+  }
+  return UNKNOWN_CA_BUCKET;
+}
+
+/**
+ * Best-effort snapshot of in-flight renewal jobs grouped by the caEndpoint
+ * recorded in the job payload. Jobs without one land in the unknown-CA
+ * bucket. The sweep is single-flight from one worker, so a point-in-time
+ * count (plus local increments for jobs the sweep itself creates) is
+ * race-tolerant enough: a concurrent manual job at worst delays a renewal
+ * by one sweep.
+ */
+async function countInFlightRenewalJobsByCaEndpoint({
+  db = pool,
+  terminalStatuses,
+} = {}) {
+  const result = await db.query(
+    `SELECT COALESCE(NULLIF(BTRIM(cj.payload->>'caEndpoint'), ''), $2) AS ca_bucket,
+            COUNT(*)::int AS in_flight
+       FROM certificate_jobs cj
+      WHERE cj.operation = 'renew'
+        AND NOT (cj.status = ANY($1::text[]))
+      GROUP BY 1`,
+    [terminalStatuses, UNKNOWN_CA_BUCKET],
+  );
+  const counts = new Map();
+  for (const row of result.rows || []) {
+    counts.set(row.ca_bucket, Number(row.in_flight) || 0);
+  }
+  return counts;
 }
 
 /**
@@ -73,7 +158,11 @@ async function findCertificatesDueForRenewal({
             mc.common_name,
             mc.not_after,
             mc.key_mode,
-            cp.renew_before_days AS profile_renew_before_days
+            cp.renew_before_days AS profile_renew_before_days,
+            NULLIF(BTRIM(mc.public_metadata->>'caEndpoint'), '')
+              AS certificate_ca_endpoint,
+            NULLIF(BTRIM(cp.public_metadata->>'caEndpoint'), '')
+              AS profile_ca_endpoint
        FROM managed_certificates mc
        LEFT JOIN certificate_profiles cp
          ON cp.workspace_id = mc.workspace_id AND cp.id = mc.profile_id
@@ -125,6 +214,13 @@ async function createRenewalJobForCertificate({
       notAfter: new Date(certificate.not_after).toISOString(),
       reason: "expiry-threshold",
     };
+    // Stamp the resolved caEndpoint on the payload when it is a valid
+    // execution-field URL, so in-flight counts in later sweeps bucket this
+    // job under the same CA the scheduler capped it against.
+    const caBucket = certificateCaBucket(certificate);
+    if (caBucket !== UNKNOWN_CA_BUCKET && isValidCaEndpointUrl(caBucket)) {
+      payload.caEndpoint = caBucket;
+    }
     // The inventory schema records no dedicated keyRotationPolicy column, so
     // the payload keyRotation execution field is only set when key_mode
     // policy data exists and the agent holds the key locally (the only modes
@@ -172,7 +268,14 @@ async function createRenewalJobForCertificate({
 
 /**
  * One renewal-planning pass. Returns a summary:
- * { thresholdDays, scanned, created, replayed, skippedPaused, errors }.
+ * { thresholdDays, perCaCap, scanned, created, replayed, skippedPaused,
+ *   skippedByCaCap, errors }.
+ *
+ * Per-CA cap: before creating a job the sweep checks how many renew jobs are
+ * already in flight for the certificate's CA bucket (point-in-time count
+ * taken once per sweep, incremented locally for jobs this sweep creates).
+ * Capped certificates are skipped, counted in skippedByCaCap, and picked up
+ * by a later sweep once the CA's in-flight jobs drain.
  */
 async function runRenewalSchedulerSweep({
   dbPool = pool,
@@ -182,6 +285,7 @@ async function runRenewalSchedulerSweep({
   logger = null,
 } = {}) {
   const thresholdDays = resolveRenewalThresholdDays(env);
+  const perCaCap = resolveRenewalPerCaCap(env);
   const terminalStatuses = [
     "rejected",
     "succeeded",
@@ -197,16 +301,29 @@ async function runRenewalSchedulerSweep({
     terminalStatuses,
   });
 
+  const inFlightByCa = await countInFlightRenewalJobsByCaEndpoint({
+    db: dbPool,
+    terminalStatuses,
+  });
+
   const summary = {
     thresholdDays,
+    perCaCap,
     scanned: dueCertificates.length,
     created: 0,
     replayed: 0,
     skippedPaused: 0,
+    skippedByCaCap: 0,
     errors: [],
   };
 
   for (const certificate of dueCertificates) {
+    const caBucket = certificateCaBucket(certificate);
+    const inFlight = inFlightByCa.get(caBucket) || 0;
+    if (inFlight >= perCaCap) {
+      summary.skippedByCaCap += 1;
+      continue;
+    }
     try {
       const { created } = await createRenewalJobForCertificate({
         dbPool,
@@ -214,8 +331,12 @@ async function runRenewalSchedulerSweep({
         jobCreator,
         env,
       });
-      if (created) summary.created += 1;
-      else summary.replayed += 1;
+      if (created) {
+        summary.created += 1;
+        inFlightByCa.set(caBucket, inFlight + 1);
+      } else {
+        summary.replayed += 1;
+      }
     } catch (error) {
       if (
         error?.code === CERTOPS_WORKSPACE_PAUSED ||
@@ -241,10 +362,16 @@ async function runRenewalSchedulerSweep({
 }
 
 module.exports = {
+  DEFAULT_RENEWAL_PER_CA_CAP,
   DEFAULT_RENEWAL_THRESHOLD_DAYS,
+  RENEWAL_PER_CA_CAP_ENV,
   RENEWAL_THRESHOLD_ENV,
+  UNKNOWN_CA_BUCKET,
+  certificateCaBucket,
+  countInFlightRenewalJobsByCaEndpoint,
   findCertificatesDueForRenewal,
   renewalIdempotencyKey,
+  resolveRenewalPerCaCap,
   resolveRenewalThresholdDays,
   runRenewalSchedulerSweep,
 };

--- a/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
+++ b/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
@@ -75,6 +75,44 @@ function shortId(value) {
   return raw.length > 12 ? `${raw.slice(0, 12)}...` : raw;
 }
 
+/** Clock offsets beyond this are flagged as drifted in the fleet table. */
+const CLOCK_DRIFT_WARN_MS = 5000;
+
+/** Signed millisecond offset for display, e.g. "+120 ms"; '--' when unknown. */
+function formatClockOffset(value) {
+  if (value === null || value === undefined) return '--';
+  const ms = Number(value);
+  if (!Number.isFinite(ms)) return '--';
+  return `${ms < 0 ? '-' : '+'}${Math.abs(ms)} ms`;
+}
+
+function isClockDrifted(value) {
+  const ms = Number(value);
+  return Number.isFinite(ms) && Math.abs(ms) > CLOCK_DRIFT_WARN_MS;
+}
+
+/** NTP sync state chip: green Synced, orange Not synced, muted when unknown. */
+function NtpBadge({ ntpSynced }) {
+  if (ntpSynced !== true && ntpSynced !== false) {
+    return (
+      <Text as='span' fontSize='sm'>
+        --
+      </Text>
+    );
+  }
+  return (
+    <Badge
+      colorScheme={ntpSynced ? 'green' : 'orange'}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+    >
+      {ntpSynced ? 'Synced' : 'Not synced'}
+    </Badge>
+  );
+}
+
 /**
  * Confirm dialog for retiring an agent (RetireCertificateModal pattern).
  * A non-forced retire is refused server-side with 409
@@ -220,7 +258,8 @@ function RetireAgentModal({ isOpen, onClose, agent, onRetire }) {
 }
 
 /**
- * Agent fleet table: name/id, status, version, last heartbeat, and a
+ * Agent fleet table: name/id, status, version, protocol version, clock
+ * drift, NTP sync state, pinned job-signing key, last heartbeat, and a
  * manager-only Retire action. Empty state points to the Deploy an agent
  * panel on the same page.
  */
@@ -302,6 +341,10 @@ export default function AgentFleetPanel() {
                 <Th>Agent</Th>
                 <Th>Status</Th>
                 <Th>Version</Th>
+                <Th>Protocol</Th>
+                <Th>Clock drift</Th>
+                <Th>NTP</Th>
+                <Th>Signing key</Th>
                 <Th>Last heartbeat</Th>
                 {canManage ? <Th textAlign='right'>Actions</Th> : null}
               </Tr>
@@ -329,6 +372,46 @@ export default function AgentFleetPanel() {
                       <Text fontSize='sm' fontFamily='mono'>
                         {agent.agentVersion || '--'}
                       </Text>
+                    </Td>
+                    <Td>
+                      <Text fontSize='sm' fontFamily='mono'>
+                        {agent.protocolVersion === null ||
+                        agent.protocolVersion === undefined
+                          ? '--'
+                          : String(agent.protocolVersion)}
+                      </Text>
+                    </Td>
+                    <Td>
+                      <HStack spacing={2}>
+                        <Text fontSize='sm' fontFamily='mono'>
+                          {formatClockOffset(agent.clockOffsetMs)}
+                        </Text>
+                        {isClockDrifted(agent.clockOffsetMs) ? (
+                          <Badge
+                            colorScheme='orange'
+                            variant='subtle'
+                            textTransform='none'
+                            fontWeight='medium'
+                            fontSize='xs'
+                            title={`Clock offset exceeds ${CLOCK_DRIFT_WARN_MS / 1000}s`}
+                          >
+                            Drift
+                          </Badge>
+                        ) : null}
+                      </HStack>
+                    </Td>
+                    <Td>
+                      <NtpBadge ntpSynced={agent.ntpSynced} />
+                    </Td>
+                    <Td>
+                      {agent.pinnedSigningKeyId ? (
+                        <CopyableId
+                          id={agent.pinnedSigningKeyId}
+                          display={shortId(agent.pinnedSigningKeyId)}
+                        />
+                      ) : (
+                        <Text fontSize='sm'>--</Text>
+                      )}
                     </Td>
                     <Td>
                       <Text

--- a/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
+++ b/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
@@ -1,0 +1,372 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Stack,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Textarea,
+  Th,
+  Thead,
+  Tr,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import {
+  DashboardModalDescription,
+  DashboardModalFrame,
+  DashboardModalTitle,
+  useDashboardModalProps,
+} from '../DashboardModalFrame.jsx';
+import CopyableId from '../CopyableId.jsx';
+import { DashboardErrorAlert } from '../DashboardPrimitives.jsx';
+import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
+import { showSuccess } from '../../utils/toast.js';
+import { retireAgent } from './certopsAgentsApi.js';
+import { formatDateTime, formatRelativeDateTime } from './certopsJobsFormat';
+import { useCertOpsCanManage } from './useCertOps.js';
+import { useCertOpsAgents } from './useCertOpsAgents.js';
+
+const AGENT_STATUS_SCHEME = {
+  active: 'green',
+  offline: 'orange',
+  retired: 'gray',
+};
+
+const AGENT_STATUS_LABEL = {
+  active: 'Active',
+  offline: 'Offline',
+  retired: 'Retired',
+};
+
+/** Subtle status chip for an agent, JobStatusBadge conventions. */
+function AgentStatusBadge({ status, fontSize = 'xs' }) {
+  const key = String(status || '').toLowerCase();
+  return (
+    <Badge
+      colorScheme={AGENT_STATUS_SCHEME[key] || 'gray'}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize={fontSize}
+    >
+      {AGENT_STATUS_LABEL[key] || (status ? String(status) : 'Unknown')}
+    </Badge>
+  );
+}
+
+function shortId(value) {
+  const raw = String(value || '');
+  return raw.length > 12 ? `${raw.slice(0, 12)}...` : raw;
+}
+
+/**
+ * Confirm dialog for retiring an agent (RetireCertificateModal pattern).
+ * A non-forced retire is refused server-side with 409
+ * CERTOPS_AGENT_RETIRE_BLOCKED while the agent holds job leases; the dialog
+ * then surfaces a force option, which requires a reason.
+ */
+function RetireAgentModal({ isOpen, onClose, agent, onRetire }) {
+  const {
+    overlayProps,
+    headerProps,
+    bodyProps,
+    footerProps,
+    closeButtonProps,
+    outlineButtonProps,
+    dangerButtonProps,
+  } = useDashboardModalProps();
+
+  const [reason, setReason] = useState('');
+  const [force, setForce] = useState(false);
+  const [blocked, setBlocked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setReason('');
+      setForce(false);
+      setBlocked(false);
+      setSubmitting(false);
+      setError('');
+    }
+  }, [isOpen]);
+
+  const forceNeedsReason = force && !reason.trim();
+
+  const handleConfirm = async () => {
+    if (submitting || forceNeedsReason) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await onRetire({
+        force,
+        reason: reason.trim() || undefined,
+      });
+    } catch (err) {
+      const code = err?.response?.data?.code;
+      if (
+        err?.response?.status === 409 ||
+        code === 'CERTOPS_AGENT_RETIRE_BLOCKED'
+      ) {
+        setBlocked(true);
+        setError(
+          'This agent still holds active job leases. Wait for its jobs to finish, or force the retirement (leased jobs will fail over).'
+        );
+      } else {
+        setError(
+          err?.response?.data?.error ||
+            'Could not retire this agent. Please try again.'
+        );
+      }
+      setSubmitting(false);
+    }
+  };
+
+  const agentLabel = agent?.name || agent?.hostname || agent?.agentId || '';
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered scrollBehavior='inside'>
+      <ModalOverlay {...overlayProps} />
+      <DashboardModalFrame
+        type='danger'
+        maxW={{ base: 'calc(100vw - 24px)', md: '520px' }}
+      >
+        <ModalHeader {...headerProps}>
+          <DashboardModalTitle>Retire agent</DashboardModalTitle>
+          <DashboardModalDescription>
+            A retired agent can no longer connect or lease jobs; its credential
+            is invalidated. This cannot be undone; deploy a new agent to replace
+            it.
+          </DashboardModalDescription>
+        </ModalHeader>
+        <ModalCloseButton {...closeButtonProps} />
+        <ModalBody {...bodyProps}>
+          <Stack spacing={3}>
+            {agentLabel ? (
+              <Text fontSize='sm' fontWeight='semibold'>
+                Agent: {agentLabel}
+              </Text>
+            ) : null}
+            <Box>
+              <Text fontSize='sm' mb={1}>
+                Reason {force ? '(required to force)' : '(optional)'}
+              </Text>
+              <Textarea
+                value={reason}
+                onChange={event => setReason(event.target.value)}
+                placeholder='e.g. host decommissioned'
+                size='sm'
+                rows={2}
+              />
+            </Box>
+            {blocked ? (
+              <Checkbox
+                isChecked={force}
+                onChange={event => setForce(event.target.checked)}
+                size='sm'
+              >
+                <Text as='span' fontSize='sm'>
+                  Force retirement even though the agent holds job leases
+                </Text>
+              </Checkbox>
+            ) : null}
+            {error ? (
+              <Alert status='error' borderRadius='md' variant='left-accent'>
+                <AlertIcon />
+                <AlertDescription fontSize='sm'>{error}</AlertDescription>
+              </Alert>
+            ) : null}
+          </Stack>
+        </ModalBody>
+        <ModalFooter {...footerProps}>
+          <Button
+            {...outlineButtonProps}
+            onClick={onClose}
+            isDisabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            {...dangerButtonProps}
+            ml={3}
+            onClick={handleConfirm}
+            isLoading={submitting}
+            loadingText='Retiring'
+            isDisabled={forceNeedsReason}
+          >
+            {force ? 'Force retire' : 'Retire agent'}
+          </Button>
+        </ModalFooter>
+      </DashboardModalFrame>
+    </Modal>
+  );
+}
+
+/**
+ * Agent fleet table: name/id, status, version, last heartbeat, and a
+ * manager-only Retire action. Empty state points to the Deploy an agent
+ * panel on the same page.
+ */
+export default function AgentFleetPanel() {
+  const { workspaceId } = useWorkspace();
+  const canManage = useCertOpsCanManage();
+  const { enabled, agents, loading, error, refresh } = useCertOpsAgents();
+
+  const [retireTarget, setRetireTarget] = useState(null);
+
+  const muted = useColorModeValue('gray.600', 'gray.400');
+  const titleColor = useColorModeValue('gray.700', 'gray.200');
+  const infoBg = useColorModeValue('blue.50', 'blue.900');
+  const infoBorder = useColorModeValue('blue.200', 'blue.700');
+  const infoText = useColorModeValue('blue.800', 'blue.100');
+
+  if (enabled !== true) return null;
+
+  const handleRetire = async ({ force, reason }) => {
+    if (!retireTarget?.id || !workspaceId) return;
+    await retireAgent(workspaceId, retireTarget.id, { force, reason });
+    showSuccess('Agent retired');
+    setRetireTarget(null);
+    refresh();
+  };
+
+  return (
+    <Stack spacing={4} align='stretch'>
+      <Box>
+        <Text fontSize='md' fontWeight='bold' color={titleColor} mb={1}>
+          Agent fleet
+        </Text>
+        <Alert
+          status='info'
+          variant='subtle'
+          borderRadius='md'
+          bg={infoBg}
+          border='1px solid'
+          borderColor={infoBorder}
+          py={2}
+          px={3}
+        >
+          <AlertIcon boxSize={4} />
+          <AlertDescription fontSize='sm' color={infoText} lineHeight='short'>
+            Agents connect outbound-only and lease jobs from this workspace. An
+            agent is marked offline when it stops sending heartbeats; retire it
+            to invalidate its credential permanently.
+          </AlertDescription>
+        </Alert>
+      </Box>
+
+      {error ? <DashboardErrorAlert>{error}</DashboardErrorAlert> : null}
+
+      {loading ? (
+        <HStack spacing={2} color={muted} py={4} justify='center'>
+          <Spinner size='sm' />
+          <Text fontSize='sm'>Loading agents...</Text>
+        </HStack>
+      ) : null}
+
+      {!loading && !error && agents.length === 0 ? (
+        <Box py={6} textAlign='center'>
+          <Text fontSize='sm' fontWeight='semibold' color={titleColor}>
+            No agents yet.
+          </Text>
+          <Text fontSize='sm' color={muted} mt={1}>
+            {canManage
+              ? 'Use the Deploy an agent panel on this page to install your first agent.'
+              : 'A workspace manager can deploy agents from this page.'}
+          </Text>
+        </Box>
+      ) : null}
+
+      {!loading && agents.length > 0 ? (
+        <TableContainer>
+          <Table size='sm' variant='simple'>
+            <Thead>
+              <Tr>
+                <Th>Agent</Th>
+                <Th>Status</Th>
+                <Th>Version</Th>
+                <Th>Last heartbeat</Th>
+                {canManage ? <Th textAlign='right'>Actions</Th> : null}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {agents.map(agent => {
+                const status = String(agent.status || '').toLowerCase();
+                return (
+                  <Tr key={agent.id}>
+                    <Td>
+                      <Box>
+                        <Text fontSize='sm' fontWeight='semibold'>
+                          {agent.name || agent.hostname || 'Unnamed agent'}
+                        </Text>
+                        <CopyableId
+                          id={agent.agentId}
+                          display={shortId(agent.agentId)}
+                        />
+                      </Box>
+                    </Td>
+                    <Td>
+                      <AgentStatusBadge status={agent.status} />
+                    </Td>
+                    <Td>
+                      <Text fontSize='sm' fontFamily='mono'>
+                        {agent.agentVersion || '--'}
+                      </Text>
+                    </Td>
+                    <Td>
+                      <Text
+                        fontSize='sm'
+                        color={muted}
+                        title={formatDateTime(agent.lastSeenAt)}
+                      >
+                        {formatRelativeDateTime(agent.lastSeenAt)}
+                      </Text>
+                    </Td>
+                    {canManage ? (
+                      <Td textAlign='right'>
+                        {status !== 'retired' ? (
+                          <Button
+                            size='xs'
+                            colorScheme='red'
+                            variant='outline'
+                            onClick={() => setRetireTarget(agent)}
+                          >
+                            Retire
+                          </Button>
+                        ) : null}
+                      </Td>
+                    ) : null}
+                  </Tr>
+                );
+              })}
+            </Tbody>
+          </Table>
+        </TableContainer>
+      ) : null}
+
+      <RetireAgentModal
+        isOpen={Boolean(retireTarget)}
+        onClose={() => setRetireTarget(null)}
+        agent={retireTarget}
+        onRetire={handleRetire}
+      />
+    </Stack>
+  );
+}

--- a/apps/dashboard/src/components/certops/DeployAgentPanel.jsx
+++ b/apps/dashboard/src/components/certops/DeployAgentPanel.jsx
@@ -36,14 +36,16 @@ import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
 import { showError, showSuccess } from '../../utils/toast.js';
 import {
   AGENT_BOOTSTRAP_TOKEN_NAME_MAX_LENGTH,
-  buildInstallCommand,
   createBootstrapToken,
   listAgents,
   revokeBootstrapToken,
 } from './certopsAgentsApi.js';
 import { formatDate } from './certopsFormat';
 import { useCertOpsCanManage } from './useCertOps.js';
-import { useCertOpsBootstrapTokens } from './useCertOpsAgents.js';
+import {
+  useCertOpsAgents,
+  useCertOpsBootstrapTokens,
+} from './useCertOpsAgents.js';
 
 const TOKEN_STATUS_SCHEME = {
   active: 'green',
@@ -88,6 +90,20 @@ function defaultExpiryLocalValue() {
   return localDatetimeValue(new Date(Date.now() + 24 * 60 * 60 * 1000));
 }
 
+/**
+ * Copy-paste install command without the bootstrap token: the installer reads
+ * the token from a hidden interactive prompt (or from the
+ * TOKENTIMER_AGENT_BOOTSTRAP_TOKEN environment variable) when no
+ * --bootstrap-token flag is given, so the secret never lands in shell history.
+ */
+function buildTokenlessInstallCommand({ apiUrl, workspaceId }) {
+  return [
+    `sudo ./install-agent.sh \\`,
+    `  --api-url '${apiUrl}' \\`,
+    `  --workspace-id '${workspaceId}'`,
+  ].join('\n');
+}
+
 function createErrorMessage(err) {
   const code = err?.response?.data?.code;
   const status = err?.response?.status;
@@ -126,9 +142,11 @@ function revokeErrorMessage(err) {
 /**
  * Guided "Deploy an agent" flow:
  *  1. create a bootstrap token (show-once secret, ApiTokenPanel pattern),
- *  2. copy a pre-filled install command (CopyableCodeBlock),
- *  3. wait for the agent to register (polls GET /certops/agents and compares
- *     against the agent ids snapshotted when the wait started).
+ *  2. copy a pre-filled install command (CopyableCodeBlock); the installer
+ *     prompts for the token, which is never embedded in the command,
+ *  3. wait for the agent to register (polls GET /certops/agents and reports
+ *     an agent whose id was not known when the token was created, or whose
+ *     registration timestamp is at or after token creation).
  * Manager-gated: viewers see a read-only explainer, no token list or actions.
  */
 export default function DeployAgentPanel({ onAgentRegistered }) {
@@ -136,6 +154,7 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
   const canManage = useCertOpsCanManage();
   const { enabled, tokens, loading, error, refresh } =
     useCertOpsBootstrapTokens();
+  const { agents: fleetAgents } = useCertOpsAgents();
 
   const [name, setName] = useState('');
   const [expiresLocal, setExpiresLocal] = useState(defaultExpiryLocalValue());
@@ -147,7 +166,13 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
   // 'idle' | 'waiting' | 'registered'
   const [waitState, setWaitState] = useState('idle');
   const [registeredAgent, setRegisteredAgent] = useState(null);
+  // Baseline snapshot of agent row ids, captured when the bootstrap token is
+  // created (not on the first poll tick): an agent that registers between
+  // token creation and the first poll must still be detected as new.
   const knownAgentIdsRef = useRef(null);
+  // Token creation time; agents registered at or after it count as new even
+  // if the baseline list was stale and already contained their id.
+  const tokenCreatedAtRef = useRef(null);
   const revokeCancelRef = useRef(null);
 
   // Show-once secret and wait state are workspace-scoped: switching
@@ -161,10 +186,12 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
     setWaitState('idle');
     setRegisteredAgent(null);
     knownAgentIdsRef.current = null;
+    tokenCreatedAtRef.current = null;
   }, [workspaceId]);
 
-  // Poll the fleet while waiting; success when an agent id appears that was
-  // not in the snapshot taken when the wait started.
+  // Poll the fleet while waiting; success when an agent appears that was not
+  // in the token-creation baseline, or that registered after the token was
+  // created (timestamp check covers a stale baseline).
   useEffect(() => {
     if (waitState !== 'waiting' || !workspaceId) return undefined;
     let cancelled = false;
@@ -177,15 +204,30 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
           return;
         }
         const items = Array.isArray(data?.items) ? data.items : [];
-        if (knownAgentIdsRef.current === null) {
+        const baselineIds = knownAgentIdsRef.current;
+        const tokenCreatedAtMs = tokenCreatedAtRef.current;
+        if (baselineIds === null && tokenCreatedAtMs === null) {
+          // No token was created in this session; fall back to snapshotting
+          // the fleet on the first tick, as before.
           knownAgentIdsRef.current = new Set(items.map(agent => agent.id));
           return;
         }
-        const fresh = items.find(
-          agent =>
-            !knownAgentIdsRef.current.has(agent.id) &&
-            agent.status !== 'retired'
-        );
+        const fresh = items.find(agent => {
+          if (agent.status === 'retired') return false;
+          if (baselineIds !== null && !baselineIds.has(agent.id)) return true;
+          if (tokenCreatedAtMs !== null) {
+            const registeredAtMs = new Date(
+              agent.createdAt || agent.registeredAt || NaN
+            ).getTime();
+            if (
+              !Number.isNaN(registeredAtMs) &&
+              registeredAtMs >= tokenCreatedAtMs
+            ) {
+              return true;
+            }
+          }
+          return false;
+        });
         if (fresh) {
           setRegisteredAgent(fresh);
           setWaitState('registered');
@@ -231,14 +273,14 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
     typeof window !== 'undefined' && window.location
       ? window.location.origin
       : '';
-  const installCommand = buildInstallCommand({
+  const installCommand = buildTokenlessInstallCommand({
     apiUrl,
     workspaceId: workspaceId || '<workspace-id>',
-    bootstrapToken: plaintextToken || null,
   });
 
   const beginWaiting = () => {
-    knownAgentIdsRef.current = null;
+    // Keep the baseline captured at token creation; it must predate any
+    // agent registered by this token. Only clear the show-once secret.
     setRegisteredAgent(null);
     setPlaintextToken('');
     setWaitState('waiting');
@@ -247,6 +289,12 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
   const handleCreate = async () => {
     if (!canSubmit) return;
     const requestWorkspaceId = workspaceId;
+    // Snapshot the fleet and the creation time before the request: any agent
+    // registering from now on can only come from this (or a newer) token.
+    const baselineIds = new Set(
+      (Array.isArray(fleetAgents) ? fleetAgents : []).map(agent => agent.id)
+    );
+    const createdAtMs = Date.now();
     setCreating(true);
     try {
       const result = await createBootstrapToken(requestWorkspaceId, {
@@ -271,6 +319,8 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
       setName('');
       setExpiresLocal(defaultExpiryLocalValue());
       setPlaintextToken(plaintext);
+      knownAgentIdsRef.current = baselineIds;
+      tokenCreatedAtRef.current = createdAtMs;
       setShowOnceOpen(true);
       showSuccess('Bootstrap token created');
     } catch (err) {
@@ -281,8 +331,9 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
     }
   };
 
-  // Keeps the plaintext in memory for the step-2 install command; it is
-  // cleared when the wait starts, on workspace switch, and on unmount.
+  // The plaintext stays in memory only to drive the step-2 guidance; it is
+  // cleared when the wait starts, on workspace switch, and on unmount. It is
+  // never embedded in the install command.
   const handleShowOnceClose = () => {
     setShowOnceOpen(false);
     refresh();
@@ -420,13 +471,15 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
               />
               {!plaintextToken ? (
                 <Text fontSize='xs' color={muted}>
-                  Create a bootstrap token in step 1 to pre-fill the command;
-                  the secret is only available until you leave this step.
+                  Create a bootstrap token in step 1 first. The command never
+                  contains the token; the installer asks for it separately.
                 </Text>
               ) : (
                 <Text fontSize='xs' color={muted}>
-                  The command includes the one-time token. Run it now; the token
-                  is cleared from this page when you start waiting.
+                  The command does not include the token. The installer will
+                  prompt for it (hidden input); paste the token from step 1 at
+                  the prompt, or set the TOKENTIMER_AGENT_BOOTSTRAP_TOKEN
+                  environment variable before running.
                 </Text>
               )}
               <Button
@@ -616,8 +669,8 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
                 <AlertIcon />
                 <AlertDescription>
                   This token is shown only once and registers exactly one agent.
-                  Use it in the install command in step 2, or store it in your
-                  secret manager now.
+                  The installer will ask for it at a hidden prompt; copy it now,
+                  or store it in your secret manager.
                 </AlertDescription>
               </Alert>
               <CopyableCodeBlock
@@ -627,8 +680,8 @@ export default function DeployAgentPanel({ onAgentRegistered }) {
                 monospace
               />
               <Text fontSize='xs' color={muted}>
-                Closing this dialog keeps the token pre-filled in the step 2
-                install command until you start waiting for the agent.
+                The install command in step 2 does not contain the token. Paste
+                the token at the installer prompt when asked.
               </Text>
             </VStack>
           </ModalBody>

--- a/apps/dashboard/src/components/certops/DeployAgentPanel.jsx
+++ b/apps/dashboard/src/components/certops/DeployAgentPanel.jsx
@@ -1,0 +1,685 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Code,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  HStack,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Stack,
+  Text,
+  useColorModeValue,
+  VStack,
+} from '@chakra-ui/react';
+import CopyableCodeBlock from '../CopyableCodeBlock.jsx';
+import { DashboardErrorAlert } from '../DashboardPrimitives.jsx';
+import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
+import { showError, showSuccess } from '../../utils/toast.js';
+import {
+  AGENT_BOOTSTRAP_TOKEN_NAME_MAX_LENGTH,
+  buildInstallCommand,
+  createBootstrapToken,
+  listAgents,
+  revokeBootstrapToken,
+} from './certopsAgentsApi.js';
+import { formatDate } from './certopsFormat';
+import { useCertOpsCanManage } from './useCertOps.js';
+import { useCertOpsBootstrapTokens } from './useCertOpsAgents.js';
+
+const TOKEN_STATUS_SCHEME = {
+  active: 'green',
+  used: 'blue',
+  revoked: 'red',
+  expired: 'orange',
+};
+
+/** Poll cadence while waiting for the freshly installed agent to register. */
+const WAIT_POLL_INTERVAL_MS = 10000;
+
+function displayTokenStatus(token) {
+  const status = String(token?.status || '').toLowerCase();
+  if (status && status !== 'active') return status;
+  if (token?.expiresAt) {
+    const expires = new Date(token.expiresAt);
+    if (!Number.isNaN(expires.getTime()) && expires.getTime() < Date.now()) {
+      return 'expired';
+    }
+  }
+  return status || 'active';
+}
+
+function toIsoExpiry(localValue) {
+  if (!localValue) return null;
+  const date = new Date(localValue);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function localDatetimeValue(date) {
+  const pad = n => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function nowLocalDatetimeValue() {
+  return localDatetimeValue(new Date());
+}
+
+/** Default token expiry: 24 hours out (server requires expiry <= 30 days). */
+function defaultExpiryLocalValue() {
+  return localDatetimeValue(new Date(Date.now() + 24 * 60 * 60 * 1000));
+}
+
+function createErrorMessage(err) {
+  const code = err?.response?.data?.code;
+  const status = err?.response?.status;
+  if (status === 403 || code === 'INSUFFICIENT_ROLE') {
+    return 'You need workspace manager permission to create bootstrap tokens.';
+  }
+  if (code === 'CERTOPS_AGENT_BOOTSTRAP_TOKEN_NAME_INVALID') {
+    return 'Token name is invalid. Use a non-empty name up to 128 characters.';
+  }
+  if (
+    code === 'CERTOPS_AGENT_BOOTSTRAP_TOKEN_EXPIRY_INVALID' ||
+    code === 'CERTOPS_AGENT_BOOTSTRAP_TOKEN_INVALID'
+  ) {
+    return 'Expiry is invalid. Choose a future date within the next 30 days.';
+  }
+  return (
+    err?.response?.data?.error ||
+    err?.message ||
+    'Could not create bootstrap token.'
+  );
+}
+
+function revokeErrorMessage(err) {
+  const code = err?.response?.data?.code;
+  const status = err?.response?.status;
+  if (status === 403 || code === 'INSUFFICIENT_ROLE') {
+    return 'You need workspace manager permission to revoke bootstrap tokens.';
+  }
+  return (
+    err?.response?.data?.error ||
+    err?.message ||
+    'Could not revoke bootstrap token.'
+  );
+}
+
+/**
+ * Guided "Deploy an agent" flow:
+ *  1. create a bootstrap token (show-once secret, ApiTokenPanel pattern),
+ *  2. copy a pre-filled install command (CopyableCodeBlock),
+ *  3. wait for the agent to register (polls GET /certops/agents and compares
+ *     against the agent ids snapshotted when the wait started).
+ * Manager-gated: viewers see a read-only explainer, no token list or actions.
+ */
+export default function DeployAgentPanel({ onAgentRegistered }) {
+  const { workspaceId } = useWorkspace();
+  const canManage = useCertOpsCanManage();
+  const { enabled, tokens, loading, error, refresh } =
+    useCertOpsBootstrapTokens();
+
+  const [name, setName] = useState('');
+  const [expiresLocal, setExpiresLocal] = useState(defaultExpiryLocalValue());
+  const [creating, setCreating] = useState(false);
+  const [plaintextToken, setPlaintextToken] = useState('');
+  const [showOnceOpen, setShowOnceOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState(null);
+  const [revoking, setRevoking] = useState(false);
+  // 'idle' | 'waiting' | 'registered'
+  const [waitState, setWaitState] = useState('idle');
+  const [registeredAgent, setRegisteredAgent] = useState(null);
+  const knownAgentIdsRef = useRef(null);
+  const revokeCancelRef = useRef(null);
+
+  // Show-once secret and wait state are workspace-scoped: switching
+  // workspaces clears the secret from memory and aborts the wait.
+  const activeWorkspaceRef = useRef(workspaceId);
+  useEffect(() => {
+    activeWorkspaceRef.current = workspaceId;
+    setPlaintextToken('');
+    setShowOnceOpen(false);
+    setRevokeTarget(null);
+    setWaitState('idle');
+    setRegisteredAgent(null);
+    knownAgentIdsRef.current = null;
+  }, [workspaceId]);
+
+  // Poll the fleet while waiting; success when an agent id appears that was
+  // not in the snapshot taken when the wait started.
+  useEffect(() => {
+    if (waitState !== 'waiting' || !workspaceId) return undefined;
+    let cancelled = false;
+    const requestWorkspaceId = workspaceId;
+
+    const poll = async () => {
+      try {
+        const data = await listAgents(requestWorkspaceId);
+        if (cancelled || activeWorkspaceRef.current !== requestWorkspaceId) {
+          return;
+        }
+        const items = Array.isArray(data?.items) ? data.items : [];
+        if (knownAgentIdsRef.current === null) {
+          knownAgentIdsRef.current = new Set(items.map(agent => agent.id));
+          return;
+        }
+        const fresh = items.find(
+          agent =>
+            !knownAgentIdsRef.current.has(agent.id) &&
+            agent.status !== 'retired'
+        );
+        if (fresh) {
+          setRegisteredAgent(fresh);
+          setWaitState('registered');
+          showSuccess('Agent registered');
+          if (typeof onAgentRegistered === 'function') onAgentRegistered();
+        }
+      } catch (_) {
+        // Transient poll failures are silent; the next tick retries.
+      }
+    };
+
+    poll();
+    const timer = setInterval(poll, WAIT_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [waitState, workspaceId, onAgentRegistered]);
+
+  const muted = useColorModeValue('gray.600', 'gray.400');
+  const border = useColorModeValue('gray.200', 'gray.700');
+  const rowBg = useColorModeValue('gray.50', 'gray.800');
+  const infoBg = useColorModeValue('blue.50', 'blue.900');
+  const infoBorder = useColorModeValue('blue.200', 'blue.700');
+  const infoText = useColorModeValue('blue.800', 'blue.100');
+  const titleColor = useColorModeValue('gray.700', 'gray.200');
+  const successBg = useColorModeValue('green.50', 'green.900');
+  const successBorder = useColorModeValue('green.200', 'green.700');
+
+  if (enabled !== true) return null;
+
+  const expiresAtIso = toIsoExpiry(expiresLocal);
+  const expiryInPast =
+    Boolean(expiresAtIso) && new Date(expiresAtIso).getTime() <= Date.now();
+  const canSubmit =
+    Boolean(name.trim()) &&
+    Boolean(expiresAtIso) &&
+    !expiryInPast &&
+    !creating &&
+    Boolean(workspaceId);
+
+  const apiUrl =
+    typeof window !== 'undefined' && window.location
+      ? window.location.origin
+      : '';
+  const installCommand = buildInstallCommand({
+    apiUrl,
+    workspaceId: workspaceId || '<workspace-id>',
+    bootstrapToken: plaintextToken || null,
+  });
+
+  const beginWaiting = () => {
+    knownAgentIdsRef.current = null;
+    setRegisteredAgent(null);
+    setPlaintextToken('');
+    setWaitState('waiting');
+  };
+
+  const handleCreate = async () => {
+    if (!canSubmit) return;
+    const requestWorkspaceId = workspaceId;
+    setCreating(true);
+    try {
+      const result = await createBootstrapToken(requestWorkspaceId, {
+        name: name.trim(),
+        expiresAt: expiresAtIso,
+      });
+      if (activeWorkspaceRef.current !== requestWorkspaceId) return;
+      // Only enter the show-once flow when the response carries the secret;
+      // a success state without the token would be unrecoverable.
+      const plaintext =
+        typeof result?.plaintextToken === 'string'
+          ? result.plaintextToken.trim()
+          : '';
+      if (!plaintext) {
+        showError(
+          'Create failed',
+          'The server response did not include the token value. The token may have been created; check the list and revoke it if needed.'
+        );
+        refresh();
+        return;
+      }
+      setName('');
+      setExpiresLocal(defaultExpiryLocalValue());
+      setPlaintextToken(plaintext);
+      setShowOnceOpen(true);
+      showSuccess('Bootstrap token created');
+    } catch (err) {
+      if (activeWorkspaceRef.current !== requestWorkspaceId) return;
+      showError('Create failed', createErrorMessage(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // Keeps the plaintext in memory for the step-2 install command; it is
+  // cleared when the wait starts, on workspace switch, and on unmount.
+  const handleShowOnceClose = () => {
+    setShowOnceOpen(false);
+    refresh();
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget?.id || !workspaceId) return;
+    const requestWorkspaceId = workspaceId;
+    setRevoking(true);
+    try {
+      await revokeBootstrapToken(requestWorkspaceId, revokeTarget.id);
+      if (activeWorkspaceRef.current !== requestWorkspaceId) return;
+      showSuccess('Bootstrap token revoked');
+      setRevokeTarget(null);
+      refresh();
+    } catch (err) {
+      if (activeWorkspaceRef.current !== requestWorkspaceId) return;
+      showError('Revoke failed', revokeErrorMessage(err));
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <Stack spacing={4} align='stretch'>
+      <Box>
+        <Text fontSize='md' fontWeight='bold' color={titleColor} mb={1}>
+          Deploy an agent
+        </Text>
+        <Alert
+          status='info'
+          variant='subtle'
+          borderRadius='md'
+          bg={infoBg}
+          border='1px solid'
+          borderColor={infoBorder}
+          py={2}
+          px={3}
+        >
+          <AlertIcon boxSize={4} />
+          <AlertDescription fontSize='sm' color={infoText} lineHeight='short'>
+            Agents run on your infrastructure and connect outbound-only. Keys
+            never leave the agent host. Deploying takes three steps: create a
+            single-use bootstrap token, run the install command on the target
+            host, then wait for the agent to register.
+          </AlertDescription>
+        </Alert>
+      </Box>
+
+      {error ? <DashboardErrorAlert>{error}</DashboardErrorAlert> : null}
+
+      {!canManage ? (
+        <Text fontSize='sm' color={muted}>
+          Deploying agents requires workspace manager permission. Ask a
+          workspace manager to create a bootstrap token and install the agent.
+        </Text>
+      ) : (
+        <Stack spacing={4} align='stretch'>
+          <Box
+            border='1px solid'
+            borderColor={border}
+            borderRadius='12px'
+            p={{ base: 3.5, md: 4 }}
+          >
+            <Text fontSize='sm' fontWeight='semibold' color={titleColor} mb={3}>
+              Step 1: Create a bootstrap token
+            </Text>
+            <VStack align='stretch' spacing={4}>
+              <FormControl isRequired>
+                <FormLabel fontSize='sm'>Name</FormLabel>
+                <Input
+                  value={name}
+                  onChange={event => setName(event.target.value)}
+                  maxLength={AGENT_BOOTSTRAP_TOKEN_NAME_MAX_LENGTH}
+                  placeholder='e.g. dc1-edge-agent'
+                  size='sm'
+                />
+                <FormHelperText>
+                  Up to {AGENT_BOOTSTRAP_TOKEN_NAME_MAX_LENGTH} characters.
+                  Single-use: one token registers exactly one agent.
+                </FormHelperText>
+              </FormControl>
+
+              <FormControl isRequired isInvalid={expiryInPast}>
+                <FormLabel fontSize='sm'>Expires</FormLabel>
+                <Input
+                  type='datetime-local'
+                  value={expiresLocal}
+                  onChange={event => setExpiresLocal(event.target.value)}
+                  min={nowLocalDatetimeValue()}
+                  size='sm'
+                  maxW='280px'
+                />
+                <FormHelperText>
+                  {expiryInPast
+                    ? 'Expiry must be in the future.'
+                    : 'Required; at most 30 days out. Defaults to 24 hours.'}
+                </FormHelperText>
+              </FormControl>
+
+              <Button
+                colorScheme='blue'
+                size='sm'
+                alignSelf='flex-start'
+                onClick={handleCreate}
+                isDisabled={!canSubmit}
+                isLoading={creating}
+                loadingText='Creating'
+              >
+                Create bootstrap token
+              </Button>
+            </VStack>
+          </Box>
+
+          <Box
+            border='1px solid'
+            borderColor={border}
+            borderRadius='12px'
+            p={{ base: 3.5, md: 4 }}
+          >
+            <Text fontSize='sm' fontWeight='semibold' color={titleColor} mb={3}>
+              Step 2: Run the installer on the target host
+            </Text>
+            <VStack align='stretch' spacing={3}>
+              <Text fontSize='sm' color={muted}>
+                From the unpacked agent package directory (
+                <Code fontSize='xs'>packages/agent/scripts</Code>) on a Linux
+                host with Node 22+:
+              </Text>
+              <CopyableCodeBlock
+                code={installCommand}
+                label='Install command'
+                copyable
+                monospace
+              />
+              {!plaintextToken ? (
+                <Text fontSize='xs' color={muted}>
+                  Create a bootstrap token in step 1 to pre-fill the command;
+                  the secret is only available until you leave this step.
+                </Text>
+              ) : (
+                <Text fontSize='xs' color={muted}>
+                  The command includes the one-time token. Run it now; the token
+                  is cleared from this page when you start waiting.
+                </Text>
+              )}
+              <Button
+                size='sm'
+                alignSelf='flex-start'
+                colorScheme='blue'
+                variant='outline'
+                onClick={beginWaiting}
+                isDisabled={waitState === 'waiting'}
+              >
+                I ran the installer
+              </Button>
+            </VStack>
+          </Box>
+
+          {waitState === 'waiting' ? (
+            <Box
+              border='1px solid'
+              borderColor={border}
+              borderRadius='12px'
+              p={{ base: 3.5, md: 4 }}
+            >
+              <Text
+                fontSize='sm'
+                fontWeight='semibold'
+                color={titleColor}
+                mb={2}
+              >
+                Step 3: Waiting for the agent to register
+              </Text>
+              <HStack spacing={2} color={muted}>
+                <Spinner size='sm' />
+                <Text fontSize='sm'>
+                  Checking every {WAIT_POLL_INTERVAL_MS / 1000}s. The agent
+                  should appear within about a minute of the service starting.
+                </Text>
+              </HStack>
+              <Button
+                size='xs'
+                variant='ghost'
+                mt={3}
+                onClick={() => setWaitState('idle')}
+              >
+                Stop waiting
+              </Button>
+            </Box>
+          ) : null}
+
+          {waitState === 'registered' && registeredAgent ? (
+            <Box
+              border='1px solid'
+              borderColor={successBorder}
+              bg={successBg}
+              borderRadius='12px'
+              p={{ base: 3.5, md: 4 }}
+            >
+              <Text fontSize='sm' fontWeight='semibold' color={titleColor}>
+                Agent registered
+              </Text>
+              <Text fontSize='sm' color={muted} mt={1}>
+                {registeredAgent.name ||
+                  registeredAgent.hostname ||
+                  registeredAgent.agentId}{' '}
+                is now connected. Manage it in the Agent fleet panel.
+              </Text>
+              <Button
+                size='xs'
+                variant='outline'
+                mt={3}
+                onClick={() => setWaitState('idle')}
+              >
+                Deploy another agent
+              </Button>
+            </Box>
+          ) : null}
+
+          <Box>
+            <Text fontSize='sm' fontWeight='semibold' color={titleColor} mb={2}>
+              Bootstrap tokens
+            </Text>
+
+            {loading ? (
+              <HStack spacing={2} color={muted} py={3} justify='center'>
+                <Spinner size='sm' />
+                <Text fontSize='sm'>Loading bootstrap tokens...</Text>
+              </HStack>
+            ) : null}
+
+            {!loading && tokens.length === 0 ? (
+              <Text fontSize='sm' color={muted}>
+                No bootstrap tokens yet. Used and expired tokens also show up
+                here.
+              </Text>
+            ) : null}
+
+            {!loading && tokens.length > 0 ? (
+              <Stack spacing={2} align='stretch'>
+                {tokens.map(token => {
+                  const status = displayTokenStatus(token);
+                  const canRevoke = status === 'active';
+                  return (
+                    <Box
+                      key={token.id}
+                      border='1px solid'
+                      borderColor={border}
+                      borderRadius='12px'
+                      bg={rowBg}
+                      p={3}
+                    >
+                      <HStack
+                        justify='space-between'
+                        align='start'
+                        spacing={3}
+                        flexWrap='wrap'
+                      >
+                        <Box minW={0}>
+                          <Text
+                            fontSize='sm'
+                            fontWeight='semibold'
+                            noOfLines={1}
+                          >
+                            {token.name || 'Unnamed token'}
+                          </Text>
+                          <Code fontSize='xs' mt={1}>
+                            {token.tokenPrefix || '--'}
+                          </Code>
+                        </Box>
+                        <HStack spacing={2} flexShrink={0}>
+                          <Badge
+                            colorScheme={TOKEN_STATUS_SCHEME[status] || 'gray'}
+                            variant='subtle'
+                            textTransform='none'
+                          >
+                            {status}
+                          </Badge>
+                          {canRevoke ? (
+                            <Button
+                              size='xs'
+                              colorScheme='red'
+                              variant='outline'
+                              onClick={() => setRevokeTarget(token)}
+                            >
+                              Revoke
+                            </Button>
+                          ) : null}
+                        </HStack>
+                      </HStack>
+                      <HStack
+                        spacing={{ base: 3, md: 6 }}
+                        flexWrap='wrap'
+                        fontSize='xs'
+                        color={muted}
+                        mt={2}
+                      >
+                        <Text>Created {formatDate(token.createdAt)}</Text>
+                        <Text>
+                          Expires{' '}
+                          {token.expiresAt ? formatDate(token.expiresAt) : '--'}
+                        </Text>
+                        {token.usedAt ? (
+                          <Text>Used {formatDate(token.usedAt)}</Text>
+                        ) : null}
+                      </HStack>
+                    </Box>
+                  );
+                })}
+              </Stack>
+            ) : null}
+          </Box>
+        </Stack>
+      )}
+
+      <Modal
+        isOpen={showOnceOpen}
+        onClose={handleShowOnceClose}
+        closeOnOverlayClick={false}
+        closeOnEsc={false}
+        isCentered
+        size='lg'
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Bootstrap token created</ModalHeader>
+          <ModalBody>
+            <VStack align='stretch' spacing={4}>
+              <Alert status='warning' borderRadius='md' variant='left-accent'>
+                <AlertIcon />
+                <AlertDescription>
+                  This token is shown only once and registers exactly one agent.
+                  Use it in the install command in step 2, or store it in your
+                  secret manager now.
+                </AlertDescription>
+              </Alert>
+              <CopyableCodeBlock
+                code={plaintextToken}
+                label='Bootstrap token'
+                copyable
+                monospace
+              />
+              <Text fontSize='xs' color={muted}>
+                Closing this dialog keeps the token pre-filled in the step 2
+                install command until you start waiting for the agent.
+              </Text>
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme='blue' onClick={handleShowOnceClose}>
+              Continue to install
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <AlertDialog
+        isOpen={Boolean(revokeTarget)}
+        leastDestructiveRef={revokeCancelRef}
+        onClose={() => (revoking ? null : setRevokeTarget(null))}
+        isCentered
+      >
+        <AlertDialogOverlay />
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize='lg' fontWeight='bold'>
+            Revoke bootstrap token
+          </AlertDialogHeader>
+          <AlertDialogBody>
+            A revoked token can no longer register an agent. Agents that already
+            registered are unaffected. This cannot be undone.
+            {revokeTarget?.name ? (
+              <Text mt={3} fontSize='sm' color={muted}>
+                Token: {revokeTarget.name}
+              </Text>
+            ) : null}
+          </AlertDialogBody>
+          <AlertDialogFooter>
+            <Button
+              ref={revokeCancelRef}
+              onClick={() => setRevokeTarget(null)}
+              isDisabled={revoking}
+            >
+              Cancel
+            </Button>
+            <Button
+              colorScheme='red'
+              ml={3}
+              onClick={handleRevoke}
+              isLoading={revoking}
+              loadingText='Revoking'
+            >
+              Revoke
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Stack>
+  );
+}

--- a/apps/dashboard/src/components/certops/certopsAgentsApi.js
+++ b/apps/dashboard/src/components/certops/certopsAgentsApi.js
@@ -1,0 +1,115 @@
+import apiClient from '../../utils/apiClient';
+
+/**
+ * CertOps agent fleet + agent bootstrap-token helpers (session surface).
+ *
+ * Additive module scoped to `/api/v1/workspaces/:id/certops/agents*` and
+ * `/api/v1/workspaces/:id/certops/agent-bootstrap-tokens*`, following the
+ * certopsTokensApi.js style. All routes are manager-only server-side
+ * (403 INSUFFICIENT_ROLE) and return 404 while `certops.enabled` is off.
+ */
+
+export const AGENT_BOOTSTRAP_TOKEN_NAME_MAX_LENGTH = 128;
+
+/** Server-enforced maximum bootstrap-token TTL (30 days). */
+export const AGENT_BOOTSTRAP_TOKEN_MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Agent statuses reported by the fleet list. */
+export const CERTOPS_AGENT_STATUSES = ['active', 'offline', 'retired'];
+
+function workspaceBase(workspaceId) {
+  return `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/certops`;
+}
+
+/**
+ * List registered agents for a workspace.
+ * Items carry: id (row UUID used by retire), agentId, name, hostname,
+ * platform, agentVersion, protocolVersion, status (active/offline/retired),
+ * lastSeenAt, clockOffsetMs, createdAt, retiredAt, retireReason.
+ * @returns {Promise<{ items: object[] }>}
+ */
+export async function listAgents(workspaceId, { signal } = {}) {
+  const res = await apiClient.get(`${workspaceBase(workspaceId)}/agents`, {
+    signal,
+  });
+  return res.data;
+}
+
+/**
+ * Retire an agent (idempotent server-side). A non-forced retire is refused
+ * with 409 CERTOPS_AGENT_RETIRE_BLOCKED while the agent holds active job
+ * leases; pass `force: true` with a `reason` to override.
+ * @returns {Promise<{ agent: object }>}
+ */
+export async function retireAgent(
+  workspaceId,
+  agentRowId,
+  { force, reason } = {}
+) {
+  const body = {};
+  if (force) body.force = true;
+  if (reason) body.reason = reason;
+  const res = await apiClient.post(
+    `${workspaceBase(workspaceId)}/agents/${encodeURIComponent(agentRowId)}/retire`,
+    body
+  );
+  return res.data;
+}
+
+/**
+ * List agent bootstrap tokens (metadata only; the ttboot_ secret is never
+ * returned). Items carry: id, name, tokenPrefix, status
+ * (active/used/revoked/expired), expiresAt, usedAt, usedByAgentId,
+ * revokedAt, createdAt.
+ * @returns {Promise<{ items: object[] }>}
+ */
+export async function listBootstrapTokens(workspaceId, { signal } = {}) {
+  const res = await apiClient.get(
+    `${workspaceBase(workspaceId)}/agent-bootstrap-tokens`,
+    { signal }
+  );
+  return res.data;
+}
+
+/**
+ * Create an agent bootstrap token. `expiresAt` is required by the server
+ * (future, at most 30 days out). The plaintext ttboot_ secret is returned
+ * once in `plaintextToken` and cannot be retrieved again.
+ * @returns {Promise<{ token: object, plaintextToken: string }>}
+ */
+export async function createBootstrapToken(
+  workspaceId,
+  { name, expiresAt } = {}
+) {
+  const res = await apiClient.post(
+    `${workspaceBase(workspaceId)}/agent-bootstrap-tokens`,
+    { name, expiresAt }
+  );
+  return res.data;
+}
+
+/**
+ * Revoke an agent bootstrap token (idempotent server-side).
+ * @returns {Promise<{ token: object }>}
+ */
+export async function revokeBootstrapToken(workspaceId, tokenId) {
+  const res = await apiClient.post(
+    `${workspaceBase(workspaceId)}/agent-bootstrap-tokens/${encodeURIComponent(tokenId)}/revoke`
+  );
+  return res.data;
+}
+
+/**
+ * Builds the copy-paste install command shown by the Deploy an agent panel.
+ * The bootstrap token travels via env var (not a flag) so it stays out of
+ * shell history-expanded argv examples and process listings.
+ */
+export function buildInstallCommand({ apiUrl, workspaceId, bootstrapToken }) {
+  const token = bootstrapToken || '<paste bootstrap token>';
+  return [
+    `sudo TOKENTIMER_AGENT_BOOTSTRAP_TOKEN='${token}' \\`,
+    `  ./install-agent.sh \\`,
+    `  --api-url '${apiUrl}' \\`,
+    `  --workspace-id '${workspaceId}'`,
+  ].join('\n');
+}

--- a/apps/dashboard/src/components/certops/useCertOpsAgents.js
+++ b/apps/dashboard/src/components/certops/useCertOpsAgents.js
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
+import { listAgents, listBootstrapTokens } from './certopsAgentsApi';
+import { useCertOpsCanManage, useCertOpsEnabled } from './useCertOps.js';
+
+/**
+ * Loads the CertOps agent fleet for the active workspace.
+ *
+ * Same gating pattern as useCertOpsApiTokens: skipped without a workspace,
+ * while `certops.enabled !== true`, or for non-managers (the endpoint is
+ * manager-only server-side, so viewers get an empty state instead of a 403
+ * banner). Retire is called imperatively via certopsAgentsApi from the panel.
+ *
+ * @returns {{ enabled: boolean|null, agents: object[], loading: boolean, error: string, refresh: function }}
+ */
+export function useCertOpsAgents() {
+  const { workspaceId } = useWorkspace();
+  const enabled = useCertOpsEnabled();
+  const canManage = useCertOpsCanManage();
+  const [agents, setAgents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadTick(tick => tick + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceId || enabled !== true || !canManage) {
+      setAgents([]);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError('');
+
+    listAgents(workspaceId, { signal: controller.signal })
+      .then(data => {
+        if (!cancelled) {
+          setAgents(Array.isArray(data?.items) ? data.items : []);
+        }
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setAgents([]);
+        setError(
+          err?.response?.data?.error ||
+            err?.message ||
+            'Could not load certificate operations agents.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [workspaceId, enabled, canManage, reloadTick]);
+
+  return { enabled, agents, loading, error, refresh };
+}
+
+/**
+ * Loads agent bootstrap-token metadata for the active workspace (read-only;
+ * the ttboot_ secret is only ever returned once at creation). Create/revoke
+ * are called imperatively via certopsAgentsApi from the panel.
+ *
+ * Manager-gated exactly like useCertOpsAgents.
+ *
+ * @returns {{ enabled: boolean|null, tokens: object[], loading: boolean, error: string, refresh: function }}
+ */
+export function useCertOpsBootstrapTokens() {
+  const { workspaceId } = useWorkspace();
+  const enabled = useCertOpsEnabled();
+  const canManage = useCertOpsCanManage();
+  const [tokens, setTokens] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadTick(tick => tick + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceId || enabled !== true || !canManage) {
+      setTokens([]);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError('');
+
+    listBootstrapTokens(workspaceId, { signal: controller.signal })
+      .then(data => {
+        if (!cancelled) {
+          setTokens(Array.isArray(data?.items) ? data.items : []);
+        }
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setTokens([]);
+        setError(
+          err?.response?.data?.error ||
+            err?.message ||
+            'Could not load agent bootstrap tokens.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [workspaceId, enabled, canManage, reloadTick]);
+
+  return { enabled, tokens, loading, error, refresh };
+}

--- a/apps/dashboard/src/pages/certops/CertOpsOperations.jsx
+++ b/apps/dashboard/src/pages/certops/CertOpsOperations.jsx
@@ -30,6 +30,8 @@ import DashboardShell from '../../components/DashboardShell';
 import { useDashboardShellProps } from '../../hooks/useDashboardShellProps';
 import SEO from '../../components/SEO.jsx';
 import ApiTokenPanel from '../../components/certops/ApiTokenPanel.jsx';
+import AgentFleetPanel from '../../components/certops/AgentFleetPanel.jsx';
+import DeployAgentPanel from '../../components/certops/DeployAgentPanel.jsx';
 import EvidenceTimeline from '../../components/certops/EvidenceTimeline.jsx';
 import JobStatusBadge from '../../components/certops/JobStatusBadge.jsx';
 import {
@@ -431,6 +433,12 @@ export default function CertOpsOperations({
                 <ExecutorJobsPanel />
                 <DashboardPanel>
                   <ApiTokenPanel />
+                </DashboardPanel>
+                <DashboardPanel>
+                  <DeployAgentPanel />
+                </DashboardPanel>
+                <DashboardPanel>
+                  <AgentFleetPanel />
                 </DashboardPanel>
               </SimpleGrid>
             ) : (

--- a/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
+++ b/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import AgentFleetPanel from '../../src/components/certops/AgentFleetPanel.jsx';
+
+const {
+  useWorkspaceMock,
+  useCertOpsCanManageMock,
+  useCertOpsAgentsMock,
+  retireAgentMock,
+} = vi.hoisted(() => ({
+  useWorkspaceMock: vi.fn(),
+  useCertOpsCanManageMock: vi.fn(),
+  useCertOpsAgentsMock: vi.fn(),
+  retireAgentMock: vi.fn(),
+}));
+
+vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
+  useWorkspace: useWorkspaceMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOps.js', () => ({
+  useCertOpsCanManage: useCertOpsCanManageMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
+  useCertOpsAgents: useCertOpsAgentsMock,
+}));
+
+vi.mock('../../src/components/certops/certopsAgentsApi.js', async () => {
+  const actual = await vi.importActual(
+    '../../src/components/certops/certopsAgentsApi.js'
+  );
+  return {
+    ...actual,
+    retireAgent: retireAgentMock,
+  };
+});
+
+function renderWithProviders(ui) {
+  return render(
+    <ChakraProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+function agentsState(overrides = {}) {
+  return {
+    enabled: true,
+    agents: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+function sampleAgents() {
+  return [
+    {
+      id: 'row-1',
+      agentId: 'agent-active-1',
+      name: 'dc1-edge',
+      hostname: 'edge01',
+      status: 'active',
+      agentVersion: '1.2.3',
+      lastSeenAt: new Date(Date.now() - 60000).toISOString(),
+    },
+    {
+      id: 'row-2',
+      agentId: 'agent-offline-1',
+      name: 'dc2-core',
+      hostname: 'core01',
+      status: 'offline',
+      agentVersion: '1.2.0',
+      lastSeenAt: new Date(Date.now() - 3600000).toISOString(),
+    },
+    {
+      id: 'row-3',
+      agentId: 'agent-retired-1',
+      name: 'old-agent',
+      hostname: 'old01',
+      status: 'retired',
+      agentVersion: '1.0.0',
+      lastSeenAt: null,
+      retiredAt: new Date().toISOString(),
+    },
+  ];
+}
+
+describe('AgentFleetPanel', () => {
+  beforeEach(() => {
+    useWorkspaceMock.mockReset();
+    useCertOpsCanManageMock.mockReset();
+    useCertOpsAgentsMock.mockReset();
+    retireAgentMock.mockReset();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+  });
+
+  it('renders nothing while CertOps availability is unresolved or disabled', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(agentsState({ enabled: false }));
+
+    const { container } = renderWithProviders(<AgentFleetPanel />);
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows an empty state pointing to the Deploy an agent panel', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(agentsState());
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(screen.getByText('No agents yet.')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Use the Deploy an agent panel on this page/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders agents with status badges, version and heartbeat, retire only on non-retired rows', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(screen.getByText('dc1-edge')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+    expect(screen.getByText('Retired')).toBeInTheDocument();
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    // Active + offline are retirable, the retired agent is not.
+    expect(screen.getAllByRole('button', { name: 'Retire' })).toHaveLength(2);
+  });
+
+  it('hides the actions column for a non-manager viewer', () => {
+    useCertOpsCanManageMock.mockReturnValue(false);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Retire' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('retires an agent through the confirm modal and refreshes', async () => {
+    const refresh = vi.fn();
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents(), refresh })
+    );
+    retireAgentMock.mockResolvedValue({
+      agent: { id: 'row-1', status: 'retired' },
+    });
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Retire' })[0]);
+    expect(
+      await screen.findByText(/can no longer connect or lease jobs/)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Retire agent' }));
+
+    await waitFor(() => {
+      expect(retireAgentMock).toHaveBeenCalledWith('ws-1', 'row-1', {
+        force: false,
+        reason: undefined,
+      });
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it('surfaces the force option when the retire is blocked by leased jobs', async () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+    retireAgentMock
+      .mockRejectedValueOnce({
+        response: {
+          status: 409,
+          data: { code: 'CERTOPS_AGENT_RETIRE_BLOCKED' },
+        },
+      })
+      .mockResolvedValue({ agent: { id: 'row-1', status: 'retired' } });
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Retire' })[0]);
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Retire agent' })
+    );
+
+    expect(
+      await screen.findByText(/still holds active job leases/)
+    ).toBeInTheDocument();
+
+    // Force requires a reason before the confirm button enables again.
+    fireEvent.click(screen.getByRole('checkbox'));
+    const forceButton = screen.getByRole('button', { name: 'Force retire' });
+    expect(forceButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. host decommissioned'), {
+      target: { value: 'host is gone' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Force retire' }));
+
+    await waitFor(() => {
+      expect(retireAgentMock).toHaveBeenLastCalledWith('ws-1', 'row-1', {
+        force: true,
+        reason: 'host is gone',
+      });
+    });
+  });
+});

--- a/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
+++ b/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
@@ -67,6 +67,10 @@ function sampleAgents() {
       hostname: 'edge01',
       status: 'active',
       agentVersion: '1.2.3',
+      protocolVersion: 2,
+      clockOffsetMs: 120,
+      ntpSynced: true,
+      pinnedSigningKeyId: 'ttsk_0123456789abcdef',
       lastSeenAt: new Date(Date.now() - 60000).toISOString(),
     },
     {
@@ -76,6 +80,10 @@ function sampleAgents() {
       hostname: 'core01',
       status: 'offline',
       agentVersion: '1.2.0',
+      protocolVersion: 1,
+      clockOffsetMs: -8200,
+      ntpSynced: false,
+      pinnedSigningKeyId: null,
       lastSeenAt: new Date(Date.now() - 3600000).toISOString(),
     },
     {
@@ -85,6 +93,10 @@ function sampleAgents() {
       hostname: 'old01',
       status: 'retired',
       agentVersion: '1.0.0',
+      protocolVersion: null,
+      clockOffsetMs: null,
+      ntpSynced: null,
+      pinnedSigningKeyId: null,
       lastSeenAt: null,
       retiredAt: new Date().toISOString(),
     },
@@ -136,6 +148,57 @@ describe('AgentFleetPanel', () => {
     expect(screen.getByText('1.2.3')).toBeInTheDocument();
     // Active + offline are retirable, the retired agent is not.
     expect(screen.getAllByRole('button', { name: 'Retire' })).toHaveLength(2);
+  });
+
+  it('renders protocol version and clock drift columns, flagging large offsets', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Protocol' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Clock drift' })
+    ).toBeInTheDocument();
+
+    // Protocol versions per row; the retired agent has none.
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    // Signed offsets; only the |offset| > 5000ms row is flagged.
+    expect(screen.getByText('+120 ms')).toBeInTheDocument();
+    expect(screen.getByText('-8200 ms')).toBeInTheDocument();
+    expect(screen.getAllByText('Drift')).toHaveLength(1);
+
+    // Unknown protocol/offset render as placeholders on the retired row.
+    expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders NTP sync state and pinned signing key columns', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'NTP' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Signing key' })
+    ).toBeInTheDocument();
+
+    // One synced, one unsynced, and the retired row's unknown placeholder.
+    expect(screen.getByText('Synced')).toBeInTheDocument();
+    expect(screen.getByText('Not synced')).toBeInTheDocument();
+
+    // Signing key ids are shortened for display.
+    expect(screen.getByText('ttsk_0123456...')).toBeInTheDocument();
   });
 
   it('hides the actions column for a non-manager viewer', () => {

--- a/apps/dashboard/tests/unit/CertOpsOperations.test.jsx
+++ b/apps/dashboard/tests/unit/CertOpsOperations.test.jsx
@@ -88,6 +88,26 @@ vi.mock('../../src/components/certops/useCertOpsJobs.js', () => ({
   }),
 }));
 
+// The agent panels have their own dedicated unit tests; here they only need
+// stable hook returns so the page renders. `enabled: false` makes them
+// render null, keeping these page-level assertions focused on jobs/tokens.
+vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
+  useCertOpsAgents: () => ({
+    enabled: false,
+    agents: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+  }),
+  useCertOpsBootstrapTokens: () => ({
+    enabled: false,
+    tokens: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+  }),
+}));
+
 function renderWithProviders(ui) {
   return render(
     <ChakraProvider>

--- a/apps/dashboard/tests/unit/DeployAgentPanel.test.jsx
+++ b/apps/dashboard/tests/unit/DeployAgentPanel.test.jsx
@@ -9,6 +9,7 @@ const {
   useWorkspaceMock,
   useCertOpsCanManageMock,
   useCertOpsBootstrapTokensMock,
+  useCertOpsAgentsMock,
   createBootstrapTokenMock,
   revokeBootstrapTokenMock,
   listAgentsMock,
@@ -16,6 +17,7 @@ const {
   useWorkspaceMock: vi.fn(),
   useCertOpsCanManageMock: vi.fn(),
   useCertOpsBootstrapTokensMock: vi.fn(),
+  useCertOpsAgentsMock: vi.fn(),
   createBootstrapTokenMock: vi.fn(),
   revokeBootstrapTokenMock: vi.fn(),
   listAgentsMock: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock('../../src/components/certops/useCertOps.js', () => ({
 
 vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
   useCertOpsBootstrapTokens: useCertOpsBootstrapTokensMock,
+  useCertOpsAgents: useCertOpsAgentsMock,
 }));
 
 vi.mock('../../src/components/certops/certopsAgentsApi.js', async () => {
@@ -64,15 +67,40 @@ function tokensState(overrides = {}) {
   };
 }
 
+function agentsState(overrides = {}) {
+  return {
+    enabled: true,
+    agents: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Runs the step-1 flow: fill the name, create the token, close the modal. */
+async function createTokenAndCloseModal() {
+  fireEvent.change(screen.getByLabelText(/^Name/), {
+    target: { value: 'dc1-edge' },
+  });
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Create bootstrap token' })
+  );
+  await screen.findByText(/shown only once and registers exactly one agent/);
+  fireEvent.click(screen.getByRole('button', { name: 'Continue to install' }));
+}
+
 describe('DeployAgentPanel', () => {
   beforeEach(() => {
     useWorkspaceMock.mockReset();
     useCertOpsCanManageMock.mockReset();
     useCertOpsBootstrapTokensMock.mockReset();
+    useCertOpsAgentsMock.mockReset();
     createBootstrapTokenMock.mockReset();
     revokeBootstrapTokenMock.mockReset();
     listAgentsMock.mockReset();
     useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    useCertOpsAgentsMock.mockReturnValue(agentsState());
     listAgentsMock.mockResolvedValue({ items: [] });
   });
 
@@ -121,7 +149,7 @@ describe('DeployAgentPanel', () => {
     expect(screen.getByText(/install-agent\.sh/)).toBeInTheDocument();
   });
 
-  it('creates a token and shows the one-time secret, then pre-fills the install command', async () => {
+  it('creates a token, shows the one-time secret, and keeps it out of the install command', async () => {
     useCertOpsCanManageMock.mockReturnValue(true);
     useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
     createBootstrapTokenMock.mockResolvedValue({
@@ -149,13 +177,103 @@ describe('DeployAgentPanel', () => {
     expect(
       await screen.findByText(/shown only once and registers exactly one agent/)
     ).toBeInTheDocument();
-    // Secret in show-once modal and pre-filled into the install command.
-    expect(screen.getAllByText(/ttboot_secret_value/).length).toBeGreaterThan(
-      0
+    // Secret appears only in the show-once display, never in the command.
+    expect(screen.getAllByText(/ttboot_secret_value/)).toHaveLength(1);
+
+    const commandBlock = screen.getByText(/install-agent\.sh/);
+    expect(commandBlock.textContent).toContain('--api-url');
+    expect(commandBlock.textContent).toContain("--workspace-id 'ws-1'");
+    expect(commandBlock.textContent).not.toContain('ttboot_secret_value');
+    expect(commandBlock.textContent).not.toContain('--bootstrap-token');
+    expect(commandBlock.textContent).not.toContain(
+      'TOKENTIMER_AGENT_BOOTSTRAP_TOKEN='
     );
+
+    // Helper text explains the installer's hidden token prompt.
+    expect(
+      screen.getByText(/installer will prompt for it \(hidden input\)/)
+    ).toBeInTheDocument();
   });
 
-  it('starts waiting after the installer step and reports a newly registered agent', async () => {
+  it('detects an agent that registered before the first poll via the token-creation baseline', async () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+    // Fleet already loaded in the panel when the token is created.
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({
+        agents: [{ id: 'row-existing', agentId: 'agent-existing' }],
+      })
+    );
+    createBootstrapTokenMock.mockResolvedValue({
+      token: { id: 'bt-1', name: 'dc1-edge' },
+      plaintextToken: 'ttboot_secret_value',
+    });
+    // The new agent registered between token creation and the first poll:
+    // it must be reported on the very first tick, not treated as baseline.
+    listAgentsMock.mockResolvedValue({
+      items: [
+        {
+          id: 'row-existing',
+          agentId: 'agent-existing',
+          name: 'old-agent',
+          status: 'active',
+          createdAt: new Date(Date.now() - 3600000).toISOString(),
+        },
+        {
+          id: 'row-new',
+          agentId: 'agent-new',
+          name: 'dc1-edge',
+          status: 'active',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    await createTokenAndCloseModal();
+    fireEvent.click(screen.getByRole('button', { name: 'I ran the installer' }));
+
+    expect(await screen.findByText(/is now connected/)).toBeInTheDocument();
+    expect(listAgentsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/dc1-edge/)).toBeInTheDocument();
+  });
+
+  it('detects a new agent by registration timestamp even when its id is in a stale baseline', async () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+    // Baseline (stale) already contains the row id of the agent that will
+    // register; detection must fall through to the timestamp comparison.
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: [{ id: 'row-1', agentId: 'agent-1' }] })
+    );
+    createBootstrapTokenMock.mockResolvedValue({
+      token: { id: 'bt-1', name: 'dc1-edge' },
+      plaintextToken: 'ttboot_secret_value',
+    });
+    listAgentsMock.mockResolvedValue({
+      items: [
+        {
+          id: 'row-1',
+          agentId: 'agent-1',
+          name: 'dc1-edge',
+          status: 'active',
+          // Registered after token creation (clock-safe margin).
+          createdAt: new Date(Date.now() + 60000).toISOString(),
+        },
+      ],
+    });
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    await createTokenAndCloseModal();
+    fireEvent.click(screen.getByRole('button', { name: 'I ran the installer' }));
+
+    expect(await screen.findByText(/is now connected/)).toBeInTheDocument();
+    expect(screen.getByText(/dc1-edge/)).toBeInTheDocument();
+  });
+
+  it('falls back to a first-tick snapshot when waiting starts without a token created', async () => {
     useCertOpsCanManageMock.mockReturnValue(true);
     useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
     // First poll snapshots the fleet; second poll returns the new agent.

--- a/apps/dashboard/tests/unit/DeployAgentPanel.test.jsx
+++ b/apps/dashboard/tests/unit/DeployAgentPanel.test.jsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import DeployAgentPanel from '../../src/components/certops/DeployAgentPanel.jsx';
+
+const {
+  useWorkspaceMock,
+  useCertOpsCanManageMock,
+  useCertOpsBootstrapTokensMock,
+  createBootstrapTokenMock,
+  revokeBootstrapTokenMock,
+  listAgentsMock,
+} = vi.hoisted(() => ({
+  useWorkspaceMock: vi.fn(),
+  useCertOpsCanManageMock: vi.fn(),
+  useCertOpsBootstrapTokensMock: vi.fn(),
+  createBootstrapTokenMock: vi.fn(),
+  revokeBootstrapTokenMock: vi.fn(),
+  listAgentsMock: vi.fn(),
+}));
+
+vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
+  useWorkspace: useWorkspaceMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOps.js', () => ({
+  useCertOpsCanManage: useCertOpsCanManageMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
+  useCertOpsBootstrapTokens: useCertOpsBootstrapTokensMock,
+}));
+
+vi.mock('../../src/components/certops/certopsAgentsApi.js', async () => {
+  const actual = await vi.importActual(
+    '../../src/components/certops/certopsAgentsApi.js'
+  );
+  return {
+    ...actual,
+    createBootstrapToken: createBootstrapTokenMock,
+    revokeBootstrapToken: revokeBootstrapTokenMock,
+    listAgents: listAgentsMock,
+  };
+});
+
+function renderWithProviders(ui) {
+  return render(
+    <ChakraProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+function tokensState(overrides = {}) {
+  return {
+    enabled: true,
+    tokens: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('DeployAgentPanel', () => {
+  beforeEach(() => {
+    useWorkspaceMock.mockReset();
+    useCertOpsCanManageMock.mockReset();
+    useCertOpsBootstrapTokensMock.mockReset();
+    createBootstrapTokenMock.mockReset();
+    revokeBootstrapTokenMock.mockReset();
+    listAgentsMock.mockReset();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    listAgentsMock.mockResolvedValue({ items: [] });
+  });
+
+  it('renders nothing while CertOps availability is unresolved or disabled', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(
+      tokensState({ enabled: false })
+    );
+
+    const { container } = renderWithProviders(<DeployAgentPanel />);
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows a read-only explainer without the deploy steps for a viewer', () => {
+    useCertOpsCanManageMock.mockReturnValue(false);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    expect(
+      screen.getByText(/requires workspace manager permission/)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Create bootstrap token' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Step 2: Run the installer on the target host')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the guided steps with accessible labels for a manager', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    expect(
+      screen.getByText('Step 1: Create a bootstrap token')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Expires/)).toBeInTheDocument();
+    expect(
+      screen.getByText('Step 2: Run the installer on the target host')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/install-agent\.sh/)).toBeInTheDocument();
+  });
+
+  it('creates a token and shows the one-time secret, then pre-fills the install command', async () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+    createBootstrapTokenMock.mockResolvedValue({
+      token: { id: 'bt-1', name: 'dc1-edge' },
+      plaintextToken: 'ttboot_secret_value',
+    });
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    fireEvent.change(screen.getByLabelText(/^Name/), {
+      target: { value: 'dc1-edge' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Create bootstrap token' })
+    );
+
+    await waitFor(() => {
+      expect(createBootstrapTokenMock).toHaveBeenCalledTimes(1);
+    });
+    const [wsArg, payload] = createBootstrapTokenMock.mock.calls[0];
+    expect(wsArg).toBe('ws-1');
+    expect(payload.name).toBe('dc1-edge');
+    expect(typeof payload.expiresAt).toBe('string');
+
+    expect(
+      await screen.findByText(/shown only once and registers exactly one agent/)
+    ).toBeInTheDocument();
+    // Secret in show-once modal and pre-filled into the install command.
+    expect(screen.getAllByText(/ttboot_secret_value/).length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('starts waiting after the installer step and reports a newly registered agent', async () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(tokensState());
+    // First poll snapshots the fleet; second poll returns the new agent.
+    listAgentsMock.mockResolvedValueOnce({ items: [] }).mockResolvedValue({
+      items: [
+        {
+          id: 'row-1',
+          agentId: 'agent-1',
+          name: 'dc1-edge',
+          status: 'active',
+        },
+      ],
+    });
+    vi.useFakeTimers();
+
+    try {
+      renderWithProviders(<DeployAgentPanel />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'I ran the installer' })
+      );
+
+      expect(
+        screen.getByText('Step 3: Waiting for the agent to register')
+      ).toBeInTheDocument();
+
+      // Snapshot poll, then the tick that finds the new agent.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(10000);
+
+      expect(screen.getByText(/is now connected/)).toBeInTheDocument();
+      expect(screen.getByText(/dc1-edge/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lists bootstrap tokens and revokes an active one', async () => {
+    const refresh = vi.fn();
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsBootstrapTokensMock.mockReturnValue(
+      tokensState({
+        refresh,
+        tokens: [
+          {
+            id: 'bt-1',
+            name: 'active-token',
+            tokenPrefix: 'ttboot_abc',
+            status: 'active',
+            expiresAt: new Date(Date.now() + 3600000).toISOString(),
+            createdAt: new Date().toISOString(),
+          },
+          {
+            id: 'bt-2',
+            name: 'used-token',
+            tokenPrefix: 'ttboot_def',
+            status: 'used',
+            usedAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      })
+    );
+    revokeBootstrapTokenMock.mockResolvedValue({ token: { id: 'bt-1' } });
+
+    renderWithProviders(<DeployAgentPanel />);
+
+    expect(screen.getByText('active-token')).toBeInTheDocument();
+    expect(screen.getByText('used-token')).toBeInTheDocument();
+    // Only the active token can be revoked.
+    const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' });
+    expect(revokeButtons).toHaveLength(1);
+
+    fireEvent.click(revokeButtons[0]);
+    expect(
+      await screen.findByText('Revoke bootstrap token')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Revoke' }).at(-1));
+
+    await waitFor(() => {
+      expect(revokeBootstrapTokenMock).toHaveBeenCalledWith('ws-1', 'bt-1');
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/certops/CONTEXT.md
+++ b/docs/certops/CONTEXT.md
@@ -29,9 +29,12 @@ never holds customer key material. See ADR-0003.
 
 - **Control plane** - Core/Cloud/Enterprise backend and dashboard. Observes,
   plans, signs jobs, records evidence. Holds no private keys.
-- **Execution plane** - the TokenTimer **agent** and the customer-side
-  Kubernetes controller. A future agent may perform key-bearing work locally.
-  The cert-manager controller never handles a key: it asks cert-manager to reconcile a
+- **Execution plane** - the TokenTimer **agent** (`packages/agent`) and the customer-side
+  Kubernetes controller. The agent performs the key-bearing work locally:
+  keypair/CSR generation, ACME issuance (native HTTP-01/DNS-01 solvers plus
+  certbot/acme.sh exec adapters), atomic deploy/rollback, and service reload.
+  Its keys, DNS provider credentials, and ACME account keys never leave the
+  agent host. The cert-manager controller never handles a key: it asks cert-manager to reconcile a
   `Certificate`, and cert-manager generates and retains the key in Kubernetes.
 
 Execution-plane components are **outbound-only**: they call the control plane.
@@ -86,6 +89,17 @@ the shared detector scans every outbound envelope.
 - **Agent-local policy** - allowlists (commands, paths, CA endpoints, DNS
   zones/providers) the agent enforces locally. Local policy wins over
   control-plane intent; rejections are reported as evidence. See ADR-0002.
+- **Sequence** - optional per-agent monotonic message counter stamped on
+  protocol envelopes and enforced server-side (compare-and-swap on
+  `certops_agents.last_sequence`, 409 on regression, generation reset on
+  re-register). Defense in depth over the nonce replay cache.
+- **Per-CA cap** - sweep-time limit on in-flight renewal jobs per
+  `caEndpoint` (`CERTOPS_RENEWAL_PER_CA_CAP`) so the scheduler cannot flood
+  one CA; skipped certificates are reported in the sweep summary and picked
+  up by later sweeps.
+- **Bulk renew** - `POST .../certops/jobs/bulk-renew`: many certificates
+  through the same creation path as single renew (validation, approval
+  gates, kill switch identical) with a per-item partial-failure envelope.
 
 ## Dashboard certificate visibility (D6)
 
@@ -99,7 +113,9 @@ rather than adding a parallel inventory page. See ADR-0006.
 - **CertOps section** - orchestration only (agents, jobs, evidence,
   approvals), not a second certificate list. It ships
   `/certops/operations` (executor jobs, evidence timelines, machine API
-  tokens) mounted via the `/certops/*` splat route. No nav entry: it is
+  tokens, the Deploy-an-agent panel with the show-once bootstrap token and
+  install command, and the Agent fleet panel with status/heartbeat/retire)
+  mounted via the `/certops/*` splat route. No nav entry: it is
   reached from the Control Center certificate-operations panel footer link
   and from a Workspace Preferences entry (last section, shown only when
   `certops.enabled` is on).

--- a/docs/certops/agent.md
+++ b/docs/certops/agent.md
@@ -107,6 +107,7 @@ Top level:
 | `discovery` | object or null | null | Null disables discovery entirely. |
 | `execution` | object or null | null | Null is treated as `{ enabled: false }` (observe-only mode). |
 | `caBundlePath` | string or null | null | Path to a PEM CA bundle trusted for the agent-to-control-plane HTTPS channel (private-CA control planes). Env override: `TOKENTIMER_AGENT_CA_BUNDLE`. Fail-loud at startup: a missing/unreadable file, a file without a `BEGIN CERTIFICATE` block, or a file containing private key material aborts before any network call. When set, the bundle replaces the default trust store for control-plane requests (it does not extend it); plain `http` URLs are unaffected. When unset, the OS trust store applies (`NODE_EXTRA_CA_CERTS` remains a coarser process-wide alternative). |
+| `dnsProviders` | object or null | null | Native DNS-01 solver configuration (see "DNS-01 providers" in section 5). Maps provider id to `{ credentialsFile: <absolute path>, ...non-secret options }`, plus a reserved `zoneProviderMap` key (zone to provider id). Credentials never live in `config.json`, only the path to a 0600 credentials file does. Fail-loud validation: unknown provider ids, relative paths, and `zoneProviderMap` entries naming unconfigured providers abort startup. |
 
 `policy` block (deep validation in `src/policy/loadPolicyConfig`, fail-loud):
 
@@ -151,8 +152,21 @@ routes (`src/protocol/index.js` `ROUTES`):
 Result and evidence share one route; the envelope's `messageType`
 disambiguates server-side. Every envelope carries `schemaVersion` (1),
 `protocolVersion`, `messageType`, `agentId`, `sentAt`, and optionally
-`workspaceId` and `clockOffsetMs`. Messages must never carry private key
-material (schema-level rule, enforced again by the evidence builder).
+`workspaceId`, `clockOffsetMs`, and `sequence`. Messages must never carry
+private key material (schema-level rule, enforced again by the evidence
+builder).
+
+Message sequence: the protocol client stamps every outbound envelope with
+`sequence`, a per-agent monotonically increasing counter, and the control
+plane rejects any message whose sequence does not exceed the last accepted
+one for that agent (HTTP 409, code `CERTOPS_AGENT_SEQUENCE_REGRESSION`).
+This is defense in depth on top of the single-use nonce replay ledger. The
+counter is not persisted: a restart begins at 1 again, which is safe because
+a successful `register` starts a new generation (the server resets its
+high-water mark to the register envelope's sequence), so regressions are only
+rejected within the current registered generation. Envelopes without
+`sequence` remain accepted for backward compatibility with already-deployed
+agents and never move the high-water mark.
 
 Authentication: `register` uses the bootstrap token as a Bearer token;
 everything else uses the stored `ttagent_...` credential as a Bearer token.
@@ -345,6 +359,77 @@ then instead of executing, the agent reports one `policy.checked` evidence
 item per step the action would run (with `dryRun: true` metadata) and
 returns `succeeded` with `keyRotated` null. Zero filesystem or exec side
 effects; the keys/acme/deploy/reload/verify modules are never called.
+
+### DNS-01 providers
+
+`src/dns` implements native TXT-record solvers so DNS-01 challenges no
+longer require the ACME tool's own DNS plugins. certbot/acme.sh still drive
+the ACME conversation; they call back into the agent through the
+`certops-dns-hook` executable (`packages/agent/bin/certops-dns-hook.js`).
+Zero npm dependencies: HTTP providers use global `fetch`, Route 53 SigV4 and
+the GCP JWT are signed with `node:crypto`, and RFC 2136 speaks the DNS wire
+format over `node:net` with a TSIG HMAC (RFC 8945, `hmac-sha1/224/256/384/512`).
+
+Wave-1 provider ids (exact-match against `policy.allowedDnsProviders`):
+`cloudflare`, `route53`, `azure-dns`, `google-cloud-dns`, `rfc2136`,
+`acme-dns`.
+
+Config (`config.json`): each configured provider maps to an object holding
+the absolute path of its agent-local credentials file plus optional
+non-secret options; the reserved `zoneProviderMap` key routes zones to
+providers on multi-provider hosts (longest matching zone wins, dot-boundary
+rule; with a single provider and no map entry, that provider is the
+default).
+
+```json
+{
+  "dnsProviders": {
+    "cloudflare": { "credentialsFile": "/etc/tokentimer-agent/dns/cloudflare.json" },
+    "rfc2136": { "credentialsFile": "/etc/tokentimer-agent/dns/rfc2136.json" },
+    "zoneProviderMap": {
+      "example.com": "cloudflare",
+      "internal.example.net": "rfc2136"
+    }
+  }
+}
+```
+
+Credentials files are JSON objects, must be `0600` (the agent refuses
+group/other-readable files on POSIX), and never leave the host:
+
+| Provider | Credentials file fields |
+|----------|-------------------------|
+| `cloudflare` | `apiToken` (scoped token, Zone.DNS:Edit); optional `zoneId` (looked up by zone name when absent) |
+| `route53` | `accessKeyId`, `secretAccessKey`; optional `sessionToken`, `hostedZoneId` (else `ListHostedZonesByName`), `region` (default `us-east-1`) |
+| `azure-dns` | `tenantId`, `clientId`, `clientSecret`, `subscriptionId`, `resourceGroup` (client-credentials flow, DNS Zone Contributor role) |
+| `google-cloud-dns` | `client_email`, `private_key`, `project_id` (standard SA JSON fields); optional `managedZone` (else looked up by `dnsName`). The SA key is a DNS credential: it signs the OAuth JWT locally and never leaves the host |
+| `rfc2136` | `server`, `keyName`, `keySecretBase64`; optional `port` (default 53), `keyAlgorithm` (default `hmac-sha256`) |
+| `acme-dns` | `baseUrl`, `username`, `password`, `subdomain` (from `/register`). Cleanup is a documented no-op: acme-dns rotates its two TXT slots automatically |
+
+Hook usage. certbot manual hooks (the hook derives the TXT name
+`_acme-challenge.$CERTBOT_DOMAIN` and reads `CERTBOT_DOMAIN` +
+`CERTBOT_VALIDATION` from the environment certbot sets):
+
+```
+certbot certonly --csr <csr.pem> --preferred-challenges dns --manual \
+  --manual-auth-hook    "certops-dns-hook present" \
+  --manual-cleanup-hook "certops-dns-hook cleanup"
+```
+
+For acme.sh, export the fallback variables from a thin dnsapi wrapper and
+call the same binary: `ACME_DOMAIN=<domain> ACME_TXT_VALUE=<txt>
+certops-dns-hook present|cleanup`.
+
+Policy gate: the hook resolves the provider and zone for the domain, then
+requires BOTH `checkDnsProvider` and `checkDnsZone` to pass against the
+agent-local policy engine before reading any credentials file or making any
+network call. A rejection prints the `{ allowed: false, rejectionReason,
+detail }` JSON to stderr and exits nonzero, so the provider id must be in
+`policy.allowedDnsProviders` and the zone covered by
+`policy.allowedDnsZones` (suffix match with dot boundary). Solver failures
+never carry secrets: every provider response excerpt is bounded to 1024
+chars and replaced wholesale with `[redacted]` if it contains a
+`PRIVATE KEY` marker or any of the credential strings themselves.
 
 ## 6. Zero-custody guarantees
 

--- a/docs/certops/agent.md
+++ b/docs/certops/agent.md
@@ -55,6 +55,27 @@ node packages/agent/bin/tokentimer-agent.js
 or `pnpm start` from `packages/agent`. There are no CLI flags; configuration
 is via `config.json` and `TOKENTIMER_AGENT_*` environment variables.
 
+### Installer script (Linux, systemd)
+
+`packages/agent/scripts/install-agent.sh` automates the production install
+that the dashboard's Deploy-an-agent panel generates a command for. It:
+
+- verifies OS/arch and a Node >= 22 runtime;
+- creates a dedicated system user and install directory;
+- writes a `config.json` skeleton and stores the bootstrap token in a
+  0600-mode file consumed once at first start;
+- installs, enables, and starts the hardened systemd unit
+  (`packages/agent/scripts/tokentimer-agent.service`, `ProtectSystem=strict`
+  among other directives).
+
+`--dry-run` prints every action without touching the system; `--uninstall`
+removes the unit, user, and install directory. The script is POSIX shell and
+requires root (or sudo) for the real install. The recommended flow is:
+create a bootstrap token in the dashboard (shown exactly once), copy the
+generated install command, run it on the target host, and watch the
+dashboard's agent fleet panel flip the agent to registered on first
+heartbeat.
+
 ### Config directory
 
 Resolution order (`resolveConfigDir`): explicit argument >
@@ -366,13 +387,15 @@ effects; the keys/acme/deploy/reload/verify modules are never called.
 longer require the ACME tool's own DNS plugins. certbot/acme.sh still drive
 the ACME conversation; they call back into the agent through the
 `certops-dns-hook` executable (`packages/agent/bin/certops-dns-hook.js`).
-Zero npm dependencies: HTTP providers use global `fetch`, Route 53 SigV4 and
-the GCP JWT are signed with `node:crypto`, and RFC 2136 speaks the DNS wire
+Zero npm dependencies: HTTP providers use global `fetch`, Route 53 SigV4,
+the GCP JWT, the OVH request signature, and the Exoscale EXO2-HMAC-SHA256
+signature are computed with `node:crypto`, and RFC 2136 speaks the DNS wire
 format over `node:net` with a TSIG HMAC (RFC 8945, `hmac-sha1/224/256/384/512`).
 
 Wave-1 provider ids (exact-match against `policy.allowedDnsProviders`):
 `cloudflare`, `route53`, `azure-dns`, `google-cloud-dns`, `rfc2136`,
-`acme-dns`.
+`acme-dns`. Wave-2 provider ids: `ovhcloud`, `hetzner`, `infomaniak`,
+`exoscale`, `powerdns`.
 
 Config (`config.json`): each configured provider maps to an object holding
 the absolute path of its agent-local credentials file plus optional
@@ -405,6 +428,11 @@ group/other-readable files on POSIX), and never leave the host:
 | `google-cloud-dns` | `client_email`, `private_key`, `project_id` (standard SA JSON fields); optional `managedZone` (else looked up by `dnsName`). The SA key is a DNS credential: it signs the OAuth JWT locally and never leaves the host |
 | `rfc2136` | `server`, `keyName`, `keySecretBase64`; optional `port` (default 53), `keyAlgorithm` (default `hmac-sha256`) |
 | `acme-dns` | `baseUrl`, `username`, `password`, `subdomain` (from `/register`). Cleanup is a documented no-op: acme-dns rotates its two TXT slots automatically |
+| `ovhcloud` | `applicationKey`, `applicationSecret`, `consumerKey`; optional `endpoint` (default `https://eu.api.ovh.com/1.0`; other regions `https://ca.api.ovh.com/1.0`, `https://us.api.ovhcloud.com/1.0`). Requests are OVH-signed (`$1$` + SHA1) with the LOCAL unix time as `X-Ovh-Timestamp` (no `/auth/time` skew correction); a `POST /domain/zone/<zone>/refresh` follows every mutation so the change actually serves |
+| `hetzner` | `apiToken` (Auth-API-Token header, account-scoped); optional `zoneId` (looked up by zone name when absent). Cleanup of an already-absent record is idempotent success |
+| `infomaniak` | `apiToken` (Bearer, "domain" scope). Every response is wrapped in a `{ result: "success"\|"error", data }` envelope; a non-`success` result is treated as failure even on HTTP 200 |
+| `exoscale` | `apiKey`, `apiSecret`; optional `apiEndpoint` (default `https://api-ch-gva-2.exoscale.com/v2`; DNS is global, any zone endpoint works). Requests are EXO2-HMAC-SHA256 signed. Mutations are async on Exoscale's side: the accepted operation response is treated as success without polling (the ACME tool's propagation wait covers the apply window) |
+| `powerdns` | `apiUrl` (e.g. `http://127.0.0.1:8081`), `apiKey` (X-API-Key header); optional `serverId` (default `localhost`). Zone and record names carry a trailing dot and TXT content is double-quoted, per PowerDNS API rules. Present merges with existing TXT values at the name and `REPLACE`s the union (parallel challenges never clobber each other); cleanup `REPLACE`s the remainder or sends `changetype: DELETE` when none remain |
 
 Hook usage. certbot manual hooks (the hook derives the TXT name
 `_acme-challenge.$CERTBOT_DOMAIN` and reads `CERTBOT_DOMAIN` +

--- a/packages/agent/bin/certops-dns-hook.js
+++ b/packages/agent/bin/certops-dns-hook.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * certops-dns-hook: DNS-01 manual-auth-hook for certbot / acme.sh.
+ *
+ * Thin wrapper wiring src/dns/hook.js to the real implementations:
+ * agent config loading, agent-local policy engine, credential file
+ * reading, and the native DNS solvers. See docs/certops/agent.md
+ * ("DNS-01 providers") for usage.
+ */
+
+const configModule = require("../src/config/index.js");
+const policyModule = require("../src/policy/index.js");
+const { createDnsSolver } = require("../src/dns/index.js");
+const { runDnsHook } = require("../src/dns/hook.js");
+
+runDnsHook({
+  env: process.env,
+  argv: process.argv.slice(2),
+  loadConfig: () => configModule.loadAgentConfig(),
+  readCredentialsFile: (providerId, config) =>
+    configModule.readDnsCredentialsFile(providerId, config),
+  createSolver: createDnsSolver,
+  policyEngineFactory: (rawPolicy) =>
+    policyModule.createPolicyEngine(policyModule.loadPolicyConfig(rawPolicy)),
+  stdout: process.stdout,
+  stderr: process.stderr,
+}).then(
+  (exitCode) => {
+    process.exitCode = exitCode;
+  },
+  (err) => {
+    // runDnsHook never throws by contract; this is a last-resort guard.
+    console.error(`certops-dns-hook: fatal error: ${err?.message || err}`);
+    process.exitCode = 1;
+  },
+);

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,7 +8,8 @@
   "type": "commonjs",
   "main": "src/index.js",
   "bin": {
-    "tokentimer-agent": "bin/tokentimer-agent.js"
+    "tokentimer-agent": "bin/tokentimer-agent.js",
+    "certops-dns-hook": "bin/certops-dns-hook.js"
   },
   "scripts": {
     "start": "node bin/tokentimer-agent.js",

--- a/packages/agent/scripts/install-agent.sh
+++ b/packages/agent/scripts/install-agent.sh
@@ -1,0 +1,311 @@
+#!/bin/sh
+# install-agent.sh - install the TokenTimer CertOps Agent as a systemd service.
+#
+# This script installs FROM THE LOCAL PACKAGE DIRECTORY it lives in
+# (packages/agent of a checked-out or unpacked release); it never downloads
+# remote artifacts. A hosted one-liner installer will come later.
+#
+# What it does (see --help for flags):
+#   1. Verifies OS/arch (Linux amd64/arm64; macOS best-effort for dev) and
+#      that the installed Node satisfies the package.json "engines" range.
+#   2. Creates the tokentimer-agent system user.
+#   3. Copies the agent package to /opt/tokentimer-agent/app and creates the
+#      state (config + credential) dir /opt/tokentimer-agent/state with 0700.
+#   4. Writes a config.json skeleton (0600) from flags/env.
+#   5. Stores the bootstrap token in state/bootstrap.env (0600) for the
+#      service's first-run registration. The token is single-use and is
+#      NEVER echoed back to the terminal by this script.
+#   6. Installs, enables and starts the tokentimer-agent systemd unit
+#      (template: tokentimer-agent.service next to this script).
+#
+# Security notes:
+#   - config.json is 0600 and the state dir is 0700, matching what the agent
+#     itself enforces (src/config/index.js re-asserts modes on every write).
+#   - Prefer passing the bootstrap token via the TOKENTIMER_AGENT_BOOTSTRAP_TOKEN
+#     environment variable over --bootstrap-token so it does not land in
+#     shell history or process listings.
+
+set -eu
+
+INSTALL_ROOT="/opt/tokentimer-agent"
+APP_DIR="$INSTALL_ROOT/app"
+STATE_DIR="$INSTALL_ROOT/state"
+AGENT_USER="tokentimer-agent"
+UNIT_NAME="tokentimer-agent.service"
+UNIT_DEST="/etc/systemd/system/$UNIT_NAME"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PACKAGE_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+UNIT_TEMPLATE="$SCRIPT_DIR/$UNIT_NAME"
+
+API_URL=""
+WORKSPACE_ID=""
+BOOTSTRAP_TOKEN="${TOKENTIMER_AGENT_BOOTSTRAP_TOKEN:-}"
+CA_BUNDLE=""
+DRY_RUN=0
+UNINSTALL=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo ./install-agent.sh --api-url URL --workspace-id ID [options]
+  sudo ./install-agent.sh --uninstall [--dry-run]
+
+Installs the TokenTimer CertOps Agent from this local package directory as a
+hardened systemd service running as the tokentimer-agent system user.
+(No remote downloads; a hosted one-liner installer comes later.)
+
+Required for install:
+  --api-url URL          Control plane base URL (config.json serverUrl).
+  --workspace-id ID      Workspace the agent belongs to (recorded in
+                         config.json; the bootstrap token is already
+                         workspace-scoped server-side).
+  Bootstrap token        Via TOKENTIMER_AGENT_BOOTSTRAP_TOKEN env var
+                         (preferred; keeps it out of shell history) or
+                         --bootstrap-token TOKEN. Single-use ttboot_ token
+                         created in the dashboard (CertOps > Deploy an agent).
+
+Options:
+  --ca-bundle PATH       PEM CA bundle for a private-CA control plane
+                         (copied into the state dir, config.json caBundlePath).
+  --dry-run              Print every action without executing anything.
+  --uninstall            Stop/disable the service and remove the app dir and
+                         unit file. The state dir (credential, keys) and the
+                         system user are preserved; remove them manually once
+                         you are sure (rm -rf /opt/tokentimer-agent &&
+                         userdel tokentimer-agent).
+  -h, --help             Show this help.
+
+Layout created:
+  /opt/tokentimer-agent/app     agent package (read-only at runtime)
+  /opt/tokentimer-agent/state   config dir, mode 0700, owner tokentimer-agent:
+                                config.json (0600), credential (0600, written
+                                by the agent at registration), bootstrap.env
+                                (0600, delete after first successful start)
+
+After install:
+  systemctl status tokentimer-agent
+  journalctl -u tokentimer-agent -f
+EOF
+}
+
+log() { printf '%s\n' "install-agent: $*"; }
+fail() { printf '%s\n' "install-agent: ERROR: $*" >&2; exit 1; }
+
+# Runs (or prints, under --dry-run) a non-secret command. Never pass the
+# bootstrap token through this function: its arguments are echoed.
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --api-url) API_URL="${2:-}"; shift 2 ;;
+    --api-url=*) API_URL="${1#--api-url=}"; shift ;;
+    --workspace-id) WORKSPACE_ID="${2:-}"; shift 2 ;;
+    --workspace-id=*) WORKSPACE_ID="${1#--workspace-id=}"; shift ;;
+    --bootstrap-token) BOOTSTRAP_TOKEN="${2:-}"; shift 2 ;;
+    --bootstrap-token=*) BOOTSTRAP_TOKEN="${1#--bootstrap-token=}"; shift ;;
+    --ca-bundle) CA_BUNDLE="${2:-}"; shift 2 ;;
+    --ca-bundle=*) CA_BUNDLE="${1#--ca-bundle=}"; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown argument: $1 (see --help)" ;;
+  esac
+done
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+IS_DARWIN=0
+case "$OS" in
+  Linux)
+    case "$ARCH" in
+      x86_64|amd64|aarch64|arm64) : ;;
+      *) fail "unsupported architecture '$ARCH' (supported: amd64/x86_64, arm64/aarch64)" ;;
+    esac
+    ;;
+  Darwin)
+    IS_DARWIN=1
+    log "macOS detected: best-effort dev install (no system user, no systemd unit)."
+    ;;
+  *)
+    fail "unsupported OS '$OS'. The agent installer supports Linux (amd64/arm64) and, best-effort for development, macOS."
+    ;;
+esac
+
+# ---------------------------------------------------------------- uninstall
+if [ "$UNINSTALL" -eq 1 ]; then
+  if [ "$IS_DARWIN" -eq 1 ]; then
+    log "macOS: no systemd unit to remove. Removing app dir only."
+    run rm -rf "$APP_DIR"
+    log "Done. State dir $STATE_DIR (credential, keys) was preserved."
+    exit 0
+  fi
+  [ "$DRY_RUN" -eq 1 ] || [ "$(id -u)" -eq 0 ] || fail "uninstall must run as root (use sudo)"
+  if [ -f "$UNIT_DEST" ] || systemctl list-unit-files "$UNIT_NAME" >/dev/null 2>&1; then
+    run systemctl stop "$UNIT_NAME" || true
+    run systemctl disable "$UNIT_NAME" || true
+  fi
+  run rm -f "$UNIT_DEST"
+  run systemctl daemon-reload
+  run rm -rf "$APP_DIR"
+  log "Uninstalled the service and app dir."
+  log "Preserved (remove manually once you are sure):"
+  log "  - $STATE_DIR (agent credential, keys, replay store)"
+  log "  - system user $AGENT_USER (userdel $AGENT_USER)"
+  exit 0
+fi
+
+# ----------------------------------------------------------- validate input
+[ -n "$API_URL" ] || fail "--api-url is required (control plane base URL)"
+[ -n "$WORKSPACE_ID" ] || fail "--workspace-id is required"
+[ -n "$BOOTSTRAP_TOKEN" ] || fail "bootstrap token is required: set TOKENTIMER_AGENT_BOOTSTRAP_TOKEN or pass --bootstrap-token"
+case "$BOOTSTRAP_TOKEN" in
+  ttboot_*) : ;;
+  *) fail "bootstrap token does not look like a ttboot_ token (value not shown)" ;;
+esac
+case "$API_URL" in
+  http://*|https://*) : ;;
+  *) fail "--api-url must start with http:// or https://" ;;
+esac
+if [ -n "$CA_BUNDLE" ]; then
+  [ -f "$CA_BUNDLE" ] || fail "--ca-bundle file not found: $CA_BUNDLE"
+  grep -q "BEGIN CERTIFICATE" "$CA_BUNDLE" || fail "--ca-bundle contains no PEM certificate block"
+  if grep -q "PRIVATE KEY" "$CA_BUNDLE"; then
+    fail "--ca-bundle contains private key material; a CA bundle must hold public certificates only"
+  fi
+fi
+
+[ -f "$PACKAGE_DIR/package.json" ] || fail "agent package.json not found next to this script (expected $PACKAGE_DIR/package.json); run from an unpacked agent package"
+[ -f "$PACKAGE_DIR/bin/tokentimer-agent.js" ] || fail "agent entrypoint bin/tokentimer-agent.js not found in $PACKAGE_DIR"
+[ -f "$UNIT_TEMPLATE" ] || { [ "$IS_DARWIN" -eq 1 ] || fail "systemd unit template not found: $UNIT_TEMPLATE"; }
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$IS_DARWIN" -eq 0 ] && [ "$(id -u)" -ne 0 ]; then
+  fail "install must run as root (use sudo)"
+fi
+
+# -------------------------------------------------------- node version gate
+# engines.node is a single ">=x.y.z" range in this package; a plain sed
+# parse avoids needing node before the node check itself.
+REQUIRED_RANGE=$(sed -n 's/.*"node"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$PACKAGE_DIR/package.json")
+command -v node >/dev/null 2>&1 || fail "node is not installed or not on PATH; the agent requires Node '$REQUIRED_RANGE'"
+REQUIRED_MAJOR=$(printf '%s' "$REQUIRED_RANGE" | sed -n 's/[^0-9]*\([0-9][0-9]*\).*/\1/p')
+NODE_MAJOR=$(node -v | sed -n 's/^v\([0-9][0-9]*\).*/\1/p')
+[ -n "$REQUIRED_MAJOR" ] || fail "could not parse required Node version from $PACKAGE_DIR/package.json (engines.node='$REQUIRED_RANGE')"
+[ -n "$NODE_MAJOR" ] || fail "could not parse installed Node version from 'node -v'"
+if [ "$NODE_MAJOR" -lt "$REQUIRED_MAJOR" ]; then
+  fail "Node $(node -v) is too old; the agent requires engines.node '$REQUIRED_RANGE'"
+fi
+log "Node $(node -v) satisfies engines.node '$REQUIRED_RANGE'."
+
+# ------------------------------------------------------------- system user
+if [ "$IS_DARWIN" -eq 0 ]; then
+  if id "$AGENT_USER" >/dev/null 2>&1; then
+    log "System user $AGENT_USER already exists."
+  elif command -v useradd >/dev/null 2>&1; then
+    run useradd --system --home-dir "$INSTALL_ROOT" --no-create-home --shell /usr/sbin/nologin "$AGENT_USER"
+  elif command -v adduser >/dev/null 2>&1; then
+    run adduser -S -H -h "$INSTALL_ROOT" -s /sbin/nologin "$AGENT_USER"
+  else
+    fail "neither useradd nor adduser is available to create the $AGENT_USER system user"
+  fi
+fi
+
+# ------------------------------------------------------------ install files
+log "Installing agent package from $PACKAGE_DIR to $APP_DIR"
+run mkdir -p "$APP_DIR"
+# Copy the package contents (src/, bin/, package.json, scripts/). The agent
+# is zero-dependency, so no npm/pnpm install step is needed.
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "[dry-run] cp -R $PACKAGE_DIR/. $APP_DIR/ (excluding node_modules)"
+else
+  # tar pipe preserves layout and lets us exclude node_modules portably.
+  (cd "$PACKAGE_DIR" && tar -cf - --exclude=./node_modules .) | (cd "$APP_DIR" && tar -xf -)
+fi
+
+run mkdir -p "$STATE_DIR"
+run chmod 0700 "$STATE_DIR"
+
+# ------------------------------------------------------- config.json (0600)
+# Fields consumed by the agent's config loader (src/config/index.js):
+# serverUrl (required) and caBundlePath (optional). workspaceId is recorded
+# for operators; the loader ignores unknown fields and the bootstrap token
+# is already workspace-scoped server-side. agentId and the credential are
+# written by the agent itself at first-run registration.
+CONFIG_PATH="$STATE_DIR/config.json"
+CA_BUNDLE_DEST=""
+if [ -n "$CA_BUNDLE" ]; then
+  CA_BUNDLE_DEST="$STATE_DIR/ca-bundle.pem"
+  run cp "$CA_BUNDLE" "$CA_BUNDLE_DEST"
+  run chmod 0644 "$CA_BUNDLE_DEST"
+fi
+
+if [ -f "$CONFIG_PATH" ] && [ "$DRY_RUN" -eq 0 ]; then
+  log "Existing $CONFIG_PATH found; leaving it untouched (delete it to re-generate)."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "[dry-run] write $CONFIG_PATH (0600) with serverUrl=$API_URL workspaceId=$WORKSPACE_ID${CA_BUNDLE_DEST:+ caBundlePath=$CA_BUNDLE_DEST}"
+else
+  umask 177
+  {
+    printf '{\n'
+    printf '  "serverUrl": "%s",\n' "$API_URL"
+    printf '  "workspaceId": "%s"' "$WORKSPACE_ID"
+    if [ -n "$CA_BUNDLE_DEST" ]; then
+      printf ',\n  "caBundlePath": "%s"' "$CA_BUNDLE_DEST"
+    fi
+    printf '\n}\n'
+  } > "$CONFIG_PATH"
+  umask 022
+  chmod 0600 "$CONFIG_PATH"
+fi
+
+# --------------------------------------- bootstrap token env file (0600)
+# The single-use ttboot_ token is stored only for the service's first-run
+# registration and is never printed by this script. Delete bootstrap.env
+# once the agent shows up as active in the dashboard.
+BOOTSTRAP_ENV="$STATE_DIR/bootstrap.env"
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "[dry-run] write $BOOTSTRAP_ENV (0600) with TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=<redacted>"
+else
+  umask 177
+  printf 'TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=%s\n' "$BOOTSTRAP_TOKEN" > "$BOOTSTRAP_ENV"
+  umask 022
+  chmod 0600 "$BOOTSTRAP_ENV"
+fi
+
+if [ "$IS_DARWIN" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+  chown -R "$AGENT_USER:$AGENT_USER" "$STATE_DIR"
+  chown -R root:root "$APP_DIR"
+elif [ "$IS_DARWIN" -eq 0 ]; then
+  printf '%s\n' "[dry-run] chown -R $AGENT_USER:$AGENT_USER $STATE_DIR; chown -R root:root $APP_DIR"
+fi
+
+# ------------------------------------------------------------ systemd unit
+if [ "$IS_DARWIN" -eq 1 ]; then
+  log "macOS dev install complete. Run the agent manually with:"
+  log "  TOKENTIMER_AGENT_CONFIG_DIR=$STATE_DIR TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=<token> node $APP_DIR/bin/tokentimer-agent.js"
+  exit 0
+fi
+
+run cp "$UNIT_TEMPLATE" "$UNIT_DEST"
+run chmod 0644 "$UNIT_DEST"
+run systemctl daemon-reload
+run systemctl enable "$UNIT_NAME"
+run systemctl start "$UNIT_NAME"
+
+log ""
+log "Install complete. Next steps:"
+log "  1. Check the service:      systemctl status $UNIT_NAME"
+log "  2. Follow the logs:        journalctl -u $UNIT_NAME -f"
+log "  3. Confirm registration in the dashboard (CertOps > Agent fleet):"
+log "     the agent should appear as active within about a minute."
+log "  4. After it registers, remove the single-use bootstrap token file:"
+log "     rm $BOOTSTRAP_ENV"
+log "  5. Configure agent-local policy and discovery in $CONFIG_PATH"
+log "     (allowlists are default-deny until you set them), then:"
+log "     systemctl restart $UNIT_NAME"

--- a/packages/agent/scripts/install-agent.sh
+++ b/packages/agent/scripts/install-agent.sh
@@ -60,10 +60,16 @@ Required for install:
   --workspace-id ID      Workspace the agent belongs to (recorded in
                          config.json; the bootstrap token is already
                          workspace-scoped server-side).
-  Bootstrap token        Via TOKENTIMER_AGENT_BOOTSTRAP_TOKEN env var
-                         (preferred; keeps it out of shell history) or
-                         --bootstrap-token TOKEN. Single-use ttboot_ token
-                         created in the dashboard (CertOps > Deploy an agent).
+  Bootstrap token        Supplied interactively: when neither the
+                         TOKENTIMER_AGENT_BOOTSTRAP_TOKEN env var nor
+                         --bootstrap-token is given, the installer reads the
+                         token from a hidden prompt (recommended; nothing
+                         lands in shell history or process listings). The
+                         env var is the non-interactive alternative.
+                         --bootstrap-token TOKEN still works but is
+                         discouraged: argv is visible in process listings.
+                         Single-use ttboot_ token created in the dashboard
+                         (CertOps > Deploy an agent).
 
 Options:
   --ca-bundle PATH       PEM CA bundle for a private-CA control plane
@@ -81,7 +87,8 @@ Layout created:
   /opt/tokentimer-agent/state   config dir, mode 0700, owner tokentimer-agent:
                                 config.json (0600), credential (0600, written
                                 by the agent at registration), bootstrap.env
-                                (0600, delete after first successful start)
+                                (0600, deleted automatically by the agent
+                                after its first successful registration)
 
 After install:
   systemctl status tokentimer-agent
@@ -164,15 +171,46 @@ fi
 # ----------------------------------------------------------- validate input
 [ -n "$API_URL" ] || fail "--api-url is required (control plane base URL)"
 [ -n "$WORKSPACE_ID" ] || fail "--workspace-id is required"
-[ -n "$BOOTSTRAP_TOKEN" ] || fail "bootstrap token is required: set TOKENTIMER_AGENT_BOOTSTRAP_TOKEN or pass --bootstrap-token"
-case "$BOOTSTRAP_TOKEN" in
-  ttboot_*) : ;;
-  *) fail "bootstrap token does not look like a ttboot_ token (value not shown)" ;;
-esac
+
+# Hidden interactive prompt (preferred path): the dashboard's copyable
+# command carries no token; the operator pastes it here, with terminal echo
+# disabled, so it never touches shell history or process listings.
+if [ -z "$BOOTSTRAP_TOKEN" ] && [ "$DRY_RUN" -eq 0 ]; then
+  if [ -t 0 ]; then
+    printf '%s' "install-agent: paste the bootstrap token (input hidden): " >&2
+    stty -echo
+    # Restore echo even if the read is interrupted.
+    trap 'stty echo 2>/dev/null || true' EXIT INT TERM
+    IFS= read -r BOOTSTRAP_TOKEN
+    stty echo
+    trap - EXIT INT TERM
+    printf '\n' >&2
+  fi
+fi
+if [ -z "$BOOTSTRAP_TOKEN" ] && [ "$DRY_RUN" -eq 1 ]; then
+  log "dry-run: no bootstrap token supplied; a real install prompts for it interactively."
+else
+  [ -n "$BOOTSTRAP_TOKEN" ] || fail "bootstrap token is required: paste it at the interactive prompt, or set TOKENTIMER_AGENT_BOOTSTRAP_TOKEN"
+  case "$BOOTSTRAP_TOKEN" in
+    ttboot_*) : ;;
+    *) fail "bootstrap token does not look like a ttboot_ token (value not shown)" ;;
+  esac
+fi
 case "$API_URL" in
   http://*|https://*) : ;;
   *) fail "--api-url must start with http:// or https://" ;;
 esac
+# These values are interpolated into config.json below; refuse anything that
+# could break out of a JSON string instead of trying to escape it.
+case "$API_URL" in
+  *\"*|*\\*) fail "--api-url must not contain double quotes or backslashes" ;;
+esac
+case "$WORKSPACE_ID" in
+  *\"*|*\\*) fail "--workspace-id must not contain double quotes or backslashes" ;;
+esac
+if printf '%s%s' "$API_URL" "$WORKSPACE_ID" | LC_ALL=C tr -d '[:print:]' | grep -q .; then
+  fail "--api-url and --workspace-id must not contain control or non-printable characters"
+fi
 if [ -n "$CA_BUNDLE" ]; then
   [ -f "$CA_BUNDLE" ] || fail "--ca-bundle file not found: $CA_BUNDLE"
   grep -q "BEGIN CERTIFICATE" "$CA_BUNDLE" || fail "--ca-bundle contains no PEM certificate block"
@@ -217,15 +255,33 @@ if [ "$IS_DARWIN" -eq 0 ]; then
 fi
 
 # ------------------------------------------------------------ install files
+# Staged, atomic-swap install: extract into a fresh staging dir next to the
+# app dir, then swap it into place. A failed copy can never leave a
+# half-written app dir behind, and a running agent keeps its old files until
+# the swap (systemd restart picks up the new tree).
 log "Installing agent package from $PACKAGE_DIR to $APP_DIR"
-run mkdir -p "$APP_DIR"
-# Copy the package contents (src/, bin/, package.json, scripts/). The agent
-# is zero-dependency, so no npm/pnpm install step is needed.
+run mkdir -p "$INSTALL_ROOT"
 if [ "$DRY_RUN" -eq 1 ]; then
-  printf '%s\n' "[dry-run] cp -R $PACKAGE_DIR/. $APP_DIR/ (excluding node_modules)"
+  printf '%s\n' "[dry-run] stage $PACKAGE_DIR into $APP_DIR.staging.\$\$ (excluding node_modules), then atomically swap into $APP_DIR"
 else
+  APP_STAGING="$APP_DIR.staging.$$"
+  APP_PREVIOUS="$APP_DIR.previous.$$"
+  rm -rf "$APP_STAGING"
+  mkdir -p "$APP_STAGING"
   # tar pipe preserves layout and lets us exclude node_modules portably.
-  (cd "$PACKAGE_DIR" && tar -cf - --exclude=./node_modules .) | (cd "$APP_DIR" && tar -xf -)
+  if ! (cd "$PACKAGE_DIR" && tar -cf - --exclude=./node_modules .) | (cd "$APP_STAGING" && tar -xf -); then
+    rm -rf "$APP_STAGING"
+    fail "failed to stage the agent package; $APP_DIR was left untouched"
+  fi
+  if [ -d "$APP_DIR" ]; then
+    mv "$APP_DIR" "$APP_PREVIOUS"
+  fi
+  if ! mv "$APP_STAGING" "$APP_DIR"; then
+    [ -d "$APP_PREVIOUS" ] && mv "$APP_PREVIOUS" "$APP_DIR"
+    rm -rf "$APP_STAGING"
+    fail "failed to activate the staged agent package; the previous install was restored"
+  fi
+  rm -rf "$APP_PREVIOUS"
 fi
 
 run mkdir -p "$STATE_DIR"
@@ -250,6 +306,10 @@ if [ -f "$CONFIG_PATH" ] && [ "$DRY_RUN" -eq 0 ]; then
 elif [ "$DRY_RUN" -eq 1 ]; then
   printf '%s\n' "[dry-run] write $CONFIG_PATH (0600) with serverUrl=$API_URL workspaceId=$WORKSPACE_ID${CA_BUNDLE_DEST:+ caBundlePath=$CA_BUNDLE_DEST}"
 else
+  # Values were charset-validated above (no quotes/backslashes/control
+  # chars), so plain interpolation cannot produce malformed JSON. Written
+  # to a temp file first and renamed so a crash never leaves a torn file.
+  CONFIG_TMP="$CONFIG_PATH.tmp.$$"
   umask 177
   {
     printf '{\n'
@@ -259,23 +319,30 @@ else
       printf ',\n  "caBundlePath": "%s"' "$CA_BUNDLE_DEST"
     fi
     printf '\n}\n'
-  } > "$CONFIG_PATH"
+  } > "$CONFIG_TMP"
   umask 022
-  chmod 0600 "$CONFIG_PATH"
+  chmod 0600 "$CONFIG_TMP"
+  mv "$CONFIG_TMP" "$CONFIG_PATH"
+  # Sanity-parse the result with the node we already verified, so a bad
+  # value can never install an unreadable config.
+  node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$CONFIG_PATH" \
+    || fail "generated $CONFIG_PATH is not valid JSON (unexpected characters in --api-url/--workspace-id?)"
 fi
 
 # --------------------------------------- bootstrap token env file (0600)
 # The single-use ttboot_ token is stored only for the service's first-run
-# registration and is never printed by this script. Delete bootstrap.env
-# once the agent shows up as active in the dashboard.
+# registration and is never printed by this script. The agent deletes
+# bootstrap.env itself right after a successful registration.
 BOOTSTRAP_ENV="$STATE_DIR/bootstrap.env"
 if [ "$DRY_RUN" -eq 1 ]; then
   printf '%s\n' "[dry-run] write $BOOTSTRAP_ENV (0600) with TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=<redacted>"
 else
+  BOOTSTRAP_ENV_TMP="$BOOTSTRAP_ENV.tmp.$$"
   umask 177
-  printf 'TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=%s\n' "$BOOTSTRAP_TOKEN" > "$BOOTSTRAP_ENV"
+  printf 'TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=%s\n' "$BOOTSTRAP_TOKEN" > "$BOOTSTRAP_ENV_TMP"
   umask 022
-  chmod 0600 "$BOOTSTRAP_ENV"
+  chmod 0600 "$BOOTSTRAP_ENV_TMP"
+  mv "$BOOTSTRAP_ENV_TMP" "$BOOTSTRAP_ENV"
 fi
 
 if [ "$IS_DARWIN" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
@@ -304,8 +371,8 @@ log "  1. Check the service:      systemctl status $UNIT_NAME"
 log "  2. Follow the logs:        journalctl -u $UNIT_NAME -f"
 log "  3. Confirm registration in the dashboard (CertOps > Agent fleet):"
 log "     the agent should appear as active within about a minute."
-log "  4. After it registers, remove the single-use bootstrap token file:"
-log "     rm $BOOTSTRAP_ENV"
-log "  5. Configure agent-local policy and discovery in $CONFIG_PATH"
+log "     (The agent deletes the single-use $BOOTSTRAP_ENV itself after"
+log "     registering; no manual cleanup is needed.)"
+log "  4. Configure agent-local policy and discovery in $CONFIG_PATH"
 log "     (allowlists are default-deny until you set them), then:"
 log "     systemctl restart $UNIT_NAME"

--- a/packages/agent/scripts/tokentimer-agent.service
+++ b/packages/agent/scripts/tokentimer-agent.service
@@ -22,12 +22,18 @@ Group=tokentimer-agent
 Environment=TOKENTIMER_AGENT_CONFIG_DIR=/opt/tokentimer-agent/state
 # Optional bootstrap env file written by install-agent.sh for first-run
 # registration (contains TOKENTIMER_AGENT_BOOTSTRAP_TOKEN, mode 0600).
-# The token is single-use; the agent never persists it. Delete the file
-# after the agent has registered.
+# The token is single-use; the agent never persists it, and deletes this
+# file itself right after a successful registration.
 EnvironmentFile=-/opt/tokentimer-agent/state/bootstrap.env
 ExecStart=/usr/bin/env node /opt/tokentimer-agent/app/bin/tokentimer-agent.js
 Restart=always
 RestartSec=5
+# The agent exits with this status when the control plane retires it
+# (heartbeat "retired" signal). A retired agent must NOT be respawned into
+# a permanent 410 loop; keep in sync with AGENT_RETIRED_EXIT_CODE in
+# packages/agent/src/index.js.
+RestartPreventExitStatus=86
+SuccessExitStatus=86
 
 # Hardening. ProtectSystem=strict makes the whole filesystem read-only for
 # the service except the explicit ReadWritePaths (its state dir).

--- a/packages/agent/scripts/tokentimer-agent.service
+++ b/packages/agent/scripts/tokentimer-agent.service
@@ -1,0 +1,58 @@
+# TokenTimer Agent systemd unit (installed by install-agent.sh).
+#
+# Layout assumed by this unit:
+#   /opt/tokentimer-agent/app    agent package (read-only at runtime)
+#   /opt/tokentimer-agent/state  config dir: config.json, credential,
+#                                signing-key-pin.json, replay-store.json, keys/
+#
+# The agent is outbound-only (no listening sockets), runs as the unprivileged
+# tokentimer-agent user, and only ever writes inside its state dir, so the
+# hardening below can be strict without breaking anything.
+
+[Unit]
+Description=TokenTimer CertOps Agent (outbound-only execution plane)
+Documentation=https://github.com/tokentimer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tokentimer-agent
+Group=tokentimer-agent
+Environment=TOKENTIMER_AGENT_CONFIG_DIR=/opt/tokentimer-agent/state
+# Optional bootstrap env file written by install-agent.sh for first-run
+# registration (contains TOKENTIMER_AGENT_BOOTSTRAP_TOKEN, mode 0600).
+# The token is single-use; the agent never persists it. Delete the file
+# after the agent has registered.
+EnvironmentFile=-/opt/tokentimer-agent/state/bootstrap.env
+ExecStart=/usr/bin/env node /opt/tokentimer-agent/app/bin/tokentimer-agent.js
+Restart=always
+RestartSec=5
+
+# Hardening. ProtectSystem=strict makes the whole filesystem read-only for
+# the service except the explicit ReadWritePaths (its state dir).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/tokentimer-agent/state
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=false
+SystemCallArchitectures=native
+# Outbound HTTPS only; the agent accepts no inbound connections.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/agent/src/acme/index.js
+++ b/packages/agent/src/acme/index.js
@@ -70,6 +70,7 @@
  */
 
 const childProcess = require("node:child_process");
+const { buildMinimalSubprocessEnv } = require("../exec-env");
 
 /**
  * Mirrors the policy module's SHELL_METACHARACTER_PATTERN (duplicated, not
@@ -236,6 +237,10 @@ function execWithoutShell(execFileImpl, argv, timeoutMs) {
         // the OS exec facility and are never interpreted by a shell.
         windowsHide: true,
         maxBuffer: 10 * 1024 * 1024,
+        // Explicit minimal environment: the agent's own env can hold the
+        // bootstrap token and other secrets that must never reach the ACME
+        // tool (or the hook children it spawns).
+        env: buildMinimalSubprocessEnv(),
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -24,6 +24,7 @@ const {
   MAX_CA_BUNDLE_BYTES,
   validateDnsProvidersObject,
   readDnsCredentialsFile,
+  KNOWN_DNS_PROVIDER_IDS,
 } = require("./index.js");
 
 const IS_WIN32 = process.platform === "win32";
@@ -948,6 +949,16 @@ describe("validateDnsProvidersObject", () => {
           zoneProviderMap: { "example.com": "route53" },
         }),
       /not configured/,
+    );
+  });
+
+  it("keeps KNOWN_DNS_PROVIDER_IDS in sync with the dns module's supported provider list", () => {
+    // The list is deliberately duplicated (config stays self-contained);
+    // this guard fails the build when one side gains or loses a provider.
+    const { listSupportedDnsProviders } = require("../dns/index.js");
+    assert.deepEqual(
+      [...KNOWN_DNS_PROVIDER_IDS].sort(),
+      listSupportedDnsProviders().sort(),
     );
   });
 });

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -22,6 +22,8 @@ const {
   recoverPendingRegistration,
   redactCredentialForLogging,
   MAX_CA_BUNDLE_BYTES,
+  validateDnsProvidersObject,
+  readDnsCredentialsFile,
 } = require("./index.js");
 
 const IS_WIN32 = process.platform === "win32";
@@ -896,5 +898,120 @@ describe("readCaBundle", () => {
     const oversizedPath = path.join(dir, "oversized.pem");
     fs.writeFileSync(oversizedPath, Buffer.alloc(MAX_CA_BUNDLE_BYTES + 1));
     assert.throws(() => readCaBundle(oversizedPath), /must be between 1 and/);
+  });
+});
+
+describe("validateDnsProvidersObject", () => {
+  const ABS = IS_WIN32 ? "C:\\certops\\dns\\cloudflare.json" : "/etc/certops/dns/cloudflare.json";
+
+  it("returns null when the block is absent", () => {
+    assert.equal(validateDnsProvidersObject(undefined), null);
+    assert.equal(validateDnsProvidersObject(null), null);
+  });
+
+  it("accepts a valid block with options and a zoneProviderMap", () => {
+    const block = {
+      cloudflare: { credentialsFile: ABS, zoneId: "z1" },
+      zoneProviderMap: { "example.com": "cloudflare" },
+    };
+    assert.equal(validateDnsProvidersObject(block), block);
+  });
+
+  it("rejects non-object blocks", () => {
+    assert.throws(() => validateDnsProvidersObject([]), /must be an object/);
+    assert.throws(() => validateDnsProvidersObject("cloudflare"), /must be an object/);
+  });
+
+  it("rejects unknown provider ids", () => {
+    assert.throws(
+      () => validateDnsProvidersObject({ namecheap: { credentialsFile: ABS } }),
+      /not a known DNS provider id/,
+    );
+  });
+
+  it("rejects a missing or relative credentialsFile", () => {
+    assert.throws(
+      () => validateDnsProvidersObject({ cloudflare: {} }),
+      /credentialsFile must be an absolute path/,
+    );
+    assert.throws(
+      () => validateDnsProvidersObject({ cloudflare: { credentialsFile: "dns/cf.json" } }),
+      /credentialsFile must be an absolute path/,
+    );
+  });
+
+  it("rejects a zoneProviderMap entry referencing an unconfigured provider", () => {
+    assert.throws(
+      () =>
+        validateDnsProvidersObject({
+          cloudflare: { credentialsFile: ABS },
+          zoneProviderMap: { "example.com": "route53" },
+        }),
+      /not configured/,
+    );
+  });
+});
+
+describe("readDnsCredentialsFile", () => {
+  function writeCredentialsFile(contents) {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    const credentialsPath = path.join(dir, "cloudflare.json");
+    fs.writeFileSync(credentialsPath, contents, { encoding: "utf8", mode: 0o600 });
+    return credentialsPath;
+  }
+
+  function configFor(credentialsPath) {
+    return { dnsProviders: { cloudflare: { credentialsFile: credentialsPath } } };
+  }
+
+  it("reads and parses a 0600 JSON credentials file", () => {
+    const credentialsPath = writeCredentialsFile('{"apiToken":"cf-token"}');
+    const parsed = readDnsCredentialsFile("cloudflare", configFor(credentialsPath));
+    assert.deepEqual(parsed, { apiToken: "cf-token" });
+  });
+
+  it("fails loudly when the provider is not configured", () => {
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", { dnsProviders: null }),
+      /not configured/,
+    );
+  });
+
+  it("fails loudly on a missing file", () => {
+    const dir = makeTempConfigDir();
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", configFor(path.join(dir, "absent.json"))),
+      IS_WIN32 ? /failed to read|failed to stat/ : /failed to stat/,
+    );
+  });
+
+  it("fails loudly on non-JSON content without echoing it", () => {
+    const credentialsPath = writeCredentialsFile("apiToken=oops-not-json");
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", configFor(credentialsPath)),
+      (err) => {
+        assert.match(err.message, /not valid JSON/);
+        assert.ok(!err.message.includes("oops-not-json"));
+        return true;
+      },
+    );
+  });
+
+  it("fails loudly on a JSON file that is not an object", () => {
+    const credentialsPath = writeCredentialsFile('["array"]');
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", configFor(credentialsPath)),
+      /must contain a JSON object/,
+    );
+  });
+
+  it("refuses a group/other-readable credentials file (POSIX)", { skip: IS_WIN32 }, () => {
+    const credentialsPath = writeCredentialsFile('{"apiToken":"cf-token"}');
+    fs.chmodSync(credentialsPath, 0o644);
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", configFor(credentialsPath)),
+      /readable by group\/other/,
+    );
   });
 });

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -281,6 +281,174 @@ function validatePolicyObject(policy) {
   return policy;
 }
 
+/** Provider ids accepted in the dnsProviders config section. Must stay in
+ * sync with src/dns listSupportedDnsProviders (duplicated, not imported,
+ * to keep this module self-contained). */
+const KNOWN_DNS_PROVIDER_IDS = Object.freeze([
+  "cloudflare",
+  "route53",
+  "azure-dns",
+  "google-cloud-dns",
+  "rfc2136",
+  "acme-dns",
+]);
+
+/**
+ * Validates the optional "dnsProviders" config block (native DNS-01
+ * solvers, src/dns). Fail-loud like validateCaBundlePath: a malformed
+ * block aborts startup instead of being silently normalized.
+ *
+ * Shape: an object mapping provider id -> { credentialsFile: absolutePath,
+ * ...providerSpecificNonSecretOptions }, plus an optional reserved
+ * `zoneProviderMap` key (zone -> provider id) for hosts with more than one
+ * provider. Credentials themselves NEVER live in config.json; only the
+ * path to the 0600 credentials file does.
+ *
+ * @param {*} dnsProviders raw config.json "dnsProviders" value
+ * @returns {object|null} the validated block, or null when absent
+ */
+function validateDnsProvidersObject(dnsProviders) {
+  if (dnsProviders === undefined || dnsProviders === null) return null;
+  if (typeof dnsProviders !== "object" || Array.isArray(dnsProviders)) {
+    throw new Error(
+      "tokentimer-agent: dnsProviders in config.json must be an object " +
+        "mapping provider id -> { credentialsFile, ...options }",
+    );
+  }
+
+  const providerIds = Object.keys(dnsProviders).filter(
+    (key) => key !== "zoneProviderMap",
+  );
+
+  for (const providerId of providerIds) {
+    if (!KNOWN_DNS_PROVIDER_IDS.includes(providerId)) {
+      throw new Error(
+        `tokentimer-agent: dnsProviders.${providerId} is not a known DNS ` +
+          `provider id (known: ${KNOWN_DNS_PROVIDER_IDS.join(", ")})`,
+      );
+    }
+    const entry = dnsProviders[providerId];
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `tokentimer-agent: dnsProviders.${providerId} must be an object ` +
+          "({ credentialsFile, ...options })",
+      );
+    }
+    if (
+      typeof entry.credentialsFile !== "string" ||
+      entry.credentialsFile.length === 0 ||
+      !path.isAbsolute(entry.credentialsFile)
+    ) {
+      throw new Error(
+        `tokentimer-agent: dnsProviders.${providerId}.credentialsFile must be ` +
+          `an absolute path string, got: ${JSON.stringify(entry.credentialsFile)}`,
+      );
+    }
+  }
+
+  const zoneProviderMap = dnsProviders.zoneProviderMap;
+  if (zoneProviderMap !== undefined) {
+    if (
+      zoneProviderMap === null ||
+      typeof zoneProviderMap !== "object" ||
+      Array.isArray(zoneProviderMap)
+    ) {
+      throw new Error(
+        "tokentimer-agent: dnsProviders.zoneProviderMap must be an object " +
+          "mapping zone -> provider id",
+      );
+    }
+    for (const [zone, providerId] of Object.entries(zoneProviderMap)) {
+      if (zone.length === 0) {
+        throw new Error(
+          "tokentimer-agent: dnsProviders.zoneProviderMap contains an empty zone key",
+        );
+      }
+      if (!providerIds.includes(providerId)) {
+        throw new Error(
+          `tokentimer-agent: dnsProviders.zoneProviderMap.${zone} references ` +
+            `provider ${JSON.stringify(providerId)}, which is not configured ` +
+            "in dnsProviders",
+        );
+      }
+    }
+  }
+
+  return dnsProviders;
+}
+
+/**
+ * Reads and JSON-parses the agent-local DNS credentials file for one
+ * configured provider. Fail-loud on every problem: missing config entry,
+ * unreadable file, non-JSON content, or (POSIX only, same posture as the
+ * 0600 credential file this module writes) a file readable by group/other.
+ * The parsed object is returned as-is; deep shape validation is the
+ * dns module's job (createDnsSolver fails loud on malformed credentials).
+ * The contents are never logged, including in errors.
+ *
+ * @param {string} providerId
+ * @param {{ dnsProviders?: object|null }} config loaded agent config
+ * @returns {object} parsed credentials object
+ */
+function readDnsCredentialsFile(providerId, config) {
+  const dnsProviders = config && config.dnsProviders;
+  const entry = dnsProviders ? dnsProviders[providerId] : undefined;
+  if (!entry || typeof entry.credentialsFile !== "string") {
+    throw new Error(
+      `tokentimer-agent: dnsProviders.${providerId} is not configured ` +
+        "(no credentialsFile)",
+    );
+  }
+
+  const credentialsPath = entry.credentialsFile;
+
+  if (process.platform !== "win32") {
+    let stats;
+    try {
+      stats = fs.statSync(credentialsPath);
+    } catch (err) {
+      throw new Error(
+        `tokentimer-agent: failed to stat DNS credentials file ${credentialsPath}: ${err.message}`,
+      );
+    }
+    // Same permission posture as the agent credential file: secrets are
+    // 0600. A group/other-readable credentials file is a misconfiguration
+    // the agent refuses to use rather than silently accepting.
+    if ((stats.mode & 0o077) !== 0) {
+      throw new Error(
+        `tokentimer-agent: refusing to read DNS credentials file ${credentialsPath}: ` +
+          "it is readable by group/other (chmod 600 it)",
+      );
+    }
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(credentialsPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `tokentimer-agent: failed to read DNS credentials file ${credentialsPath}: ${err.message}`,
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Deliberately does not include the parser message: it can echo file
+    // content, and this file holds secrets.
+    throw new Error(
+      `tokentimer-agent: DNS credentials file ${credentialsPath} is not valid JSON`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `tokentimer-agent: DNS credentials file ${credentialsPath} must contain a JSON object`,
+    );
+  }
+  return parsed;
+}
+
 function validateDiscoveryObject(discovery) {
   if (discovery === undefined || discovery === null) return null;
   if (typeof discovery !== "object" || Array.isArray(discovery)) {
@@ -471,6 +639,7 @@ function validateExecutionObject(execution, configDir) {
  *     clockDriftToleranceMs: number,
  *   }|null,
  *   pinnedSigningKey: {signingKeyId: string, publicKeyPem: string}|null,
+ *   dnsProviders: object|null,
  * }}
  */
 function loadAgentConfig({ configDir } = {}) {
@@ -553,6 +722,11 @@ function loadAgentConfig({ configDir } = {}) {
   // writeSigningKeyPin. Public key material only.
   const pinnedSigningKey = readSigningKeyPin(resolvedDir);
 
+  // Native DNS-01 solver configuration (src/dns + certops-dns-hook). Only
+  // credential file PATHS live here; the secrets stay in their own 0600
+  // files, read on demand via readDnsCredentialsFile.
+  const dnsProviders = validateDnsProvidersObject(fileConfig.dnsProviders);
+
   return {
     serverUrl,
     agentId,
@@ -567,6 +741,7 @@ function loadAgentConfig({ configDir } = {}) {
     allowInsecureLocalHttp,
     execution,
     pinnedSigningKey,
+    dnsProviders,
   };
 }
 
@@ -900,6 +1075,8 @@ module.exports = {
   writeSigningKeyPin,
   readSigningKeyPin,
   validateExecutionObject,
+  validateDnsProvidersObject,
+  readDnsCredentialsFile,
   readCredential,
   writeCredential,
   rotateCredential,

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -39,6 +39,13 @@ const PENDING_REGISTRATION_FILE_NAME = "registration.pending.json";
 // is not a secret; it still gets 0600 in the 0700 config dir purely as an
 // integrity measure (only the agent user may swap the pin).
 const SIGNING_KEY_PIN_FILE_NAME = "signing-key-pin.json";
+// Persisted outbound-message sequence state (crash-safe block reservation;
+// see createSequenceAllocator). Not a secret, but 0600 like everything else
+// in the state dir so only the agent user can tamper with it.
+const SEQUENCE_STATE_FILE_NAME = "sequence-state.json";
+// Bootstrap env file written by install-agent.sh for first-run registration;
+// the agent deletes it after a successful registration (single-use token).
+const BOOTSTRAP_ENV_FILE_NAME = "bootstrap.env";
 
 const AGENT_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/;
 // Same character/length policy as the protocol validator's key-id bound;
@@ -51,6 +58,8 @@ const CREDENTIAL_SHAPE_PATTERN =
   /^ttagent_([A-Za-z0-9_.:-]{1,128})_([A-Za-z0-9._~+\/-]{16,1024})$/;
 const PEM_CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----/;
 const MAX_CA_BUNDLE_BYTES = 1024 * 1024;
+// DNS provider credential files are small JSON objects; 64 KiB is generous.
+const MAX_DNS_CREDENTIALS_BYTES = 64 * 1024;
 
 const DEFAULT_PROTOCOL_VERSION = "1.0.0";
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
@@ -283,7 +292,8 @@ function validatePolicyObject(policy) {
 
 /** Provider ids accepted in the dnsProviders config section. Must stay in
  * sync with src/dns listSupportedDnsProviders (duplicated, not imported,
- * to keep this module self-contained). */
+ * to keep this module self-contained; config.test.js fails if the two
+ * lists drift). */
 const KNOWN_DNS_PROVIDER_IDS = Object.freeze([
   "cloudflare",
   "route53",
@@ -410,10 +420,15 @@ function readDnsCredentialsFile(providerId, config) {
   if (process.platform !== "win32") {
     let stats;
     try {
-      stats = fs.statSync(credentialsPath);
+      stats = fs.lstatSync(credentialsPath);
     } catch (err) {
       throw new Error(
         `tokentimer-agent: failed to stat DNS credentials file ${credentialsPath}: ${err.message}`,
+      );
+    }
+    if (stats.isSymbolicLink() || !stats.isFile()) {
+      throw new Error(
+        `tokentimer-agent: DNS credentials file ${credentialsPath} must be a regular non-symlink file`,
       );
     }
     // Same permission posture as the agent credential file: secrets are
@@ -425,11 +440,28 @@ function readDnsCredentialsFile(providerId, config) {
           "it is readable by group/other (chmod 600 it)",
       );
     }
+    // Must be owned by the agent user (or root, so operators can provision
+    // credentials without a login shell for the service account).
+    if (typeof process.getuid === "function") {
+      const uid = process.getuid();
+      if (stats.uid !== uid && stats.uid !== 0) {
+        throw new Error(
+          `tokentimer-agent: refusing to read DNS credentials file ${credentialsPath}: ` +
+            "it is not owned by the agent user or root",
+        );
+      }
+    }
   }
 
   let raw;
   try {
-    raw = fs.readFileSync(credentialsPath, "utf8");
+    // Bounded, O_NOFOLLOW re-verified read (defense in depth on top of the
+    // lstat above against swap-to-symlink races and oversized files).
+    raw = readBoundedRegularFile(
+      credentialsPath,
+      MAX_DNS_CREDENTIALS_BYTES,
+      "DNS credentials file",
+    ).toString("utf8");
   } catch (err) {
     throw new Error(
       `tokentimer-agent: failed to read DNS credentials file ${credentialsPath}: ${err.message}`,
@@ -1070,6 +1102,113 @@ function redactCredentialForLogging(_value) {
   return REDACTED_CREDENTIAL_PLACEHOLDER;
 }
 
+// --- Persisted outbound-message sequence allocator ---
+
+/**
+ * How many sequence values one durable write reserves. Every allocation
+ * inside the reserved block is memory-only; crossing the block boundary
+ * persists a new `reservedThrough` BEFORE any value from the new block is
+ * handed out, so a crash can never lead to reuse: a restart resumes AFTER
+ * the highest value that was ever reserved on disk.
+ */
+const SEQUENCE_RESERVATION_BLOCK = 64;
+const MAX_SEQUENCE_STATE_BYTES = 4096;
+
+/**
+ * Creates the agent's single crash-safe, persisted sequence allocator.
+ *
+ * One allocator instance must be shared by every protocol client the
+ * process creates (registration + steady-state), so all outbound messages
+ * draw from one strictly increasing stream that survives restarts. The
+ * control plane hard-rejects sequence regressions; without persistence a
+ * restarted agent's counter would restart at 1 and lock the agent out.
+ *
+ * State file (sequence-state.json, 0600): { "reservedThrough": <int> }.
+ * Corrupted or missing state starts a fresh reservation from 0 -- safe for
+ * a missing file (first run); a corrupted file loses at most one block of
+ * already-reserved values... which only ever moves the counter FORWARD
+ * after re-reservation, never backward, because the fresh block is written
+ * before use. To be safe against a truncated-but-parseable low value, the
+ * reader treats any parse problem as "unknown" and the writer always
+ * persists max(current, disk) + block.
+ *
+ * @param {string} configDir
+ * @returns {{ next: () => number, peekReservedThrough: () => number }}
+ */
+function createSequenceAllocator(configDir) {
+  ensureConfigDir(configDir);
+  const statePath = path.join(configDir, SEQUENCE_STATE_FILE_NAME);
+
+  function readReservedThrough() {
+    if (!fs.existsSync(statePath)) return 0;
+    try {
+      const raw = readBoundedRegularFile(
+        statePath,
+        MAX_SEQUENCE_STATE_BYTES,
+        "sequence state file",
+      ).toString("utf8");
+      const parsed = JSON.parse(raw);
+      const value = parsed?.reservedThrough;
+      return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+    } catch (_err) {
+      // Unreadable/corrupt state: treated as 0 here; reserveThrough()
+      // below still writes before any allocation, and the control plane
+      // rejecting a regression is the final backstop.
+      return 0;
+    }
+  }
+
+  function reserveThrough(target) {
+    writeFileAtomically(
+      statePath,
+      `${JSON.stringify({ reservedThrough: target })}\n`,
+      0o600,
+    );
+    return target;
+  }
+
+  let reservedThrough = readReservedThrough();
+  // Resume strictly after everything ever reserved on disk.
+  let lastAllocated = reservedThrough;
+
+  return {
+    next() {
+      const candidate = lastAllocated + 1;
+      if (candidate > reservedThrough) {
+        // Durable write FIRST, allocation second: a crash between the two
+        // wastes a block but can never reuse a value.
+        reservedThrough = reserveThrough(candidate + SEQUENCE_RESERVATION_BLOCK - 1);
+      }
+      lastAllocated = candidate;
+      return candidate;
+    },
+    peekReservedThrough() {
+      return reservedThrough;
+    },
+  };
+}
+
+/**
+ * Best-effort removal of the installer-written bootstrap env file after a
+ * successful registration. The bootstrap token is single-use; once the
+ * agent holds a credential, keeping the token on disk (where every later
+ * process start re-exports it into the agent environment via systemd
+ * EnvironmentFile) only widens exposure.
+ *
+ * @param {string} configDir
+ * @returns {boolean} true when a file was removed
+ */
+function deleteBootstrapEnvFile(configDir) {
+  const bootstrapEnvPath = path.join(configDir, BOOTSTRAP_ENV_FILE_NAME);
+  try {
+    fs.unlinkSync(bootstrapEnvPath);
+    fsyncParentDirectory(bootstrapEnvPath);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
 module.exports = {
   resolveConfigDir,
   ensureConfigDir,
@@ -1088,6 +1227,9 @@ module.exports = {
   persistRegistration,
   recoverPendingRegistration,
   redactCredentialForLogging,
+  createSequenceAllocator,
+  deleteBootstrapEnvFile,
+  KNOWN_DNS_PROVIDER_IDS,
   CREDENTIAL_SHAPE_PATTERN,
   MAX_CA_BUNDLE_BYTES,
 };

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -291,6 +291,11 @@ const KNOWN_DNS_PROVIDER_IDS = Object.freeze([
   "google-cloud-dns",
   "rfc2136",
   "acme-dns",
+  "ovhcloud",
+  "hetzner",
+  "infomaniak",
+  "exoscale",
+  "powerdns",
 ]);
 
 /**

--- a/packages/agent/src/dns/dns.test.js
+++ b/packages/agent/src/dns/dns.test.js
@@ -40,7 +40,7 @@ const CHALLENGE = {
 // listSupportedDnsProviders
 // ---------------------------------------------------------------------------
 
-test("listSupportedDnsProviders returns the six wave-1 provider ids", () => {
+test("listSupportedDnsProviders returns the wave-1 then wave-2 provider ids", () => {
   assert.deepEqual(listSupportedDnsProviders(), [
     "cloudflare",
     "route53",
@@ -48,6 +48,11 @@ test("listSupportedDnsProviders returns the six wave-1 provider ids", () => {
     "google-cloud-dns",
     "rfc2136",
     "acme-dns",
+    "ovhcloud",
+    "hetzner",
+    "infomaniak",
+    "exoscale",
+    "powerdns",
   ]);
 });
 

--- a/packages/agent/src/dns/dns.test.js
+++ b/packages/agent/src/dns/dns.test.js
@@ -1,0 +1,247 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createDnsSolver,
+  listSupportedDnsProviders,
+  OUTPUT_EXCERPT_MAX_CHARS,
+} = require("./index.js");
+
+const CLOUDFLARE_CREDENTIALS = { apiToken: "cf-token-SECRET", zoneId: "zone123" };
+
+/**
+ * fetch stub factory: records calls and answers each one from `respond`
+ * (a function of (url, options) returning { status, body }).
+ */
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function cloudflareSolver(fetchImpl, credentials = CLOUDFLARE_CREDENTIALS) {
+  return createDnsSolver({ provider: "cloudflare", credentials, fetchImpl });
+}
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.www.example.com",
+  txtValue: "token-value",
+};
+
+// ---------------------------------------------------------------------------
+// listSupportedDnsProviders
+// ---------------------------------------------------------------------------
+
+test("listSupportedDnsProviders returns the six wave-1 provider ids", () => {
+  assert.deepEqual(listSupportedDnsProviders(), [
+    "cloudflare",
+    "route53",
+    "azure-dns",
+    "google-cloud-dns",
+    "rfc2136",
+    "acme-dns",
+  ]);
+});
+
+test("listSupportedDnsProviders returns a fresh copy each call", () => {
+  const first = listSupportedDnsProviders();
+  first.push("mutated");
+  assert.equal(listSupportedDnsProviders().includes("mutated"), false);
+});
+
+// ---------------------------------------------------------------------------
+// createDnsSolver construction validation (fail loud)
+// ---------------------------------------------------------------------------
+
+test("createDnsSolver throws on an unsupported provider", () => {
+  assert.throws(
+    () => createDnsSolver({ provider: "namecheap", credentials: {} }),
+    /unsupported provider/,
+  );
+});
+
+test("createDnsSolver throws on a missing provider", () => {
+  assert.throws(() => createDnsSolver({ credentials: {} }), /non-empty provider/);
+});
+
+test("createDnsSolver throws on non-object credentials", () => {
+  assert.throws(
+    () => createDnsSolver({ provider: "cloudflare", credentials: "token" }),
+    /credentials must be an object/,
+  );
+  assert.throws(
+    () => createDnsSolver({ provider: "cloudflare", credentials: null }),
+    /credentials must be an object/,
+  );
+});
+
+test("createDnsSolver throws on malformed credentials (fail loud at construction)", () => {
+  assert.throws(
+    () => createDnsSolver({ provider: "cloudflare", credentials: {} }),
+    /apiToken/,
+  );
+});
+
+test("createDnsSolver throws on a non-positive timeoutMs", () => {
+  assert.throws(
+    () =>
+      createDnsSolver({
+        provider: "cloudflare",
+        credentials: CLOUDFLARE_CREDENTIALS,
+        timeoutMs: 0,
+      }),
+    /timeoutMs/,
+  );
+});
+
+test("createDnsSolver throws on a non-function dnsUpdateImpl", () => {
+  assert.throws(
+    () =>
+      createDnsSolver({
+        provider: "cloudflare",
+        credentials: CLOUDFLARE_CREDENTIALS,
+        dnsUpdateImpl: "not-a-function",
+      }),
+    /dnsUpdateImpl/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// challenge input validation (programmer error => throws)
+// ---------------------------------------------------------------------------
+
+test("presentChallenge throws on missing zone/recordName/txtValue", async () => {
+  const solver = cloudflareSolver(makeFetchStub(() => ({})));
+  await assert.rejects(
+    solver.presentChallenge({ recordName: "_acme-challenge.example.com", txtValue: "v" }),
+    /zone must be a non-empty string/,
+  );
+  await assert.rejects(
+    solver.presentChallenge({ zone: "example.com", txtValue: "v" }),
+    /recordName must be a non-empty string/,
+  );
+  await assert.rejects(
+    solver.presentChallenge({ zone: "example.com", recordName: "_acme-challenge.example.com" }),
+    /txtValue must be a non-empty string/,
+  );
+});
+
+test("recordName outside the zone throws (dot-boundary rule)", async () => {
+  const fetchStub = makeFetchStub(() => ({}));
+  const solver = cloudflareSolver(fetchStub);
+
+  // evilexample.com must NOT match zone example.com (naive endsWith would).
+  await assert.rejects(
+    solver.presentChallenge({
+      zone: "example.com",
+      recordName: "_acme-challenge.evilexample.com",
+      txtValue: "v",
+    }),
+    /is not within zone/,
+  );
+  assert.equal(fetchStub.calls.length, 0);
+});
+
+test("recordName equal to the zone is accepted", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: "{}" }));
+  const solver = cloudflareSolver(fetchStub);
+  const result = await solver.presentChallenge({
+    zone: "_acme-challenge.example.com",
+    recordName: "_acme-challenge.example.com",
+    txtValue: "v",
+  });
+  assert.equal(result.ok, true);
+});
+
+test("cleanupChallenge validates inputs the same way as presentChallenge", async () => {
+  const solver = cloudflareSolver(makeFetchStub(() => ({})));
+  await assert.rejects(
+    solver.cleanupChallenge({
+      zone: "example.com",
+      recordName: "_acme-challenge.other.org",
+      txtValue: "v",
+    }),
+    /is not within zone/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// operational failure contract: never throw, always { ok:false }
+// ---------------------------------------------------------------------------
+
+test("a throwing fetch maps to ok:false with the provider id, never a throw", async () => {
+  const solver = createDnsSolver({
+    provider: "cloudflare",
+    credentials: CLOUDFLARE_CREDENTIALS,
+    fetchImpl: async () => {
+      throw new Error("ECONNREFUSED 1.2.3.4:443");
+    },
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.ok, false);
+  assert.equal(result.provider, "cloudflare");
+  assert.match(result.detail, /ECONNREFUSED/);
+});
+
+test("results carry the provider id on success too", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: "{}" }));
+  const solver = cloudflareSolver(fetchStub);
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.deepEqual(result, { provider: "cloudflare", ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// excerpt bounding and credential redaction
+// ---------------------------------------------------------------------------
+
+test("HTTP error details are bounded to the documented maximum", async () => {
+  const longBody = "x".repeat(OUTPUT_EXCERPT_MAX_CHARS + 500);
+  const fetchStub = makeFetchStub(() => ({ status: 500, body: longBody }));
+  const solver = cloudflareSolver(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+  assert.ok(result.detail.length <= OUTPUT_EXCERPT_MAX_CHARS);
+});
+
+test("a response echoing the credential is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: `{"error":"invalid token cf-token-SECRET supplied"}`,
+  }));
+  const solver = cloudflareSolver(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});
+
+test("a response containing a PRIVATE KEY marker is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 500,
+    body: "-----BEGIN RSA PRIVATE KEY-----\nnot-real\n",
+  }));
+  const solver = cloudflareSolver(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});
+
+test("a credential echoed past the excerpt window still triggers redaction", async () => {
+  const body = "y".repeat(OUTPUT_EXCERPT_MAX_CHARS + 10) + " cf-token-SECRET";
+  const fetchStub = makeFetchStub(() => ({ status: 500, body }));
+  const solver = cloudflareSolver(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/dns.test.js
+++ b/packages/agent/src/dns/dns.test.js
@@ -250,3 +250,173 @@ test("a credential echoed past the excerpt window still triggers redaction", asy
   const result = await solver.presentChallenge(CHALLENGE);
   assert.equal(result.detail, "[redacted]");
 });
+
+// ---------------------------------------------------------------------------
+// shared HTTP transport hardening (internal.js)
+// ---------------------------------------------------------------------------
+
+const {
+  fetchWithTimeout,
+  assertSafeProviderBaseUrl,
+  MAX_PROVIDER_RESPONSE_BYTES,
+} = require("./internal.js");
+
+/** Minimal WHATWG-ish body stream double built from Buffer chunks. */
+function fakeBodyStream(chunks) {
+  const state = { cancelled: false };
+  let index = 0;
+  const stream = {
+    getReader() {
+      return {
+        async read() {
+          if (state.cancelled || index >= chunks.length) {
+            return { done: true, value: undefined };
+          }
+          const value = chunks[index];
+          index += 1;
+          return { done: false, value };
+        },
+        async cancel() {
+          state.cancelled = true;
+        },
+        releaseLock() {},
+      };
+    },
+  };
+  return { stream, state };
+}
+
+test("fetchWithTimeout always passes redirect:\"error\" to the fetch impl", async () => {
+  let seenOptions;
+  const fetchImpl = async (url, options) => {
+    seenOptions = options;
+    return { status: 200, text: async () => "{}" };
+  };
+
+  await fetchWithTimeout(fetchImpl, "https://api.example", { method: "GET" }, 1000);
+  assert.equal(seenOptions.redirect, "error");
+
+  // A provider going through the solver layer gets the same treatment.
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: "{}" }));
+  await cloudflareSolver(fetchStub).presentChallenge(CHALLENGE);
+  assert.equal(fetchStub.calls[0].options.redirect, "error");
+});
+
+test("fetchWithTimeout rejects an oversized text() body instead of truncating", async () => {
+  const huge = "z".repeat(MAX_PROVIDER_RESPONSE_BYTES + 1);
+  const fetchImpl = async () => ({ status: 200, text: async () => huge });
+
+  await assert.rejects(
+    fetchWithTimeout(fetchImpl, "https://api.example", { method: "GET" }, 1000),
+    /size limit/,
+  );
+});
+
+test("fetchWithTimeout reads streamed bodies and rejects past the bound (reader cancelled)", async () => {
+  const chunk = Buffer.alloc(64 * 1024, 0x61);
+  const { stream, state } = fakeBodyStream([chunk, chunk, chunk, chunk, chunk]);
+  const fetchImpl = async () => ({ status: 200, body: stream });
+
+  await assert.rejects(
+    fetchWithTimeout(fetchImpl, "https://api.example", { method: "GET" }, 1000),
+    /size limit/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("fetchWithTimeout resolves streamed bodies within the bound", async () => {
+  const { stream } = fakeBodyStream([Buffer.from("hello "), Buffer.from("world")]);
+  const fetchImpl = async () => ({ status: 200, body: stream });
+
+  const result = await fetchWithTimeout(fetchImpl, "https://api.example", { method: "GET" }, 1000);
+  assert.equal(result.ok, true);
+  assert.equal(result.bodyText, "hello world");
+});
+
+test("an oversized provider response maps to ok:false through the solver layer", async () => {
+  const huge = "z".repeat(MAX_PROVIDER_RESPONSE_BYTES + 1);
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: huge }));
+  const solver = cloudflareSolver(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /size limit/);
+});
+
+test("assertSafeProviderBaseUrl accepts https and rejects unsafe URLs", () => {
+  assert.ok(assertSafeProviderBaseUrl("https://api.example/path"));
+  assert.throws(() => assertSafeProviderBaseUrl("not a url"), /not a valid URL/);
+  assert.throws(() => assertSafeProviderBaseUrl("https://u:p@api.example"), /embed credentials/);
+  assert.throws(() => assertSafeProviderBaseUrl("https://api.example#frag"), /hash fragment/);
+  assert.throws(() => assertSafeProviderBaseUrl("ftp://api.example"), /not allowed/);
+  assert.throws(() => assertSafeProviderBaseUrl("http://api.example"), /https/);
+});
+
+test("assertSafeProviderBaseUrl gates plain http behind allowInsecureLocalHttp + loopback", () => {
+  const opts = { allowInsecureLocalHttp: true };
+  assert.ok(assertSafeProviderBaseUrl("http://127.0.0.1:8081", opts));
+  assert.ok(assertSafeProviderBaseUrl("http://localhost:8081", opts));
+  assert.ok(assertSafeProviderBaseUrl("http://pdns.localhost", opts));
+  assert.ok(assertSafeProviderBaseUrl("http://[::1]:8081", opts));
+  assert.throws(() => assertSafeProviderBaseUrl("http://10.0.0.5:8081", opts), /loopback/);
+  assert.throws(() => assertSafeProviderBaseUrl("http://api.example", opts), /loopback/);
+});
+
+// ---------------------------------------------------------------------------
+// in-process per-record serialization
+// ---------------------------------------------------------------------------
+
+test("concurrent operations on the same record are serialized in-process", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const fetchImpl = async () => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    inFlight -= 1;
+    return { status: 200, text: async () => "{}" };
+  };
+  const solver = cloudflareSolver(fetchImpl);
+
+  const [first, second] = await Promise.all([
+    solver.presentChallenge(CHALLENGE),
+    solver.cleanupChallenge(CHALLENGE),
+  ]);
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(maxInFlight, 1);
+});
+
+test("operations on different records are NOT serialized against each other", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const fetchImpl = async () => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    inFlight -= 1;
+    return { status: 200, text: async () => "{}" };
+  };
+  const solver = cloudflareSolver(fetchImpl);
+
+  await Promise.all([
+    solver.presentChallenge(CHALLENGE),
+    solver.presentChallenge({ ...CHALLENGE, recordName: "_acme-challenge.other.example.com" }),
+  ]);
+
+  assert.equal(maxInFlight, 2);
+});
+
+test("a rejected operation does not poison the per-record chain", async () => {
+  const solver = cloudflareSolver(makeFetchStub(() => ({ status: 200, body: "{}" })));
+
+  // Programmer error (missing txtValue) rejects...
+  await assert.rejects(
+    solver.presentChallenge({ zone: CHALLENGE.zone, recordName: CHALLENGE.recordName }),
+    /txtValue/,
+  );
+  // ...but the next operation on the same record still runs.
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.ok, true);
+});

--- a/packages/agent/src/dns/hook.js
+++ b/packages/agent/src/dns/hook.js
@@ -1,0 +1,226 @@
+"use strict";
+
+/**
+ * DNS-01 manual-auth-hook runtime.
+ *
+ * Backs the `certops-dns-hook` executable (bin/certops-dns-hook.js) that
+ * certbot and acme.sh invoke to present/clean up `_acme-challenge` TXT
+ * records via the native solvers in src/dns:
+ *
+ *   certbot ... --manual \
+ *     --manual-auth-hook    "certops-dns-hook present" \
+ *     --manual-cleanup-hook "certops-dns-hook cleanup"
+ *
+ * Environment contract: certbot's manual-hook variables CERTBOT_DOMAIN and
+ * CERTBOT_VALIDATION are read first; ACME_DOMAIN / ACME_TXT_VALUE are
+ * accepted as fallbacks so a thin acme.sh dnsapi wrapper can export those
+ * instead. The TXT record name is always `_acme-challenge.${domain}`.
+ *
+ * Policy first (ADR-0002): checkDnsProvider AND checkDnsZone must both
+ * pass against the agent-local policy engine BEFORE any credential file is
+ * read or any network call is made. A rejection prints the policy
+ * rejection JSON ({ allowed:false, rejectionReason, detail }) to stderr
+ * and exits nonzero.
+ *
+ * Output hygiene: this hook never prints credentials or raw provider
+ * responses. Solver results only ever carry bounded, redacted excerpts
+ * (src/dns excerpt rules), and those results are the only provider data
+ * echoed here.
+ *
+ * Everything is injectable so the module is unit-testable without disk,
+ * network, or process globals; bin/certops-dns-hook.js supplies the real
+ * implementations.
+ */
+
+const CHALLENGE_LABEL = "_acme-challenge";
+const USAGE = 'usage: certops-dns-hook <present|cleanup>';
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** Dot-boundary zone coverage, mirroring the policy engine's rule. */
+function isDomainWithinZone(domain, zone) {
+  const normalizedDomain = domain.toLowerCase();
+  const normalizedZone = zone.toLowerCase();
+  return (
+    normalizedDomain === normalizedZone ||
+    normalizedDomain.endsWith(`.${normalizedZone}`)
+  );
+}
+
+/**
+ * Resolves which provider (and which zone) serves `domain` from the
+ * config's dnsProviders section.
+ *
+ * Resolution order:
+ *   1. Longest zoneProviderMap zone covering the domain (dot boundary).
+ *   2. Otherwise, when exactly one provider is configured, that provider
+ *      (zone falls back to the domain itself; provider-side zone lookups
+ *      and per-provider options like zoneId/hostedZoneId/managedZone
+ *      handle nesting).
+ *
+ * @param {object} dnsProviders validated config section
+ * @param {string} domain
+ * @returns {{ provider: string, zone: string, options: object }}
+ */
+function resolveProviderForDomain(dnsProviders, domain) {
+  const zoneProviderMap = dnsProviders.zoneProviderMap || {};
+  const providerIds = Object.keys(dnsProviders).filter(
+    (key) => key !== "zoneProviderMap",
+  );
+
+  let bestZone = null;
+  for (const zone of Object.keys(zoneProviderMap)) {
+    if (!isDomainWithinZone(domain, zone)) {
+      continue;
+    }
+    if (bestZone === null || zone.length > bestZone.length) {
+      bestZone = zone;
+    }
+  }
+
+  if (bestZone !== null) {
+    const provider = zoneProviderMap[bestZone];
+    if (!dnsProviders[provider]) {
+      throw new Error(
+        `certops-dns-hook: zoneProviderMap maps ${JSON.stringify(bestZone)} to ` +
+          `${JSON.stringify(provider)}, but dnsProviders.${provider} is not configured`,
+      );
+    }
+    return { provider, zone: bestZone, options: dnsProviders[provider] };
+  }
+
+  if (providerIds.length === 1) {
+    return {
+      provider: providerIds[0],
+      zone: domain,
+      options: dnsProviders[providerIds[0]],
+    };
+  }
+
+  throw new Error(
+    `certops-dns-hook: no zoneProviderMap entry covers ${JSON.stringify(domain)} ` +
+      `and ${providerIds.length} providers are configured; add a zoneProviderMap ` +
+      "entry so the provider choice is unambiguous",
+  );
+}
+
+/**
+ * Runs one hook invocation. Returns the process exit code (0 success,
+ * nonzero failure); never throws.
+ *
+ * @param {object} options
+ * @param {object} options.env environment (certbot/acme.sh variables).
+ * @param {string[]} options.argv args after the script name; argv[0] is
+ *   the mode ("present" or "cleanup").
+ * @param {() => object} options.loadConfig returns the loaded agent config
+ *   (src/config loadAgentConfig shape, incl. `policy` and `dnsProviders`).
+ * @param {(providerId: string, config: object) => object} options.readCredentialsFile
+ *   reads + parses the provider's agent-local credentials file
+ *   (src/config readDnsCredentialsFile).
+ * @param {Function} options.createSolver createDnsSolver-shaped factory.
+ * @param {(rawPolicy: object) => { checkDnsProvider: Function, checkDnsZone: Function }} options.policyEngineFactory
+ *   builds the agent-local policy engine from config.policy.
+ * @param {{ write: Function }} options.stdout
+ * @param {{ write: Function }} options.stderr
+ * @returns {Promise<number>}
+ */
+async function runDnsHook({
+  env,
+  argv,
+  loadConfig,
+  readCredentialsFile,
+  createSolver,
+  policyEngineFactory,
+  stdout,
+  stderr,
+} = {}) {
+  const mode = Array.isArray(argv) ? argv[0] : undefined;
+  if (mode !== "present" && mode !== "cleanup") {
+    stderr.write(`certops-dns-hook: unknown mode ${JSON.stringify(mode)}\n${USAGE}\n`);
+    return 2;
+  }
+
+  const domain = env.CERTBOT_DOMAIN || env.ACME_DOMAIN;
+  const txtValue = env.CERTBOT_VALIDATION || env.ACME_TXT_VALUE;
+  if (!isNonEmptyString(domain)) {
+    stderr.write(
+      "certops-dns-hook: CERTBOT_DOMAIN (or ACME_DOMAIN) must be set in the environment\n",
+    );
+    return 2;
+  }
+  if (!isNonEmptyString(txtValue)) {
+    stderr.write(
+      "certops-dns-hook: CERTBOT_VALIDATION (or ACME_TXT_VALUE) must be set in the environment\n",
+    );
+    return 2;
+  }
+
+  try {
+    const config = loadConfig();
+
+    const dnsProviders = config.dnsProviders;
+    if (!dnsProviders || Object.keys(dnsProviders).filter((k) => k !== "zoneProviderMap").length === 0) {
+      stderr.write(
+        "certops-dns-hook: no dnsProviders section is configured in config.json\n",
+      );
+      return 1;
+    }
+
+    const { provider, zone, options } = resolveProviderForDomain(dnsProviders, domain);
+
+    // Policy gate: BOTH checks must pass before any credential read or
+    // network call. Local policy always wins over anything the caller
+    // (or the control plane behind it) intended.
+    const policyEngine = policyEngineFactory(config.policy || {});
+    for (const rejection of [
+      policyEngine.checkDnsProvider(provider),
+      policyEngine.checkDnsZone(zone),
+    ]) {
+      if (!rejection || rejection.allowed !== true) {
+        stderr.write(`${JSON.stringify(rejection)}\n`);
+        return 1;
+      }
+    }
+
+    const credentials = readCredentialsFile(provider, config);
+
+    // Non-secret per-provider options from config.json (zoneId,
+    // hostedZoneId, managedZone, ...) merge under the credentials file's
+    // own fields; the file wins on conflicts.
+    const { credentialsFile: _credentialsFile, ...nonSecretOptions } = options;
+    const solver = createSolver({
+      provider,
+      credentials: { ...nonSecretOptions, ...credentials },
+    });
+
+    const recordName = `${CHALLENGE_LABEL}.${domain}`;
+    const inputs = { zone, recordName, txtValue };
+    const result =
+      mode === "present"
+        ? await solver.presentChallenge(inputs)
+        : await solver.cleanupChallenge(inputs);
+
+    if (!result || result.ok !== true) {
+      stderr.write(`${JSON.stringify(result)}\n`);
+      return 1;
+    }
+
+    stdout.write(
+      `certops-dns-hook: ${mode} ok for ${recordName} via ${provider}\n`,
+    );
+    return 0;
+  } catch (err) {
+    stderr.write(
+      `certops-dns-hook: ${err && err.message ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+}
+
+module.exports = {
+  runDnsHook,
+  resolveProviderForDomain,
+  CHALLENGE_LABEL,
+};

--- a/packages/agent/src/dns/hook.test.js
+++ b/packages/agent/src/dns/hook.test.js
@@ -1,0 +1,315 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { runDnsHook, resolveProviderForDomain, CHALLENGE_LABEL } = require("./hook.js");
+
+const allow = () => ({ allowed: true });
+const rejectWith = (rejectionReason) => () => ({
+  allowed: false,
+  rejectionReason,
+  detail: `rejected: ${rejectionReason}`,
+});
+
+function makeStream() {
+  const chunks = [];
+  return {
+    write: (chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    },
+    get output() {
+      return chunks.join("");
+    },
+  };
+}
+
+/**
+ * Builds a full runDnsHook options object with recording fakes; overrides
+ * are shallow-merged on top.
+ */
+function makeHarness(overrides = {}) {
+  const solverCalls = [];
+  const solver = {
+    provider: "cloudflare",
+    presentChallenge: async (inputs) => {
+      solverCalls.push({ operation: "present", inputs });
+      return { ok: true, provider: "cloudflare" };
+    },
+    cleanupChallenge: async (inputs) => {
+      solverCalls.push({ operation: "cleanup", inputs });
+      return { ok: true, provider: "cloudflare" };
+    },
+  };
+
+  const createSolverCalls = [];
+  const readCredentialsCalls = [];
+
+  const harness = {
+    env: { CERTBOT_DOMAIN: "www.example.com", CERTBOT_VALIDATION: "token-value" },
+    argv: ["present"],
+    loadConfig: () => ({
+      policy: {
+        allowedDnsProviders: ["cloudflare"],
+        allowedDnsZones: ["example.com"],
+      },
+      dnsProviders: {
+        cloudflare: { credentialsFile: "/etc/tokentimer-agent/dns/cloudflare.json" },
+        zoneProviderMap: { "example.com": "cloudflare" },
+      },
+    }),
+    readCredentialsFile: (providerId, config) => {
+      readCredentialsCalls.push({ providerId, config });
+      return { apiToken: "cf-token" };
+    },
+    createSolver: (options) => {
+      createSolverCalls.push(options);
+      return solver;
+    },
+    policyEngineFactory: () => ({
+      checkDnsProvider: allow,
+      checkDnsZone: allow,
+    }),
+    stdout: makeStream(),
+    stderr: makeStream(),
+    ...overrides,
+  };
+
+  harness.solverCalls = solverCalls;
+  harness.createSolverCalls = createSolverCalls;
+  harness.readCredentialsCalls = readCredentialsCalls;
+  return harness;
+}
+
+// ---------------------------------------------------------------------------
+// argv / env contract
+// ---------------------------------------------------------------------------
+
+test("hook: an unknown mode fails with usage and exit code 2", async () => {
+  const harness = makeHarness({ argv: ["bogus"] });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 2);
+  assert.match(harness.stderr.output, /unknown mode/);
+  assert.match(harness.stderr.output, /usage: certops-dns-hook/);
+});
+
+test("hook: a missing mode fails with exit code 2", async () => {
+  const harness = makeHarness({ argv: [] });
+  assert.equal(await runDnsHook(harness), 2);
+});
+
+test("hook: missing CERTBOT_DOMAIN fails before any work", async () => {
+  const harness = makeHarness({ env: { CERTBOT_VALIDATION: "v" } });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 2);
+  assert.match(harness.stderr.output, /CERTBOT_DOMAIN/);
+  assert.equal(harness.solverCalls.length, 0);
+});
+
+test("hook: missing CERTBOT_VALIDATION fails before any work", async () => {
+  const harness = makeHarness({ env: { CERTBOT_DOMAIN: "www.example.com" } });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 2);
+  assert.match(harness.stderr.output, /CERTBOT_VALIDATION/);
+});
+
+test("hook: ACME_DOMAIN / ACME_TXT_VALUE work as acme.sh-wrapper fallbacks", async () => {
+  const harness = makeHarness({
+    env: { ACME_DOMAIN: "www.example.com", ACME_TXT_VALUE: "acme-sh-token" },
+  });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 0);
+  assert.equal(harness.solverCalls[0].inputs.txtValue, "acme-sh-token");
+});
+
+// ---------------------------------------------------------------------------
+// policy short-circuit: no credentials read, no solver, no network
+// ---------------------------------------------------------------------------
+
+test("hook: a provider policy rejection short-circuits before credentials or solver", async () => {
+  const harness = makeHarness({
+    policyEngineFactory: () => ({
+      checkDnsProvider: rejectWith("dns_provider_not_allowlisted"),
+      checkDnsZone: allow,
+    }),
+  });
+
+  const exitCode = await runDnsHook(harness);
+
+  assert.equal(exitCode, 1);
+  const rejection = JSON.parse(harness.stderr.output);
+  assert.equal(rejection.allowed, false);
+  assert.equal(rejection.rejectionReason, "dns_provider_not_allowlisted");
+  assert.equal(harness.readCredentialsCalls.length, 0);
+  assert.equal(harness.createSolverCalls.length, 0);
+  assert.equal(harness.solverCalls.length, 0);
+});
+
+test("hook: a zone policy rejection short-circuits the same way", async () => {
+  const harness = makeHarness({
+    policyEngineFactory: () => ({
+      checkDnsProvider: allow,
+      checkDnsZone: rejectWith("dns_zone_not_allowlisted"),
+    }),
+  });
+
+  const exitCode = await runDnsHook(harness);
+
+  assert.equal(exitCode, 1);
+  assert.match(harness.stderr.output, /dns_zone_not_allowlisted/);
+  assert.equal(harness.readCredentialsCalls.length, 0);
+  assert.equal(harness.createSolverCalls.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// present / cleanup dispatch
+// ---------------------------------------------------------------------------
+
+test("hook: present dispatches presentChallenge with the derived record name", async () => {
+  const harness = makeHarness();
+  const exitCode = await runDnsHook(harness);
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(harness.solverCalls, [
+    {
+      operation: "present",
+      inputs: {
+        zone: "example.com",
+        recordName: `${CHALLENGE_LABEL}.www.example.com`,
+        txtValue: "token-value",
+      },
+    },
+  ]);
+  assert.match(harness.stdout.output, /present ok .* via cloudflare/);
+});
+
+test("hook: cleanup dispatches cleanupChallenge", async () => {
+  const harness = makeHarness({ argv: ["cleanup"] });
+  const exitCode = await runDnsHook(harness);
+
+  assert.equal(exitCode, 0);
+  assert.equal(harness.solverCalls[0].operation, "cleanup");
+});
+
+test("hook: a solver failure result exits nonzero with the redacted result JSON", async () => {
+  const harness = makeHarness({
+    createSolver: () => ({
+      presentChallenge: async () => ({
+        ok: false,
+        provider: "cloudflare",
+        statusCode: 403,
+        detail: "[redacted]",
+      }),
+      cleanupChallenge: async () => ({ ok: true }),
+    }),
+  });
+
+  const exitCode = await runDnsHook(harness);
+
+  assert.equal(exitCode, 1);
+  const failure = JSON.parse(harness.stderr.output);
+  assert.equal(failure.ok, false);
+  assert.equal(failure.statusCode, 403);
+});
+
+test("hook: non-secret config options merge into credentials, file wins", async () => {
+  const harness = makeHarness({
+    loadConfig: () => ({
+      policy: {},
+      dnsProviders: {
+        cloudflare: {
+          credentialsFile: "/etc/tokentimer-agent/dns/cloudflare.json",
+          zoneId: "config-zone-id",
+        },
+        zoneProviderMap: { "example.com": "cloudflare" },
+      },
+    }),
+    readCredentialsFile: () => ({ apiToken: "cf-token" }),
+  });
+
+  await runDnsHook(harness);
+
+  assert.equal(harness.createSolverCalls.length, 1);
+  assert.deepEqual(harness.createSolverCalls[0], {
+    provider: "cloudflare",
+    credentials: { zoneId: "config-zone-id", apiToken: "cf-token" },
+  });
+});
+
+test("hook: missing dnsProviders section fails with a clear message", async () => {
+  const harness = makeHarness({ loadConfig: () => ({ policy: {} }) });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 1);
+  assert.match(harness.stderr.output, /no dnsProviders section/);
+});
+
+test("hook: a throwing loadConfig maps to exit 1, never a throw", async () => {
+  const harness = makeHarness({
+    loadConfig: () => {
+      throw new Error("config.json is malformed");
+    },
+  });
+  const exitCode = await runDnsHook(harness);
+  assert.equal(exitCode, 1);
+  assert.match(harness.stderr.output, /config\.json is malformed/);
+});
+
+// ---------------------------------------------------------------------------
+// provider resolution
+// ---------------------------------------------------------------------------
+
+test("resolveProviderForDomain: longest zoneProviderMap match wins", () => {
+  const dnsProviders = {
+    cloudflare: { credentialsFile: "/a" },
+    route53: { credentialsFile: "/b" },
+    zoneProviderMap: {
+      "example.com": "cloudflare",
+      "internal.example.com": "route53",
+    },
+  };
+
+  const resolved = resolveProviderForDomain(dnsProviders, "host.internal.example.com");
+  assert.equal(resolved.provider, "route53");
+  assert.equal(resolved.zone, "internal.example.com");
+});
+
+test("resolveProviderForDomain: dot boundary prevents evil-suffix matches", () => {
+  const dnsProviders = {
+    cloudflare: { credentialsFile: "/a" },
+    route53: { credentialsFile: "/b" },
+    zoneProviderMap: { "example.com": "cloudflare", "evilexample.com": "route53" },
+  };
+
+  const resolved = resolveProviderForDomain(dnsProviders, "evilexample.com");
+  assert.equal(resolved.provider, "route53");
+});
+
+test("resolveProviderForDomain: a single configured provider is the default", () => {
+  const dnsProviders = { cloudflare: { credentialsFile: "/a" } };
+  const resolved = resolveProviderForDomain(dnsProviders, "anything.example.net");
+  assert.equal(resolved.provider, "cloudflare");
+  assert.equal(resolved.zone, "anything.example.net");
+});
+
+test("resolveProviderForDomain: multiple providers without a map entry throw", () => {
+  const dnsProviders = {
+    cloudflare: { credentialsFile: "/a" },
+    route53: { credentialsFile: "/b" },
+  };
+  assert.throws(
+    () => resolveProviderForDomain(dnsProviders, "www.example.com"),
+    /zoneProviderMap/,
+  );
+});
+
+test("resolveProviderForDomain: a map entry naming an unconfigured provider throws", () => {
+  const dnsProviders = {
+    cloudflare: { credentialsFile: "/a" },
+    zoneProviderMap: { "example.com": "route53" },
+  };
+  assert.throws(
+    () => resolveProviderForDomain(dnsProviders, "www.example.com"),
+    /not configured/,
+  );
+});

--- a/packages/agent/src/dns/index.js
+++ b/packages/agent/src/dns/index.js
@@ -1,0 +1,227 @@
+"use strict";
+
+/**
+ * DNS-01 challenge solvers (wave 1).
+ *
+ * Native, zero-dependency TXT-record solvers so the agent can satisfy ACME
+ * DNS-01 challenges itself instead of relying on certbot/acme.sh DNS
+ * plugins. certbot/acme.sh still drive the ACME conversation; they call
+ * back into this module through the manual-auth-hook CLI
+ * (bin/certops-dns-hook.js -> src/dns/hook.js).
+ *
+ * Trust and custody model:
+ *   - DNS provider credentials are agent-local secrets, loaded from files
+ *     on this host by the caller (config.readDnsCredentialsFile) and passed
+ *     in as plain data. They are never uploaded to the control plane and
+ *     this module never reads files itself. Note the GCP service-account
+ *     private key is a DNS credential, not certificate key material: it
+ *     stays on this host and is only ever used locally to sign an OAuth
+ *     JWT (zero private-key custody, ADR-0001, is about certificate keys;
+ *     the same never-leaves-the-host discipline is applied here anyway).
+ *   - Policy first: callers (the hook, the dispatch layer) must pass
+ *     checkDnsProvider + checkDnsZone against the agent-local policy
+ *     engine BEFORE constructing/using a solver. This module trusts that
+ *     contract but still enforces the same dot-boundary rule between
+ *     recordName and zone as defense in depth.
+ *   - Every provider response excerpt that can appear in a returned
+ *     `detail` passes through a bounding + redacting helper (max 1024
+ *     chars; wholesale [redacted] on any PRIVATE KEY marker or any
+ *     occurrence of the credential strings themselves).
+ *
+ * Error contract (mirrors src/acme): operational failures (HTTP error,
+ * timeout, network refusal, DNS server REFUSED) never throw -- they come
+ * back as `{ ok: false, provider, statusCode?, detail }`. Throws are
+ * reserved for programmer error and malformed credentials, which fail loud
+ * at construction/call time.
+ *
+ * Supported providers (exact ids, matched against the policy engine's
+ * allowedDnsProviders exact-match allowlist):
+ *   cloudflare, route53, azure-dns, google-cloud-dns, rfc2136, acme-dns
+ *
+ * This module is self-contained within src/dns: it does not import policy,
+ * config, or other sibling src/<name> modules. Wiring policy checks +
+ * credential loading + this solver together is the hook's/dispatch
+ * layer's job.
+ */
+
+const {
+  OUTPUT_EXCERPT_MAX_CHARS,
+  isNonEmptyString,
+  isRecordNameWithinZone,
+  makeExcerptRedactor,
+} = require("./internal.js");
+
+const cloudflare = require("./providers/cloudflare.js");
+const route53 = require("./providers/route53.js");
+const azureDns = require("./providers/azure-dns.js");
+const googleCloudDns = require("./providers/google-cloud-dns.js");
+const rfc2136 = require("./providers/rfc2136.js");
+const acmeDns = require("./providers/acme-dns.js");
+
+/** Default per-request timeout. DNS APIs are fast; propagation waiting is
+ * the ACME tool's job, not this module's. */
+const DEFAULT_TIMEOUT_MS = 30 * 1000;
+
+const PROVIDER_MODULES = Object.freeze({
+  cloudflare,
+  route53,
+  "azure-dns": azureDns,
+  "google-cloud-dns": googleCloudDns,
+  rfc2136,
+  "acme-dns": acmeDns,
+});
+
+const SUPPORTED_DNS_PROVIDERS = Object.freeze([
+  "cloudflare",
+  "route53",
+  "azure-dns",
+  "google-cloud-dns",
+  "rfc2136",
+  "acme-dns",
+]);
+
+/**
+ * @returns {string[]} provider ids accepted by createDnsSolver (fresh copy).
+ */
+function listSupportedDnsProviders() {
+  return [...SUPPORTED_DNS_PROVIDERS];
+}
+
+/**
+ * Creates a DNS-01 solver bound to one provider and one credential set.
+ *
+ * Throws on programmer error / malformed credentials (fail loud at
+ * construction); never throws from presentChallenge/cleanupChallenge on
+ * operational failure.
+ *
+ * @param {object} options
+ * @param {string} options.provider one of listSupportedDnsProviders().
+ * @param {object} options.credentials provider-specific plain-data
+ *   credentials (see each providers/<id>.js header for the exact shape).
+ *   Loaded from agent-local files by the caller; never read from disk here.
+ * @param {Function} [options.fetchImpl] fetch-shaped injection point for
+ *   tests; defaults to the global fetch. Unused by rfc2136.
+ * @param {Function} [options.dnsUpdateImpl] rfc2136-only injection point:
+ *   ({ host, port, message, timeoutMs }) => Promise<Buffer> sending one
+ *   length-prefixed DNS message over TCP and resolving with the response
+ *   (without the length prefix). Defaults to a node:net implementation.
+ *   Tests inject this so they never open sockets.
+ * @param {number} [options.timeoutMs] per-request timeout, default 30 s.
+ * @returns {{
+ *   provider: string,
+ *   presentChallenge: (inputs: { zone: string, recordName: string, txtValue: string }) => Promise<object>,
+ *   cleanupChallenge: (inputs: { zone: string, recordName: string, txtValue: string }) => Promise<object>,
+ * }}
+ */
+function createDnsSolver({
+  provider,
+  credentials,
+  fetchImpl = globalThis.fetch,
+  dnsUpdateImpl,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  if (!isNonEmptyString(provider)) {
+    throw new Error("dns: createDnsSolver requires a non-empty provider string");
+  }
+
+  const providerModule = PROVIDER_MODULES[provider];
+  if (!providerModule) {
+    throw new Error(
+      `dns: unsupported provider ${JSON.stringify(provider)}; supported: ${SUPPORTED_DNS_PROVIDERS.join(", ")}`,
+    );
+  }
+
+  if (credentials === null || typeof credentials !== "object" || Array.isArray(credentials)) {
+    throw new Error(`dns: ${provider} credentials must be an object`);
+  }
+
+  if (typeof fetchImpl !== "function") {
+    throw new Error("dns: fetchImpl must be a function (or global fetch must exist)");
+  }
+
+  if (dnsUpdateImpl !== undefined && typeof dnsUpdateImpl !== "function") {
+    throw new Error("dns: dnsUpdateImpl must be a function when provided");
+  }
+
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `dns: timeoutMs must be a positive integer, got ${JSON.stringify(timeoutMs)}`,
+    );
+  }
+
+  // Fail loud on malformed credentials at construction, per provider.
+  const normalizedCredentials = providerModule.validateCredentials(credentials);
+
+  // Every detail string a caller can see passes through this redactor.
+  const excerpt = makeExcerptRedactor(
+    providerModule.collectSecretStrings(normalizedCredentials),
+  );
+
+  const impl = providerModule.createSolverImpl({
+    credentials: normalizedCredentials,
+    fetchImpl,
+    dnsUpdateImpl,
+    timeoutMs,
+    excerpt,
+  });
+
+  /**
+   * Programmer-error validation shared by present and cleanup. Throws.
+   * @param {{ zone?: unknown, recordName?: unknown, txtValue?: unknown }} inputs
+   */
+  function validateChallengeInputs({ zone, recordName, txtValue } = {}) {
+    if (!isNonEmptyString(zone)) {
+      throw new Error("dns: zone must be a non-empty string");
+    }
+    if (!isNonEmptyString(recordName)) {
+      throw new Error("dns: recordName must be a non-empty string");
+    }
+    if (!isNonEmptyString(txtValue)) {
+      throw new Error("dns: txtValue must be a non-empty string");
+    }
+    if (!isRecordNameWithinZone(recordName, zone)) {
+      throw new Error(
+        `dns: recordName ${JSON.stringify(recordName)} is not within zone ` +
+          `${JSON.stringify(zone)} (must equal the zone or end with ".${zone}")`,
+      );
+    }
+  }
+
+  /**
+   * Runs one provider operation with the never-throw-on-operational-failure
+   * contract: anything the impl throws (network error, timeout abort,
+   * unexpected response shape) is mapped to { ok: false } with a redacted
+   * detail. Input validation throws BEFORE this wrapper engages.
+   *
+   * @param {"presentChallenge"|"cleanupChallenge"} operation
+   * @param {{ zone: string, recordName: string, txtValue: string }} inputs
+   */
+  async function run(operation, inputs) {
+    validateChallengeInputs(inputs);
+    try {
+      const result = await impl[operation](inputs);
+      return { provider, ...result };
+    } catch (err) {
+      return {
+        ok: false,
+        provider,
+        detail: excerpt(
+          `${operation} failed: ${err && err.message ? err.message : String(err)}`,
+        ),
+      };
+    }
+  }
+
+  return {
+    provider,
+    presentChallenge: (inputs) => run("presentChallenge", inputs),
+    cleanupChallenge: (inputs) => run("cleanupChallenge", inputs),
+  };
+}
+
+module.exports = {
+  listSupportedDnsProviders,
+  createDnsSolver,
+  DEFAULT_TIMEOUT_MS,
+  OUTPUT_EXCERPT_MAX_CHARS,
+};

--- a/packages/agent/src/dns/index.js
+++ b/packages/agent/src/dns/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * DNS-01 challenge solvers (wave 1).
+ * DNS-01 challenge solvers (waves 1 and 2).
  *
  * Native, zero-dependency TXT-record solvers so the agent can satisfy ACME
  * DNS-01 challenges itself instead of relying on certbot/acme.sh DNS
@@ -36,7 +36,9 @@
  *
  * Supported providers (exact ids, matched against the policy engine's
  * allowedDnsProviders exact-match allowlist):
- *   cloudflare, route53, azure-dns, google-cloud-dns, rfc2136, acme-dns
+ *   wave 1: cloudflare, route53, azure-dns, google-cloud-dns, rfc2136,
+ *           acme-dns
+ *   wave 2: ovhcloud, hetzner, infomaniak, exoscale, powerdns
  *
  * This module is self-contained within src/dns: it does not import policy,
  * config, or other sibling src/<name> modules. Wiring policy checks +
@@ -57,6 +59,11 @@ const azureDns = require("./providers/azure-dns.js");
 const googleCloudDns = require("./providers/google-cloud-dns.js");
 const rfc2136 = require("./providers/rfc2136.js");
 const acmeDns = require("./providers/acme-dns.js");
+const ovhcloud = require("./providers/ovhcloud.js");
+const hetzner = require("./providers/hetzner.js");
+const infomaniak = require("./providers/infomaniak.js");
+const exoscale = require("./providers/exoscale.js");
+const powerdns = require("./providers/powerdns.js");
 
 /** Default per-request timeout. DNS APIs are fast; propagation waiting is
  * the ACME tool's job, not this module's. */
@@ -69,6 +76,11 @@ const PROVIDER_MODULES = Object.freeze({
   "google-cloud-dns": googleCloudDns,
   rfc2136,
   "acme-dns": acmeDns,
+  ovhcloud,
+  hetzner,
+  infomaniak,
+  exoscale,
+  powerdns,
 });
 
 const SUPPORTED_DNS_PROVIDERS = Object.freeze([
@@ -78,6 +90,11 @@ const SUPPORTED_DNS_PROVIDERS = Object.freeze([
   "google-cloud-dns",
   "rfc2136",
   "acme-dns",
+  "ovhcloud",
+  "hetzner",
+  "infomaniak",
+  "exoscale",
+  "powerdns",
 ]);
 
 /**

--- a/packages/agent/src/dns/index.js
+++ b/packages/agent/src/dns/index.js
@@ -69,6 +69,46 @@ const powerdns = require("./providers/powerdns.js");
  * the ACME tool's job, not this module's. */
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
 
+/**
+ * In-process serialization of present/cleanup operations per
+ * `${provider}:${zone}:${recordName}`: a Map of promise chains so two
+ * concurrent operations on the same record within one process never
+ * interleave their read-modify-write sequences. Entries are deleted once
+ * a chain settles and is still the tail.
+ *
+ * Cross-process serialization is deliberately OUT OF SCOPE: each hook
+ * invocation is its own process, so no in-process lock can cover it. The
+ * providers' read-modify-write merging (GET existing values, merge, write
+ * back) is the primary protection against concurrent challenge writers;
+ * this mutex only removes the avoidable in-process race window.
+ */
+const recordOperationChains = new Map();
+
+/**
+ * Chains `task` behind any in-flight operation for `key`, returning the
+ * task's own promise (rejections propagate to the caller but never poison
+ * the stored chain).
+ *
+ * @param {string} key
+ * @param {() => Promise<object>} task
+ * @returns {Promise<object>}
+ */
+function withRecordLock(key, task) {
+  const previous = recordOperationChains.get(key) || Promise.resolve();
+  const result = previous.then(() => task());
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  recordOperationChains.set(key, tail);
+  tail.then(() => {
+    if (recordOperationChains.get(key) === tail) {
+      recordOperationChains.delete(key);
+    }
+  });
+  return result;
+}
+
 const PROVIDER_MODULES = Object.freeze({
   cloudflare,
   route53,
@@ -231,9 +271,18 @@ function createDnsSolver({
 
   return {
     provider,
-    presentChallenge: (inputs) => run("presentChallenge", inputs),
-    cleanupChallenge: (inputs) => run("cleanupChallenge", inputs),
+    presentChallenge: (inputs) =>
+      withRecordLock(recordLockKey(inputs), () => run("presentChallenge", inputs)),
+    cleanupChallenge: (inputs) =>
+      withRecordLock(recordLockKey(inputs), () => run("cleanupChallenge", inputs)),
   };
+
+  /** @param {{ zone?: unknown, recordName?: unknown }} [inputs] */
+  function recordLockKey(inputs) {
+    const zone = inputs && inputs.zone;
+    const recordName = inputs && inputs.recordName;
+    return `${provider}:${String(zone)}:${String(recordName)}`;
+  }
 }
 
 module.exports = {

--- a/packages/agent/src/dns/internal.js
+++ b/packages/agent/src/dns/internal.js
@@ -19,6 +19,12 @@ const OUTPUT_EXCERPT_MAX_CHARS = 1024;
 const PRIVATE_KEY_MARKER = "PRIVATE KEY";
 const REDACTED_EXCERPT_PLACEHOLDER = "[redacted]";
 
+/** Hard cap on any provider HTTP response body. DNS APIs answer with small
+ * JSON/XML payloads; anything larger is either a misconfigured endpoint or
+ * an attempt to exhaust memory, and must FAIL (never be truncated, which
+ * could silently hide the tail of a response a provider parses). */
+const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
+
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }
@@ -103,13 +109,62 @@ function makeExcerptRedactor(secretValues) {
 }
 
 /**
+ * Reads a response body stream, enforcing MAX_PROVIDER_RESPONSE_BYTES.
+ * Throws (operational failure, mapped to ok:false by the solver wrapper)
+ * when the bound is exceeded; the reader is cancelled first so no further
+ * bytes are pulled off the wire.
+ *
+ * @param {{ getReader: () => any }} bodyStream WHATWG ReadableStream
+ * @returns {Promise<string>}
+ */
+async function readBoundedBodyText(bodyStream) {
+  const reader = bodyStream.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_PROVIDER_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw new Error(
+          `provider response exceeded the ${MAX_PROVIDER_RESPONSE_BYTES}-byte size limit`,
+        );
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    if (typeof reader.releaseLock === "function") {
+      try {
+        reader.releaseLock();
+      } catch {
+        // reader already released by cancel(); nothing to do
+      }
+    }
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
  * fetch wrapper with an AbortController timeout, resolving to a plain
  * { status, ok, bodyText } record. Never inspects the body as JSON here;
  * providers parse what they need and always run raw text through their
  * excerpt redactor before surfacing any of it.
  *
- * Throws on network failure / abort; the solver layer in index.js maps
- * those throws to { ok: false } operational results.
+ * Hardening:
+ *   - redirect: "error" is always passed so credential-bearing requests
+ *     are never replayed against a redirect target.
+ *   - The body is read through the response stream with a hard
+ *     MAX_PROVIDER_RESPONSE_BYTES bound; an over-limit body FAILS (throws)
+ *     rather than being truncated. Test doubles without a body stream fall
+ *     back to response.text() with the same post-hoc limit check.
+ *
+ * Throws on network failure / abort / oversized body; the solver layer in
+ * index.js maps those throws to { ok: false } operational results.
  *
  * @param {Function} fetchImpl fetch-shaped implementation
  * @param {string} url
@@ -126,9 +181,24 @@ async function fetchWithTimeout(fetchImpl, url, options, timeoutMs) {
   try {
     const response = await fetchImpl(url, {
       ...options,
+      redirect: "error",
       signal: controller.signal,
     });
-    const bodyText = await response.text();
+
+    let bodyText;
+    if (response.body && typeof response.body.getReader === "function") {
+      bodyText = await readBoundedBodyText(response.body);
+    } else {
+      // Test doubles expose only text(); the size limit still applies and
+      // an over-limit body fails (truncation is never acceptable).
+      bodyText = await response.text();
+      if (Buffer.byteLength(bodyText, "utf8") > MAX_PROVIDER_RESPONSE_BYTES) {
+        throw new Error(
+          `provider response exceeded the ${MAX_PROVIDER_RESPONSE_BYTES}-byte size limit`,
+        );
+      }
+    }
+
     return {
       status: response.status,
       ok: response.status >= 200 && response.status < 300,
@@ -139,13 +209,75 @@ async function fetchWithTimeout(fetchImpl, url, options, timeoutMs) {
   }
 }
 
+/**
+ * Validates a user-configured provider base URL. Throws (programmer error /
+ * malformed credentials, surfaced at construction time) unless the URL is
+ * parseable, carries no embedded username/password and no hash fragment,
+ * and uses https: -- or http: only when `allowInsecureLocalHttp` is true
+ * AND the hostname is loopback (localhost, *.localhost, 127.x.x.x, ::1).
+ *
+ * @param {string} url
+ * @param {{ allowInsecureLocalHttp?: boolean }} [options]
+ * @returns {URL} the parsed URL
+ */
+function assertSafeProviderBaseUrl(url, { allowInsecureLocalHttp = false } = {}) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`dns: provider base URL is not a valid URL: ${JSON.stringify(url)}`);
+  }
+
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new Error(
+      "dns: provider base URL must not embed credentials (user:pass@host)",
+    );
+  }
+  if (parsed.hash !== "") {
+    throw new Error("dns: provider base URL must not carry a hash fragment");
+  }
+
+  if (parsed.protocol === "https:") {
+    return parsed;
+  }
+
+  if (parsed.protocol === "http:") {
+    if (!allowInsecureLocalHttp) {
+      throw new Error(
+        "dns: provider base URL must use https: " +
+          "(set allowInsecureLocalHttp for a loopback-only http endpoint)",
+      );
+    }
+    const hostname = parsed.hostname.toLowerCase();
+    const isLoopback =
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      /^127(\.\d{1,3}){3}$/.test(hostname) ||
+      hostname === "::1" ||
+      hostname === "[::1]";
+    if (!isLoopback) {
+      throw new Error(
+        "dns: allowInsecureLocalHttp only permits http: for loopback hosts " +
+          "(localhost, *.localhost, 127.x.x.x, ::1)",
+      );
+    }
+    return parsed;
+  }
+
+  throw new Error(
+    `dns: provider base URL protocol ${JSON.stringify(parsed.protocol)} is not allowed`,
+  );
+}
+
 module.exports = {
   OUTPUT_EXCERPT_MAX_CHARS,
   PRIVATE_KEY_MARKER,
   REDACTED_EXCERPT_PLACEHOLDER,
+  MAX_PROVIDER_RESPONSE_BYTES,
   isNonEmptyString,
   isRecordNameWithinZone,
   relativeRecordName,
   makeExcerptRedactor,
   fetchWithTimeout,
+  assertSafeProviderBaseUrl,
 };

--- a/packages/agent/src/dns/internal.js
+++ b/packages/agent/src/dns/internal.js
@@ -1,0 +1,151 @@
+"use strict";
+
+/**
+ * Shared internals for the DNS-01 solver layer (src/dns). This file is
+ * private to the dns module: index.js, hook.js, and the providers/ files
+ * require it, and nothing outside src/dns should.
+ *
+ * Everything here is deliberately dependency-free and side-effect-free so
+ * provider implementations stay pure "data in, data out" HTTP/wire builders
+ * that tests can drive with injected fakes.
+ */
+
+/** Hard cap on any provider-response excerpt carried into results. Mirrors
+ * the acme module's OUTPUT_EXCERPT_MAX_CHARS. */
+const OUTPUT_EXCERPT_MAX_CHARS = 1024;
+
+/** Marker whose presence anywhere in an excerpt causes the whole excerpt to
+ * be replaced, never partially scrubbed (same rule as src/acme). */
+const PRIVATE_KEY_MARKER = "PRIVATE KEY";
+const REDACTED_EXCERPT_PLACEHOLDER = "[redacted]";
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Suffix-with-dot-boundary match, identical in spirit to the policy
+ * module's isZoneCoveredBy (duplicated, not imported, to keep src/dns
+ * self-contained): `recordName` is within `zone` if they are equal or if
+ * recordName ends with `.${zone}`. Prevents `evilexample.com` matching a
+ * zone of `example.com`.
+ *
+ * @param {string} recordName
+ * @param {string} zone
+ * @returns {boolean}
+ */
+function isRecordNameWithinZone(recordName, zone) {
+  const normalizedRecord = recordName.toLowerCase();
+  const normalizedZone = zone.toLowerCase();
+  return (
+    normalizedRecord === normalizedZone ||
+    normalizedRecord.endsWith(`.${normalizedZone}`)
+  );
+}
+
+/**
+ * The record name relative to its zone: "" when recordName === zone,
+ * otherwise recordName with the trailing `.${zone}` removed. Callers map
+ * "" to their provider's apex spelling ("@" for Azure, etc.). Assumes the
+ * dot-boundary check already passed.
+ *
+ * @param {string} recordName
+ * @param {string} zone
+ * @returns {string}
+ */
+function relativeRecordName(recordName, zone) {
+  if (recordName.toLowerCase() === zone.toLowerCase()) {
+    return "";
+  }
+  return recordName.slice(0, recordName.length - zone.length - 1);
+}
+
+/**
+ * Builds a bounding + redacting excerpt function closed over the caller's
+ * secret strings. DNS provider credentials are takeover-grade (they can
+ * redirect a whole zone), so an excerpt containing any credential value --
+ * or any PRIVATE KEY marker -- is redacted WHOLESALE, never partially
+ * scrubbed, exactly like the acme module treats key material.
+ *
+ * @param {string[]} secretValues credential strings to redact on sight
+ * @returns {(output: unknown) => string}
+ */
+function makeExcerptRedactor(secretValues) {
+  const secrets = (secretValues || []).filter(isNonEmptyString);
+
+  return function boundAndRedactExcerpt(output) {
+    let text;
+    if (typeof output === "string") {
+      text = output;
+    } else if (Buffer.isBuffer(output)) {
+      text = output.toString("utf8");
+    } else if (output === undefined || output === null) {
+      text = "";
+    } else {
+      try {
+        text = JSON.stringify(output);
+      } catch {
+        text = String(output);
+      }
+    }
+
+    // Redaction is checked on the FULL text (not just the excerpt window)
+    // so a secret echoed past the first 1024 chars still triggers it.
+    if (text.includes(PRIVATE_KEY_MARKER)) {
+      return REDACTED_EXCERPT_PLACEHOLDER;
+    }
+    if (secrets.some((secret) => text.includes(secret))) {
+      return REDACTED_EXCERPT_PLACEHOLDER;
+    }
+
+    return text.slice(0, OUTPUT_EXCERPT_MAX_CHARS);
+  };
+}
+
+/**
+ * fetch wrapper with an AbortController timeout, resolving to a plain
+ * { status, ok, bodyText } record. Never inspects the body as JSON here;
+ * providers parse what they need and always run raw text through their
+ * excerpt redactor before surfacing any of it.
+ *
+ * Throws on network failure / abort; the solver layer in index.js maps
+ * those throws to { ok: false } operational results.
+ *
+ * @param {Function} fetchImpl fetch-shaped implementation
+ * @param {string} url
+ * @param {object} options fetch options (method, headers, body)
+ * @param {number} timeoutMs
+ * @returns {Promise<{ status: number, ok: boolean, bodyText: string }>}
+ */
+async function fetchWithTimeout(fetchImpl, url, options, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`request timed out after ${timeoutMs} ms`));
+  }, timeoutMs);
+
+  try {
+    const response = await fetchImpl(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    return {
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      bodyText,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+module.exports = {
+  OUTPUT_EXCERPT_MAX_CHARS,
+  PRIVATE_KEY_MARKER,
+  REDACTED_EXCERPT_PLACEHOLDER,
+  isNonEmptyString,
+  isRecordNameWithinZone,
+  relativeRecordName,
+  makeExcerptRedactor,
+  fetchWithTimeout,
+};

--- a/packages/agent/src/dns/providers/acme-dns.js
+++ b/packages/agent/src/dns/providers/acme-dns.js
@@ -11,9 +11,14 @@
  * wave-1 provider when the authoritative DNS host has no scoped API tokens.
  *
  * Credentials shape:
- *   { baseUrl: string, username: string, password: string, subdomain: string }
+ *   { baseUrl: string, username: string, password: string, subdomain: string,
+ *     allowInsecureLocalHttp?: boolean }
  *   (the fields returned by acme-dns /register; fulldomain is the CNAME
- *   target and is not needed here).
+ *   target and is not needed here). baseUrl must be https:; set
+ *   allowInsecureLocalHttp: true (default false) to permit a plain-http
+ *   baseUrl for loopback hosts only (localhost, *.localhost, 127.x.x.x,
+ *   ::1) in local test setups. Embedded credentials and hash fragments are
+ *   always rejected.
  *
  * API surface used: POST {baseUrl}/update with X-Api-User / X-Api-Key
  * headers and body { subdomain, txt }.
@@ -23,7 +28,11 @@
  * update, so there is nothing to delete and no delete endpoint exists.
  */
 
-const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+const {
+  isNonEmptyString,
+  fetchWithTimeout,
+  assertSafeProviderBaseUrl,
+} = require("../internal.js");
 
 const PROVIDER_ID = "acme-dns";
 
@@ -37,18 +46,16 @@ function validateCredentials(credentials) {
       throw new Error(`dns: acme-dns credentials require a non-empty ${field} string`);
     }
   }
+  if (
+    credentials.allowInsecureLocalHttp !== undefined &&
+    typeof credentials.allowInsecureLocalHttp !== "boolean"
+  ) {
+    throw new Error("dns: acme-dns allowInsecureLocalHttp must be a boolean when provided");
+  }
 
-  let parsedBaseUrl;
-  try {
-    parsedBaseUrl = new URL(credentials.baseUrl);
-  } catch {
-    throw new Error(
-      `dns: acme-dns baseUrl is not a valid URL: ${JSON.stringify(credentials.baseUrl)}`,
-    );
-  }
-  if (parsedBaseUrl.protocol !== "https:" && parsedBaseUrl.protocol !== "http:") {
-    throw new Error("dns: acme-dns baseUrl must be an http(s) URL");
-  }
+  assertSafeProviderBaseUrl(credentials.baseUrl, {
+    allowInsecureLocalHttp: credentials.allowInsecureLocalHttp === true,
+  });
 
   return {
     baseUrl: credentials.baseUrl.endsWith("/")

--- a/packages/agent/src/dns/providers/acme-dns.js
+++ b/packages/agent/src/dns/providers/acme-dns.js
@@ -1,0 +1,119 @@
+"use strict";
+
+/**
+ * acme-dns DNS-01 provider (https://github.com/joohoi/acme-dns).
+ *
+ * acme-dns is a purpose-built minimal DNS server: the operator registers an
+ * account once, points a CNAME from _acme-challenge.<domain> at the
+ * acme-dns subdomain, and challenges are satisfied by updating that
+ * subdomain's TXT value. The blast radius of a leaked credential is one
+ * TXT record, not a whole zone -- which is why acme-dns is the recommended
+ * wave-1 provider when the authoritative DNS host has no scoped API tokens.
+ *
+ * Credentials shape:
+ *   { baseUrl: string, username: string, password: string, subdomain: string }
+ *   (the fields returned by acme-dns /register; fulldomain is the CNAME
+ *   target and is not needed here).
+ *
+ * API surface used: POST {baseUrl}/update with X-Api-User / X-Api-Key
+ * headers and body { subdomain, txt }.
+ *
+ * cleanupChallenge is a deliberate no-op success: the acme-dns server keeps
+ * exactly two TXT slots per subdomain and rotates the oldest out on every
+ * update, so there is nothing to delete and no delete endpoint exists.
+ */
+
+const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+
+const PROVIDER_ID = "acme-dns";
+
+/**
+ * @param {object} credentials
+ * @returns {{ baseUrl: string, username: string, password: string, subdomain: string }}
+ */
+function validateCredentials(credentials) {
+  for (const field of ["baseUrl", "username", "password", "subdomain"]) {
+    if (!isNonEmptyString(credentials[field])) {
+      throw new Error(`dns: acme-dns credentials require a non-empty ${field} string`);
+    }
+  }
+
+  let parsedBaseUrl;
+  try {
+    parsedBaseUrl = new URL(credentials.baseUrl);
+  } catch {
+    throw new Error(
+      `dns: acme-dns baseUrl is not a valid URL: ${JSON.stringify(credentials.baseUrl)}`,
+    );
+  }
+  if (parsedBaseUrl.protocol !== "https:" && parsedBaseUrl.protocol !== "http:") {
+    throw new Error("dns: acme-dns baseUrl must be an http(s) URL");
+  }
+
+  return {
+    baseUrl: credentials.baseUrl.endsWith("/")
+      ? credentials.baseUrl.slice(0, -1)
+      : credentials.baseUrl,
+    username: credentials.username,
+    password: credentials.password,
+    subdomain: credentials.subdomain,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.password, credentials.username];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  async function presentChallenge({ txtValue }) {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${credentials.baseUrl}/update`,
+      {
+        method: "POST",
+        headers: {
+          "X-Api-User": credentials.username,
+          "X-Api-Key": credentials.password,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          subdomain: credentials.subdomain,
+          txt: txtValue,
+        }),
+      },
+      timeoutMs,
+    );
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`acme-dns update failed (HTTP ${response.status}): ${response.bodyText}`),
+      };
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * No-op success by design: acme-dns rotates its two TXT slots
+   * automatically on each update and exposes no delete endpoint.
+   * (Synchronous; the solver layer awaits it either way.)
+   */
+  function cleanupChallenge() {
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+};

--- a/packages/agent/src/dns/providers/acme-dns.test.js
+++ b/packages/agent/src/dns/providers/acme-dns.test.js
@@ -49,6 +49,46 @@ test("acme-dns: a non-URL baseUrl throws at construction", () => {
   );
 });
 
+test("acme-dns: a baseUrl with embedded credentials throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, baseUrl: "https://user:pass@acmedns.example.net" }),
+    /embed credentials/,
+  );
+});
+
+test("acme-dns: a baseUrl with a hash fragment throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, baseUrl: "https://acmedns.example.net#frag" }),
+    /hash fragment/,
+  );
+});
+
+test("acme-dns: a plain-http non-local baseUrl throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, baseUrl: "http://acmedns.example.net" }),
+    /https/,
+  );
+  // Even with the escape hatch, a non-loopback http host is rejected.
+  assert.throws(
+    () =>
+      validateCredentials({
+        ...CREDENTIALS,
+        baseUrl: "http://acmedns.example.net",
+        allowInsecureLocalHttp: true,
+      }),
+    /loopback/,
+  );
+});
+
+test("acme-dns: http://127.0.0.1 is accepted with allowInsecureLocalHttp", () => {
+  const normalized = validateCredentials({
+    ...CREDENTIALS,
+    baseUrl: "http://127.0.0.1:8053",
+    allowInsecureLocalHttp: true,
+  });
+  assert.equal(normalized.baseUrl, "http://127.0.0.1:8053");
+});
+
 test("acme-dns: a trailing slash on baseUrl is normalized away", () => {
   const normalized = validateCredentials({
     ...CREDENTIALS,

--- a/packages/agent/src/dns/providers/acme-dns.test.js
+++ b/packages/agent/src/dns/providers/acme-dns.test.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const { validateCredentials } = require("./acme-dns.js");
+
+const CREDENTIALS = {
+  baseUrl: "https://acmedns.example.net",
+  username: "user-uuid",
+  password: "api-key-SECRET",
+  subdomain: "subdomain-uuid",
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("acme-dns: every credential field is required", () => {
+  for (const field of ["baseUrl", "username", "password", "subdomain"]) {
+    const broken = { ...CREDENTIALS };
+    delete broken[field];
+    assert.throws(() => validateCredentials(broken), new RegExp(field));
+  }
+});
+
+test("acme-dns: a non-URL baseUrl throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, baseUrl: "not a url" }),
+    /not a valid URL/,
+  );
+});
+
+test("acme-dns: a trailing slash on baseUrl is normalized away", () => {
+  const normalized = validateCredentials({
+    ...CREDENTIALS,
+    baseUrl: "https://acmedns.example.net/",
+  });
+  assert.equal(normalized.baseUrl, "https://acmedns.example.net");
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("acme-dns: present POSTs /update with the api headers and body", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"txt":"token-value"}' }));
+  const solver = createDnsSolver({
+    provider: "acme-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+  const call = fetchStub.calls[0];
+  assert.equal(call.url, "https://acmedns.example.net/update");
+  assert.equal(call.options.method, "POST");
+  assert.equal(call.options.headers["X-Api-User"], "user-uuid");
+  assert.equal(call.options.headers["X-Api-Key"], "api-key-SECRET");
+  assert.deepEqual(JSON.parse(call.options.body), {
+    subdomain: "subdomain-uuid",
+    txt: "token-value",
+  });
+});
+
+test("acme-dns: HTTP error maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 401, body: '{"error":"unauthorized"}' }));
+  const solver = createDnsSolver({
+    provider: "acme-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 401);
+  assert.match(result.detail, /HTTP 401/);
+});
+
+test("acme-dns: error body echoing the api key is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 401,
+    body: 'key api-key-SECRET was rejected',
+  }));
+  const solver = createDnsSolver({
+    provider: "acme-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});
+
+// ---------------------------------------------------------------------------
+// cleanup (documented no-op)
+// ---------------------------------------------------------------------------
+
+test("acme-dns: cleanup is a no-op success and performs no fetch", async () => {
+  const fetchStub = makeFetchStub(() => ({}));
+  const solver = createDnsSolver({
+    provider: "acme-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.deepEqual(result, { provider: "acme-dns", ok: true });
+  assert.equal(fetchStub.calls.length, 0);
+});

--- a/packages/agent/src/dns/providers/azure-dns.js
+++ b/packages/agent/src/dns/providers/azure-dns.js
@@ -19,8 +19,16 @@
  *   }
  *
  * API surface used (management.azure.com, api-version 2018-05-01):
+ *   GET    .../dnsZones/<zone>/TXT/<relativeRecordName>   read TXT rrset
  *   PUT    .../dnsZones/<zone>/TXT/<relativeRecordName>   create/replace TXT
  *   DELETE .../dnsZones/<zone>/TXT/<relativeRecordName>   delete TXT
+ *
+ * PUT replaces the WHOLE record set, so present() first GETs the existing
+ * set (404 => empty) and PUTs the union of existing values plus the new
+ * one; cleanup() removes only the entries carrying the challenge value and
+ * PUTs the remainder back, DELETEing the set only when nothing remains.
+ * Parallel challenges at the same name (wildcard + apex orders) and
+ * third-party TXT values therefore never clobber each other.
  *
  * The record name sent to Azure is RELATIVE to the zone ("@" at the apex).
  * A fresh token is fetched per operation; challenge flows are far shorter
@@ -135,11 +143,74 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
     );
   }
 
+  /**
+   * GETs the existing TXT record set at the name. Returns
+   * { ok:true, absent, txtRecords } where txtRecords is a normalized array
+   * of { value: string[] } entries (empty when the set does not exist), or
+   * an ok:false operational failure.
+   *
+   * @param {string} accessToken
+   * @param {string} zone
+   * @param {string} recordName
+   */
+  async function readExistingTxtRecords(accessToken, zone, recordName) {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      recordSetUrl(zone, recordName),
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+      timeoutMs,
+    );
+    if (response.status === 404) {
+      return { ok: true, absent: true, txtRecords: [] };
+    }
+    if (!response.ok) {
+      return httpFailure("record GET", response);
+    }
+
+    let txtRecords = [];
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      const rawRecords =
+        parsed && parsed.properties && Array.isArray(parsed.properties.TXTRecords)
+          ? parsed.properties.TXTRecords
+          : [];
+      txtRecords = rawRecords
+        .filter((entry) => entry && Array.isArray(entry.value))
+        .map((entry) => ({
+          value: entry.value.filter((chunk) => typeof chunk === "string"),
+        }));
+    } catch {
+      // A 2xx with an unparseable body is treated as an empty set; the
+      // subsequent PUT surfaces any real API problem.
+    }
+    return { ok: true, absent: false, txtRecords };
+  }
+
   async function presentChallenge({ zone, recordName, txtValue }) {
     const tokenResult = await fetchAccessToken();
     if (!tokenResult.ok) {
       return tokenResult;
     }
+
+    const existing = await readExistingTxtRecords(
+      tokenResult.accessToken,
+      zone,
+      recordName,
+    );
+    if (!existing.ok) {
+      return existing;
+    }
+
+    // Merge: keep every pre-existing entry, add ours only when absent.
+    const alreadyPresent = existing.txtRecords.some(
+      (entry) => entry.value.length === 1 && entry.value[0] === txtValue,
+    );
+    const merged = alreadyPresent
+      ? existing.txtRecords
+      : [...existing.txtRecords, { value: [txtValue] }];
 
     const response = await fetchWithTimeout(
       fetchImpl,
@@ -153,7 +224,7 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
         body: JSON.stringify({
           properties: {
             TTL: TXT_TTL_SECONDS,
-            TXTRecords: [{ value: [txtValue] }],
+            TXTRecords: merged,
           },
         }),
       },
@@ -166,10 +237,54 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
     return { ok: true };
   }
 
-  async function cleanupChallenge({ zone, recordName }) {
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
     const tokenResult = await fetchAccessToken();
     if (!tokenResult.ok) {
       return tokenResult;
+    }
+
+    const existing = await readExistingTxtRecords(
+      tokenResult.accessToken,
+      zone,
+      recordName,
+    );
+    if (!existing.ok) {
+      return existing;
+    }
+    if (existing.absent) {
+      // Record set already gone: cleanup is idempotent success.
+      return { ok: true };
+    }
+
+    // Remove only entries carrying exactly the challenge value; every
+    // other TXT value at the name is preserved.
+    const remaining = existing.txtRecords.filter(
+      (entry) => !(entry.value.length === 1 && entry.value[0] === txtValue),
+    );
+
+    if (remaining.length > 0) {
+      const putResponse = await fetchWithTimeout(
+        fetchImpl,
+        recordSetUrl(zone, recordName),
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${tokenResult.accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            properties: {
+              TTL: TXT_TTL_SECONDS,
+              TXTRecords: remaining,
+            },
+          }),
+        },
+        timeoutMs,
+      );
+      if (!putResponse.ok) {
+        return httpFailure("record PUT", putResponse);
+      }
+      return { ok: true };
     }
 
     const response = await fetchWithTimeout(

--- a/packages/agent/src/dns/providers/azure-dns.js
+++ b/packages/agent/src/dns/providers/azure-dns.js
@@ -1,0 +1,203 @@
+"use strict";
+
+/**
+ * Azure DNS DNS-01 provider.
+ *
+ * Auth: OAuth2 client-credentials flow against
+ * login.microsoftonline.com/<tenantId>/oauth2/v2.0/token with scope
+ * https://management.azure.com/.default, then bearer calls against the
+ * Azure Resource Manager API. Scope the service principal to the
+ * "DNS Zone Contributor" role on the target zone(s) only.
+ *
+ * Credentials shape:
+ *   {
+ *     tenantId: string,
+ *     clientId: string,
+ *     clientSecret: string,
+ *     subscriptionId: string,
+ *     resourceGroup: string,
+ *   }
+ *
+ * API surface used (management.azure.com, api-version 2018-05-01):
+ *   PUT    .../dnsZones/<zone>/TXT/<relativeRecordName>   create/replace TXT
+ *   DELETE .../dnsZones/<zone>/TXT/<relativeRecordName>   delete TXT
+ *
+ * The record name sent to Azure is RELATIVE to the zone ("@" at the apex).
+ * A fresh token is fetched per operation; challenge flows are far shorter
+ * than token lifetimes, so no caching layer is warranted here.
+ */
+
+const {
+  isNonEmptyString,
+  relativeRecordName,
+  fetchWithTimeout,
+} = require("../internal.js");
+
+const PROVIDER_ID = "azure-dns";
+const LOGIN_BASE_URL = "https://login.microsoftonline.com";
+const MANAGEMENT_BASE_URL = "https://management.azure.com";
+const MANAGEMENT_SCOPE = "https://management.azure.com/.default";
+const API_VERSION = "2018-05-01";
+const TXT_TTL_SECONDS = 60;
+
+const REQUIRED_FIELDS = Object.freeze([
+  "tenantId",
+  "clientId",
+  "clientSecret",
+  "subscriptionId",
+  "resourceGroup",
+]);
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  for (const field of REQUIRED_FIELDS) {
+    if (!isNonEmptyString(credentials[field])) {
+      throw new Error(`dns: azure-dns credentials require a non-empty ${field} string`);
+    }
+  }
+  return {
+    tenantId: credentials.tenantId,
+    clientId: credentials.clientId,
+    clientSecret: credentials.clientSecret,
+    subscriptionId: credentials.subscriptionId,
+    resourceGroup: credentials.resourceGroup,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.clientSecret, credentials.clientId];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`azure-dns ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  /**
+   * Client-credentials token request. Returns { ok:true, accessToken } or
+   * an ok:false operational failure.
+   */
+  async function fetchAccessToken() {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${LOGIN_BASE_URL}/${encodeURIComponent(credentials.tenantId)}/oauth2/v2.0/token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: credentials.clientId,
+          client_secret: credentials.clientSecret,
+          scope: MANAGEMENT_SCOPE,
+        }).toString(),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("token request", response);
+    }
+
+    let accessToken = null;
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      accessToken = parsed && typeof parsed.access_token === "string" ? parsed.access_token : null;
+    } catch {
+      // fall through to the failure below
+    }
+    if (!isNonEmptyString(accessToken)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt("azure-dns token response carried no access_token"),
+      };
+    }
+    return { ok: true, accessToken };
+  }
+
+  function recordSetUrl(zone, recordName) {
+    const relative = relativeRecordName(recordName, zone) || "@";
+    return (
+      `${MANAGEMENT_BASE_URL}/subscriptions/${encodeURIComponent(credentials.subscriptionId)}` +
+      `/resourceGroups/${encodeURIComponent(credentials.resourceGroup)}` +
+      `/providers/Microsoft.Network/dnsZones/${encodeURIComponent(zone)}` +
+      `/TXT/${encodeURIComponent(relative)}` +
+      `?api-version=${API_VERSION}`
+    );
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const tokenResult = await fetchAccessToken();
+    if (!tokenResult.ok) {
+      return tokenResult;
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      recordSetUrl(zone, recordName),
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${tokenResult.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          properties: {
+            TTL: TXT_TTL_SECONDS,
+            TXTRecords: [{ value: [txtValue] }],
+          },
+        }),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("record PUT", response);
+    }
+
+    return { ok: true };
+  }
+
+  async function cleanupChallenge({ zone, recordName }) {
+    const tokenResult = await fetchAccessToken();
+    if (!tokenResult.ok) {
+      return tokenResult;
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      recordSetUrl(zone, recordName),
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${tokenResult.accessToken}` },
+      },
+      timeoutMs,
+    );
+    // 404 on delete means the record is already gone: cleanup is
+    // idempotent, so that is success, not failure.
+    if (!response.ok && response.status !== 404) {
+      return httpFailure("record DELETE", response);
+    }
+
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  LOGIN_BASE_URL,
+  MANAGEMENT_BASE_URL,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+};

--- a/packages/agent/src/dns/providers/azure-dns.test.js
+++ b/packages/agent/src/dns/providers/azure-dns.test.js
@@ -1,0 +1,181 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const { validateCredentials, LOGIN_BASE_URL, MANAGEMENT_BASE_URL } = require("./azure-dns.js");
+
+const CREDENTIALS = {
+  tenantId: "tenant-1",
+  clientId: "client-1",
+  clientSecret: "client-secret-SECRET",
+  subscriptionId: "sub-1",
+  resourceGroup: "rg-dns",
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.www.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function tokenResponder(rest) {
+  return (url, options) => {
+    if (url.startsWith(LOGIN_BASE_URL)) {
+      return { status: 200, body: '{"access_token":"azure-access-token"}' };
+    }
+    return rest(url, options);
+  };
+}
+
+function solverWith(fetchImpl) {
+  return createDnsSolver({
+    provider: "azure-dns",
+    credentials: CREDENTIALS,
+    fetchImpl,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("azure-dns: every credential field is required", () => {
+  for (const field of ["tenantId", "clientId", "clientSecret", "subscriptionId", "resourceGroup"]) {
+    const broken = { ...CREDENTIALS };
+    delete broken[field];
+    assert.throws(() => validateCredentials(broken), new RegExp(field));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("azure-dns: present fetches a token then PUTs the relative TXT record", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 201, body: "{}" })));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+
+  const tokenCall = fetchStub.calls[0];
+  assert.equal(tokenCall.url, `${LOGIN_BASE_URL}/tenant-1/oauth2/v2.0/token`);
+  assert.match(tokenCall.options.body, /grant_type=client_credentials/);
+  assert.match(tokenCall.options.body, /client_id=client-1/);
+
+  const putCall = fetchStub.calls[1];
+  assert.equal(
+    putCall.url,
+    `${MANAGEMENT_BASE_URL}/subscriptions/sub-1/resourceGroups/rg-dns` +
+      "/providers/Microsoft.Network/dnsZones/example.com" +
+      "/TXT/_acme-challenge.www?api-version=2018-05-01",
+  );
+  assert.equal(putCall.options.method, "PUT");
+  assert.equal(putCall.options.headers.Authorization, "Bearer azure-access-token");
+  assert.deepEqual(JSON.parse(putCall.options.body), {
+    properties: { TTL: 60, TXTRecords: [{ value: ["token-value"] }] },
+  });
+});
+
+test("azure-dns: a record at the zone apex uses the @ relative name", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+  const solver = solverWith(fetchStub);
+
+  await solver.presentChallenge({
+    zone: "_acme-challenge.example.com",
+    recordName: "_acme-challenge.example.com",
+    txtValue: "v",
+  });
+
+  assert.match(fetchStub.calls[1].url, /\/TXT\/%40\?api-version/);
+});
+
+test("azure-dns: token failure maps to ok:false and skips the record call", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 401,
+    body: '{"error":"invalid_client"}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 401);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("azure-dns: a token response with no access_token maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"nope":true}' }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /no access_token/);
+});
+
+test("azure-dns: HTTP error on PUT maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder(() => ({ status: 403, body: '{"error":"authorization failed"}' })),
+  );
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 403);
+  assert.match(result.detail, /HTTP 403/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("azure-dns: cleanup DELETEs the record set", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "" })));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls[1].options.method, "DELETE");
+});
+
+test("azure-dns: a 404 on delete is idempotent success", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 404, body: "" })));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("azure-dns: error body echoing the clientSecret is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 400,
+    body: 'bad secret client-secret-SECRET rejected',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/azure-dns.test.js
+++ b/packages/agent/src/dns/providers/azure-dns.test.js
@@ -64,27 +64,38 @@ test("azure-dns: every credential field is required", () => {
 // present
 // ---------------------------------------------------------------------------
 
-test("azure-dns: present fetches a token then PUTs the relative TXT record", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 201, body: "{}" })));
+test("azure-dns: present fetches a token, GETs the set, then PUTs the relative TXT record", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 404, body: "" };
+      }
+      return { status: 201, body: "{}" };
+    }),
+  );
   const solver = solverWith(fetchStub);
 
   const result = await solver.presentChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls.length, 3);
 
   const tokenCall = fetchStub.calls[0];
   assert.equal(tokenCall.url, `${LOGIN_BASE_URL}/tenant-1/oauth2/v2.0/token`);
   assert.match(tokenCall.options.body, /grant_type=client_credentials/);
   assert.match(tokenCall.options.body, /client_id=client-1/);
 
-  const putCall = fetchStub.calls[1];
-  assert.equal(
-    putCall.url,
+  const recordSetUrl =
     `${MANAGEMENT_BASE_URL}/subscriptions/sub-1/resourceGroups/rg-dns` +
-      "/providers/Microsoft.Network/dnsZones/example.com" +
-      "/TXT/_acme-challenge.www?api-version=2018-05-01",
-  );
+    "/providers/Microsoft.Network/dnsZones/example.com" +
+    "/TXT/_acme-challenge.www?api-version=2018-05-01";
+
+  const getCall = fetchStub.calls[1];
+  assert.equal(getCall.url, recordSetUrl);
+  assert.equal(getCall.options.method, "GET");
+
+  const putCall = fetchStub.calls[2];
+  assert.equal(putCall.url, recordSetUrl);
   assert.equal(putCall.options.method, "PUT");
   assert.equal(putCall.options.headers.Authorization, "Bearer azure-access-token");
   assert.deepEqual(JSON.parse(putCall.options.body), {
@@ -92,8 +103,75 @@ test("azure-dns: present fetches a token then PUTs the relative TXT record", asy
   });
 });
 
+test("azure-dns: present merges with pre-existing TXT values instead of replacing them", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            properties: {
+              TTL: 60,
+              TXTRecords: [{ value: ["sibling-value"] }, { value: ["spf-ish third-party"] }],
+            },
+          }),
+        };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const putCall = fetchStub.calls[2];
+  assert.equal(putCall.options.method, "PUT");
+  assert.deepEqual(JSON.parse(putCall.options.body), {
+    properties: {
+      TTL: 60,
+      TXTRecords: [
+        { value: ["sibling-value"] },
+        { value: ["spf-ish third-party"] },
+        { value: ["token-value"] },
+      ],
+    },
+  });
+});
+
+test("azure-dns: present is idempotent when the value is already in the set", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            properties: { TTL: 60, TXTRecords: [{ value: ["token-value"] }] },
+          }),
+        };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(JSON.parse(fetchStub.calls[2].options.body), {
+    properties: { TTL: 60, TXTRecords: [{ value: ["token-value"] }] },
+  });
+});
+
 test("azure-dns: a record at the zone apex uses the @ relative name", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 404, body: "" };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
   const solver = solverWith(fetchStub);
 
   await solver.presentChallenge({
@@ -103,6 +181,7 @@ test("azure-dns: a record at the zone apex uses the @ relative name", async () =
   });
 
   assert.match(fetchStub.calls[1].url, /\/TXT\/%40\?api-version/);
+  assert.match(fetchStub.calls[2].url, /\/TXT\/%40\?api-version/);
 });
 
 test("azure-dns: token failure maps to ok:false and skips the record call", async () => {
@@ -131,7 +210,12 @@ test("azure-dns: a token response with no access_token maps to ok:false", async 
 
 test("azure-dns: HTTP error on PUT maps to ok:false with statusCode", async () => {
   const fetchStub = makeFetchStub(
-    tokenResponder(() => ({ status: 403, body: '{"error":"authorization failed"}' })),
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 404, body: "" };
+      }
+      return { status: 403, body: '{"error":"authorization failed"}' };
+    }),
   );
   const solver = solverWith(fetchStub);
 
@@ -146,23 +230,74 @@ test("azure-dns: HTTP error on PUT maps to ok:false with statusCode", async () =
 // cleanup
 // ---------------------------------------------------------------------------
 
-test("azure-dns: cleanup DELETEs the record set", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "" })));
+test("azure-dns: cleanup DELETEs the record set when only the challenge value remains", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            properties: { TTL: 60, TXTRecords: [{ value: ["token-value"] }] },
+          }),
+        };
+      }
+      return { status: 200, body: "" };
+    }),
+  );
   const solver = solverWith(fetchStub);
 
   const result = await solver.cleanupChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls[1].options.method, "DELETE");
+  assert.equal(fetchStub.calls.length, 3);
+  assert.equal(fetchStub.calls[1].options.method, "GET");
+  assert.equal(fetchStub.calls[2].options.method, "DELETE");
 });
 
-test("azure-dns: a 404 on delete is idempotent success", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 404, body: "" })));
+test("azure-dns: cleanup keeps sibling TXT values and removes only the challenge value", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            properties: {
+              TTL: 60,
+              TXTRecords: [{ value: ["sibling-value"] }, { value: ["token-value"] }],
+            },
+          }),
+        };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
   const solver = solverWith(fetchStub);
 
   const result = await solver.cleanupChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
+  const putCall = fetchStub.calls[2];
+  assert.equal(putCall.options.method, "PUT");
+  assert.deepEqual(JSON.parse(putCall.options.body), {
+    properties: { TTL: 60, TXTRecords: [{ value: ["sibling-value"] }] },
+  });
+});
+
+test("azure-dns: cleanup of an already-absent record set is idempotent success", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 404, body: "" };
+      }
+      return { status: 500, body: "should never be called" };
+    }),
+  );
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/dns/providers/cloudflare.js
+++ b/packages/agent/src/dns/providers/cloudflare.js
@@ -1,0 +1,202 @@
+"use strict";
+
+/**
+ * Cloudflare DNS-01 provider.
+ *
+ * Auth: scoped API token (Authorization: Bearer). Create a token with
+ * Zone.DNS:Edit on the target zone(s) only; never use a Global API Key.
+ *
+ * Credentials shape: { apiToken: string, zoneId?: string }
+ *   - zoneId is optional; when absent the zone id is looked up by name via
+ *     GET /zones?name=<zone> on every operation.
+ *
+ * API surface used (api.cloudflare.com/client/v4):
+ *   GET    /zones?name=<zone>                       zone id lookup
+ *   GET    /zones/<zoneId>/dns_records?...          record id lookup (cleanup)
+ *   POST   /zones/<zoneId>/dns_records              create TXT
+ *   DELETE /zones/<zoneId>/dns_records/<recordId>   delete TXT
+ */
+
+const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+
+const PROVIDER_ID = "cloudflare";
+const API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const TXT_TTL_SECONDS = 60;
+
+/**
+ * @param {object} credentials
+ * @returns {{ apiToken: string, zoneId: string|null }}
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.apiToken)) {
+    throw new Error("dns: cloudflare credentials require a non-empty apiToken string");
+  }
+  if (credentials.zoneId !== undefined && !isNonEmptyString(credentials.zoneId)) {
+    throw new Error("dns: cloudflare zoneId must be a non-empty string when provided");
+  }
+  return {
+    apiToken: credentials.apiToken,
+    zoneId: credentials.zoneId || null,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.apiToken];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function authHeaders() {
+    return {
+      Authorization: `Bearer ${credentials.apiToken}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  /**
+   * Parses a Cloudflare v4 envelope body, returning null on any parse
+   * problem (callers treat null as "unexpected response").
+   * @param {string} bodyText
+   */
+  function parseEnvelope(bodyText) {
+    try {
+      const parsed = JSON.parse(bodyText);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Maps a non-2xx response to the operational-failure result shape. */
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`cloudflare ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  /**
+   * Resolves the zone id: configured zoneId wins, otherwise looked up by
+   * exact zone name. Returns { ok:true, zoneId } or an ok:false failure.
+   * @param {string} zone
+   */
+  async function resolveZoneId(zone) {
+    if (credentials.zoneId) {
+      return { ok: true, zoneId: credentials.zoneId };
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/zones?name=${encodeURIComponent(zone)}`,
+      { method: "GET", headers: authHeaders() },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("zone lookup", response);
+    }
+
+    const envelope = parseEnvelope(response.bodyText);
+    const zoneId =
+      envelope && Array.isArray(envelope.result) && envelope.result[0]
+        ? envelope.result[0].id
+        : null;
+    if (!isNonEmptyString(zoneId)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`cloudflare zone lookup returned no zone named ${JSON.stringify(zone)}`),
+      };
+    }
+    return { ok: true, zoneId };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const zoneResult = await resolveZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/zones/${encodeURIComponent(zoneResult.zoneId)}/dns_records`,
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          type: "TXT",
+          name: recordName,
+          content: txtValue,
+          ttl: TXT_TTL_SECONDS,
+        }),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("record create", response);
+    }
+
+    return { ok: true };
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const zoneResult = await resolveZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    // Find the exact TXT record (name + content match) so cleanup never
+    // deletes an unrelated record that happens to share the name.
+    const listUrl =
+      `${API_BASE_URL}/zones/${encodeURIComponent(zoneResult.zoneId)}/dns_records` +
+      `?type=TXT&name=${encodeURIComponent(recordName)}&content=${encodeURIComponent(txtValue)}`;
+    const listResponse = await fetchWithTimeout(
+      fetchImpl,
+      listUrl,
+      { method: "GET", headers: authHeaders() },
+      timeoutMs,
+    );
+    if (!listResponse.ok) {
+      return httpFailure("record lookup", listResponse);
+    }
+
+    const envelope = parseEnvelope(listResponse.bodyText);
+    const records =
+      envelope && Array.isArray(envelope.result) ? envelope.result : [];
+    if (records.length === 0) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    for (const record of records) {
+      if (!isNonEmptyString(record.id)) {
+        continue;
+      }
+      const deleteResponse = await fetchWithTimeout(
+        fetchImpl,
+        `${API_BASE_URL}/zones/${encodeURIComponent(zoneResult.zoneId)}/dns_records/${encodeURIComponent(record.id)}`,
+        { method: "DELETE", headers: authHeaders() },
+        timeoutMs,
+      );
+      if (!deleteResponse.ok) {
+        return httpFailure("record delete", deleteResponse);
+      }
+    }
+
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  API_BASE_URL,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+};

--- a/packages/agent/src/dns/providers/cloudflare.test.js
+++ b/packages/agent/src/dns/providers/cloudflare.test.js
@@ -1,0 +1,177 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const { validateCredentials, API_BASE_URL } = require("./cloudflare.js");
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options, calls.length) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = { apiToken: "cf-token" }) {
+  return createDnsSolver({ provider: "cloudflare", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("cloudflare: missing apiToken throws at construction", () => {
+  assert.throws(() => validateCredentials({}), /apiToken/);
+  assert.throws(() => validateCredentials({ apiToken: "" }), /apiToken/);
+});
+
+test("cloudflare: non-string zoneId throws at construction", () => {
+  assert.throws(() => validateCredentials({ apiToken: "t", zoneId: 42 }), /zoneId/);
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("cloudflare: present with configured zoneId POSTs the TXT record directly", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"success":true}' }));
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+  const call = fetchStub.calls[0];
+  assert.equal(call.url, `${API_BASE_URL}/zones/zone123/dns_records`);
+  assert.equal(call.options.method, "POST");
+  assert.equal(call.options.headers.Authorization, "Bearer cf-token");
+  assert.deepEqual(JSON.parse(call.options.body), {
+    type: "TXT",
+    name: CHALLENGE.recordName,
+    content: CHALLENGE.txtValue,
+    ttl: 60,
+  });
+});
+
+test("cloudflare: present without zoneId looks the zone up by name first", async () => {
+  const fetchStub = makeFetchStub((url) => {
+    if (url.includes("/zones?name=")) {
+      return { status: 200, body: '{"result":[{"id":"looked-up-zone"}]}' };
+    }
+    return { status: 200, body: '{"success":true}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(
+    fetchStub.calls[0].url,
+    `${API_BASE_URL}/zones?name=example.com`,
+  );
+  assert.match(fetchStub.calls[1].url, /\/zones\/looked-up-zone\/dns_records$/);
+});
+
+test("cloudflare: zone lookup finding no zone maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"result":[]}' }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /no zone named/);
+});
+
+test("cloudflare: HTTP error on create maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: '{"errors":[{"message":"forbidden"}]}',
+  }));
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 403);
+  assert.match(result.detail, /HTTP 403/);
+  assert.match(result.detail, /forbidden/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("cloudflare: cleanup looks up the exact record and DELETEs it", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: '{"result":[{"id":"rec1"}]}' };
+    }
+    return { status: 200, body: '{"success":true}' };
+  });
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  const listUrl = fetchStub.calls[0].url;
+  assert.match(listUrl, /type=TXT/);
+  assert.match(listUrl, /name=_acme-challenge\.example\.com/);
+  assert.match(listUrl, /content=token-value/);
+  assert.equal(fetchStub.calls[1].options.method, "DELETE");
+  assert.match(fetchStub.calls[1].url, /\/dns_records\/rec1$/);
+});
+
+test("cloudflare: cleanup of an already-absent record is idempotent success", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"result":[]}' }));
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("cloudflare: failing DELETE maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: '{"result":[{"id":"rec1"}]}' };
+    }
+    return { status: 500, body: "server error" };
+  });
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("cloudflare: error body echoing the apiToken is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 400,
+    body: 'bad token "cf-token" rejected',
+  }));
+  const solver = solverWith(fetchStub, { apiToken: "cf-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/exoscale.js
+++ b/packages/agent/src/dns/providers/exoscale.js
@@ -1,0 +1,290 @@
+"use strict";
+
+/**
+ * Exoscale DNS-01 provider.
+ *
+ * Auth: Exoscale API v2 request signing (EXO2-HMAC-SHA256), implemented
+ * here with node:crypto only. Scope the IAM API key to the DNS service
+ * only.
+ *
+ * Credentials shape:
+ *   {
+ *     apiKey: string,
+ *     apiSecret: string,
+ *     apiEndpoint?: string,  // default https://api-ch-gva-2.exoscale.com/v2;
+ *                            // DNS is global, so any zone endpoint works
+ *   }
+ *
+ * Signing spec (v2): the signed message is
+ *   "METHOD /path\n" + body + "\n" + signedQueryArgs + "\n" + signedHeaders
+ *   + "\n" + expires
+ * with no signed query args and no signed headers (both lines empty --
+ * this module never signs query strings), i.e. exactly
+ *   `${method} ${path}\n${body}\n\n\n${expires}`
+ * where `path` is the full URL pathname (including the /v2 prefix) and
+ * `expires` is a unix-seconds expiry (now + 10 minutes here). The
+ * signature is base64(HMAC-SHA256(apiSecret, message)), sent as
+ *   Authorization: EXO2-HMAC-SHA256 credential=<apiKey>,expires=<unix>,signature=<b64>
+ *
+ * API surface used:
+ *   GET    /dns-domain                          domain id lookup
+ *   POST   /dns-domain/<id>/record              create TXT
+ *   GET    /dns-domain/<id>/record              record lookup (cleanup)
+ *   DELETE /dns-domain/<id>/record/<recordId>   delete TXT
+ *
+ * Exoscale v2 mutations are ASYNC: they return an operation object that
+ * would normally be polled via /operation/<id>. This module deliberately
+ * does NOT poll -- an accepted (2xx) response is treated as success, since
+ * the ACME tool's propagation wait covers the (short) async apply window.
+ *
+ * The record name sent to Exoscale is RELATIVE to the zone ("" at the
+ * apex). Record listing has no server-side filter, so cleanup matches
+ * type + name + content client-side (accepting the content in raw or
+ * quoted spelling, as the API returns TXT content quoted).
+ */
+
+const crypto = require("node:crypto");
+
+const {
+  isNonEmptyString,
+  relativeRecordName,
+  fetchWithTimeout,
+} = require("../internal.js");
+
+const PROVIDER_ID = "exoscale";
+const DEFAULT_API_ENDPOINT = "https://api-ch-gva-2.exoscale.com/v2";
+const TXT_TTL_SECONDS = 60;
+const EXPIRES_WINDOW_SECONDS = 10 * 60;
+
+// --------------------------------------------------------------------------
+// EXO2-HMAC-SHA256 signing (exported for the fixed-vector signature test)
+// --------------------------------------------------------------------------
+
+/**
+ * Computes the Exoscale v2 Authorization header. Deterministic given
+ * `expires`, so tests can pin an exact signature for fixed keys.
+ *
+ * @param {object} options
+ * @param {string} options.apiKey
+ * @param {string} options.apiSecret
+ * @param {string} options.method uppercase HTTP method
+ * @param {string} options.path full URL pathname (e.g. "/v2/dns-domain")
+ * @param {string} options.body raw request body ("" when none)
+ * @param {number} options.expires unix seconds
+ * @returns {{ message: string, signature: string, authorizationHeader: string }}
+ */
+function signExoscaleRequest({ apiKey, apiSecret, method, path, body, expires }) {
+  // Empty signed-query-args and signed-headers lines: this module never
+  // signs query strings or extra headers.
+  const message = `${method} ${path}\n${body}\n\n\n${expires}`;
+  const signature = crypto
+    .createHmac("sha256", apiSecret)
+    .update(message)
+    .digest("base64");
+  return {
+    message,
+    signature,
+    authorizationHeader: `EXO2-HMAC-SHA256 credential=${apiKey},expires=${expires},signature=${signature}`,
+  };
+}
+
+// --------------------------------------------------------------------------
+// Provider contract
+// --------------------------------------------------------------------------
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.apiKey)) {
+    throw new Error("dns: exoscale credentials require a non-empty apiKey string");
+  }
+  if (!isNonEmptyString(credentials.apiSecret)) {
+    throw new Error("dns: exoscale credentials require a non-empty apiSecret string");
+  }
+  if (credentials.apiEndpoint !== undefined && !isNonEmptyString(credentials.apiEndpoint)) {
+    throw new Error("dns: exoscale apiEndpoint must be a non-empty string when provided");
+  }
+  return {
+    apiKey: credentials.apiKey,
+    apiSecret: credentials.apiSecret,
+    apiEndpoint: (credentials.apiEndpoint || DEFAULT_API_ENDPOINT).replace(/\/+$/, ""),
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.apiSecret, credentials.apiKey];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  /**
+   * Signs and sends one request against the configured endpoint.
+   * @param {{ method: string, path: string, body?: object|null }} request
+   *   `path` is relative to the endpoint (starts with "/", no query).
+   */
+  function signedFetch({ method, path, body = null }) {
+    const url = `${credentials.apiEndpoint}${path}`;
+    const bodyText = body === null ? "" : JSON.stringify(body);
+    const expires = Math.floor(Date.now() / 1000) + EXPIRES_WINDOW_SECONDS;
+    const { authorizationHeader } = signExoscaleRequest({
+      apiKey: credentials.apiKey,
+      apiSecret: credentials.apiSecret,
+      method,
+      path: new URL(url).pathname,
+      body: bodyText,
+      expires,
+    });
+
+    const headers = { Authorization: authorizationHeader };
+    if (bodyText) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    return fetchWithTimeout(
+      fetchImpl,
+      url,
+      { method, headers, ...(bodyText ? { body: bodyText } : {}) },
+      timeoutMs,
+    );
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`exoscale ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  function parseJson(bodyText) {
+    try {
+      const parsed = JSON.parse(bodyText);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Looks the DNS domain id up by zone name (GET /dns-domain lists all
+   * domains; there is no server-side name filter). Returns
+   * { ok:true, domainId } or an ok:false failure.
+   * @param {string} zone
+   */
+  async function resolveDomainId(zone) {
+    const response = await signedFetch({ method: "GET", path: "/dns-domain" });
+    if (!response.ok) {
+      return httpFailure("domain lookup", response);
+    }
+
+    const parsed = parseJson(response.bodyText);
+    const domains =
+      parsed && Array.isArray(parsed["dns-domains"]) ? parsed["dns-domains"] : [];
+    const normalizedZone = zone.toLowerCase();
+    const match = domains.find((domain) => {
+      const name = domain && (domain["unicode-name"] || domain.name);
+      return typeof name === "string" && name.toLowerCase() === normalizedZone;
+    });
+    if (!match || !isNonEmptyString(match.id)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`exoscale domain lookup returned no domain named ${JSON.stringify(zone)}`),
+      };
+    }
+    return { ok: true, domainId: match.id };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const domainResult = await resolveDomainId(zone);
+    if (!domainResult.ok) {
+      return domainResult;
+    }
+
+    const response = await signedFetch({
+      method: "POST",
+      path: `/dns-domain/${encodeURIComponent(domainResult.domainId)}/record`,
+      body: {
+        name: relativeRecordName(recordName, zone),
+        type: "TXT",
+        content: txtValue,
+        ttl: TXT_TTL_SECONDS,
+      },
+    });
+    if (!response.ok) {
+      return httpFailure("record create", response);
+    }
+
+    // The 2xx response is an async operation object; accepted == success
+    // here (no polling), see the module header.
+    return { ok: true };
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const domainResult = await resolveDomainId(zone);
+    if (!domainResult.ok) {
+      return domainResult;
+    }
+
+    const listResponse = await signedFetch({
+      method: "GET",
+      path: `/dns-domain/${encodeURIComponent(domainResult.domainId)}/record`,
+    });
+    if (!listResponse.ok) {
+      return httpFailure("record lookup", listResponse);
+    }
+
+    const relative = relativeRecordName(recordName, zone);
+    const parsed = parseJson(listResponse.bodyText);
+    const records =
+      parsed && Array.isArray(parsed["dns-domain-records"])
+        ? parsed["dns-domain-records"]
+        : [];
+    // Exact type + name + content match (raw or quoted content spelling)
+    // so cleanup never deletes an unrelated record sharing the name.
+    const matches = records.filter(
+      (record) =>
+        record &&
+        record.type === "TXT" &&
+        record.name === relative &&
+        (record.content === txtValue || record.content === `"${txtValue}"`) &&
+        isNonEmptyString(record.id),
+    );
+    if (matches.length === 0) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    for (const record of matches) {
+      const deleteResponse = await signedFetch({
+        method: "DELETE",
+        path:
+          `/dns-domain/${encodeURIComponent(domainResult.domainId)}` +
+          `/record/${encodeURIComponent(record.id)}`,
+      });
+      // 404 means the record is already gone: idempotent success.
+      if (!deleteResponse.ok && deleteResponse.status !== 404) {
+        return httpFailure("record delete", deleteResponse);
+      }
+    }
+
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  DEFAULT_API_ENDPOINT,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for the fixed-vector signature test only.
+  signExoscaleRequest,
+};

--- a/packages/agent/src/dns/providers/exoscale.test.js
+++ b/packages/agent/src/dns/providers/exoscale.test.js
@@ -1,0 +1,295 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  signExoscaleRequest,
+  DEFAULT_API_ENDPOINT,
+} = require("./exoscale.js");
+
+const CREDENTIALS = { apiKey: "EXOexample", apiSecret: "exo-secret" };
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+const DOMAIN_LIST_BODY = JSON.stringify({
+  "dns-domains": [
+    { id: "d0", "unicode-name": "other.org" },
+    { id: "d1", "unicode-name": "example.com" },
+  ],
+});
+
+function makeFetchStub(respond) {
+  const calls = [];
+  function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options, calls.length) || {};
+    return Promise.resolve({ status, text: () => Promise.resolve(body) });
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = CREDENTIALS) {
+  return createDnsSolver({ provider: "exoscale", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("exoscale: apiKey and apiSecret are required", () => {
+  assert.throws(() => validateCredentials({ apiSecret: "s" }), /apiKey/);
+  assert.throws(() => validateCredentials({ apiKey: "k" }), /apiSecret/);
+});
+
+test("exoscale: apiEndpoint defaults to ch-gva-2 and trailing slashes are stripped", () => {
+  assert.equal(validateCredentials(CREDENTIALS).apiEndpoint, DEFAULT_API_ENDPOINT);
+  assert.equal(
+    validateCredentials({ ...CREDENTIALS, apiEndpoint: "https://api-de-fra-1.exoscale.com/v2/" }).apiEndpoint,
+    "https://api-de-fra-1.exoscale.com/v2",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// EXO2-HMAC-SHA256 fixed vectors (deterministic given expires)
+// ---------------------------------------------------------------------------
+
+test("exoscale: bodyless request signature matches the fixed vector", () => {
+  const { message, signature, authorizationHeader } = signExoscaleRequest({
+    apiKey: "EXOexample",
+    apiSecret: "exo-secret",
+    method: "GET",
+    path: "/v2/dns-domain",
+    body: "",
+    expires: 1767226200,
+  });
+
+  assert.equal(message, "GET /v2/dns-domain\n\n\n\n1767226200");
+  // base64(HMAC-SHA256("exo-secret", message))
+  assert.equal(signature, "OF0CBDTW+FO/o5wT9j9K6+7gm0hcaW/RWZWAkzzHaEE=");
+  assert.equal(
+    authorizationHeader,
+    "EXO2-HMAC-SHA256 credential=EXOexample,expires=1767226200," +
+      "signature=OF0CBDTW+FO/o5wT9j9K6+7gm0hcaW/RWZWAkzzHaEE=",
+  );
+});
+
+test("exoscale: request signature with a body matches the fixed vector", () => {
+  const body = '{"name":"_acme-challenge","type":"TXT","content":"token-value","ttl":60}';
+  const { signature } = signExoscaleRequest({
+    apiKey: "EXOexample",
+    apiSecret: "exo-secret",
+    method: "POST",
+    path: "/v2/dns-domain/d1/record",
+    body,
+    expires: 1767226200,
+  });
+
+  assert.equal(signature, "xwKtY8kd+r31ZM9/FMXvlwNlwQrnHFQoQXsfHknuXjU=");
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("exoscale: present resolves the domain id then POSTs the TXT record", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    return { status: 200, body: '{"id":"op-1","state":"pending"}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls[0].url, `${DEFAULT_API_ENDPOINT}/dns-domain`);
+
+  const create = fetchStub.calls[1];
+  assert.equal(create.url, `${DEFAULT_API_ENDPOINT}/dns-domain/d1/record`);
+  assert.equal(create.options.method, "POST");
+  assert.deepEqual(JSON.parse(create.options.body), {
+    name: "_acme-challenge",
+    type: "TXT",
+    content: CHALLENGE.txtValue,
+    ttl: 60,
+  });
+});
+
+test("exoscale: the Authorization header is a verifiable EXO2-HMAC-SHA256 signature", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: DOMAIN_LIST_BODY }));
+  const solver = solverWith(fetchStub);
+
+  await solver.presentChallenge(CHALLENGE);
+
+  const header = fetchStub.calls[0].options.headers.Authorization;
+  const match = /^EXO2-HMAC-SHA256 credential=EXOexample,expires=(\d+),signature=(.+)$/.exec(header);
+  assert.ok(match, `unexpected Authorization header: ${header}`);
+
+  // Recompute the signature from the sent request parts.
+  const { signature } = signExoscaleRequest({
+    apiKey: "EXOexample",
+    apiSecret: "exo-secret",
+    method: "GET",
+    path: "/v2/dns-domain",
+    body: "",
+    expires: Number(match[1]),
+  });
+  assert.equal(match[2], signature);
+});
+
+test("exoscale: a domain lookup with no matching zone maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body: '{"dns-domains":[{"id":"d0","unicode-name":"other.org"}]}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /no domain named/);
+});
+
+test("exoscale: HTTP error on create maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    return { status: 403, body: '{"message":"forbidden"}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 403);
+  assert.match(result.detail, /HTTP 403/);
+});
+
+test("exoscale: a custom apiEndpoint override is used for every call", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: DOMAIN_LIST_BODY }));
+  const solver = solverWith(fetchStub, {
+    ...CREDENTIALS,
+    apiEndpoint: "https://api-de-fra-1.exoscale.com/v2",
+  });
+
+  await solver.presentChallenge(CHALLENGE);
+
+  assert.match(fetchStub.calls[0].url, /^https:\/\/api-de-fra-1\.exoscale\.com\/v2\//);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("exoscale: cleanup lists records and DELETEs the exact match only", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.endsWith("/dns-domain")) {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: JSON.stringify({
+          "dns-domain-records": [
+            { id: "keep-1", type: "TXT", name: "_acme-challenge", content: '"other-value"' },
+            { id: "keep-2", type: "A", name: "_acme-challenge", content: "1.2.3.4" },
+            { id: "del-1", type: "TXT", name: "_acme-challenge", content: '"token-value"' },
+          ],
+        }),
+      };
+    }
+    return { status: 200, body: '{"id":"op-2","state":"pending"}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const deletes = fetchStub.calls.filter((call) => call.options.method === "DELETE");
+  assert.equal(deletes.length, 1);
+  assert.equal(deletes[0].url, `${DEFAULT_API_ENDPOINT}/dns-domain/d1/record/del-1`);
+});
+
+test("exoscale: cleanup of an already-absent record is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.endsWith("/dns-domain")) {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    return { status: 200, body: '{"dns-domain-records":[]}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.filter((c) => c.options.method === "DELETE").length, 0);
+});
+
+test("exoscale: a 404 on record delete is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.endsWith("/dns-domain")) {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"dns-domain-records":[{"id":"gone","type":"TXT","name":"_acme-challenge","content":"token-value"}]}',
+      };
+    }
+    return { status: 404, body: '{"message":"record not found"}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+});
+
+test("exoscale: failing DELETE maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.endsWith("/dns-domain")) {
+      return { status: 200, body: DOMAIN_LIST_BODY };
+    }
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"dns-domain-records":[{"id":"del-1","type":"TXT","name":"_acme-challenge","content":"token-value"}]}',
+      };
+    }
+    return { status: 500, body: "server error" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("exoscale: error body echoing the apiSecret is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: 'signature mismatch for secret "exo-secret"',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/google-cloud-dns.js
+++ b/packages/agent/src/dns/providers/google-cloud-dns.js
@@ -26,11 +26,16 @@
  *   }
  *
  * API surface used (dns.googleapis.com/dns/v1):
- *   GET  /projects/<p>/managedZones?dnsName=<zone>.      zone lookup
- *   POST /projects/<p>/managedZones/<mz>/changes         additions/deletions
+ *   GET  /projects/<p>/managedZones?dnsName=<zone>.       zone lookup
+ *   GET  /projects/<p>/managedZones/<mz>/rrsets?name=&type=TXT  rrset read
+ *   POST /projects/<p>/managedZones/<mz>/changes          additions/deletions
  *
  * Cloud DNS rrset TXT values are quoted strings and names are absolute
- * (trailing dot).
+ * (trailing dot). Changes REPLACE the whole rrset (deletions must match
+ * the live rrset exactly), so present() first reads the existing TXT
+ * rrset and submits deletions(old) + additions(old union new value);
+ * cleanup() removes only the quoted challenge value, adding the remainder
+ * back and deleting the rrset outright only when nothing remains.
  */
 
 const crypto = require("node:crypto");
@@ -202,6 +207,54 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
   }
 
   /**
+   * Reads the live TXT rrset at `recordFqdn` (absolute, trailing dot) via
+   * the rrsets list endpoint. Returns { ok:true, rrset } where rrset is
+   * { name, type, ttl, rrdatas } or null when it does not exist, or an
+   * ok:false operational failure. A 404 (older API surfaces) counts as
+   * "does not exist".
+   *
+   * @param {string} accessToken
+   * @param {string} managedZone
+   * @param {string} recordFqdn
+   */
+  async function readExistingTxtRrset(accessToken, managedZone, recordFqdn) {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/projects/${encodeURIComponent(credentials.project_id)}/managedZones/${encodeURIComponent(managedZone)}/rrsets?name=${encodeURIComponent(recordFqdn)}&type=TXT`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+      timeoutMs,
+    );
+    if (response.status === 404) {
+      return { ok: true, rrset: null };
+    }
+    if (!response.ok) {
+      return httpFailure("rrset read", response);
+    }
+
+    let rrset = null;
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      const first =
+        parsed && Array.isArray(parsed.rrsets) ? parsed.rrsets[0] : null;
+      if (first && Array.isArray(first.rrdatas)) {
+        rrset = {
+          name: typeof first.name === "string" ? first.name : recordFqdn,
+          type: "TXT",
+          ttl: Number.isInteger(first.ttl) ? first.ttl : TXT_TTL_SECONDS,
+          rrdatas: first.rrdatas.filter((rrdata) => typeof rrdata === "string"),
+        };
+      }
+    } catch {
+      // A 2xx with an unparseable body is treated as "no rrset"; the
+      // subsequent change POST surfaces any real API problem.
+    }
+    return { ok: true, rrset };
+  }
+
+  /**
    * @param {"additions"|"deletions"} changeKind
    * @param {{ zone: string, recordName: string, txtValue: string }} inputs
    */
@@ -217,12 +270,50 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
     }
 
     const recordFqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
-    const rrset = {
-      name: recordFqdn,
-      type: "TXT",
-      ttl: TXT_TTL_SECONDS,
-      rrdatas: [`"${txtValue}"`],
-    };
+    const existing = await readExistingTxtRrset(
+      tokenResult.accessToken,
+      zoneResult.managedZone,
+      recordFqdn,
+    );
+    if (!existing.ok) {
+      return existing;
+    }
+
+    const quoted = `"${txtValue}"`;
+    const existingRrdatas = existing.rrset ? existing.rrset.rrdatas : [];
+
+    let newRrdatas;
+    if (changeKind === "additions") {
+      newRrdatas = existingRrdatas.includes(quoted)
+        ? existingRrdatas
+        : [...existingRrdatas, quoted];
+    } else {
+      if (!existing.rrset || !existingRrdatas.includes(quoted)) {
+        // Nothing to delete: cleanup is idempotent success.
+        return { ok: true };
+      }
+      newRrdatas = existingRrdatas.filter((rrdata) => rrdata !== quoted);
+    }
+
+    // Changes replace whole rrsets: deletions must mirror the live rrset
+    // exactly, additions carry the merged/remaining values.
+    const change = {};
+    if (existing.rrset) {
+      change.deletions = [existing.rrset];
+    }
+    if (newRrdatas.length > 0) {
+      change.additions = [
+        {
+          name: recordFqdn,
+          type: "TXT",
+          ttl: existing.rrset ? existing.rrset.ttl : TXT_TTL_SECONDS,
+          rrdatas: newRrdatas,
+        },
+      ];
+    }
+    if (!change.deletions && !change.additions) {
+      return { ok: true };
+    }
 
     const response = await fetchWithTimeout(
       fetchImpl,
@@ -233,7 +324,7 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
           Authorization: `Bearer ${tokenResult.accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ [changeKind]: [rrset] }),
+        body: JSON.stringify(change),
       },
       timeoutMs,
     );

--- a/packages/agent/src/dns/providers/google-cloud-dns.js
+++ b/packages/agent/src/dns/providers/google-cloud-dns.js
@@ -1,0 +1,262 @@
+"use strict";
+
+/**
+ * Google Cloud DNS DNS-01 provider.
+ *
+ * Auth: service-account JWT bearer flow -- an RS256-signed JWT (built and
+ * signed locally with node:crypto against the SA private key) exchanged at
+ * oauth2.googleapis.com/token for an access token, then bearer calls
+ * against the Cloud DNS v1 API. Grant the service account roles/dns.admin
+ * scoped as tightly as the project allows.
+ *
+ * Custody note: the service-account private key is a DNS PROVIDER
+ * credential, not certificate key material. It lives in an agent-local
+ * credentials file, is only ever used on this host to sign the OAuth JWT,
+ * and never leaves the host (the token endpoint receives the signed JWT,
+ * not the key). This is squarely within the agent's credential-locality
+ * rules; ADR-0001 zero private-key custody concerns certificate keys.
+ *
+ * Credentials shape (standard GCP service-account JSON fields, subset):
+ *   {
+ *     client_email: string,
+ *     private_key: string,       // PEM, RS256-capable
+ *     project_id: string,
+ *     managedZone?: string,      // Cloud DNS managed zone NAME; looked up
+ *                                // by dnsName when absent
+ *   }
+ *
+ * API surface used (dns.googleapis.com/dns/v1):
+ *   GET  /projects/<p>/managedZones?dnsName=<zone>.      zone lookup
+ *   POST /projects/<p>/managedZones/<mz>/changes         additions/deletions
+ *
+ * Cloud DNS rrset TXT values are quoted strings and names are absolute
+ * (trailing dot).
+ */
+
+const crypto = require("node:crypto");
+
+const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+
+const PROVIDER_ID = "google-cloud-dns";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const API_BASE_URL = "https://dns.googleapis.com/dns/v1";
+const OAUTH_SCOPE = "https://www.googleapis.com/auth/ndev.clouddns.readwrite";
+const JWT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+const TXT_TTL_SECONDS = 60;
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  for (const field of ["client_email", "private_key", "project_id"]) {
+    if (!isNonEmptyString(credentials[field])) {
+      throw new Error(`dns: google-cloud-dns credentials require a non-empty ${field} string`);
+    }
+  }
+  if (!credentials.private_key.includes("PRIVATE KEY")) {
+    throw new Error(
+      "dns: google-cloud-dns private_key does not look like a PEM private key",
+    );
+  }
+  if (credentials.managedZone !== undefined && !isNonEmptyString(credentials.managedZone)) {
+    throw new Error("dns: google-cloud-dns managedZone must be a non-empty string when provided");
+  }
+
+  return {
+    client_email: credentials.client_email,
+    private_key: credentials.private_key,
+    project_id: credentials.project_id,
+    managedZone: credentials.managedZone || null,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt (the
+ *   PRIVATE KEY marker rule catches the key PEM as well; listing it here
+ *   is belt and braces).
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.private_key];
+}
+
+function base64UrlEncode(input) {
+  return Buffer.from(input).toString("base64url");
+}
+
+/**
+ * Builds and RS256-signs the service-account assertion JWT locally.
+ * @param {{ client_email: string, private_key: string }} credentials
+ * @param {number} nowEpochSeconds
+ * @returns {string}
+ */
+function buildServiceAccountJwt(credentials, nowEpochSeconds) {
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64UrlEncode(
+    JSON.stringify({
+      iss: credentials.client_email,
+      scope: OAUTH_SCOPE,
+      aud: TOKEN_URL,
+      iat: nowEpochSeconds,
+      exp: nowEpochSeconds + 300,
+    }),
+  );
+  const signingInput = `${header}.${claims}`;
+  const signature = crypto
+    .sign("RSA-SHA256", Buffer.from(signingInput), credentials.private_key)
+    .toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`google-cloud-dns ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  async function fetchAccessToken() {
+    const assertion = buildServiceAccountJwt(
+      credentials,
+      Math.floor(Date.now() / 1000),
+    );
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      TOKEN_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: JWT_GRANT_TYPE,
+          assertion,
+        }).toString(),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("token request", response);
+    }
+
+    let accessToken = null;
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      accessToken = parsed && typeof parsed.access_token === "string" ? parsed.access_token : null;
+    } catch {
+      // fall through to the failure below
+    }
+    if (!isNonEmptyString(accessToken)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt("google-cloud-dns token response carried no access_token"),
+      };
+    }
+    return { ok: true, accessToken };
+  }
+
+  /**
+   * Resolves the managed zone name: configured name wins, otherwise looked
+   * up by dnsName (absolute form with trailing dot).
+   * @param {string} accessToken
+   * @param {string} zone
+   */
+  async function resolveManagedZone(accessToken, zone) {
+    if (credentials.managedZone) {
+      return { ok: true, managedZone: credentials.managedZone };
+    }
+
+    const zoneFqdn = zone.endsWith(".") ? zone : `${zone}.`;
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/projects/${encodeURIComponent(credentials.project_id)}/managedZones?dnsName=${encodeURIComponent(zoneFqdn)}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("managed zone lookup", response);
+    }
+
+    let managedZone = null;
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      const first =
+        parsed && Array.isArray(parsed.managedZones) ? parsed.managedZones[0] : null;
+      managedZone = first && typeof first.name === "string" ? first.name : null;
+    } catch {
+      // fall through to the failure below
+    }
+    if (!isNonEmptyString(managedZone)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`google-cloud-dns managed zone lookup found no zone for ${JSON.stringify(zone)}`),
+      };
+    }
+    return { ok: true, managedZone };
+  }
+
+  /**
+   * @param {"additions"|"deletions"} changeKind
+   * @param {{ zone: string, recordName: string, txtValue: string }} inputs
+   */
+  async function applyChange(changeKind, { zone, recordName, txtValue }) {
+    const tokenResult = await fetchAccessToken();
+    if (!tokenResult.ok) {
+      return tokenResult;
+    }
+
+    const zoneResult = await resolveManagedZone(tokenResult.accessToken, zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const recordFqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
+    const rrset = {
+      name: recordFqdn,
+      type: "TXT",
+      ttl: TXT_TTL_SECONDS,
+      rrdatas: [`"${txtValue}"`],
+    };
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/projects/${encodeURIComponent(credentials.project_id)}/managedZones/${encodeURIComponent(zoneResult.managedZone)}/changes`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tokenResult.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ [changeKind]: [rrset] }),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure(`changes ${changeKind}`, response);
+    }
+
+    return { ok: true };
+  }
+
+  return {
+    presentChallenge: (inputs) => applyChange("additions", inputs),
+    cleanupChallenge: (inputs) => applyChange("deletions", inputs),
+  };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  TOKEN_URL,
+  API_BASE_URL,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for tests (deterministic given nowEpochSeconds).
+  buildServiceAccountJwt,
+};

--- a/packages/agent/src/dns/providers/google-cloud-dns.test.js
+++ b/packages/agent/src/dns/providers/google-cloud-dns.test.js
@@ -112,7 +112,14 @@ test("google-cloud-dns: the assertion JWT is RS256-signed and carries the SA cla
 // ---------------------------------------------------------------------------
 
 test("google-cloud-dns: present exchanges the JWT then POSTs an additions change", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 200, body: '{"rrsets":[]}' };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
   const solver = createDnsSolver({
     provider: "google-cloud-dns",
     credentials: CREDENTIALS,
@@ -122,14 +129,21 @@ test("google-cloud-dns: present exchanges the JWT then POSTs an additions change
   const result = await solver.presentChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls.length, 3);
 
   const tokenCall = fetchStub.calls[0];
   assert.equal(tokenCall.url, TOKEN_URL);
   assert.match(tokenCall.options.body, /grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer/);
   assert.match(tokenCall.options.body, /assertion=/);
 
-  const changeCall = fetchStub.calls[1];
+  const rrsetCall = fetchStub.calls[1];
+  assert.match(
+    rrsetCall.url,
+    /\/managedZones\/example-zone\/rrsets\?name=_acme-challenge\.example\.com\.&type=TXT$/,
+  );
+  assert.equal(rrsetCall.options.method, "GET");
+
+  const changeCall = fetchStub.calls[2];
   assert.equal(
     changeCall.url,
     `${API_BASE_URL}/projects/project-1/managedZones/example-zone/changes`,
@@ -147,8 +161,58 @@ test("google-cloud-dns: present exchanges the JWT then POSTs an additions change
   });
 });
 
-test("google-cloud-dns: cleanup POSTs a deletions change for the same rrset", async () => {
-  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+test("google-cloud-dns: present merges with pre-existing rrdatas (deletions + additions)", async () => {
+  const existingRrset = {
+    name: "_acme-challenge.example.com.",
+    type: "TXT",
+    ttl: 120,
+    rrdatas: ['"sibling-value"'],
+  };
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 200, body: JSON.stringify({ rrsets: [existingRrset] }) };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(JSON.parse(fetchStub.calls[2].options.body), {
+    deletions: [existingRrset],
+    additions: [
+      {
+        name: "_acme-challenge.example.com.",
+        type: "TXT",
+        ttl: 120,
+        rrdatas: ['"sibling-value"', '"token-value"'],
+      },
+    ],
+  });
+});
+
+test("google-cloud-dns: cleanup removes only the challenge value and keeps siblings", async () => {
+  const existingRrset = {
+    name: "_acme-challenge.example.com.",
+    type: "TXT",
+    ttl: 60,
+    rrdatas: ['"sibling-value"', '"token-value"'],
+  };
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 200, body: JSON.stringify({ rrsets: [existingRrset] }) };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
   const solver = createDnsSolver({
     provider: "google-cloud-dns",
     credentials: CREDENTIALS,
@@ -158,16 +222,76 @@ test("google-cloud-dns: cleanup POSTs a deletions change for the same rrset", as
   const result = await solver.cleanupChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  const body = JSON.parse(fetchStub.calls[1].options.body);
-  assert.ok(Array.isArray(body.deletions));
-  assert.equal(body.deletions[0].name, "_acme-challenge.example.com.");
+  assert.deepEqual(JSON.parse(fetchStub.calls[2].options.body), {
+    deletions: [existingRrset],
+    additions: [
+      {
+        name: "_acme-challenge.example.com.",
+        type: "TXT",
+        ttl: 60,
+        rrdatas: ['"sibling-value"'],
+      },
+    ],
+  });
+});
+
+test("google-cloud-dns: cleanup of the last value deletes the rrset outright", async () => {
+  const existingRrset = {
+    name: "_acme-challenge.example.com.",
+    type: "TXT",
+    ttl: 60,
+    rrdatas: ['"token-value"'],
+  };
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 200, body: JSON.stringify({ rrsets: [existingRrset] }) };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const body = JSON.parse(fetchStub.calls[2].options.body);
+  assert.deepEqual(body, { deletions: [existingRrset] });
+});
+
+test("google-cloud-dns: cleanup of an already-absent value is idempotent success", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url, options) => {
+      if (options.method === "GET") {
+        return { status: 200, body: '{"rrsets":[]}' };
+      }
+      return { status: 500, body: "should never be called" };
+    }),
+  );
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
 });
 
 test("google-cloud-dns: the managed zone is looked up by dnsName when absent", async () => {
   const fetchStub = makeFetchStub(
-    tokenResponder((url) => {
+    tokenResponder((url, options) => {
       if (url.includes("/managedZones?dnsName=")) {
         return { status: 200, body: '{"managedZones":[{"name":"looked-up-zone"}]}' };
+      }
+      if (options.method === "GET") {
+        return { status: 200, body: '{"rrsets":[]}' };
       }
       return { status: 200, body: "{}" };
     }),
@@ -181,9 +305,10 @@ test("google-cloud-dns: the managed zone is looked up by dnsName when absent", a
   const result = await solver.presentChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls.length, 3);
+  assert.equal(fetchStub.calls.length, 4);
   assert.match(fetchStub.calls[1].url, /managedZones\?dnsName=example\.com\.$/);
-  assert.match(fetchStub.calls[2].url, /\/managedZones\/looked-up-zone\/changes$/);
+  assert.match(fetchStub.calls[2].url, /\/managedZones\/looked-up-zone\/rrsets\?/);
+  assert.match(fetchStub.calls[3].url, /\/managedZones\/looked-up-zone\/changes$/);
 });
 
 test("google-cloud-dns: an empty managed zone lookup maps to ok:false", async () => {

--- a/packages/agent/src/dns/providers/google-cloud-dns.test.js
+++ b/packages/agent/src/dns/providers/google-cloud-dns.test.js
@@ -1,0 +1,234 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  buildServiceAccountJwt,
+  TOKEN_URL,
+  API_BASE_URL,
+} = require("./google-cloud-dns.js");
+
+// One real (throwaway) RSA keypair for the whole file: the JWT must be
+// RS256-signed with an actual key for the signature-verification test.
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } =
+  crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const TEST_PRIVATE_KEY_PEM = TEST_PRIVATE_KEY.export({
+  type: "pkcs8",
+  format: "pem",
+});
+
+const CREDENTIALS = {
+  client_email: "sa@project-1.iam.gserviceaccount.com",
+  private_key: TEST_PRIVATE_KEY_PEM,
+  project_id: "project-1",
+  managedZone: "example-zone",
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function tokenResponder(rest) {
+  return (url, options) => {
+    if (url === TOKEN_URL) {
+      return { status: 200, body: '{"access_token":"gcp-access-token"}' };
+    }
+    return rest(url, options);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("google-cloud-dns: client_email, private_key, project_id are required", () => {
+  for (const field of ["client_email", "private_key", "project_id"]) {
+    const broken = { ...CREDENTIALS };
+    delete broken[field];
+    assert.throws(() => validateCredentials(broken), new RegExp(field));
+  }
+});
+
+test("google-cloud-dns: a private_key that is not PEM key material throws", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, private_key: "not-a-key" }),
+    /PEM private key/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// service-account JWT
+// ---------------------------------------------------------------------------
+
+test("google-cloud-dns: the assertion JWT is RS256-signed and carries the SA claims", () => {
+  const nowEpochSeconds = 1700000000;
+  const jwt = buildServiceAccountJwt(
+    { client_email: CREDENTIALS.client_email, private_key: TEST_PRIVATE_KEY_PEM },
+    nowEpochSeconds,
+  );
+
+  const [headerB64, claimsB64, signatureB64] = jwt.split(".");
+  assert.deepEqual(JSON.parse(Buffer.from(headerB64, "base64url").toString()), {
+    alg: "RS256",
+    typ: "JWT",
+  });
+  const claims = JSON.parse(Buffer.from(claimsB64, "base64url").toString());
+  assert.equal(claims.iss, CREDENTIALS.client_email);
+  assert.equal(claims.aud, TOKEN_URL);
+  assert.equal(claims.iat, nowEpochSeconds);
+  assert.equal(claims.exp, nowEpochSeconds + 300);
+  assert.match(claims.scope, /ndev\.clouddns\.readwrite/);
+
+  // Signature must verify against the matching public key: the key is used
+  // locally to sign and never leaves the host.
+  const verified = crypto.verify(
+    "RSA-SHA256",
+    Buffer.from(`${headerB64}.${claimsB64}`),
+    TEST_PUBLIC_KEY,
+    Buffer.from(signatureB64, "base64url"),
+  );
+  assert.equal(verified, true);
+});
+
+// ---------------------------------------------------------------------------
+// present / cleanup
+// ---------------------------------------------------------------------------
+
+test("google-cloud-dns: present exchanges the JWT then POSTs an additions change", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+
+  const tokenCall = fetchStub.calls[0];
+  assert.equal(tokenCall.url, TOKEN_URL);
+  assert.match(tokenCall.options.body, /grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer/);
+  assert.match(tokenCall.options.body, /assertion=/);
+
+  const changeCall = fetchStub.calls[1];
+  assert.equal(
+    changeCall.url,
+    `${API_BASE_URL}/projects/project-1/managedZones/example-zone/changes`,
+  );
+  assert.equal(changeCall.options.headers.Authorization, "Bearer gcp-access-token");
+  assert.deepEqual(JSON.parse(changeCall.options.body), {
+    additions: [
+      {
+        name: "_acme-challenge.example.com.",
+        type: "TXT",
+        ttl: 60,
+        rrdatas: ['"token-value"'],
+      },
+    ],
+  });
+});
+
+test("google-cloud-dns: cleanup POSTs a deletions change for the same rrset", async () => {
+  const fetchStub = makeFetchStub(tokenResponder(() => ({ status: 200, body: "{}" })));
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const body = JSON.parse(fetchStub.calls[1].options.body);
+  assert.ok(Array.isArray(body.deletions));
+  assert.equal(body.deletions[0].name, "_acme-challenge.example.com.");
+});
+
+test("google-cloud-dns: the managed zone is looked up by dnsName when absent", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder((url) => {
+      if (url.includes("/managedZones?dnsName=")) {
+        return { status: 200, body: '{"managedZones":[{"name":"looked-up-zone"}]}' };
+      }
+      return { status: 200, body: "{}" };
+    }),
+  );
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: { ...CREDENTIALS, managedZone: undefined },
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 3);
+  assert.match(fetchStub.calls[1].url, /managedZones\?dnsName=example\.com\.$/);
+  assert.match(fetchStub.calls[2].url, /\/managedZones\/looked-up-zone\/changes$/);
+});
+
+test("google-cloud-dns: an empty managed zone lookup maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(
+    tokenResponder(() => ({ status: 200, body: '{"managedZones":[]}' })),
+  );
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: { ...CREDENTIALS, managedZone: undefined },
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /found no zone/);
+});
+
+test("google-cloud-dns: token failure maps to ok:false and stops the flow", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 401, body: '{"error":"invalid_grant"}' }));
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 401);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("google-cloud-dns: an error body echoing key material is redacted wholesale", async () => {
+  // Any PRIVATE KEY marker in a response body redacts the whole excerpt.
+  const fetchStub = makeFetchStub(() => ({
+    status: 400,
+    body: "error near -----BEGIN PRIVATE KEY----- input",
+  }));
+  const solver = createDnsSolver({
+    provider: "google-cloud-dns",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/hetzner.js
+++ b/packages/agent/src/dns/providers/hetzner.js
@@ -1,0 +1,212 @@
+"use strict";
+
+/**
+ * Hetzner DNS DNS-01 provider.
+ *
+ * Auth: Hetzner DNS API token sent as the Auth-API-Token header. Create
+ * the token in the Hetzner DNS console; it is account-scoped (Hetzner DNS
+ * has no per-zone tokens), so prefer a dedicated account for automation.
+ *
+ * Credentials shape: { apiToken: string, zoneId?: string }
+ *   - zoneId is optional; when absent the zone id is looked up by name via
+ *     GET /zones?name=<zone> on every operation.
+ *
+ * API surface used (dns.hetzner.com/api/v1):
+ *   GET    /zones?name=<zone>          zone id lookup
+ *   POST   /records                    create TXT
+ *   GET    /records?zone_id=<zoneId>   record lookup (cleanup)
+ *   DELETE /records/<recordId>         delete TXT
+ *
+ * The record name sent to Hetzner is RELATIVE to the zone ("@" at the
+ * apex). The record list endpoint has no name/type filter, so cleanup
+ * lists the zone's records and matches type + name + value client-side.
+ */
+
+const {
+  isNonEmptyString,
+  relativeRecordName,
+  fetchWithTimeout,
+} = require("../internal.js");
+
+const PROVIDER_ID = "hetzner";
+const API_BASE_URL = "https://dns.hetzner.com/api/v1";
+const TXT_TTL_SECONDS = 60;
+
+/**
+ * @param {object} credentials
+ * @returns {{ apiToken: string, zoneId: string|null }}
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.apiToken)) {
+    throw new Error("dns: hetzner credentials require a non-empty apiToken string");
+  }
+  if (credentials.zoneId !== undefined && !isNonEmptyString(credentials.zoneId)) {
+    throw new Error("dns: hetzner zoneId must be a non-empty string when provided");
+  }
+  return {
+    apiToken: credentials.apiToken,
+    zoneId: credentials.zoneId || null,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.apiToken];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function authHeaders() {
+    return {
+      "Auth-API-Token": credentials.apiToken,
+      "Content-Type": "application/json",
+    };
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`hetzner ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  function parseJson(bodyText) {
+    try {
+      const parsed = JSON.parse(bodyText);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Resolves the zone id: configured zoneId wins, otherwise looked up by
+   * exact zone name. Returns { ok:true, zoneId } or an ok:false failure.
+   * @param {string} zone
+   */
+  async function resolveZoneId(zone) {
+    if (credentials.zoneId) {
+      return { ok: true, zoneId: credentials.zoneId };
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/zones?name=${encodeURIComponent(zone)}`,
+      { method: "GET", headers: authHeaders() },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("zone lookup", response);
+    }
+
+    const parsed = parseJson(response.bodyText);
+    const zones = parsed && Array.isArray(parsed.zones) ? parsed.zones : [];
+    const match = zones.find(
+      (candidate) =>
+        candidate &&
+        typeof candidate.name === "string" &&
+        candidate.name.toLowerCase() === zone.toLowerCase(),
+    );
+    if (!match || !isNonEmptyString(match.id)) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`hetzner zone lookup returned no zone named ${JSON.stringify(zone)}`),
+      };
+    }
+    return { ok: true, zoneId: match.id };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const zoneResult = await resolveZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/records`,
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          zone_id: zoneResult.zoneId,
+          type: "TXT",
+          name: relativeRecordName(recordName, zone) || "@",
+          value: txtValue,
+          ttl: TXT_TTL_SECONDS,
+        }),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("record create", response);
+    }
+
+    return { ok: true };
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const zoneResult = await resolveZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const listResponse = await fetchWithTimeout(
+      fetchImpl,
+      `${API_BASE_URL}/records?zone_id=${encodeURIComponent(zoneResult.zoneId)}`,
+      { method: "GET", headers: authHeaders() },
+      timeoutMs,
+    );
+    if (!listResponse.ok) {
+      return httpFailure("record lookup", listResponse);
+    }
+
+    const relative = relativeRecordName(recordName, zone) || "@";
+    const parsed = parseJson(listResponse.bodyText);
+    const records = parsed && Array.isArray(parsed.records) ? parsed.records : [];
+    // Exact type + name + value match so cleanup never deletes an
+    // unrelated record that happens to share the name.
+    const matches = records.filter(
+      (record) =>
+        record &&
+        record.type === "TXT" &&
+        record.name === relative &&
+        record.value === txtValue &&
+        isNonEmptyString(record.id),
+    );
+    if (matches.length === 0) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    for (const record of matches) {
+      const deleteResponse = await fetchWithTimeout(
+        fetchImpl,
+        `${API_BASE_URL}/records/${encodeURIComponent(record.id)}`,
+        { method: "DELETE", headers: authHeaders() },
+        timeoutMs,
+      );
+      // 404 means the record is already gone: idempotent success.
+      if (!deleteResponse.ok && deleteResponse.status !== 404) {
+        return httpFailure("record delete", deleteResponse);
+      }
+    }
+
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  API_BASE_URL,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+};

--- a/packages/agent/src/dns/providers/hetzner.test.js
+++ b/packages/agent/src/dns/providers/hetzner.test.js
@@ -1,0 +1,224 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const { validateCredentials, API_BASE_URL } = require("./hetzner.js");
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options, calls.length) || {};
+    return Promise.resolve({ status, text: () => Promise.resolve(body) });
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = { apiToken: "hetzner-token" }) {
+  return createDnsSolver({ provider: "hetzner", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("hetzner: missing apiToken throws at construction", () => {
+  assert.throws(() => validateCredentials({}), /apiToken/);
+  assert.throws(() => validateCredentials({ apiToken: "" }), /apiToken/);
+});
+
+test("hetzner: non-string zoneId throws at construction", () => {
+  assert.throws(() => validateCredentials({ apiToken: "t", zoneId: 42 }), /zoneId/);
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("hetzner: present with configured zoneId POSTs the TXT record directly", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"record":{"id":"r1"}}' }));
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+  const call = fetchStub.calls[0];
+  assert.equal(call.url, `${API_BASE_URL}/records`);
+  assert.equal(call.options.method, "POST");
+  assert.equal(call.options.headers["Auth-API-Token"], "hetzner-token");
+  assert.deepEqual(JSON.parse(call.options.body), {
+    zone_id: "zone123",
+    type: "TXT",
+    name: "_acme-challenge",
+    value: CHALLENGE.txtValue,
+    ttl: 60,
+  });
+});
+
+test("hetzner: present without zoneId looks the zone up by name first", async () => {
+  const fetchStub = makeFetchStub((url) => {
+    if (url.includes("/zones?name=")) {
+      return {
+        status: 200,
+        body: '{"zones":[{"id":"looked-up-zone","name":"example.com"}]}',
+      };
+    }
+    return { status: 200, body: '{"record":{"id":"r1"}}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls[0].url, `${API_BASE_URL}/zones?name=example.com`);
+  assert.equal(
+    JSON.parse(fetchStub.calls[1].options.body).zone_id,
+    "looked-up-zone",
+  );
+});
+
+test("hetzner: a zone lookup returning a non-matching zone maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body: '{"zones":[{"id":"zother","name":"other.example.org"}]}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /no zone named/);
+});
+
+test("hetzner: apex record name maps to @", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge({
+    zone: "example.com",
+    recordName: "example.com",
+    txtValue: "v",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(JSON.parse(fetchStub.calls[0].options.body).name, "@");
+});
+
+test("hetzner: HTTP error on create maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 422,
+    body: '{"error":{"message":"invalid record"}}',
+  }));
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 422);
+  assert.match(result.detail, /HTTP 422/);
+  assert.match(result.detail, /invalid record/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("hetzner: cleanup lists zone records and DELETEs the exact match only", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: JSON.stringify({
+          records: [
+            { id: "keep-1", type: "TXT", name: "_acme-challenge", value: "other-value" },
+            { id: "keep-2", type: "A", name: "_acme-challenge", value: "token-value" },
+            { id: "del-1", type: "TXT", name: "_acme-challenge", value: "token-value" },
+          ],
+        }),
+      };
+    }
+    return { status: 200, body: "{}" };
+  });
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.match(fetchStub.calls[0].url, /\/records\?zone_id=zone123$/);
+  assert.equal(fetchStub.calls[1].options.method, "DELETE");
+  assert.match(fetchStub.calls[1].url, /\/records\/del-1$/);
+});
+
+test("hetzner: cleanup of an already-absent record is idempotent success", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"records":[]}' }));
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("hetzner: a 404 on record delete is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"records":[{"id":"gone","type":"TXT","name":"_acme-challenge","value":"token-value"}]}',
+      };
+    }
+    return { status: 404, body: '{"error":{"message":"record not found"}}' };
+  });
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+});
+
+test("hetzner: failing DELETE maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"records":[{"id":"del-1","type":"TXT","name":"_acme-challenge","value":"token-value"}]}',
+      };
+    }
+    return { status: 500, body: "server error" };
+  });
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("hetzner: error body echoing the apiToken is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 401,
+    body: 'invalid token "hetzner-token" supplied',
+  }));
+  const solver = solverWith(fetchStub, { apiToken: "hetzner-token", zoneId: "zone123" });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/infomaniak.js
+++ b/packages/agent/src/dns/providers/infomaniak.js
@@ -1,0 +1,189 @@
+"use strict";
+
+/**
+ * Infomaniak DNS-01 provider.
+ *
+ * Auth: Infomaniak API token sent as a Bearer header. Create the token in
+ * the Infomaniak manager with the "domain" scope only.
+ *
+ * Credentials shape: { apiToken: string }
+ *
+ * API surface used (api.infomaniak.com, v2 zone records):
+ *   POST   /2/zones/<zone>/records          create TXT
+ *   GET    /2/zones/<zone>/records          record lookup (cleanup)
+ *   DELETE /2/zones/<zone>/records/<id>     delete TXT
+ *
+ * Response envelope: every response wraps its payload as
+ * { result: "success"|"error", data, error? }. A `result` other than
+ * "success" is an operational failure EVEN ON HTTP 200, so both the HTTP
+ * status and the envelope are checked on every call.
+ *
+ * The record `source` sent to Infomaniak is RELATIVE to the zone ("." at
+ * the apex, Infomaniak's spelling for the zone root).
+ */
+
+const {
+  isNonEmptyString,
+  relativeRecordName,
+  fetchWithTimeout,
+} = require("../internal.js");
+
+const PROVIDER_ID = "infomaniak";
+const API_BASE_URL = "https://api.infomaniak.com";
+const TXT_TTL_SECONDS = 60;
+
+/**
+ * @param {object} credentials
+ * @returns {{ apiToken: string }}
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.apiToken)) {
+    throw new Error("dns: infomaniak credentials require a non-empty apiToken string");
+  }
+  return { apiToken: credentials.apiToken };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.apiToken];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function authHeaders() {
+    return {
+      Authorization: `Bearer ${credentials.apiToken}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  function recordsUrl(zone, recordId) {
+    const base = `${API_BASE_URL}/2/zones/${encodeURIComponent(zone)}/records`;
+    return recordId === undefined ? base : `${base}/${encodeURIComponent(recordId)}`;
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`infomaniak ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  /**
+   * Parses the { result, data } envelope; returns null on any parse
+   * problem (callers treat null as "unexpected response").
+   * @param {string} bodyText
+   */
+  function parseEnvelope(bodyText) {
+    try {
+      const parsed = JSON.parse(bodyText);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Runs one request and enforces both the HTTP status and the
+   * { result: "success" } envelope. Returns { ok:true, data } or an
+   * ok:false operational failure.
+   * @param {string} operationLabel
+   * @param {string} url
+   * @param {object} options fetch options
+   */
+  async function envelopeFetch(operationLabel, url, options) {
+    const response = await fetchWithTimeout(fetchImpl, url, options, timeoutMs);
+    if (!response.ok) {
+      return httpFailure(operationLabel, response);
+    }
+
+    const envelope = parseEnvelope(response.bodyText);
+    if (!envelope || envelope.result !== "success") {
+      // Infomaniak reports application errors as { result: "error" } even
+      // on HTTP 200; that is an operational failure, not a success.
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`infomaniak ${operationLabel} returned a non-success envelope: ${response.bodyText}`),
+      };
+    }
+    return { ok: true, data: envelope.data };
+  }
+
+  /** Infomaniak spells the zone apex as ".". */
+  function sourceName(zone, recordName) {
+    return relativeRecordName(recordName, zone) || ".";
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const result = await envelopeFetch("record create", recordsUrl(zone), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        type: "TXT",
+        source: sourceName(zone, recordName),
+        target: txtValue,
+        ttl: TXT_TTL_SECONDS,
+      }),
+    });
+    if (!result.ok) {
+      return result;
+    }
+    return { ok: true };
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const listResult = await envelopeFetch("record lookup", recordsUrl(zone), {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!listResult.ok) {
+      return listResult;
+    }
+
+    const source = sourceName(zone, recordName);
+    const records = Array.isArray(listResult.data) ? listResult.data : [];
+    // Exact type + source + target match so cleanup never deletes an
+    // unrelated record that happens to share the name.
+    const matches = records.filter(
+      (record) =>
+        record &&
+        record.type === "TXT" &&
+        record.source === source &&
+        record.target === txtValue &&
+        (isNonEmptyString(record.id) || Number.isInteger(record.id)),
+    );
+    if (matches.length === 0) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    for (const record of matches) {
+      const deleteResult = await envelopeFetch(
+        "record delete",
+        recordsUrl(zone, record.id),
+        { method: "DELETE", headers: authHeaders() },
+      );
+      // A 404 means the record is already gone: idempotent success.
+      if (!deleteResult.ok && deleteResult.statusCode !== 404) {
+        return deleteResult;
+      }
+    }
+
+    return { ok: true };
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  API_BASE_URL,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+};

--- a/packages/agent/src/dns/providers/infomaniak.test.js
+++ b/packages/agent/src/dns/providers/infomaniak.test.js
@@ -1,0 +1,205 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const { validateCredentials, API_BASE_URL } = require("./infomaniak.js");
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = '{"result":"success","data":null}' } =
+      respond(url, options, calls.length) || {};
+    return Promise.resolve({ status, text: () => Promise.resolve(body) });
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = { apiToken: "infomaniak-token" }) {
+  return createDnsSolver({ provider: "infomaniak", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("infomaniak: missing apiToken throws at construction", () => {
+  assert.throws(() => validateCredentials({}), /apiToken/);
+  assert.throws(() => validateCredentials({ apiToken: "" }), /apiToken/);
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("infomaniak: present POSTs the TXT record with a relative source and Bearer auth", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body: '{"result":"success","data":{"id":77}}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+  const call = fetchStub.calls[0];
+  assert.equal(call.url, `${API_BASE_URL}/2/zones/example.com/records`);
+  assert.equal(call.options.method, "POST");
+  assert.equal(call.options.headers.Authorization, "Bearer infomaniak-token");
+  assert.deepEqual(JSON.parse(call.options.body), {
+    type: "TXT",
+    source: "_acme-challenge",
+    target: CHALLENGE.txtValue,
+    ttl: 60,
+  });
+});
+
+test("infomaniak: apex record source maps to .", async () => {
+  const fetchStub = makeFetchStub(() => ({}));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge({
+    zone: "example.com",
+    recordName: "example.com",
+    txtValue: "v",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(JSON.parse(fetchStub.calls[0].options.body).source, ".");
+});
+
+test("infomaniak: an error envelope on HTTP 200 maps to ok:false", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body: '{"result":"error","error":{"code":"not_authorized"}}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 200);
+  assert.match(result.detail, /non-success envelope/);
+  assert.match(result.detail, /not_authorized/);
+});
+
+test("infomaniak: HTTP error maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 422,
+    body: '{"result":"error","error":{"code":"invalid_record"}}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 422);
+  assert.match(result.detail, /HTTP 422/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("infomaniak: cleanup lists zone records and DELETEs the exact match only", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: JSON.stringify({
+          result: "success",
+          data: [
+            { id: 1, type: "TXT", source: "_acme-challenge", target: "other-value" },
+            { id: 2, type: "A", source: "_acme-challenge", target: "token-value" },
+            { id: 3, type: "TXT", source: "_acme-challenge", target: "token-value" },
+          ],
+        }),
+      };
+    }
+    return { status: 200, body: '{"result":"success","data":true}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls[0].url, `${API_BASE_URL}/2/zones/example.com/records`);
+  assert.equal(fetchStub.calls[1].options.method, "DELETE");
+  assert.match(fetchStub.calls[1].url, /\/2\/zones\/example\.com\/records\/3$/);
+});
+
+test("infomaniak: cleanup of an already-absent record is idempotent success", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body: '{"result":"success","data":[]}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("infomaniak: a 404 on record delete is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"result":"success","data":[{"id":9,"type":"TXT","source":"_acme-challenge","target":"token-value"}]}',
+      };
+    }
+    return { status: 404, body: '{"result":"error","error":{"code":"not_found"}}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+});
+
+test("infomaniak: an error envelope on delete maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: '{"result":"success","data":[{"id":9,"type":"TXT","source":"_acme-challenge","target":"token-value"}]}',
+      };
+    }
+    return { status: 200, body: '{"result":"error","error":{"code":"locked"}}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /non-success envelope/);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("infomaniak: error body echoing the apiToken is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 401,
+    body: 'invalid token "infomaniak-token" supplied',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/ovhcloud.js
+++ b/packages/agent/src/dns/providers/ovhcloud.js
@@ -1,0 +1,274 @@
+"use strict";
+
+/**
+ * OVHcloud DNS-01 provider.
+ *
+ * Auth: OVH API v1 request signing (application key + application secret +
+ * consumer key). Create the consumer key with rights scoped to
+ * GET/POST/DELETE on /domain/zone/<zone>/* only.
+ *
+ * Credentials shape:
+ *   {
+ *     applicationKey: string,
+ *     applicationSecret: string,
+ *     consumerKey: string,
+ *     endpoint?: string,   // API base URL, default https://eu.api.ovh.com/1.0
+ *                          // (other regions: https://ca.api.ovh.com/1.0,
+ *                          //  https://us.api.ovhcloud.com/1.0)
+ *   }
+ *
+ * Request signing per the OVH spec: "$1$" + SHA1 hex of
+ *   applicationSecret + "+" + consumerKey + "+" + METHOD + "+" + fullUrl
+ *   + "+" + body + "+" + timestamp
+ * sent as X-Ovh-Signature alongside X-Ovh-Application, X-Ovh-Consumer and
+ * X-Ovh-Timestamp. The timestamp is the LOCAL unix time: no /auth/time
+ * skew correction is performed (documented simplification; OVH tolerates
+ * normal NTP-grade drift and a skewed clock surfaces as a plain HTTP 403
+ * operational failure, never a throw).
+ *
+ * API surface used:
+ *   POST   /domain/zone/<zone>/record          create TXT (fieldType,
+ *                                              subDomain relative, target)
+ *   POST   /domain/zone/<zone>/refresh         apply zone changes
+ *   GET    /domain/zone/<zone>/record?...      list record ids (cleanup)
+ *   GET    /domain/zone/<zone>/record/<id>     record detail (target match)
+ *   DELETE /domain/zone/<zone>/record/<id>     delete TXT
+ *
+ * The subDomain sent to OVH is RELATIVE to the zone ("" at the apex).
+ * OVH's list filter only matches fieldType + subDomain, so cleanup fetches
+ * each candidate record and deletes only those whose target matches the
+ * challenge value (never an unrelated record sharing the name). A zone
+ * refresh is POSTed after every mutation so the change actually serves.
+ */
+
+const crypto = require("node:crypto");
+
+const {
+  isNonEmptyString,
+  relativeRecordName,
+  fetchWithTimeout,
+} = require("../internal.js");
+
+const PROVIDER_ID = "ovhcloud";
+const DEFAULT_ENDPOINT = "https://eu.api.ovh.com/1.0";
+const TXT_TTL_SECONDS = 60;
+
+// --------------------------------------------------------------------------
+// OVH request signing (exported for the fixed-vector signature test)
+// --------------------------------------------------------------------------
+
+/**
+ * Computes the OVH v1 request signature. Deterministic given timestamp, so
+ * tests can pin an exact signature for fixed keys.
+ *
+ * @param {object} options
+ * @param {string} options.applicationSecret
+ * @param {string} options.consumerKey
+ * @param {string} options.method uppercase HTTP method
+ * @param {string} options.url full request URL (including query string)
+ * @param {string} options.body raw request body ("" when none)
+ * @param {number} options.timestamp unix seconds
+ * @returns {string} "$1$" + SHA1 hex
+ */
+function signOvhRequest({ applicationSecret, consumerKey, method, url, body, timestamp }) {
+  const material = [applicationSecret, consumerKey, method, url, body, String(timestamp)].join("+");
+  return `$1$${crypto.createHash("sha1").update(material).digest("hex")}`;
+}
+
+// --------------------------------------------------------------------------
+// Provider contract
+// --------------------------------------------------------------------------
+
+const REQUIRED_FIELDS = Object.freeze([
+  "applicationKey",
+  "applicationSecret",
+  "consumerKey",
+]);
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  for (const field of REQUIRED_FIELDS) {
+    if (!isNonEmptyString(credentials[field])) {
+      throw new Error(`dns: ovhcloud credentials require a non-empty ${field} string`);
+    }
+  }
+  if (credentials.endpoint !== undefined && !isNonEmptyString(credentials.endpoint)) {
+    throw new Error("dns: ovhcloud endpoint must be a non-empty string when provided");
+  }
+  return {
+    applicationKey: credentials.applicationKey,
+    applicationSecret: credentials.applicationSecret,
+    consumerKey: credentials.consumerKey,
+    endpoint: (credentials.endpoint || DEFAULT_ENDPOINT).replace(/\/+$/, ""),
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [
+    credentials.applicationSecret,
+    credentials.consumerKey,
+    credentials.applicationKey,
+  ];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  /**
+   * Signs and sends one request against the configured endpoint.
+   * @param {{ method: string, path: string, body?: object|null }} request
+   *   `path` starts with "/" and may carry a query string; `body` is
+   *   JSON-serialized when present, "" otherwise (both are signed as sent).
+   */
+  function signedFetch({ method, path, body = null }) {
+    const url = `${credentials.endpoint}${path}`;
+    const bodyText = body === null ? "" : JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signOvhRequest({
+      applicationSecret: credentials.applicationSecret,
+      consumerKey: credentials.consumerKey,
+      method,
+      url,
+      body: bodyText,
+      timestamp,
+    });
+
+    const headers = {
+      "X-Ovh-Application": credentials.applicationKey,
+      "X-Ovh-Consumer": credentials.consumerKey,
+      "X-Ovh-Timestamp": String(timestamp),
+      "X-Ovh-Signature": signature,
+    };
+    if (bodyText) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    return fetchWithTimeout(
+      fetchImpl,
+      url,
+      { method, headers, ...(bodyText ? { body: bodyText } : {}) },
+      timeoutMs,
+    );
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`ovhcloud ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  function parseJson(bodyText) {
+    try {
+      return JSON.parse(bodyText);
+    } catch {
+      return null;
+    }
+  }
+
+  /** POST /domain/zone/<zone>/refresh so the mutation actually serves. */
+  async function refreshZone(zone) {
+    const response = await signedFetch({
+      method: "POST",
+      path: `/domain/zone/${encodeURIComponent(zone)}/refresh`,
+    });
+    if (!response.ok) {
+      return httpFailure("zone refresh", response);
+    }
+    return { ok: true };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const subDomain = relativeRecordName(recordName, zone);
+
+    const response = await signedFetch({
+      method: "POST",
+      path: `/domain/zone/${encodeURIComponent(zone)}/record`,
+      body: {
+        fieldType: "TXT",
+        subDomain,
+        target: txtValue,
+        ttl: TXT_TTL_SECONDS,
+      },
+    });
+    if (!response.ok) {
+      return httpFailure("record create", response);
+    }
+
+    return refreshZone(zone);
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const subDomain = relativeRecordName(recordName, zone);
+
+    // OVH's list filter matches fieldType + subDomain only; the target is
+    // matched below via each record's detail so cleanup never deletes an
+    // unrelated record that happens to share the name.
+    const listResponse = await signedFetch({
+      method: "GET",
+      path:
+        `/domain/zone/${encodeURIComponent(zone)}/record` +
+        `?fieldType=TXT&subDomain=${encodeURIComponent(subDomain)}`,
+    });
+    if (!listResponse.ok) {
+      return httpFailure("record lookup", listResponse);
+    }
+
+    const ids = parseJson(listResponse.bodyText);
+    const recordIds = Array.isArray(ids) ? ids.filter((id) => Number.isInteger(id) || isNonEmptyString(id)) : [];
+    if (recordIds.length === 0) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    let deletedAny = false;
+    for (const recordId of recordIds) {
+      const detailResponse = await signedFetch({
+        method: "GET",
+        path: `/domain/zone/${encodeURIComponent(zone)}/record/${encodeURIComponent(recordId)}`,
+      });
+      if (!detailResponse.ok) {
+        return httpFailure("record detail", detailResponse);
+      }
+      const record = parseJson(detailResponse.bodyText);
+      const target = record && typeof record.target === "string" ? record.target : null;
+      // OVH may store the target quoted; accept both spellings.
+      if (target !== txtValue && target !== `"${txtValue}"`) {
+        continue;
+      }
+
+      const deleteResponse = await signedFetch({
+        method: "DELETE",
+        path: `/domain/zone/${encodeURIComponent(zone)}/record/${encodeURIComponent(recordId)}`,
+      });
+      // 404 means the record is already gone: idempotent success.
+      if (!deleteResponse.ok && deleteResponse.status !== 404) {
+        return httpFailure("record delete", deleteResponse);
+      }
+      deletedAny = true;
+    }
+
+    if (!deletedAny) {
+      return { ok: true };
+    }
+    return refreshZone(zone);
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  DEFAULT_ENDPOINT,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for the fixed-vector signature test only.
+  signOvhRequest,
+};

--- a/packages/agent/src/dns/providers/ovhcloud.test.js
+++ b/packages/agent/src/dns/providers/ovhcloud.test.js
@@ -1,0 +1,289 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  signOvhRequest,
+  DEFAULT_ENDPOINT,
+} = require("./ovhcloud.js");
+
+const CREDENTIALS = {
+  applicationKey: "app-key",
+  applicationSecret: "app-secret",
+  consumerKey: "consumer-key",
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options, calls.length) || {};
+    return Promise.resolve({ status, text: () => Promise.resolve(body) });
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = CREDENTIALS) {
+  return createDnsSolver({ provider: "ovhcloud", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("ovhcloud: applicationKey, applicationSecret and consumerKey are required", () => {
+  assert.throws(
+    () => validateCredentials({ applicationSecret: "s", consumerKey: "c" }),
+    /applicationKey/,
+  );
+  assert.throws(
+    () => validateCredentials({ applicationKey: "a", consumerKey: "c" }),
+    /applicationSecret/,
+  );
+  assert.throws(
+    () => validateCredentials({ applicationKey: "a", applicationSecret: "s" }),
+    /consumerKey/,
+  );
+});
+
+test("ovhcloud: endpoint defaults to the EU API and trailing slashes are stripped", () => {
+  assert.equal(validateCredentials(CREDENTIALS).endpoint, DEFAULT_ENDPOINT);
+  assert.equal(
+    validateCredentials({ ...CREDENTIALS, endpoint: "https://ca.api.ovh.com/1.0/" }).endpoint,
+    "https://ca.api.ovh.com/1.0",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// signature fixed vector (deterministic given timestamp)
+// ---------------------------------------------------------------------------
+
+test("ovhcloud: request signature matches the fixed vector", () => {
+  const signature = signOvhRequest({
+    applicationSecret: "app-secret",
+    consumerKey: "consumer-key",
+    method: "POST",
+    url: "https://eu.api.ovh.com/1.0/domain/zone/example.com/record",
+    body: '{"fieldType":"TXT"}',
+    timestamp: 1767225600,
+  });
+  // SHA1 of "app-secret+consumer-key+POST+https://eu.api.ovh.com/1.0/domain/zone/example.com/record+{\"fieldType\":\"TXT\"}+1767225600"
+  assert.equal(signature, "$1$eee7898dc253b3f58e1efd88f0ae537fc7144fd7");
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("ovhcloud: present POSTs the TXT record then refreshes the zone", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: '{"id":42}' }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+
+  const create = fetchStub.calls[0];
+  assert.equal(create.url, `${DEFAULT_ENDPOINT}/domain/zone/example.com/record`);
+  assert.equal(create.options.method, "POST");
+  assert.deepEqual(JSON.parse(create.options.body), {
+    fieldType: "TXT",
+    subDomain: "_acme-challenge",
+    target: CHALLENGE.txtValue,
+    ttl: 60,
+  });
+
+  const refresh = fetchStub.calls[1];
+  assert.equal(refresh.url, `${DEFAULT_ENDPOINT}/domain/zone/example.com/refresh`);
+  assert.equal(refresh.options.method, "POST");
+});
+
+test("ovhcloud: signed headers carry application, consumer, timestamp and signature", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+  const solver = solverWith(fetchStub);
+
+  await solver.presentChallenge(CHALLENGE);
+
+  const headers = fetchStub.calls[0].options.headers;
+  assert.equal(headers["X-Ovh-Application"], "app-key");
+  assert.equal(headers["X-Ovh-Consumer"], "consumer-key");
+  assert.match(headers["X-Ovh-Timestamp"], /^\d+$/);
+  assert.match(headers["X-Ovh-Signature"], /^\$1\$[0-9a-f]{40}$/);
+
+  // The signature must be reproducible from the sent request parts.
+  const call = fetchStub.calls[0];
+  assert.equal(
+    headers["X-Ovh-Signature"],
+    signOvhRequest({
+      applicationSecret: "app-secret",
+      consumerKey: "consumer-key",
+      method: "POST",
+      url: call.url,
+      body: call.options.body,
+      timestamp: Number(headers["X-Ovh-Timestamp"]),
+    }),
+  );
+});
+
+test("ovhcloud: a custom endpoint override is used for every call", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+  const solver = solverWith(fetchStub, {
+    ...CREDENTIALS,
+    endpoint: "https://us.api.ovhcloud.com/1.0",
+  });
+
+  await solver.presentChallenge(CHALLENGE);
+
+  assert.match(fetchStub.calls[0].url, /^https:\/\/us\.api\.ovhcloud\.com\/1\.0\//);
+});
+
+test("ovhcloud: HTTP error on create maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: '{"message":"This credential is not valid"}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 403);
+  assert.match(result.detail, /HTTP 403/);
+});
+
+test("ovhcloud: a failing zone refresh after create maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url) => {
+    if (url.endsWith("/refresh")) {
+      return { status: 500, body: '{"message":"refresh failed"}' };
+    }
+    return { status: 200, body: '{"id":42}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+  assert.match(result.detail, /zone refresh/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("ovhcloud: cleanup deletes only the record whose target matches, then refreshes", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.includes("?fieldType=TXT")) {
+      return { status: 200, body: "[11,22]" };
+    }
+    if (options.method === "GET" && url.endsWith("/record/11")) {
+      return { status: 200, body: '{"id":11,"target":"other-value"}' };
+    }
+    if (options.method === "GET" && url.endsWith("/record/22")) {
+      return { status: 200, body: '{"id":22,"target":"token-value"}' };
+    }
+    return { status: 200, body: "null" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const listUrl = fetchStub.calls[0].url;
+  assert.match(listUrl, /\/domain\/zone\/example\.com\/record\?fieldType=TXT&subDomain=_acme-challenge$/);
+
+  const deletes = fetchStub.calls.filter((call) => call.options.method === "DELETE");
+  assert.equal(deletes.length, 1);
+  assert.match(deletes[0].url, /\/record\/22$/);
+
+  const last = fetchStub.calls[fetchStub.calls.length - 1];
+  assert.match(last.url, /\/refresh$/);
+});
+
+test("ovhcloud: cleanup of an already-absent record is idempotent success (no refresh)", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: "[]" }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("ovhcloud: a 404 on record delete is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.includes("?fieldType=TXT")) {
+      return { status: 200, body: "[11]" };
+    }
+    if (options.method === "GET") {
+      return { status: 200, body: '{"id":11,"target":"token-value"}' };
+    }
+    if (options.method === "DELETE") {
+      return { status: 404, body: '{"message":"not found"}' };
+    }
+    return { status: 200, body: "null" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+});
+
+test("ovhcloud: failing DELETE maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET" && url.includes("?fieldType=TXT")) {
+      return { status: 200, body: "[11]" };
+    }
+    if (options.method === "GET") {
+      return { status: 200, body: '{"id":11,"target":"token-value"}' };
+    }
+    return { status: 500, body: "server error" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("ovhcloud: error body echoing the applicationSecret is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 400,
+    body: 'invalid signature computed from secret "app-secret"',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});
+
+test("ovhcloud: error body echoing the consumerKey is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: "consumer-key is not allowed on this route",
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/powerdns.js
+++ b/packages/agent/src/dns/providers/powerdns.js
@@ -9,9 +9,15 @@
  *
  * Credentials shape:
  *   {
- *     apiUrl: string,     // e.g. "http://127.0.0.1:8081" (no trailing /api)
+ *     apiUrl: string,     // e.g. "https://pdns.example:8081" (no trailing
+ *                         // /api). Must be https:; set
+ *                         // allowInsecureLocalHttp for a loopback-only
+ *                         // http endpoint (localhost, *.localhost,
+ *                         // 127.x.x.x, ::1). Embedded credentials and
+ *                         // hash fragments are always rejected.
  *     apiKey: string,
  *     serverId?: string,  // default "localhost"
+ *     allowInsecureLocalHttp?: boolean,  // default false
  *   }
  *
  * API surface used (/api/v1/servers/<serverId>):
@@ -29,7 +35,11 @@
  * remaining values, or sends changetype DELETE when none remain.
  */
 
-const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+const {
+  isNonEmptyString,
+  fetchWithTimeout,
+  assertSafeProviderBaseUrl,
+} = require("../internal.js");
 
 const PROVIDER_ID = "powerdns";
 const DEFAULT_SERVER_ID = "localhost";
@@ -59,6 +69,17 @@ function validateCredentials(credentials) {
   if (credentials.serverId !== undefined && !isNonEmptyString(credentials.serverId)) {
     throw new Error("dns: powerdns serverId must be a non-empty string when provided");
   }
+  if (
+    credentials.allowInsecureLocalHttp !== undefined &&
+    typeof credentials.allowInsecureLocalHttp !== "boolean"
+  ) {
+    throw new Error("dns: powerdns allowInsecureLocalHttp must be a boolean when provided");
+  }
+
+  assertSafeProviderBaseUrl(credentials.apiUrl, {
+    allowInsecureLocalHttp: credentials.allowInsecureLocalHttp === true,
+  });
+
   return {
     apiUrl: credentials.apiUrl.replace(/\/+$/, ""),
     apiKey: credentials.apiKey,

--- a/packages/agent/src/dns/providers/powerdns.js
+++ b/packages/agent/src/dns/providers/powerdns.js
@@ -1,0 +1,241 @@
+"use strict";
+
+/**
+ * PowerDNS Authoritative Server DNS-01 provider.
+ *
+ * Auth: the PowerDNS built-in HTTP API key sent as the X-API-Key header
+ * (enable with `api=yes` + `api-key=...` in pdns.conf, webserver bound to
+ * a trusted interface only).
+ *
+ * Credentials shape:
+ *   {
+ *     apiUrl: string,     // e.g. "http://127.0.0.1:8081" (no trailing /api)
+ *     apiKey: string,
+ *     serverId?: string,  // default "localhost"
+ *   }
+ *
+ * API surface used (/api/v1/servers/<serverId>):
+ *   GET   /zones/<zone.>   read the zone's rrsets (merge + cleanup basis)
+ *   PATCH /zones/<zone.>   REPLACE / DELETE one TXT rrset
+ *
+ * PowerDNS spellings the caller never sees: zone and record names carry a
+ * TRAILING DOT in URLs and rrset names, and TXT record content must be
+ * wrapped in double quotes (backslash and quote characters escaped).
+ *
+ * REPLACE swaps the ENTIRE rrset, so present() first reads the existing
+ * TXT rrset at the name and REPLACEs with the union of existing values
+ * plus the new one -- parallel challenges at the same name (wildcard +
+ * apex orders) never clobber each other. cleanup() REPLACEs with the
+ * remaining values, or sends changetype DELETE when none remain.
+ */
+
+const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+
+const PROVIDER_ID = "powerdns";
+const DEFAULT_SERVER_ID = "localhost";
+const TXT_TTL_SECONDS = 60;
+
+/** PowerDNS TXT content quoting: wrap in double quotes, escape \ and ". */
+function quoteTxtValue(txtValue) {
+  return `"${txtValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Canonical PowerDNS name: lowercased with exactly one trailing dot. */
+function toCanonicalFqdn(name) {
+  return `${name.replace(/\.+$/, "").toLowerCase()}.`;
+}
+
+/**
+ * @param {object} credentials
+ * @returns {{ apiUrl: string, apiKey: string, serverId: string }}
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.apiUrl)) {
+    throw new Error("dns: powerdns credentials require a non-empty apiUrl string");
+  }
+  if (!isNonEmptyString(credentials.apiKey)) {
+    throw new Error("dns: powerdns credentials require a non-empty apiKey string");
+  }
+  if (credentials.serverId !== undefined && !isNonEmptyString(credentials.serverId)) {
+    throw new Error("dns: powerdns serverId must be a non-empty string when provided");
+  }
+  return {
+    apiUrl: credentials.apiUrl.replace(/\/+$/, ""),
+    apiKey: credentials.apiKey,
+    serverId: credentials.serverId || DEFAULT_SERVER_ID,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.apiKey];
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function authHeaders() {
+    return {
+      "X-API-Key": credentials.apiKey,
+      "Content-Type": "application/json",
+    };
+  }
+
+  function zoneUrl(zone) {
+    return (
+      `${credentials.apiUrl}/api/v1/servers/${encodeURIComponent(credentials.serverId)}` +
+      `/zones/${encodeURIComponent(toCanonicalFqdn(zone))}`
+    );
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`powerdns ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  /**
+   * Reads the current TXT record contents at `recordFqdn` from the zone.
+   * Returns { ok:true, contents: string[] } (empty when the rrset does not
+   * exist) or an ok:false operational failure.
+   * @param {string} zone
+   * @param {string} recordFqdn canonical name with trailing dot
+   */
+  async function readExistingTxtContents(zone, recordFqdn) {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      zoneUrl(zone),
+      { method: "GET", headers: authHeaders() },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure("zone read", response);
+    }
+
+    let rrsets = [];
+    try {
+      const parsed = JSON.parse(response.bodyText);
+      rrsets = parsed && Array.isArray(parsed.rrsets) ? parsed.rrsets : [];
+    } catch {
+      // Treat an unparseable zone body as "no rrsets"; the subsequent
+      // PATCH will surface any real API problem.
+    }
+
+    const rrset = rrsets.find(
+      (candidate) =>
+        candidate &&
+        candidate.type === "TXT" &&
+        typeof candidate.name === "string" &&
+        toCanonicalFqdn(candidate.name) === recordFqdn,
+    );
+    const contents =
+      rrset && Array.isArray(rrset.records)
+        ? rrset.records
+            .map((record) => (record && typeof record.content === "string" ? record.content : null))
+            .filter((content) => content !== null)
+        : [];
+    return { ok: true, contents };
+  }
+
+  /**
+   * PATCHes one TXT rrset change into the zone.
+   * @param {string} zone
+   * @param {object} rrset one rrsets[] entry
+   * @param {string} operationLabel
+   */
+  async function patchRrset(zone, rrset, operationLabel) {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      zoneUrl(zone),
+      {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ rrsets: [rrset] }),
+      },
+      timeoutMs,
+    );
+    if (!response.ok) {
+      return httpFailure(operationLabel, response);
+    }
+    return { ok: true };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
+    const recordFqdn = toCanonicalFqdn(recordName);
+    const existing = await readExistingTxtContents(zone, recordFqdn);
+    if (!existing.ok) {
+      return existing;
+    }
+
+    // Union with whatever is already there so parallel challenges at the
+    // same name never clobber each other (REPLACE swaps the whole rrset).
+    const quoted = quoteTxtValue(txtValue);
+    const contents = existing.contents.includes(quoted)
+      ? existing.contents
+      : [...existing.contents, quoted];
+
+    return patchRrset(
+      zone,
+      {
+        name: recordFqdn,
+        type: "TXT",
+        ttl: TXT_TTL_SECONDS,
+        changetype: "REPLACE",
+        records: contents.map((content) => ({ content, disabled: false })),
+      },
+      "rrset REPLACE",
+    );
+  }
+
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const recordFqdn = toCanonicalFqdn(recordName);
+    const existing = await readExistingTxtContents(zone, recordFqdn);
+    if (!existing.ok) {
+      return existing;
+    }
+
+    const quoted = quoteTxtValue(txtValue);
+    if (!existing.contents.includes(quoted)) {
+      // Nothing to delete: cleanup is idempotent, an already-absent record
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    const remaining = existing.contents.filter((content) => content !== quoted);
+    if (remaining.length === 0) {
+      return patchRrset(
+        zone,
+        { name: recordFqdn, type: "TXT", changetype: "DELETE", records: [] },
+        "rrset DELETE",
+      );
+    }
+
+    return patchRrset(
+      zone,
+      {
+        name: recordFqdn,
+        type: "TXT",
+        ttl: TXT_TTL_SECONDS,
+        changetype: "REPLACE",
+        records: remaining.map((content) => ({ content, disabled: false })),
+      },
+      "rrset REPLACE",
+    );
+  }
+
+  return { presentChallenge, cleanupChallenge };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  DEFAULT_SERVER_ID,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for tests.
+  quoteTxtValue,
+  toCanonicalFqdn,
+};

--- a/packages/agent/src/dns/providers/powerdns.test.js
+++ b/packages/agent/src/dns/providers/powerdns.test.js
@@ -10,7 +10,11 @@ const {
   toCanonicalFqdn,
 } = require("./powerdns.js");
 
-const CREDENTIALS = { apiUrl: "http://127.0.0.1:8081", apiKey: "pdns-key" };
+const CREDENTIALS = {
+  apiUrl: "http://127.0.0.1:8081",
+  apiKey: "pdns-key",
+  allowInsecureLocalHttp: true,
+};
 
 const CHALLENGE = {
   zone: "example.com",
@@ -48,8 +52,44 @@ test("powerdns: apiUrl and apiKey are required", () => {
   assert.throws(() => validateCredentials({ apiUrl: "http://x" }), /apiKey/);
 });
 
+test("powerdns: apiUrl is validated (https only, no creds/fragments, loopback http opt-in)", () => {
+  assert.throws(
+    () => validateCredentials({ apiUrl: "https://u:p@pdns.example:8081", apiKey: "k" }),
+    /embed credentials/,
+  );
+  assert.throws(
+    () => validateCredentials({ apiUrl: "https://pdns.example:8081#frag", apiKey: "k" }),
+    /hash fragment/,
+  );
+  // Plain http without the loopback escape hatch is rejected...
+  assert.throws(
+    () => validateCredentials({ apiUrl: "http://127.0.0.1:8081", apiKey: "k" }),
+    /https/,
+  );
+  // ...and even with it, only loopback hosts qualify.
+  assert.throws(
+    () =>
+      validateCredentials({
+        apiUrl: "http://pdns.example:8081",
+        apiKey: "k",
+        allowInsecureLocalHttp: true,
+      }),
+    /loopback/,
+  );
+  // https always works; loopback http works with the flag.
+  assert.equal(
+    validateCredentials({ apiUrl: "https://pdns.example:8081", apiKey: "k" }).apiUrl,
+    "https://pdns.example:8081",
+  );
+  assert.equal(validateCredentials(CREDENTIALS).apiUrl, "http://127.0.0.1:8081");
+});
+
 test("powerdns: serverId defaults to localhost and trailing slashes are stripped", () => {
-  const normalized = validateCredentials({ apiUrl: "http://127.0.0.1:8081/", apiKey: "k" });
+  const normalized = validateCredentials({
+    apiUrl: "http://127.0.0.1:8081/",
+    apiKey: "k",
+    allowInsecureLocalHttp: true,
+  });
   assert.equal(normalized.serverId, "localhost");
   assert.equal(normalized.apiUrl, "http://127.0.0.1:8081");
 });

--- a/packages/agent/src/dns/providers/powerdns.test.js
+++ b/packages/agent/src/dns/providers/powerdns.test.js
@@ -1,0 +1,325 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  quoteTxtValue,
+  toCanonicalFqdn,
+} = require("./powerdns.js");
+
+const CREDENTIALS = { apiUrl: "http://127.0.0.1:8081", apiKey: "pdns-key" };
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+const ZONE_URL = "http://127.0.0.1:8081/api/v1/servers/localhost/zones/example.com.";
+
+function zoneBody(rrsets) {
+  return JSON.stringify({ name: "example.com.", rrsets });
+}
+
+function makeFetchStub(respond) {
+  const calls = [];
+  function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "{}" } = respond(url, options, calls.length) || {};
+    return Promise.resolve({ status, text: () => Promise.resolve(body) });
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+function solverWith(fetchImpl, credentials = CREDENTIALS) {
+  return createDnsSolver({ provider: "powerdns", credentials, fetchImpl });
+}
+
+// ---------------------------------------------------------------------------
+// credential validation and helpers
+// ---------------------------------------------------------------------------
+
+test("powerdns: apiUrl and apiKey are required", () => {
+  assert.throws(() => validateCredentials({ apiKey: "k" }), /apiUrl/);
+  assert.throws(() => validateCredentials({ apiUrl: "http://x" }), /apiKey/);
+});
+
+test("powerdns: serverId defaults to localhost and trailing slashes are stripped", () => {
+  const normalized = validateCredentials({ apiUrl: "http://127.0.0.1:8081/", apiKey: "k" });
+  assert.equal(normalized.serverId, "localhost");
+  assert.equal(normalized.apiUrl, "http://127.0.0.1:8081");
+});
+
+test("powerdns: TXT values are double-quoted with backslash/quote escaping", () => {
+  assert.equal(quoteTxtValue("plain"), '"plain"');
+  assert.equal(quoteTxtValue('has"quote'), '"has\\"quote"');
+  assert.equal(quoteTxtValue("has\\backslash"), '"has\\\\backslash"');
+});
+
+test("powerdns: canonical FQDNs are lowercased with exactly one trailing dot", () => {
+  assert.equal(toCanonicalFqdn("Example.COM"), "example.com.");
+  assert.equal(toCanonicalFqdn("example.com."), "example.com.");
+});
+
+// ---------------------------------------------------------------------------
+// present
+// ---------------------------------------------------------------------------
+
+test("powerdns: present on an empty name REPLACEs with the single quoted value", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: zoneBody([]) };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls[0].url, ZONE_URL);
+  assert.equal(fetchStub.calls[0].options.headers["X-API-Key"], "pdns-key");
+
+  const patch = fetchStub.calls[1];
+  assert.equal(patch.url, ZONE_URL);
+  assert.equal(patch.options.method, "PATCH");
+  assert.deepEqual(JSON.parse(patch.options.body), {
+    rrsets: [
+      {
+        name: "_acme-challenge.example.com.",
+        type: "TXT",
+        ttl: 60,
+        changetype: "REPLACE",
+        records: [{ content: '"token-value"', disabled: false }],
+      },
+    ],
+  });
+});
+
+test("powerdns: present merges with existing TXT records at the same name", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: zoneBody([
+          {
+            name: "_acme-challenge.example.com.",
+            type: "TXT",
+            ttl: 60,
+            records: [{ content: '"sibling-value"', disabled: false }],
+          },
+          {
+            name: "example.com.",
+            type: "SOA",
+            ttl: 3600,
+            records: [{ content: "ns1.example.com. hostmaster.example.com. 1 2 3 4 5", disabled: false }],
+          },
+        ]),
+      };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const rrset = JSON.parse(fetchStub.calls[1].options.body).rrsets[0];
+  assert.equal(rrset.changetype, "REPLACE");
+  assert.deepEqual(rrset.records, [
+    { content: '"sibling-value"', disabled: false },
+    { content: '"token-value"', disabled: false },
+  ]);
+});
+
+test("powerdns: present is idempotent when the value is already in the rrset", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: zoneBody([
+          {
+            name: "_acme-challenge.example.com.",
+            type: "TXT",
+            ttl: 60,
+            records: [{ content: '"token-value"', disabled: false }],
+          },
+        ]),
+      };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const rrset = JSON.parse(fetchStub.calls[1].options.body).rrsets[0];
+  assert.deepEqual(rrset.records, [{ content: '"token-value"', disabled: false }]);
+});
+
+test("powerdns: a custom serverId is used in the zone URL", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: zoneBody([]) };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub, { ...CREDENTIALS, serverId: "pdns-2" });
+
+  await solver.presentChallenge(CHALLENGE);
+
+  assert.match(fetchStub.calls[0].url, /\/api\/v1\/servers\/pdns-2\/zones\/example\.com\.$/);
+});
+
+test("powerdns: HTTP error on zone read maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 404,
+    body: '{"error":"Not Found"}',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 404);
+  assert.match(result.detail, /zone read/);
+});
+
+test("powerdns: HTTP error on PATCH maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: zoneBody([]) };
+    }
+    return { status: 422, body: '{"error":"RRset content invalid"}' };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 422);
+  assert.match(result.detail, /HTTP 422/);
+});
+
+// ---------------------------------------------------------------------------
+// cleanup
+// ---------------------------------------------------------------------------
+
+test("powerdns: cleanup with remaining siblings REPLACEs with the leftovers", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: zoneBody([
+          {
+            name: "_acme-challenge.example.com.",
+            type: "TXT",
+            ttl: 60,
+            records: [
+              { content: '"sibling-value"', disabled: false },
+              { content: '"token-value"', disabled: false },
+            ],
+          },
+        ]),
+      };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const rrset = JSON.parse(fetchStub.calls[1].options.body).rrsets[0];
+  assert.equal(rrset.changetype, "REPLACE");
+  assert.deepEqual(rrset.records, [{ content: '"sibling-value"', disabled: false }]);
+});
+
+test("powerdns: cleanup of the last value sends changetype DELETE", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: zoneBody([
+          {
+            name: "_acme-challenge.example.com.",
+            type: "TXT",
+            ttl: 60,
+            records: [{ content: '"token-value"', disabled: false }],
+          },
+        ]),
+      };
+    }
+    return { status: 204, body: "" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const rrset = JSON.parse(fetchStub.calls[1].options.body).rrsets[0];
+  assert.deepEqual(rrset, {
+    name: "_acme-challenge.example.com.",
+    type: "TXT",
+    changetype: "DELETE",
+    records: [],
+  });
+});
+
+test("powerdns: cleanup of an already-absent value is idempotent success", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200, body: zoneBody([]) }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+});
+
+test("powerdns: failing PATCH on cleanup maps to ok:false", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: zoneBody([
+          {
+            name: "_acme-challenge.example.com.",
+            type: "TXT",
+            ttl: 60,
+            records: [{ content: '"token-value"', disabled: false }],
+          },
+        ]),
+      };
+    }
+    return { status: 500, body: "server error" };
+  });
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 500);
+});
+
+// ---------------------------------------------------------------------------
+// redaction
+// ---------------------------------------------------------------------------
+
+test("powerdns: error body echoing the apiKey is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 401,
+    body: 'wrong key "pdns-key" supplied',
+  }));
+  const solver = solverWith(fetchStub);
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/rfc2136.js
+++ b/packages/agent/src/dns/providers/rfc2136.js
@@ -1,0 +1,432 @@
+"use strict";
+
+/**
+ * RFC 2136 dynamic DNS UPDATE provider with TSIG (RFC 8945).
+ *
+ * Speaks the DNS wire format directly over TCP port 53 (node:net +
+ * node:crypto only): one UPDATE message per operation, authenticated with
+ * a TSIG HMAC. Works against BIND, Knot, PowerDNS, and anything else that
+ * accepts TSIG-signed dynamic updates. Scope the TSIG key with an
+ * update-policy limited to _acme-challenge TXT records where the server
+ * supports it.
+ *
+ * Credentials shape:
+ *   {
+ *     server: string,               // authoritative server host/IP
+ *     port?: number,                // default 53
+ *     keyName: string,              // TSIG key name
+ *     keyAlgorithm?: string,        // default "hmac-sha256"
+ *     keySecretBase64: string,      // TSIG shared secret, base64
+ *   }
+ *
+ * Message shapes:
+ *   present: UPDATE adding  <recordName> 60 IN TXT "<txtValue>"
+ *   cleanup: UPDATE deleting the whole TXT RRset at <recordName>
+ *            (CLASS ANY, TTL 0, empty RDATA per RFC 2136 s2.5.2)
+ *
+ * The socket layer is injectable (dnsUpdateImpl) so tests never open
+ * sockets; buildUpdateMessage is deterministic given messageId +
+ * timeSigned, so tests can assert a stable TSIG HMAC for fixed inputs.
+ */
+
+const crypto = require("node:crypto");
+const net = require("node:net");
+
+const { isNonEmptyString } = require("../internal.js");
+
+const PROVIDER_ID = "rfc2136";
+const DEFAULT_PORT = 53;
+const DEFAULT_KEY_ALGORITHM = "hmac-sha256";
+const DEFAULT_FUDGE_SECONDS = 300;
+const TXT_TTL_SECONDS = 60;
+
+const TYPE_TXT = 16;
+const TYPE_SOA = 6;
+const TYPE_TSIG = 250;
+const CLASS_IN = 1;
+const CLASS_ANY = 255;
+const OPCODE_UPDATE = 5;
+
+/** TSIG algorithm name -> node:crypto HMAC hash name. */
+const TSIG_ALGORITHMS = Object.freeze({
+  "hmac-sha1": "sha1",
+  "hmac-sha224": "sha224",
+  "hmac-sha256": "sha256",
+  "hmac-sha384": "sha384",
+  "hmac-sha512": "sha512",
+});
+
+const RCODE_NAMES = Object.freeze({
+  0: "NOERROR",
+  1: "FORMERR",
+  2: "SERVFAIL",
+  3: "NXDOMAIN",
+  4: "NOTIMP",
+  5: "REFUSED",
+  6: "YXDOMAIN",
+  7: "YXRRSET",
+  8: "NXRRSET",
+  9: "NOTAUTH",
+  10: "NOTZONE",
+});
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.server)) {
+    throw new Error("dns: rfc2136 credentials require a non-empty server string");
+  }
+  if (
+    credentials.port !== undefined &&
+    (!Number.isInteger(credentials.port) || credentials.port <= 0 || credentials.port > 65535)
+  ) {
+    throw new Error(
+      `dns: rfc2136 port must be an integer in 1..65535, got ${JSON.stringify(credentials.port)}`,
+    );
+  }
+  if (!isNonEmptyString(credentials.keyName)) {
+    throw new Error("dns: rfc2136 credentials require a non-empty keyName string");
+  }
+
+  const keyAlgorithm = credentials.keyAlgorithm || DEFAULT_KEY_ALGORITHM;
+  if (!TSIG_ALGORITHMS[keyAlgorithm]) {
+    throw new Error(
+      `dns: rfc2136 keyAlgorithm ${JSON.stringify(keyAlgorithm)} is not supported; ` +
+        `supported: ${Object.keys(TSIG_ALGORITHMS).join(", ")}`,
+    );
+  }
+
+  if (!isNonEmptyString(credentials.keySecretBase64)) {
+    throw new Error("dns: rfc2136 credentials require a non-empty keySecretBase64 string");
+  }
+  const keySecret = Buffer.from(credentials.keySecretBase64, "base64");
+  if (
+    keySecret.length === 0 ||
+    keySecret.toString("base64").replace(/=+$/, "") !==
+      credentials.keySecretBase64.replace(/\s+/g, "").replace(/=+$/, "")
+  ) {
+    throw new Error("dns: rfc2136 keySecretBase64 is not valid base64");
+  }
+
+  return {
+    server: credentials.server,
+    port: credentials.port || DEFAULT_PORT,
+    keyName: credentials.keyName,
+    keyAlgorithm,
+    keySecretBase64: credentials.keySecretBase64,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [credentials.keySecretBase64];
+}
+
+// --------------------------------------------------------------------------
+// Wire-format encoding (exported pieces are used by the stable-HMAC test)
+// --------------------------------------------------------------------------
+
+/**
+ * Encodes a domain name in uncompressed DNS wire format (RFC 1035 s3.1).
+ * @param {string} name
+ * @returns {Buffer}
+ */
+function encodeName(name) {
+  const trimmed = name.endsWith(".") ? name.slice(0, -1) : name;
+  const parts = [];
+  if (trimmed.length > 0) {
+    for (const label of trimmed.split(".")) {
+      const labelBytes = Buffer.from(label, "ascii");
+      if (labelBytes.length === 0 || labelBytes.length > 63) {
+        throw new Error(`dns: rfc2136 invalid label in name ${JSON.stringify(name)}`);
+      }
+      parts.push(Buffer.from([labelBytes.length]), labelBytes);
+    }
+  }
+  parts.push(Buffer.from([0]));
+  return Buffer.concat(parts);
+}
+
+function uint16(value) {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16BE(value, 0);
+  return buffer;
+}
+
+function uint32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value, 0);
+  return buffer;
+}
+
+/** 48-bit big-endian (TSIG time signed). */
+function uint48(value) {
+  const buffer = Buffer.alloc(6);
+  buffer.writeUIntBE(value, 0, 6);
+  return buffer;
+}
+
+/** TXT RDATA: one or more <character-string>s of at most 255 bytes each. */
+function encodeTxtRdata(txtValue) {
+  const bytes = Buffer.from(txtValue, "utf8");
+  const chunks = [];
+  for (let offset = 0; offset < bytes.length; offset += 255) {
+    const chunk = bytes.subarray(offset, offset + 255);
+    chunks.push(Buffer.from([chunk.length]), chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Builds one complete, TSIG-signed DNS UPDATE message (without the TCP
+ * length prefix). Deterministic given messageId + timeSigned, which is
+ * what makes the TSIG HMAC test vector stable.
+ *
+ * Per RFC 8945 s4.3.3 the MAC covers the unsigned message (ARCOUNT still
+ * excluding the TSIG RR) followed by the TSIG variables (key name, class
+ * ANY, TTL 0, algorithm name, time signed, fudge, error 0, other-len 0);
+ * the TSIG RR itself is then appended and ARCOUNT incremented.
+ *
+ * @param {object} options
+ * @param {"present"|"cleanup"} options.action
+ * @param {string} options.zone
+ * @param {string} options.recordName
+ * @param {string} [options.txtValue] required for "present"
+ * @param {string} options.keyName
+ * @param {string} options.keyAlgorithm one of TSIG_ALGORITHMS keys
+ * @param {string} options.keySecretBase64
+ * @param {number} options.messageId 0..65535
+ * @param {number} options.timeSigned epoch seconds
+ * @param {number} [options.fudge] default 300
+ * @returns {Buffer}
+ */
+function buildUpdateMessage({
+  action,
+  zone,
+  recordName,
+  txtValue,
+  keyName,
+  keyAlgorithm,
+  keySecretBase64,
+  messageId,
+  timeSigned,
+  fudge = DEFAULT_FUDGE_SECONDS,
+}) {
+  if (action !== "present" && action !== "cleanup") {
+    throw new Error(`dns: rfc2136 unknown update action ${JSON.stringify(action)}`);
+  }
+  if (action === "present" && !isNonEmptyString(txtValue)) {
+    throw new Error("dns: rfc2136 present requires a txtValue");
+  }
+
+  // Header: ZOCOUNT=1 (zone), PRCOUNT=0, UPCOUNT=1, ADCOUNT=0 (pre-TSIG).
+  const header = Buffer.concat([
+    uint16(messageId),
+    uint16(OPCODE_UPDATE << 11),
+    uint16(1),
+    uint16(0),
+    uint16(1),
+    uint16(0),
+  ]);
+
+  // Zone section: <zone> SOA IN.
+  const zoneSection = Buffer.concat([encodeName(zone), uint16(TYPE_SOA), uint16(CLASS_IN)]);
+
+  // Update section.
+  let updateRecord;
+  if (action === "present") {
+    const rdata = encodeTxtRdata(txtValue);
+    updateRecord = Buffer.concat([
+      encodeName(recordName),
+      uint16(TYPE_TXT),
+      uint16(CLASS_IN),
+      uint32(TXT_TTL_SECONDS),
+      uint16(rdata.length),
+      rdata,
+    ]);
+  } else {
+    // Delete the whole TXT RRset at the name: CLASS ANY, TTL 0, no RDATA.
+    updateRecord = Buffer.concat([
+      encodeName(recordName),
+      uint16(TYPE_TXT),
+      uint16(CLASS_ANY),
+      uint32(0),
+      uint16(0),
+    ]);
+  }
+
+  const unsignedMessage = Buffer.concat([header, zoneSection, updateRecord]);
+
+  // TSIG variables covered by the MAC.
+  const algorithmWire = encodeName(keyAlgorithm.toLowerCase());
+  const tsigVariables = Buffer.concat([
+    encodeName(keyName.toLowerCase()),
+    uint16(CLASS_ANY),
+    uint32(0),
+    algorithmWire,
+    uint48(timeSigned),
+    uint16(fudge),
+    uint16(0), // error
+    uint16(0), // other-len (no other data)
+  ]);
+
+  const mac = crypto
+    .createHmac(TSIG_ALGORITHMS[keyAlgorithm], Buffer.from(keySecretBase64, "base64"))
+    .update(Buffer.concat([unsignedMessage, tsigVariables]))
+    .digest();
+
+  // TSIG RR appended to the additional section.
+  const tsigRdata = Buffer.concat([
+    algorithmWire,
+    uint48(timeSigned),
+    uint16(fudge),
+    uint16(mac.length),
+    mac,
+    uint16(messageId), // original ID
+    uint16(0), // error
+    uint16(0), // other-len
+  ]);
+  const tsigRecord = Buffer.concat([
+    encodeName(keyName.toLowerCase()),
+    uint16(TYPE_TSIG),
+    uint16(CLASS_ANY),
+    uint32(0),
+    uint16(tsigRdata.length),
+    tsigRdata,
+  ]);
+
+  // Final message: same header with ADCOUNT=1.
+  const signedHeader = Buffer.concat([
+    uint16(messageId),
+    uint16(OPCODE_UPDATE << 11),
+    uint16(1),
+    uint16(0),
+    uint16(1),
+    uint16(1),
+  ]);
+
+  return Buffer.concat([
+    signedHeader,
+    zoneSection,
+    updateRecord,
+    tsigRecord,
+  ]);
+}
+
+/**
+ * Default socket layer: sends one length-prefixed DNS message over TCP and
+ * resolves with the response (length prefix stripped). Rejects on connect
+ * error, timeout, or truncated response; the solver layer maps rejections
+ * to { ok: false } results.
+ *
+ * @param {{ host: string, port: number, message: Buffer, timeoutMs: number }} options
+ * @returns {Promise<Buffer>}
+ */
+function sendTcpDnsMessage({ host, port, message, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host, port });
+    const received = [];
+    let settled = false;
+
+    function finish(error, response) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      if (error) reject(error);
+      else resolve(response);
+    }
+
+    socket.setTimeout(timeoutMs, () => {
+      finish(new Error(`rfc2136 update timed out after ${timeoutMs} ms`));
+    });
+    socket.on("error", (err) => finish(err));
+    socket.on("connect", () => {
+      const framed = Buffer.concat([uint16(message.length), message]);
+      socket.write(framed);
+    });
+    socket.on("data", (chunk) => {
+      received.push(chunk);
+      const buffered = Buffer.concat(received);
+      if (buffered.length < 2) return;
+      const expected = buffered.readUInt16BE(0);
+      if (buffered.length >= 2 + expected) {
+        finish(null, buffered.subarray(2, 2 + expected));
+      }
+    });
+    socket.on("close", () => {
+      finish(new Error("rfc2136 connection closed before a full response arrived"));
+    });
+  });
+}
+
+function createSolverImpl({ credentials, dnsUpdateImpl, timeoutMs, excerpt }) {
+  const sendMessage = dnsUpdateImpl || sendTcpDnsMessage;
+
+  /**
+   * @param {"present"|"cleanup"} action
+   * @param {{ zone: string, recordName: string, txtValue: string }} inputs
+   */
+  async function runUpdate(action, { zone, recordName, txtValue }) {
+    const message = buildUpdateMessage({
+      action,
+      zone,
+      recordName,
+      txtValue,
+      keyName: credentials.keyName,
+      keyAlgorithm: credentials.keyAlgorithm,
+      keySecretBase64: credentials.keySecretBase64,
+      messageId: crypto.randomBytes(2).readUInt16BE(0),
+      timeSigned: Math.floor(Date.now() / 1000),
+    });
+
+    const response = await sendMessage({
+      host: credentials.server,
+      port: credentials.port,
+      message,
+      timeoutMs,
+    });
+
+    if (!Buffer.isBuffer(response) || response.length < 12) {
+      return {
+        ok: false,
+        detail: excerpt("rfc2136 server returned a malformed (short) DNS response"),
+      };
+    }
+
+    const rcode = response[3] & 0x0f;
+    if (rcode !== 0) {
+      return {
+        ok: false,
+        detail: excerpt(
+          `rfc2136 update was refused: RCODE ${rcode} (${RCODE_NAMES[rcode] || "unknown"})`,
+        ),
+      };
+    }
+
+    return { ok: true };
+  }
+
+  return {
+    presentChallenge: (inputs) => runUpdate("present", inputs),
+    cleanupChallenge: (inputs) => runUpdate("cleanup", inputs),
+  };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  DEFAULT_PORT,
+  DEFAULT_KEY_ALGORITHM,
+  TSIG_ALGORITHMS,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for the wire-format / stable-HMAC tests.
+  buildUpdateMessage,
+  encodeName,
+  encodeTxtRdata,
+  sendTcpDnsMessage,
+};

--- a/packages/agent/src/dns/providers/rfc2136.js
+++ b/packages/agent/src/dns/providers/rfc2136.js
@@ -21,8 +21,16 @@
  *
  * Message shapes:
  *   present: UPDATE adding  <recordName> 60 IN TXT "<txtValue>"
- *   cleanup: UPDATE deleting the whole TXT RRset at <recordName>
- *            (CLASS ANY, TTL 0, empty RDATA per RFC 2136 s2.5.2)
+ *   cleanup: UPDATE deleting ONLY the exact TXT RR carrying the challenge
+ *            value (CLASS NONE, TTL 0, RDATA = the value, RFC 2136
+ *            s2.5.4) so sibling TXT values at the name survive.
+ *
+ * Responses are fully verified before being trusted: transaction ID, QR
+ * bit, opcode, and the response TSIG MAC (RFC 8945 s5.3: HMAC over the
+ * 2-byte length-prefixed request MAC, the response with the TSIG RR
+ * removed and ARCOUNT decremented and the original ID restored, then the
+ * TSIG variables). Unsigned, forged, or mis-signed responses are
+ * operational failures (ok:false), never accepted.
  *
  * The socket layer is injectable (dnsUpdateImpl) so tests never open
  * sockets; buildUpdateMessage is deterministic given messageId +
@@ -44,6 +52,7 @@ const TYPE_TXT = 16;
 const TYPE_SOA = 6;
 const TYPE_TSIG = 250;
 const CLASS_IN = 1;
+const CLASS_NONE = 254;
 const CLASS_ANY = 255;
 const OPCODE_UPDATE = 5;
 
@@ -182,9 +191,124 @@ function encodeTxtRdata(txtValue) {
 }
 
 /**
+ * TSIG "variables" block covered by every TSIG MAC (RFC 8945 s4.3.3):
+ * canonical key name, class ANY, TTL 0, algorithm name, time signed,
+ * fudge, error, other-len/other-data.
+ *
+ * @param {object} options
+ * @param {string} options.keyName
+ * @param {string} options.keyAlgorithm
+ * @param {number} options.timeSigned epoch seconds
+ * @param {number} options.fudge
+ * @param {number} [options.error]
+ * @param {Buffer} [options.otherData]
+ * @returns {Buffer}
+ */
+function buildTsigVariables({
+  keyName,
+  keyAlgorithm,
+  timeSigned,
+  fudge,
+  error = 0,
+  otherData = Buffer.alloc(0),
+}) {
+  return Buffer.concat([
+    encodeName(keyName.toLowerCase()),
+    uint16(CLASS_ANY),
+    uint32(0),
+    encodeName(keyAlgorithm.toLowerCase()),
+    uint48(timeSigned),
+    uint16(fudge),
+    uint16(error),
+    uint16(otherData.length),
+    otherData,
+  ]);
+}
+
+/**
+ * One complete TSIG RR (name through RDATA) for the additional section.
+ *
+ * @param {object} options
+ * @param {string} options.keyName
+ * @param {string} options.keyAlgorithm
+ * @param {number} options.timeSigned
+ * @param {number} options.fudge
+ * @param {Buffer} options.mac
+ * @param {number} options.originalId
+ * @param {number} [options.error]
+ * @param {Buffer} [options.otherData]
+ * @returns {Buffer}
+ */
+function buildTsigRecord({
+  keyName,
+  keyAlgorithm,
+  timeSigned,
+  fudge,
+  mac,
+  originalId,
+  error = 0,
+  otherData = Buffer.alloc(0),
+}) {
+  const tsigRdata = Buffer.concat([
+    encodeName(keyAlgorithm.toLowerCase()),
+    uint48(timeSigned),
+    uint16(fudge),
+    uint16(mac.length),
+    mac,
+    uint16(originalId),
+    uint16(error),
+    uint16(otherData.length),
+    otherData,
+  ]);
+  return Buffer.concat([
+    encodeName(keyName.toLowerCase()),
+    uint16(TYPE_TSIG),
+    uint16(CLASS_ANY),
+    uint32(0),
+    uint16(tsigRdata.length),
+    tsigRdata,
+  ]);
+}
+
+/**
+ * Response TSIG MAC per RFC 8945 s5.3: HMAC over the 2-byte
+ * length-prefixed request MAC, the response message with the TSIG RR
+ * removed (ARCOUNT decremented, original ID restored), and the TSIG
+ * variables.
+ *
+ * @param {object} options
+ * @param {Buffer} options.requestMac
+ * @param {Buffer} options.responseMessageWithoutTsig
+ * @param {Buffer} options.tsigVariables
+ * @param {string} options.keyAlgorithm one of TSIG_ALGORITHMS keys
+ * @param {string} options.keySecretBase64
+ * @returns {Buffer}
+ */
+function computeResponseMac({
+  requestMac,
+  responseMessageWithoutTsig,
+  tsigVariables,
+  keyAlgorithm,
+  keySecretBase64,
+}) {
+  return crypto
+    .createHmac(TSIG_ALGORITHMS[keyAlgorithm], Buffer.from(keySecretBase64, "base64"))
+    .update(
+      Buffer.concat([
+        uint16(requestMac.length),
+        requestMac,
+        responseMessageWithoutTsig,
+        tsigVariables,
+      ]),
+    )
+    .digest();
+}
+
+/**
  * Builds one complete, TSIG-signed DNS UPDATE message (without the TCP
- * length prefix). Deterministic given messageId + timeSigned, which is
- * what makes the TSIG HMAC test vector stable.
+ * length prefix) and returns it together with its request MAC (needed to
+ * verify the response TSIG). Deterministic given messageId + timeSigned,
+ * which is what makes the TSIG HMAC test vector stable.
  *
  * Per RFC 8945 s4.3.3 the MAC covers the unsigned message (ARCOUNT still
  * excluding the TSIG RR) followed by the TSIG variables (key name, class
@@ -195,16 +319,17 @@ function encodeTxtRdata(txtValue) {
  * @param {"present"|"cleanup"} options.action
  * @param {string} options.zone
  * @param {string} options.recordName
- * @param {string} [options.txtValue] required for "present"
+ * @param {string} options.txtValue required for both actions (cleanup
+ *   deletes only the exact RR carrying this value)
  * @param {string} options.keyName
  * @param {string} options.keyAlgorithm one of TSIG_ALGORITHMS keys
  * @param {string} options.keySecretBase64
  * @param {number} options.messageId 0..65535
  * @param {number} options.timeSigned epoch seconds
  * @param {number} [options.fudge] default 300
- * @returns {Buffer}
+ * @returns {{ message: Buffer, mac: Buffer }}
  */
-function buildUpdateMessage({
+function buildSignedUpdate({
   action,
   zone,
   recordName,
@@ -219,8 +344,8 @@ function buildUpdateMessage({
   if (action !== "present" && action !== "cleanup") {
     throw new Error(`dns: rfc2136 unknown update action ${JSON.stringify(action)}`);
   }
-  if (action === "present" && !isNonEmptyString(txtValue)) {
-    throw new Error("dns: rfc2136 present requires a txtValue");
+  if (!isNonEmptyString(txtValue)) {
+    throw new Error(`dns: rfc2136 ${action} requires a txtValue`);
   }
 
   // Header: ZOCOUNT=1 (zone), PRCOUNT=0, UPCOUNT=1, ADCOUNT=0 (pre-TSIG).
@@ -237,9 +362,9 @@ function buildUpdateMessage({
   const zoneSection = Buffer.concat([encodeName(zone), uint16(TYPE_SOA), uint16(CLASS_IN)]);
 
   // Update section.
+  const rdata = encodeTxtRdata(txtValue);
   let updateRecord;
   if (action === "present") {
-    const rdata = encodeTxtRdata(txtValue);
     updateRecord = Buffer.concat([
       encodeName(recordName),
       uint16(TYPE_TXT),
@@ -249,30 +374,23 @@ function buildUpdateMessage({
       rdata,
     ]);
   } else {
-    // Delete the whole TXT RRset at the name: CLASS ANY, TTL 0, no RDATA.
+    // Delete ONLY the exact TXT RR carrying the challenge value: CLASS
+    // NONE, TTL 0, RDATA = the value (RFC 2136 s2.5.4). Sibling TXT
+    // values at the name are preserved.
     updateRecord = Buffer.concat([
       encodeName(recordName),
       uint16(TYPE_TXT),
-      uint16(CLASS_ANY),
+      uint16(CLASS_NONE),
       uint32(0),
-      uint16(0),
+      uint16(rdata.length),
+      rdata,
     ]);
   }
 
   const unsignedMessage = Buffer.concat([header, zoneSection, updateRecord]);
 
   // TSIG variables covered by the MAC.
-  const algorithmWire = encodeName(keyAlgorithm.toLowerCase());
-  const tsigVariables = Buffer.concat([
-    encodeName(keyName.toLowerCase()),
-    uint16(CLASS_ANY),
-    uint32(0),
-    algorithmWire,
-    uint48(timeSigned),
-    uint16(fudge),
-    uint16(0), // error
-    uint16(0), // other-len (no other data)
-  ]);
+  const tsigVariables = buildTsigVariables({ keyName, keyAlgorithm, timeSigned, fudge });
 
   const mac = crypto
     .createHmac(TSIG_ALGORITHMS[keyAlgorithm], Buffer.from(keySecretBase64, "base64"))
@@ -280,24 +398,14 @@ function buildUpdateMessage({
     .digest();
 
   // TSIG RR appended to the additional section.
-  const tsigRdata = Buffer.concat([
-    algorithmWire,
-    uint48(timeSigned),
-    uint16(fudge),
-    uint16(mac.length),
+  const tsigRecord = buildTsigRecord({
+    keyName,
+    keyAlgorithm,
+    timeSigned,
+    fudge,
     mac,
-    uint16(messageId), // original ID
-    uint16(0), // error
-    uint16(0), // other-len
-  ]);
-  const tsigRecord = Buffer.concat([
-    encodeName(keyName.toLowerCase()),
-    uint16(TYPE_TSIG),
-    uint16(CLASS_ANY),
-    uint32(0),
-    uint16(tsigRdata.length),
-    tsigRdata,
-  ]);
+    originalId: messageId,
+  });
 
   // Final message: same header with ADCOUNT=1.
   const signedHeader = Buffer.concat([
@@ -309,12 +417,309 @@ function buildUpdateMessage({
     uint16(1),
   ]);
 
-  return Buffer.concat([
-    signedHeader,
-    zoneSection,
-    updateRecord,
-    tsigRecord,
+  return {
+    message: Buffer.concat([signedHeader, zoneSection, updateRecord, tsigRecord]),
+    mac,
+  };
+}
+
+/**
+ * Back-compat wrapper returning only the wire message.
+ * @param {Parameters<typeof buildSignedUpdate>[0]} options
+ * @returns {Buffer}
+ */
+function buildUpdateMessage(options) {
+  return buildSignedUpdate(options).message;
+}
+
+// --------------------------------------------------------------------------
+// Response parsing + TSIG verification (RFC 8945 s5.3)
+// --------------------------------------------------------------------------
+
+/**
+ * Skips one wire-format name starting at `offset`, following the RFC 1035
+ * rules (a compression pointer terminates the name). Throws on truncation.
+ * @param {Buffer} buffer
+ * @param {number} offset
+ * @returns {number} offset just past the name
+ */
+function skipEncodedName(buffer, offset) {
+  for (;;) {
+    if (offset >= buffer.length) {
+      throw new Error("dns: rfc2136 truncated name in DNS message");
+    }
+    const length = buffer[offset];
+    if (length === 0) {
+      return offset + 1;
+    }
+    if ((length & 0xc0) === 0xc0) {
+      if (offset + 2 > buffer.length) {
+        throw new Error("dns: rfc2136 truncated compression pointer in DNS message");
+      }
+      return offset + 2;
+    }
+    offset += 1 + length;
+  }
+}
+
+/**
+ * Reads a wire-format name (following compression pointers) into its
+ * dotted lowercase text form. Throws on truncation or pointer loops.
+ * @param {Buffer} buffer
+ * @param {number} offset
+ * @returns {string}
+ */
+function readEncodedName(buffer, offset) {
+  const labels = [];
+  let jumps = 0;
+  for (;;) {
+    if (offset >= buffer.length) {
+      throw new Error("dns: rfc2136 truncated name in DNS message");
+    }
+    const length = buffer[offset];
+    if (length === 0) {
+      break;
+    }
+    if ((length & 0xc0) === 0xc0) {
+      if (offset + 2 > buffer.length) {
+        throw new Error("dns: rfc2136 truncated compression pointer in DNS message");
+      }
+      jumps += 1;
+      if (jumps > 32) {
+        throw new Error("dns: rfc2136 compression pointer loop in DNS message");
+      }
+      offset = ((length & 0x3f) << 8) | buffer[offset + 1];
+      continue;
+    }
+    if (offset + 1 + length > buffer.length) {
+      throw new Error("dns: rfc2136 truncated label in DNS message");
+    }
+    labels.push(buffer.subarray(offset + 1, offset + 1 + length).toString("ascii"));
+    offset += 1 + length;
+  }
+  return labels.join(".").toLowerCase();
+}
+
+/**
+ * Locates and parses the TSIG record in a DNS message's additional
+ * section. Returns null when the message carries no TSIG; throws on a
+ * structurally malformed message.
+ *
+ * @param {Buffer} message
+ * @returns {null | {
+ *   recordStart: number,
+ *   recordEnd: number,
+ *   keyName: string,
+ *   algorithmName: string,
+ *   timeSigned: number,
+ *   fudge: number,
+ *   mac: Buffer,
+ *   originalId: number,
+ *   error: number,
+ *   otherData: Buffer,
+ * }}
+ */
+function parseTsigFromMessage(message) {
+  if (message.length < 12) {
+    throw new Error("dns: rfc2136 DNS message shorter than a header");
+  }
+  const zoCount = message.readUInt16BE(4);
+  const prCount = message.readUInt16BE(6);
+  const upCount = message.readUInt16BE(8);
+  const adCount = message.readUInt16BE(10);
+
+  let offset = 12;
+  // Zone/question section entries: name + type(2) + class(2).
+  for (let i = 0; i < zoCount; i += 1) {
+    offset = skipEncodedName(message, offset) + 4;
+  }
+  // Full resource records: name + type/class/ttl/rdlength(10) + rdata.
+  function skipRecord(startOffset) {
+    const afterName = skipEncodedName(message, startOffset);
+    if (afterName + 10 > message.length) {
+      throw new Error("dns: rfc2136 truncated resource record in DNS message");
+    }
+    const rdLength = message.readUInt16BE(afterName + 8);
+    const end = afterName + 10 + rdLength;
+    if (end > message.length) {
+      throw new Error("dns: rfc2136 truncated RDATA in DNS message");
+    }
+    return end;
+  }
+  for (let i = 0; i < prCount + upCount; i += 1) {
+    offset = skipRecord(offset);
+  }
+
+  for (let i = 0; i < adCount; i += 1) {
+    const recordStart = offset;
+    const afterName = skipEncodedName(message, offset);
+    if (afterName + 10 > message.length) {
+      throw new Error("dns: rfc2136 truncated resource record in DNS message");
+    }
+    const type = message.readUInt16BE(afterName);
+    const rdLength = message.readUInt16BE(afterName + 8);
+    const recordEnd = afterName + 10 + rdLength;
+    if (recordEnd > message.length) {
+      throw new Error("dns: rfc2136 truncated RDATA in DNS message");
+    }
+    if (type !== TYPE_TSIG) {
+      offset = recordEnd;
+      continue;
+    }
+
+    // TSIG RDATA: algorithm name, time signed (48), fudge, mac-len, mac,
+    // original id, error, other-len, other data.
+    const rdataStart = afterName + 10;
+    const afterAlgorithm = skipEncodedName(message, rdataStart);
+    if (afterAlgorithm + 10 > message.length) {
+      throw new Error("dns: rfc2136 truncated TSIG RDATA");
+    }
+    const timeSigned = message.readUIntBE(afterAlgorithm, 6);
+    const fudge = message.readUInt16BE(afterAlgorithm + 6);
+    const macLength = message.readUInt16BE(afterAlgorithm + 8);
+    const macStart = afterAlgorithm + 10;
+    if (macStart + macLength + 6 > message.length) {
+      throw new Error("dns: rfc2136 truncated TSIG MAC");
+    }
+    const mac = message.subarray(macStart, macStart + macLength);
+    const originalId = message.readUInt16BE(macStart + macLength);
+    const error = message.readUInt16BE(macStart + macLength + 2);
+    const otherLength = message.readUInt16BE(macStart + macLength + 4);
+    const otherStart = macStart + macLength + 6;
+    if (otherStart + otherLength > message.length) {
+      throw new Error("dns: rfc2136 truncated TSIG other data");
+    }
+
+    return {
+      recordStart,
+      recordEnd,
+      keyName: readEncodedName(message, recordStart),
+      algorithmName: readEncodedName(message, rdataStart),
+      timeSigned,
+      fudge,
+      mac: Buffer.from(mac),
+      originalId,
+      error,
+      otherData: Buffer.from(message.subarray(otherStart, otherStart + otherLength)),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Verifies a TSIG-signed response to one of our signed UPDATE requests.
+ * Checks: transaction ID, QR bit, opcode, TSIG presence, key/algorithm
+ * match, TSIG error field, and the response MAC (constant-time compare).
+ * Never throws on a bad response; returns { ok:false, detail } instead
+ * (structural parse errors included).
+ *
+ * @param {object} options
+ * @param {Buffer} options.response
+ * @param {number} options.requestId
+ * @param {Buffer} options.requestMac
+ * @param {string} options.keyName
+ * @param {string} options.keyAlgorithm one of TSIG_ALGORITHMS keys
+ * @param {string} options.keySecretBase64
+ * @returns {{ ok: true, rcode: number } | { ok: false, detail: string }}
+ */
+function verifyTsigSignedResponse({
+  response,
+  requestId,
+  requestMac,
+  keyName,
+  keyAlgorithm,
+  keySecretBase64,
+}) {
+  if (!Buffer.isBuffer(response) || response.length < 12) {
+    return { ok: false, detail: "rfc2136 server returned a malformed (short) DNS response" };
+  }
+
+  const responseId = response.readUInt16BE(0);
+  if (responseId !== requestId) {
+    return {
+      ok: false,
+      detail: "rfc2136 response transaction ID does not match the request (possible forgery)",
+    };
+  }
+
+  const flags = response.readUInt16BE(2);
+  if ((flags & 0x8000) === 0) {
+    return { ok: false, detail: "rfc2136 response does not have the QR bit set" };
+  }
+  const opcode = (flags >>> 11) & 0x0f;
+  if (opcode !== OPCODE_UPDATE) {
+    return {
+      ok: false,
+      detail: `rfc2136 response opcode ${opcode} is not UPDATE (${OPCODE_UPDATE})`,
+    };
+  }
+
+  let tsig;
+  try {
+    tsig = parseTsigFromMessage(response);
+  } catch (err) {
+    return {
+      ok: false,
+      detail: `rfc2136 response could not be parsed: ${err && err.message ? err.message : String(err)}`,
+    };
+  }
+  if (!tsig) {
+    return {
+      ok: false,
+      detail: "rfc2136 response is not TSIG-signed; refusing to trust an unsigned response",
+    };
+  }
+
+  if (tsig.keyName !== keyName.toLowerCase().replace(/\.$/, "")) {
+    return { ok: false, detail: "rfc2136 response TSIG key name does not match the configured key" };
+  }
+  if (tsig.algorithmName !== keyAlgorithm.toLowerCase().replace(/\.$/, "")) {
+    return { ok: false, detail: "rfc2136 response TSIG algorithm does not match the configured key" };
+  }
+
+  // Reduced message: TSIG RR removed, ARCOUNT decremented, original ID
+  // restored (no-op when the server kept our ID).
+  const reduced = Buffer.concat([
+    response.subarray(0, tsig.recordStart),
+    response.subarray(tsig.recordEnd),
   ]);
+  reduced.writeUInt16BE(tsig.originalId, 0);
+  reduced.writeUInt16BE(response.readUInt16BE(10) - 1, 10);
+
+  const expectedMac = computeResponseMac({
+    requestMac,
+    responseMessageWithoutTsig: reduced,
+    tsigVariables: buildTsigVariables({
+      keyName,
+      keyAlgorithm,
+      timeSigned: tsig.timeSigned,
+      fudge: tsig.fudge,
+      error: tsig.error,
+      otherData: tsig.otherData,
+    }),
+    keyAlgorithm,
+    keySecretBase64,
+  });
+
+  if (
+    tsig.mac.length !== expectedMac.length ||
+    !crypto.timingSafeEqual(tsig.mac, expectedMac)
+  ) {
+    return {
+      ok: false,
+      detail: "rfc2136 response TSIG MAC verification failed (wrong key or tampered response)",
+    };
+  }
+
+  if (tsig.error !== 0) {
+    return {
+      ok: false,
+      detail: `rfc2136 response TSIG error ${tsig.error} (${RCODE_NAMES[tsig.error] || "unknown"})`,
+    };
+  }
+
+  return { ok: true, rcode: flags & 0x0f };
 }
 
 /**
@@ -371,7 +776,8 @@ function createSolverImpl({ credentials, dnsUpdateImpl, timeoutMs, excerpt }) {
    * @param {{ zone: string, recordName: string, txtValue: string }} inputs
    */
   async function runUpdate(action, { zone, recordName, txtValue }) {
-    const message = buildUpdateMessage({
+    const messageId = crypto.randomBytes(2).readUInt16BE(0);
+    const { message, mac: requestMac } = buildSignedUpdate({
       action,
       zone,
       recordName,
@@ -379,7 +785,7 @@ function createSolverImpl({ credentials, dnsUpdateImpl, timeoutMs, excerpt }) {
       keyName: credentials.keyName,
       keyAlgorithm: credentials.keyAlgorithm,
       keySecretBase64: credentials.keySecretBase64,
-      messageId: crypto.randomBytes(2).readUInt16BE(0),
+      messageId,
       timeSigned: Math.floor(Date.now() / 1000),
     });
 
@@ -390,19 +796,26 @@ function createSolverImpl({ credentials, dnsUpdateImpl, timeoutMs, excerpt }) {
       timeoutMs,
     });
 
-    if (!Buffer.isBuffer(response) || response.length < 12) {
-      return {
-        ok: false,
-        detail: excerpt("rfc2136 server returned a malformed (short) DNS response"),
-      };
+    // Full response verification: transaction ID, QR/opcode, and the
+    // response TSIG MAC. Anything unsigned, forged, or mis-signed is an
+    // operational failure, never trusted.
+    const verified = verifyTsigSignedResponse({
+      response,
+      requestId: messageId,
+      requestMac,
+      keyName: credentials.keyName,
+      keyAlgorithm: credentials.keyAlgorithm,
+      keySecretBase64: credentials.keySecretBase64,
+    });
+    if (!verified.ok) {
+      return { ok: false, detail: excerpt(verified.detail) };
     }
 
-    const rcode = response[3] & 0x0f;
-    if (rcode !== 0) {
+    if (verified.rcode !== 0) {
       return {
         ok: false,
         detail: excerpt(
-          `rfc2136 update was refused: RCODE ${rcode} (${RCODE_NAMES[rcode] || "unknown"})`,
+          `rfc2136 update was refused: RCODE ${verified.rcode} (${RCODE_NAMES[verified.rcode] || "unknown"})`,
         ),
       };
     }
@@ -424,9 +837,23 @@ module.exports = {
   validateCredentials,
   collectSecretStrings,
   createSolverImpl,
-  // Exported for the wire-format / stable-HMAC tests.
+  // Exported for the wire-format / stable-HMAC / response-verification
+  // tests (following the module's existing export-internals style).
   buildUpdateMessage,
+  buildSignedUpdate,
+  buildTsigVariables,
+  buildTsigRecord,
+  computeResponseMac,
+  parseTsigFromMessage,
+  verifyTsigSignedResponse,
   encodeName,
   encodeTxtRdata,
+  uint16,
+  uint32,
+  uint48,
+  OPCODE_UPDATE,
+  TYPE_TSIG,
+  CLASS_ANY,
+  CLASS_NONE,
   sendTcpDnsMessage,
 };

--- a/packages/agent/src/dns/providers/rfc2136.test.js
+++ b/packages/agent/src/dns/providers/rfc2136.test.js
@@ -9,6 +9,11 @@ const {
   buildUpdateMessage,
   encodeName,
   encodeTxtRdata,
+  buildTsigVariables,
+  buildTsigRecord,
+  computeResponseMac,
+  parseTsigFromMessage,
+  uint16,
 } = require("./rfc2136.js");
 
 const SECRET_BASE64 = Buffer.from("shared-secret").toString("base64"); // c2hhcmVkLXNlY3JldA==
@@ -36,20 +41,71 @@ const FIXED_MESSAGE_INPUTS = {
   fudge: 300,
 };
 
-/** A DNS response with the given RCODE (header-only is all the impl reads). */
-function makeResponse(rcode) {
-  const response = Buffer.alloc(12);
-  response.writeUInt16BE(0x1234, 0);
-  response[2] = 0xa8; // QR=1, opcode UPDATE
-  response[3] = rcode & 0x0f;
-  return response;
+/**
+ * Builds a properly TSIG-signed UPDATE response for a given signed request,
+ * using the same helpers the module itself exports. Options allow forging
+ * (wrong id), signing with the wrong key, or omitting the TSIG entirely.
+ */
+function makeSignedResponse(
+  requestMessage,
+  {
+    rcode = 0,
+    id,
+    secretBase64 = SECRET_BASE64,
+    keyName = "tsig-key",
+    keyAlgorithm = "hmac-sha256",
+    unsigned = false,
+  } = {},
+) {
+  const responseId = id !== undefined ? id : requestMessage.readUInt16BE(0);
+  const flags = 0x8000 | (5 << 11) | (rcode & 0x0f);
+  const headerWithoutTsig = Buffer.concat([
+    uint16(responseId),
+    uint16(flags),
+    uint16(0),
+    uint16(0),
+    uint16(0),
+    uint16(0),
+  ]);
+  if (unsigned) {
+    return headerWithoutTsig;
+  }
+
+  const requestTsig = parseTsigFromMessage(requestMessage);
+  const timeSigned = requestTsig.timeSigned;
+  const fudge = 300;
+  const mac = computeResponseMac({
+    requestMac: requestTsig.mac,
+    responseMessageWithoutTsig: headerWithoutTsig,
+    tsigVariables: buildTsigVariables({ keyName, keyAlgorithm, timeSigned, fudge }),
+    keyAlgorithm,
+    keySecretBase64: secretBase64,
+  });
+  const tsigRecord = buildTsigRecord({
+    keyName,
+    keyAlgorithm,
+    timeSigned,
+    fudge,
+    mac,
+    originalId: responseId,
+  });
+  const signedHeader = Buffer.concat([
+    uint16(responseId),
+    uint16(flags),
+    uint16(0),
+    uint16(0),
+    uint16(0),
+    uint16(1),
+  ]);
+  return Buffer.concat([signedHeader, tsigRecord]);
 }
 
-function makeDnsUpdateStub(response) {
+/** @param {(request: Buffer) => Buffer} respond */
+function makeDnsUpdateStub(respond) {
   const calls = [];
   async function dnsUpdateStub(options) {
     calls.push(options);
-    return response;
+    return respond(options.message);
   }
   dnsUpdateStub.calls = calls;
   return dnsUpdateStub;
@@ -135,19 +191,36 @@ test("rfc2136: the signed present UPDATE matches the fixed wire vector", () => {
   );
 });
 
-test("rfc2136: the signed cleanup UPDATE (RRset delete) matches the fixed wire vector", () => {
+test("rfc2136: the signed cleanup UPDATE deletes only the exact TXT RR (class NONE)", () => {
   const message = buildUpdateMessage({
     ...FIXED_MESSAGE_INPUTS,
     action: "cleanup",
+    txtValue: "test-token-value",
   });
 
-  assert.equal(
-    message.toString("hex"),
-    "123428000001000000010001076578616d706c6503636f6d00000600010f5f61636d" +
-      "652d6368616c6c656e6765076578616d706c6503636f6d00001000ff000000000000" +
-      "08747369672d6b65790000fa00ff00000000003d0b686d61632d7368613235360000" +
-      "006553f100012c0020b17269f6cc1f1780336507ce9da5a741e9b7bbefd0c537e79e" +
-      "d4f0e1aee1042d123400000000",
+  // The update RR follows the 12-byte header + zone section
+  // (encodeName("example.com") = 13 bytes + type(2) + class(2)).
+  const updateOffset = 12 + 13 + 4;
+  const nameLength = encodeName(FIXED_MESSAGE_INPUTS.recordName).length;
+  assert.equal(message.readUInt16BE(updateOffset + nameLength), 16); // TXT
+  assert.equal(message.readUInt16BE(updateOffset + nameLength + 2), 254); // NONE
+  assert.equal(message.readUInt32BE(updateOffset + nameLength + 4), 0); // TTL
+  const expectedRdata = encodeTxtRdata("test-token-value");
+  assert.equal(message.readUInt16BE(updateOffset + nameLength + 8), expectedRdata.length);
+  assert.ok(
+    message
+      .subarray(
+        updateOffset + nameLength + 10,
+        updateOffset + nameLength + 10 + expectedRdata.length,
+      )
+      .equals(expectedRdata),
+  );
+});
+
+test("rfc2136: cleanup without a txtValue throws (programmer error)", () => {
+  assert.throws(
+    () => buildUpdateMessage({ ...FIXED_MESSAGE_INPUTS, action: "cleanup" }),
+    /requires a txtValue/,
   );
 });
 
@@ -177,8 +250,8 @@ test("rfc2136: present without a txtValue throws (programmer error)", () => {
 // solver behavior with an injected socket layer (no sockets ever opened)
 // ---------------------------------------------------------------------------
 
-test("rfc2136: present sends one UPDATE to the configured server and succeeds on NOERROR", async () => {
-  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(0));
+test("rfc2136: present sends one UPDATE and succeeds on a correctly signed NOERROR", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) => makeSignedResponse(request));
   const solver = createDnsSolver({
     provider: "rfc2136",
     credentials: CREDENTIALS,
@@ -197,8 +270,8 @@ test("rfc2136: present sends one UPDATE to the configured server and succeeds on
   assert.equal(call.message.readUInt16BE(2) >>> 11, 5);
 });
 
-test("rfc2136: a REFUSED response maps to ok:false with the rcode name", async () => {
-  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(5));
+test("rfc2136: a signed REFUSED response maps to ok:false with the rcode name", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) => makeSignedResponse(request, { rcode: 5 }));
   const solver = createDnsSolver({
     provider: "rfc2136",
     credentials: CREDENTIALS,
@@ -211,8 +284,73 @@ test("rfc2136: a REFUSED response maps to ok:false with the rcode name", async (
   assert.match(result.detail, /RCODE 5 \(REFUSED\)/);
 });
 
+test("rfc2136: a forged response with the wrong transaction ID maps to ok:false", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) =>
+    makeSignedResponse(request, { id: (request.readUInt16BE(0) + 1) & 0xffff }),
+  );
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /transaction ID/);
+});
+
+test("rfc2136: an unsigned response is rejected even with NOERROR", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) =>
+    makeSignedResponse(request, { unsigned: true }),
+  );
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /unsigned/);
+});
+
+test("rfc2136: a response signed with the wrong key fails MAC verification", async () => {
+  const wrongSecret = Buffer.from("some-other-secret").toString("base64");
+  const dnsUpdateStub = makeDnsUpdateStub((request) =>
+    makeSignedResponse(request, { secretBase64: wrongSecret }),
+  );
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /MAC verification failed/);
+});
+
+test("rfc2136: a response signed under a different key name is rejected", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) =>
+    makeSignedResponse(request, { keyName: "other-key" }),
+  );
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /key name does not match/);
+});
+
 test("rfc2136: a short/malformed response maps to ok:false", async () => {
-  const dnsUpdateStub = makeDnsUpdateStub(Buffer.from([0x00, 0x01]));
+  const dnsUpdateStub = makeDnsUpdateStub(() => Buffer.from([0x00, 0x01]));
   const solver = createDnsSolver({
     provider: "rfc2136",
     credentials: CREDENTIALS,
@@ -240,8 +378,8 @@ test("rfc2136: a socket-layer rejection maps to ok:false, never a throw", async 
   assert.match(result.detail, /ECONNREFUSED/);
 });
 
-test("rfc2136: cleanup sends a class-ANY TXT RRset delete", async () => {
-  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(0));
+test("rfc2136: cleanup sends a class-NONE exact-RR delete (siblings preserved)", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub((request) => makeSignedResponse(request));
   const solver = createDnsSolver({
     provider: "rfc2136",
     credentials: CREDENTIALS,
@@ -253,13 +391,16 @@ test("rfc2136: cleanup sends a class-ANY TXT RRset delete", async () => {
   assert.equal(result.ok, true);
   const message = dnsUpdateStub.calls[0].message;
   // The update RR follows the 12-byte header + zone section; its class is
-  // ANY (255) and TTL 0 for an RRset delete. Zone section length:
+  // NONE (254) with TTL 0 and the exact TXT rdata (RFC 2136 s2.5.4), so
+  // only the challenge value is removed. Zone section length:
   // encodeName("example.com") = 13 bytes + type(2) + class(2).
   const updateOffset = 12 + 13 + 4;
   const nameLength = encodeName(CHALLENGE.recordName).length;
   assert.equal(message.readUInt16BE(updateOffset + nameLength), 16); // TXT
-  assert.equal(message.readUInt16BE(updateOffset + nameLength + 2), 255); // ANY
+  assert.equal(message.readUInt16BE(updateOffset + nameLength + 2), 254); // NONE
   assert.equal(message.readUInt32BE(updateOffset + nameLength + 4), 0); // TTL
+  const expectedRdata = encodeTxtRdata(CHALLENGE.txtValue);
+  assert.equal(message.readUInt16BE(updateOffset + nameLength + 8), expectedRdata.length);
 });
 
 test("rfc2136: an error detail echoing the TSIG secret is redacted wholesale", async () => {

--- a/packages/agent/src/dns/providers/rfc2136.test.js
+++ b/packages/agent/src/dns/providers/rfc2136.test.js
@@ -1,0 +1,276 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  buildUpdateMessage,
+  encodeName,
+  encodeTxtRdata,
+} = require("./rfc2136.js");
+
+const SECRET_BASE64 = Buffer.from("shared-secret").toString("base64"); // c2hhcmVkLXNlY3JldA==
+
+const CREDENTIALS = {
+  server: "ns1.example.com",
+  keyName: "tsig-key",
+  keySecretBase64: SECRET_BASE64,
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "test-token-value",
+};
+
+const FIXED_MESSAGE_INPUTS = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  keyName: "tsig-key",
+  keyAlgorithm: "hmac-sha256",
+  keySecretBase64: SECRET_BASE64,
+  messageId: 0x1234,
+  timeSigned: 1700000000,
+  fudge: 300,
+};
+
+/** A DNS response with the given RCODE (header-only is all the impl reads). */
+function makeResponse(rcode) {
+  const response = Buffer.alloc(12);
+  response.writeUInt16BE(0x1234, 0);
+  response[2] = 0xa8; // QR=1, opcode UPDATE
+  response[3] = rcode & 0x0f;
+  return response;
+}
+
+function makeDnsUpdateStub(response) {
+  const calls = [];
+  async function dnsUpdateStub(options) {
+    calls.push(options);
+    return response;
+  }
+  dnsUpdateStub.calls = calls;
+  return dnsUpdateStub;
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("rfc2136: server, keyName, keySecretBase64 are required", () => {
+  assert.throws(() => validateCredentials({ keyName: "k", keySecretBase64: SECRET_BASE64 }), /server/);
+  assert.throws(() => validateCredentials({ server: "s", keySecretBase64: SECRET_BASE64 }), /keyName/);
+  assert.throws(() => validateCredentials({ server: "s", keyName: "k" }), /keySecretBase64/);
+});
+
+test("rfc2136: invalid base64 secret throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, keySecretBase64: "!!!not-base64!!!" }),
+    /not valid base64/,
+  );
+});
+
+test("rfc2136: unsupported keyAlgorithm throws at construction", () => {
+  assert.throws(
+    () => validateCredentials({ ...CREDENTIALS, keyAlgorithm: "hmac-md5" }),
+    /not supported/,
+  );
+});
+
+test("rfc2136: port defaults to 53 and algorithm to hmac-sha256", () => {
+  const normalized = validateCredentials(CREDENTIALS);
+  assert.equal(normalized.port, 53);
+  assert.equal(normalized.keyAlgorithm, "hmac-sha256");
+});
+
+// ---------------------------------------------------------------------------
+// wire-format building blocks
+// ---------------------------------------------------------------------------
+
+test("rfc2136: encodeName produces uncompressed labels with a root terminator", () => {
+  assert.equal(
+    encodeName("example.com").toString("hex"),
+    "076578616d706c6503636f6d00",
+  );
+});
+
+test("rfc2136: encodeName treats a trailing dot as already-absolute", () => {
+  assert.ok(encodeName("example.com.").equals(encodeName("example.com")));
+});
+
+test("rfc2136: encodeName rejects oversized labels", () => {
+  assert.throws(() => encodeName(`${"a".repeat(64)}.com`), /invalid label/);
+});
+
+test("rfc2136: TXT rdata is split into 255-byte character-strings", () => {
+  const short = encodeTxtRdata("abc");
+  assert.equal(short.toString("hex"), "03616263");
+
+  const long = encodeTxtRdata("x".repeat(300));
+  assert.equal(long[0], 255);
+  assert.equal(long[256], 45); // 300 - 255
+  assert.equal(long.length, 1 + 255 + 1 + 45);
+});
+
+// ---------------------------------------------------------------------------
+// stable TSIG message vectors (deterministic given messageId + timeSigned)
+// ---------------------------------------------------------------------------
+
+test("rfc2136: the signed present UPDATE matches the fixed wire vector", () => {
+  const message = buildUpdateMessage({
+    ...FIXED_MESSAGE_INPUTS,
+    action: "present",
+    txtValue: "test-token-value",
+  });
+
+  assert.equal(
+    message.toString("hex"),
+    "123428000001000000010001076578616d706c6503636f6d00000600010f5f61636d" +
+      "652d6368616c6c656e6765076578616d706c6503636f6d00001000010000003c0011" +
+      "10746573742d746f6b656e2d76616c756508747369672d6b65790000fa00ff000000" +
+      "00003d0b686d61632d7368613235360000006553f100012c002061b96cd3d8993a46" +
+      "82abab7b9bebee931cc3944d8ff37394086567132d968a81123400000000",
+  );
+});
+
+test("rfc2136: the signed cleanup UPDATE (RRset delete) matches the fixed wire vector", () => {
+  const message = buildUpdateMessage({
+    ...FIXED_MESSAGE_INPUTS,
+    action: "cleanup",
+  });
+
+  assert.equal(
+    message.toString("hex"),
+    "123428000001000000010001076578616d706c6503636f6d00000600010f5f61636d" +
+      "652d6368616c6c656e6765076578616d706c6503636f6d00001000ff000000000000" +
+      "08747369672d6b65790000fa00ff00000000003d0b686d61632d7368613235360000" +
+      "006553f100012c0020b17269f6cc1f1780336507ce9da5a741e9b7bbefd0c537e79e" +
+      "d4f0e1aee1042d123400000000",
+  );
+});
+
+test("rfc2136: the TSIG MAC is a stable HMAC for fixed inputs", () => {
+  const message = buildUpdateMessage({
+    ...FIXED_MESSAGE_INPUTS,
+    action: "present",
+    txtValue: "test-token-value",
+  });
+  // MAC is the 32 bytes preceding the trailing originalId+error+otherLen
+  // (6 bytes) in the TSIG RDATA.
+  const mac = message.subarray(message.length - 6 - 32, message.length - 6);
+  assert.equal(
+    mac.toString("hex"),
+    "61b96cd3d8993a4682abab7b9bebee931cc3944d8ff37394086567132d968a81",
+  );
+});
+
+test("rfc2136: present without a txtValue throws (programmer error)", () => {
+  assert.throws(
+    () => buildUpdateMessage({ ...FIXED_MESSAGE_INPUTS, action: "present" }),
+    /requires a txtValue/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// solver behavior with an injected socket layer (no sockets ever opened)
+// ---------------------------------------------------------------------------
+
+test("rfc2136: present sends one UPDATE to the configured server and succeeds on NOERROR", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(0));
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(dnsUpdateStub.calls.length, 1);
+  const call = dnsUpdateStub.calls[0];
+  assert.equal(call.host, "ns1.example.com");
+  assert.equal(call.port, 53);
+  assert.ok(Buffer.isBuffer(call.message));
+  // Opcode UPDATE in the header flags.
+  assert.equal(call.message.readUInt16BE(2) >>> 11, 5);
+});
+
+test("rfc2136: a REFUSED response maps to ok:false with the rcode name", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(5));
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /RCODE 5 \(REFUSED\)/);
+});
+
+test("rfc2136: a short/malformed response maps to ok:false", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub(Buffer.from([0x00, 0x01]));
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /malformed/);
+});
+
+test("rfc2136: a socket-layer rejection maps to ok:false, never a throw", async () => {
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: async () => {
+      throw new Error("connect ECONNREFUSED 192.0.2.53:53");
+    },
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /ECONNREFUSED/);
+});
+
+test("rfc2136: cleanup sends a class-ANY TXT RRset delete", async () => {
+  const dnsUpdateStub = makeDnsUpdateStub(makeResponse(0));
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: dnsUpdateStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const message = dnsUpdateStub.calls[0].message;
+  // The update RR follows the 12-byte header + zone section; its class is
+  // ANY (255) and TTL 0 for an RRset delete. Zone section length:
+  // encodeName("example.com") = 13 bytes + type(2) + class(2).
+  const updateOffset = 12 + 13 + 4;
+  const nameLength = encodeName(CHALLENGE.recordName).length;
+  assert.equal(message.readUInt16BE(updateOffset + nameLength), 16); // TXT
+  assert.equal(message.readUInt16BE(updateOffset + nameLength + 2), 255); // ANY
+  assert.equal(message.readUInt32BE(updateOffset + nameLength + 4), 0); // TTL
+});
+
+test("rfc2136: an error detail echoing the TSIG secret is redacted wholesale", async () => {
+  const solver = createDnsSolver({
+    provider: "rfc2136",
+    credentials: CREDENTIALS,
+    dnsUpdateImpl: async () => {
+      throw new Error(`server rejected key ${SECRET_BASE64}`);
+    },
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/route53.js
+++ b/packages/agent/src/dns/providers/route53.js
@@ -21,8 +21,17 @@
  *
  * API surface used (route53.amazonaws.com, XML API 2013-04-01):
  *   GET  /2013-04-01/hostedzonebyname?dnsname=<zone>&maxitems=1
+ *   GET  /2013-04-01/hostedzone/<id>/rrset?name=&type=TXT&maxitems=1
+ *        ListResourceRecordSets (read-modify-write basis)
  *   POST /2013-04-01/hostedzone/<id>/rrset   ChangeResourceRecordSets
- *        (UPSERT on present, DELETE on cleanup)
+ *        (UPSERT on present, UPSERT-remainder or DELETE on cleanup)
+ *
+ * UPSERT replaces the WHOLE record set and DELETE must match the live set
+ * exactly, so present() first lists the existing TXT values at the name
+ * and UPSERTs the union plus the new value; cleanup() removes only the
+ * challenge value, UPSERTing the remainder back and DELETEing the set
+ * only when nothing remains. Parallel challenges at the same name and
+ * third-party TXT values therefore never clobber each other.
  *
  * TXT values are wrapped in double quotes per Route 53 rules, with
  * backslash and double-quote characters escaped.
@@ -212,6 +221,14 @@ function xmlEscape(value) {
     .replace(/"/g, "&quot;");
 }
 
+function xmlUnescape(value) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
 /** Route 53 TXT value quoting: wrap in double quotes, escape \ and ". */
 function quoteTxtValue(txtValue) {
   return `"${txtValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
@@ -220,11 +237,15 @@ function quoteTxtValue(txtValue) {
 /**
  * @param {"UPSERT"|"DELETE"} action
  * @param {string} recordName
- * @param {string} txtValue
+ * @param {string[]} quotedValues already-quoted TXT values (whole rrset)
+ * @param {number} [ttl]
  * @returns {string} ChangeResourceRecordSets XML body
  */
-function buildChangeBatchXml(action, recordName, txtValue) {
+function buildChangeBatchXml(action, recordName, quotedValues, ttl = TXT_TTL_SECONDS) {
   const fqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
+  const resourceRecordsXml = quotedValues
+    .map((value) => `<ResourceRecord><Value>${xmlEscape(value)}</Value></ResourceRecord>`)
+    .join("");
   return (
     '<?xml version="1.0" encoding="UTF-8"?>' +
     `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/${API_VERSION}/">` +
@@ -233,10 +254,8 @@ function buildChangeBatchXml(action, recordName, txtValue) {
     "<ResourceRecordSet>" +
     `<Name>${xmlEscape(fqdn)}</Name>` +
     "<Type>TXT</Type>" +
-    `<TTL>${TXT_TTL_SECONDS}</TTL>` +
-    "<ResourceRecords><ResourceRecord>" +
-    `<Value>${xmlEscape(quoteTxtValue(txtValue))}</Value>` +
-    "</ResourceRecord></ResourceRecords>" +
+    `<TTL>${ttl}</TTL>` +
+    `<ResourceRecords>${resourceRecordsXml}</ResourceRecords>` +
     "</ResourceRecordSet>" +
     "</Change></Changes></ChangeBatch>" +
     "</ChangeResourceRecordSetsRequest>"
@@ -330,31 +349,150 @@ function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
   }
 
   /**
-   * @param {"UPSERT"|"DELETE"} action
-   * @param {{ zone: string, recordName: string, txtValue: string }} inputs
+   * ListResourceRecordSets for the exact name/TXT. Returns
+   * { ok:true, exists, values, ttl } where values are the (still-quoted)
+   * live TXT values, or an ok:false operational failure.
+   * @param {string} hostedZoneId
+   * @param {string} recordFqdn absolute name with trailing dot
    */
-  async function changeRecordSet(action, { zone, recordName, txtValue }) {
+  async function listExistingTxtValues(hostedZoneId, recordFqdn) {
+    const response = await signedFetch({
+      method: "GET",
+      path: `/${API_VERSION}/hostedzone/${hostedZoneId}/rrset`,
+      query: [
+        ["name", recordFqdn],
+        ["type", "TXT"],
+        ["maxitems", "1"],
+      ],
+    });
+    if (!response.ok) {
+      return httpFailure("ListResourceRecordSets", response);
+    }
+
+    // The list starts at-or-after the requested name, so the first record
+    // set must actually match name + type or the set does not exist.
+    const rrsetMatch = /<ResourceRecordSet>([\s\S]*?)<\/ResourceRecordSet>/.exec(
+      response.bodyText,
+    );
+    if (!rrsetMatch) {
+      return { ok: true, exists: false, values: [], ttl: null };
+    }
+    const block = rrsetMatch[1];
+    const nameMatch = /<Name>([^<]*)<\/Name>/.exec(block);
+    const typeMatch = /<Type>([^<]*)<\/Type>/.exec(block);
+    if (
+      !nameMatch ||
+      !typeMatch ||
+      typeMatch[1] !== "TXT" ||
+      xmlUnescape(nameMatch[1]).toLowerCase() !== recordFqdn.toLowerCase()
+    ) {
+      return { ok: true, exists: false, values: [], ttl: null };
+    }
+
+    const ttlMatch = /<TTL>(\d+)<\/TTL>/.exec(block);
+    const values = [];
+    const valuePattern = /<Value>([^<]*)<\/Value>/g;
+    let valueMatch;
+    while ((valueMatch = valuePattern.exec(block)) !== null) {
+      values.push(xmlUnescape(valueMatch[1]));
+    }
+    return {
+      ok: true,
+      exists: true,
+      values,
+      ttl: ttlMatch ? Number.parseInt(ttlMatch[1], 10) : null,
+    };
+  }
+
+  /**
+   * @param {"UPSERT"|"DELETE"} action
+   * @param {string} hostedZoneId
+   * @param {string} recordFqdn
+   * @param {string[]} quotedValues
+   * @param {number} ttl
+   */
+  async function postChangeBatch(action, hostedZoneId, recordFqdn, quotedValues, ttl) {
+    const response = await signedFetch({
+      method: "POST",
+      path: `/${API_VERSION}/hostedzone/${hostedZoneId}/rrset`,
+      body: buildChangeBatchXml(action, recordFqdn, quotedValues, ttl),
+    });
+    if (!response.ok) {
+      return httpFailure(`ChangeResourceRecordSets ${action}`, response);
+    }
+    return { ok: true };
+  }
+
+  async function presentChallenge({ zone, recordName, txtValue }) {
     const zoneResult = await resolveHostedZoneId(zone);
     if (!zoneResult.ok) {
       return zoneResult;
     }
 
-    const response = await signedFetch({
-      method: "POST",
-      path: `/${API_VERSION}/hostedzone/${zoneResult.hostedZoneId}/rrset`,
-      body: buildChangeBatchXml(action, recordName, txtValue),
-    });
-    if (!response.ok) {
-      return httpFailure(`ChangeResourceRecordSets ${action}`, response);
+    const recordFqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
+    const existing = await listExistingTxtValues(zoneResult.hostedZoneId, recordFqdn);
+    if (!existing.ok) {
+      return existing;
     }
 
-    return { ok: true };
+    // Merge with the live set so parallel challenges and third-party TXT
+    // values are preserved (UPSERT replaces the whole record set).
+    const quoted = quoteTxtValue(txtValue);
+    const merged = existing.values.includes(quoted)
+      ? existing.values
+      : [...existing.values, quoted];
+
+    return postChangeBatch(
+      "UPSERT",
+      zoneResult.hostedZoneId,
+      recordFqdn,
+      merged,
+      existing.ttl !== null ? existing.ttl : TXT_TTL_SECONDS,
+    );
   }
 
-  return {
-    presentChallenge: (inputs) => changeRecordSet("UPSERT", inputs),
-    cleanupChallenge: (inputs) => changeRecordSet("DELETE", inputs),
-  };
+  async function cleanupChallenge({ zone, recordName, txtValue }) {
+    const zoneResult = await resolveHostedZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const recordFqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
+    const existing = await listExistingTxtValues(zoneResult.hostedZoneId, recordFqdn);
+    if (!existing.ok) {
+      return existing;
+    }
+
+    const quoted = quoteTxtValue(txtValue);
+    if (!existing.exists || !existing.values.includes(quoted)) {
+      // Nothing to delete: cleanup is idempotent, an already-absent value
+      // is success, not failure.
+      return { ok: true };
+    }
+
+    const ttl = existing.ttl !== null ? existing.ttl : TXT_TTL_SECONDS;
+    const remaining = existing.values.filter((value) => value !== quoted);
+    if (remaining.length > 0) {
+      return postChangeBatch(
+        "UPSERT",
+        zoneResult.hostedZoneId,
+        recordFqdn,
+        remaining,
+        ttl,
+      );
+    }
+
+    // DELETE must carry the exact live record set.
+    return postChangeBatch(
+      "DELETE",
+      zoneResult.hostedZoneId,
+      recordFqdn,
+      existing.values,
+      ttl,
+    );
+  }
+
+  return { presentChallenge, cleanupChallenge };
 }
 
 module.exports = {
@@ -368,4 +506,5 @@ module.exports = {
   signRequest,
   buildChangeBatchXml,
   quoteTxtValue,
+  xmlUnescape,
 };

--- a/packages/agent/src/dns/providers/route53.js
+++ b/packages/agent/src/dns/providers/route53.js
@@ -1,0 +1,371 @@
+"use strict";
+
+/**
+ * Amazon Route 53 DNS-01 provider.
+ *
+ * Auth: AWS Signature Version 4, implemented here with node:crypto only
+ * (no AWS SDK -- the agent is zero-dependency). Scope the IAM principal to
+ * route53:ChangeResourceRecordSets + route53:ListHostedZonesByName on the
+ * target hosted zone(s).
+ *
+ * Credentials shape:
+ *   {
+ *     accessKeyId: string,
+ *     secretAccessKey: string,
+ *     sessionToken?: string,     // for temporary STS credentials
+ *     hostedZoneId?: string,     // "Z..." or "/hostedzone/Z..."; looked up
+ *                                // by name via ListHostedZonesByName when absent
+ *     region?: string,           // SigV4 scope region, default "us-east-1"
+ *                                // (Route 53 is a global service signed there)
+ *   }
+ *
+ * API surface used (route53.amazonaws.com, XML API 2013-04-01):
+ *   GET  /2013-04-01/hostedzonebyname?dnsname=<zone>&maxitems=1
+ *   POST /2013-04-01/hostedzone/<id>/rrset   ChangeResourceRecordSets
+ *        (UPSERT on present, DELETE on cleanup)
+ *
+ * TXT values are wrapped in double quotes per Route 53 rules, with
+ * backslash and double-quote characters escaped.
+ */
+
+const crypto = require("node:crypto");
+
+const { isNonEmptyString, fetchWithTimeout } = require("../internal.js");
+
+const PROVIDER_ID = "route53";
+const API_HOST = "route53.amazonaws.com";
+const API_VERSION = "2013-04-01";
+const SERVICE = "route53";
+const DEFAULT_REGION = "us-east-1";
+const TXT_TTL_SECONDS = 60;
+
+// --------------------------------------------------------------------------
+// SigV4 (exported for the fixed-vector signature test)
+// --------------------------------------------------------------------------
+
+function sha256Hex(data) {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+function hmac(key, data) {
+  return crypto.createHmac("sha256", key).update(data).digest();
+}
+
+/** RFC 3986 strict encoding (SigV4 requires !'()* encoded too). */
+function rfc3986Encode(value) {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Builds the SigV4 canonical request and derived signature for one request
+ * against a fixed host. Deterministic given amzDate, so tests can assert an
+ * exact canonical request + signature for a fixed key/date.
+ *
+ * @param {object} options
+ * @param {string} options.method
+ * @param {string} options.path already-encoded absolute path (no query)
+ * @param {Array<[string, string]>} options.query raw key/value pairs
+ * @param {string} options.body
+ * @param {string} options.amzDate "YYYYMMDDTHHMMSSZ"
+ * @param {string} options.accessKeyId
+ * @param {string} options.secretAccessKey
+ * @param {string|null} options.sessionToken
+ * @param {string} options.region
+ * @returns {{
+ *   canonicalRequest: string,
+ *   stringToSign: string,
+ *   signature: string,
+ *   headers: object,
+ * }}
+ */
+function signRequest({
+  method,
+  path,
+  query = [],
+  body = "",
+  amzDate,
+  accessKeyId,
+  secretAccessKey,
+  sessionToken = null,
+  region,
+}) {
+  const dateStamp = amzDate.slice(0, 8);
+
+  const canonicalQueryString = query
+    .map(([key, value]) => [rfc3986Encode(key), rfc3986Encode(value)])
+    .sort(([aKey, aValue], [bKey, bValue]) =>
+      aKey === bKey ? aValue.localeCompare(bValue) : aKey.localeCompare(bKey),
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  const headerEntries = [
+    ["host", API_HOST],
+    ["x-amz-date", amzDate],
+  ];
+  if (sessionToken) {
+    headerEntries.push(["x-amz-security-token", sessionToken]);
+  }
+  headerEntries.sort(([a], [b]) => a.localeCompare(b));
+
+  const canonicalHeaders = headerEntries
+    .map(([name, value]) => `${name}:${value}\n`)
+    .join("");
+  const signedHeaders = headerEntries.map(([name]) => name).join(";");
+
+  const payloadHash = sha256Hex(body);
+
+  const canonicalRequest = [
+    method,
+    path,
+    canonicalQueryString,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${region}/${SERVICE}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const kDate = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, SERVICE);
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = hmac(kSigning, stringToSign).toString("hex");
+
+  const headers = {
+    Host: API_HOST,
+    "X-Amz-Date": amzDate,
+    Authorization:
+      `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+  if (sessionToken) {
+    headers["X-Amz-Security-Token"] = sessionToken;
+  }
+
+  return { canonicalRequest, stringToSign, signature, headers };
+}
+
+// --------------------------------------------------------------------------
+// Provider contract
+// --------------------------------------------------------------------------
+
+/**
+ * @param {object} credentials
+ */
+function validateCredentials(credentials) {
+  if (!isNonEmptyString(credentials.accessKeyId)) {
+    throw new Error("dns: route53 credentials require a non-empty accessKeyId string");
+  }
+  if (!isNonEmptyString(credentials.secretAccessKey)) {
+    throw new Error("dns: route53 credentials require a non-empty secretAccessKey string");
+  }
+  if (credentials.sessionToken !== undefined && !isNonEmptyString(credentials.sessionToken)) {
+    throw new Error("dns: route53 sessionToken must be a non-empty string when provided");
+  }
+  if (credentials.hostedZoneId !== undefined && !isNonEmptyString(credentials.hostedZoneId)) {
+    throw new Error("dns: route53 hostedZoneId must be a non-empty string when provided");
+  }
+  if (credentials.region !== undefined && !isNonEmptyString(credentials.region)) {
+    throw new Error("dns: route53 region must be a non-empty string when provided");
+  }
+
+  const hostedZoneId = credentials.hostedZoneId
+    ? credentials.hostedZoneId.replace(/^\/hostedzone\//, "")
+    : null;
+
+  return {
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken || null,
+    hostedZoneId,
+    region: credentials.region || DEFAULT_REGION,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof validateCredentials>} credentials
+ * @returns {string[]} secret strings to redact from any excerpt
+ */
+function collectSecretStrings(credentials) {
+  return [
+    credentials.secretAccessKey,
+    credentials.sessionToken,
+    credentials.accessKeyId,
+  ].filter(Boolean);
+}
+
+function xmlEscape(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Route 53 TXT value quoting: wrap in double quotes, escape \ and ". */
+function quoteTxtValue(txtValue) {
+  return `"${txtValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * @param {"UPSERT"|"DELETE"} action
+ * @param {string} recordName
+ * @param {string} txtValue
+ * @returns {string} ChangeResourceRecordSets XML body
+ */
+function buildChangeBatchXml(action, recordName, txtValue) {
+  const fqdn = recordName.endsWith(".") ? recordName : `${recordName}.`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/${API_VERSION}/">` +
+    "<ChangeBatch><Changes><Change>" +
+    `<Action>${action}</Action>` +
+    "<ResourceRecordSet>" +
+    `<Name>${xmlEscape(fqdn)}</Name>` +
+    "<Type>TXT</Type>" +
+    `<TTL>${TXT_TTL_SECONDS}</TTL>` +
+    "<ResourceRecords><ResourceRecord>" +
+    `<Value>${xmlEscape(quoteTxtValue(txtValue))}</Value>` +
+    "</ResourceRecord></ResourceRecords>" +
+    "</ResourceRecordSet>" +
+    "</Change></Changes></ChangeBatch>" +
+    "</ChangeResourceRecordSetsRequest>"
+  );
+}
+
+function createSolverImpl({ credentials, fetchImpl, timeoutMs, excerpt }) {
+  function currentAmzDate() {
+    return new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+  }
+
+  /**
+   * Signs and sends one request. Returns fetchWithTimeout's result record.
+   * @param {{ method: string, path: string, query?: Array<[string,string]>, body?: string }} request
+   */
+  function signedFetch({ method, path, query = [], body = "" }) {
+    const { headers } = signRequest({
+      method,
+      path,
+      query,
+      body,
+      amzDate: currentAmzDate(),
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      region: credentials.region,
+    });
+
+    const queryString = query
+      .map(([key, value]) => `${rfc3986Encode(key)}=${rfc3986Encode(value)}`)
+      .join("&");
+    const url = `https://${API_HOST}${path}${queryString ? `?${queryString}` : ""}`;
+
+    return fetchWithTimeout(
+      fetchImpl,
+      url,
+      {
+        method,
+        headers: { ...headers, "Content-Type": "text/xml" },
+        ...(body ? { body } : {}),
+      },
+      timeoutMs,
+    );
+  }
+
+  function httpFailure(operationLabel, response) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      detail: excerpt(`route53 ${operationLabel} failed (HTTP ${response.status}): ${response.bodyText}`),
+    };
+  }
+
+  /**
+   * Resolves the hosted zone id: configured id wins, otherwise
+   * ListHostedZonesByName. The response's first zone must actually match
+   * the requested name (the API returns the lexicographically next zone
+   * when there is no exact match).
+   * @param {string} zone
+   */
+  async function resolveHostedZoneId(zone) {
+    if (credentials.hostedZoneId) {
+      return { ok: true, hostedZoneId: credentials.hostedZoneId };
+    }
+
+    const response = await signedFetch({
+      method: "GET",
+      path: `/${API_VERSION}/hostedzonebyname`,
+      query: [
+        ["dnsname", zone],
+        ["maxitems", "1"],
+      ],
+    });
+    if (!response.ok) {
+      return httpFailure("hosted zone lookup", response);
+    }
+
+    const zoneFqdn = zone.endsWith(".") ? zone : `${zone}.`;
+    const nameMatch = /<Name>([^<]+)<\/Name>/.exec(response.bodyText);
+    const idMatch = /<Id>\/hostedzone\/([^<]+)<\/Id>/.exec(response.bodyText);
+
+    if (!idMatch || !nameMatch || nameMatch[1].toLowerCase() !== zoneFqdn.toLowerCase()) {
+      return {
+        ok: false,
+        statusCode: response.status,
+        detail: excerpt(`route53 hosted zone lookup found no zone named ${JSON.stringify(zone)}`),
+      };
+    }
+
+    return { ok: true, hostedZoneId: idMatch[1] };
+  }
+
+  /**
+   * @param {"UPSERT"|"DELETE"} action
+   * @param {{ zone: string, recordName: string, txtValue: string }} inputs
+   */
+  async function changeRecordSet(action, { zone, recordName, txtValue }) {
+    const zoneResult = await resolveHostedZoneId(zone);
+    if (!zoneResult.ok) {
+      return zoneResult;
+    }
+
+    const response = await signedFetch({
+      method: "POST",
+      path: `/${API_VERSION}/hostedzone/${zoneResult.hostedZoneId}/rrset`,
+      body: buildChangeBatchXml(action, recordName, txtValue),
+    });
+    if (!response.ok) {
+      return httpFailure(`ChangeResourceRecordSets ${action}`, response);
+    }
+
+    return { ok: true };
+  }
+
+  return {
+    presentChallenge: (inputs) => changeRecordSet("UPSERT", inputs),
+    cleanupChallenge: (inputs) => changeRecordSet("DELETE", inputs),
+  };
+}
+
+module.exports = {
+  PROVIDER_ID,
+  API_HOST,
+  DEFAULT_REGION,
+  validateCredentials,
+  collectSecretStrings,
+  createSolverImpl,
+  // Exported for the SigV4 fixed-vector test only.
+  signRequest,
+  buildChangeBatchXml,
+  quoteTxtValue,
+};

--- a/packages/agent/src/dns/providers/route53.test.js
+++ b/packages/agent/src/dns/providers/route53.test.js
@@ -1,0 +1,254 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDnsSolver } = require("../index.js");
+const {
+  validateCredentials,
+  signRequest,
+  buildChangeBatchXml,
+  quoteTxtValue,
+  API_HOST,
+} = require("./route53.js");
+
+const CREDENTIALS = {
+  accessKeyId: "AKIDEXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+  hostedZoneId: "Z123EXAMPLE",
+};
+
+const CHALLENGE = {
+  zone: "example.com",
+  recordName: "_acme-challenge.example.com",
+  txtValue: "token-value",
+};
+
+function makeFetchStub(respond) {
+  const calls = [];
+  async function fetchStub(url, options) {
+    calls.push({ url, options });
+    const { status = 200, body = "<ok/>" } = respond(url, options) || {};
+    return { status, text: async () => body };
+  }
+  fetchStub.calls = calls;
+  return fetchStub;
+}
+
+// ---------------------------------------------------------------------------
+// credential validation
+// ---------------------------------------------------------------------------
+
+test("route53: accessKeyId and secretAccessKey are required", () => {
+  assert.throws(() => validateCredentials({ secretAccessKey: "s" }), /accessKeyId/);
+  assert.throws(() => validateCredentials({ accessKeyId: "a" }), /secretAccessKey/);
+});
+
+test("route53: region defaults to us-east-1 and /hostedzone/ prefix is stripped", () => {
+  const normalized = validateCredentials({
+    accessKeyId: "a",
+    secretAccessKey: "s",
+    hostedZoneId: "/hostedzone/Z42",
+  });
+  assert.equal(normalized.region, "us-east-1");
+  assert.equal(normalized.hostedZoneId, "Z42");
+});
+
+// ---------------------------------------------------------------------------
+// SigV4 fixed vector (deterministic given amzDate)
+// ---------------------------------------------------------------------------
+
+test("route53: SigV4 canonical request and signature match the fixed vector", () => {
+  const { canonicalRequest, signature, headers } = signRequest({
+    method: "POST",
+    path: "/2013-04-01/hostedzone/Z123EXAMPLE/rrset",
+    query: [],
+    body: "<xml/>",
+    amzDate: "20260101T000000Z",
+    accessKeyId: "AKIDEXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+    sessionToken: null,
+    region: "us-east-1",
+  });
+
+  assert.equal(
+    canonicalRequest,
+    [
+      "POST",
+      "/2013-04-01/hostedzone/Z123EXAMPLE/rrset",
+      "",
+      "host:route53.amazonaws.com",
+      "x-amz-date:20260101T000000Z",
+      "",
+      "host;x-amz-date",
+      // sha256 of "<xml/>"
+      "6eb820e0f9762c611c2a77189f686afeca64dfb212e023017e0346e7ab826c39",
+    ].join("\n"),
+  );
+  assert.equal(
+    signature,
+    "4c722057e42432b0d0bd9e18d1572f7bb597f1ec5d385aa4d9f53a41b117aef0",
+  );
+  assert.equal(
+    headers.Authorization,
+    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260101/us-east-1/route53/aws4_request, " +
+      "SignedHeaders=host;x-amz-date, " +
+      "Signature=4c722057e42432b0d0bd9e18d1572f7bb597f1ec5d385aa4d9f53a41b117aef0",
+  );
+});
+
+test("route53: a sessionToken joins the signed headers", () => {
+  const { canonicalRequest, headers } = signRequest({
+    method: "GET",
+    path: "/2013-04-01/hostedzonebyname",
+    query: [["dnsname", "example.com"]],
+    body: "",
+    amzDate: "20260101T000000Z",
+    accessKeyId: "AKIDEXAMPLE",
+    secretAccessKey: "secret",
+    sessionToken: "the-session-token",
+    region: "us-east-1",
+  });
+
+  assert.match(canonicalRequest, /x-amz-security-token:the-session-token\n/);
+  assert.match(canonicalRequest, /host;x-amz-date;x-amz-security-token/);
+  assert.equal(headers["X-Amz-Security-Token"], "the-session-token");
+});
+
+// ---------------------------------------------------------------------------
+// TXT quoting and change batch XML
+// ---------------------------------------------------------------------------
+
+test("route53: TXT values are double-quoted with backslash/quote escaping", () => {
+  assert.equal(quoteTxtValue("plain"), '"plain"');
+  assert.equal(quoteTxtValue('has"quote'), '"has\\"quote"');
+  assert.equal(quoteTxtValue("has\\backslash"), '"has\\\\backslash"');
+});
+
+test("route53: change batch XML carries action, FQDN name, and quoted value", () => {
+  const xml = buildChangeBatchXml("UPSERT", "_acme-challenge.example.com", "abc");
+  assert.match(xml, /<Action>UPSERT<\/Action>/);
+  assert.match(xml, /<Name>_acme-challenge\.example\.com\.<\/Name>/);
+  assert.match(xml, /<Type>TXT<\/Type>/);
+  assert.match(xml, /<Value>&quot;abc&quot;<\/Value>/);
+});
+
+// ---------------------------------------------------------------------------
+// present / cleanup dispatch
+// ---------------------------------------------------------------------------
+
+test("route53: present UPSERTs via ChangeResourceRecordSets on the configured zone", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
+  const call = fetchStub.calls[0];
+  assert.equal(call.url, `https://${API_HOST}/2013-04-01/hostedzone/Z123EXAMPLE/rrset`);
+  assert.equal(call.options.method, "POST");
+  assert.match(call.options.headers.Authorization, /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+  assert.match(call.options.body, /<Action>UPSERT<\/Action>/);
+  assert.match(call.options.body, /&quot;token-value&quot;/);
+});
+
+test("route53: cleanup sends a DELETE change for the same rrset", async () => {
+  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.match(fetchStub.calls[0].options.body, /<Action>DELETE<\/Action>/);
+});
+
+test("route53: hosted zone is looked up by name when hostedZoneId is absent", async () => {
+  const fetchStub = makeFetchStub((url) => {
+    if (url.includes("/hostedzonebyname")) {
+      return {
+        status: 200,
+        body:
+          "<ListHostedZonesByNameResponse><HostedZones><HostedZone>" +
+          "<Id>/hostedzone/ZLOOKEDUP</Id><Name>example.com.</Name>" +
+          "</HostedZone></HostedZones></ListHostedZonesByNameResponse>",
+      };
+    }
+    return { status: 200 };
+  });
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: { accessKeyId: "AKIDLOOKUP", secretAccessKey: "lookup-secret-key" },
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 2);
+  assert.match(fetchStub.calls[0].url, /hostedzonebyname\?dnsname=example\.com&maxitems=1$/);
+  assert.match(fetchStub.calls[1].url, /\/hostedzone\/ZLOOKEDUP\/rrset$/);
+});
+
+test("route53: a lookup returning a non-matching zone maps to ok:false", async () => {
+  // ListHostedZonesByName returns the lexicographically NEXT zone when no
+  // exact match exists; that must not be treated as a hit.
+  const fetchStub = makeFetchStub(() => ({
+    status: 200,
+    body:
+      "<ListHostedZonesByNameResponse><HostedZones><HostedZone>" +
+      "<Id>/hostedzone/ZOTHER</Id><Name>example.org.</Name>" +
+      "</HostedZone></HostedZones></ListHostedZonesByNameResponse>",
+  }));
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: { accessKeyId: "AKIDLOOKUP", secretAccessKey: "lookup-secret-key" },
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /found no zone named/);
+});
+
+test("route53: HTTP error maps to ok:false with statusCode", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 400,
+    body: "<ErrorResponse><Error><Code>InvalidChangeBatch</Code></Error></ErrorResponse>",
+  }));
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 400);
+  assert.match(result.detail, /InvalidChangeBatch/);
+});
+
+test("route53: error body echoing the secret key is redacted wholesale", async () => {
+  const fetchStub = makeFetchStub(() => ({
+    status: 403,
+    body: `SignatureDoesNotMatch for key wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY`,
+  }));
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+  assert.equal(result.detail, "[redacted]");
+});

--- a/packages/agent/src/dns/providers/route53.test.js
+++ b/packages/agent/src/dns/providers/route53.test.js
@@ -125,20 +125,42 @@ test("route53: TXT values are double-quoted with backslash/quote escaping", () =
   assert.equal(quoteTxtValue("has\\backslash"), '"has\\\\backslash"');
 });
 
-test("route53: change batch XML carries action, FQDN name, and quoted value", () => {
-  const xml = buildChangeBatchXml("UPSERT", "_acme-challenge.example.com", "abc");
+test("route53: change batch XML carries action, FQDN name, and the whole value set", async () => {
+  const xml = buildChangeBatchXml("UPSERT", "_acme-challenge.example.com", ['"abc"', '"def"'], 60);
   assert.match(xml, /<Action>UPSERT<\/Action>/);
   assert.match(xml, /<Name>_acme-challenge\.example\.com\.<\/Name>/);
   assert.match(xml, /<Type>TXT<\/Type>/);
   assert.match(xml, /<Value>&quot;abc&quot;<\/Value>/);
+  assert.match(xml, /<Value>&quot;def&quot;<\/Value>/);
 });
 
 // ---------------------------------------------------------------------------
 // present / cleanup dispatch
 // ---------------------------------------------------------------------------
 
-test("route53: present UPSERTs via ChangeResourceRecordSets on the configured zone", async () => {
-  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+/** ListResourceRecordSets XML with one TXT record set (or none). */
+function listRrsetsBody(name, values, ttl = 60) {
+  if (!values) {
+    return "<ListResourceRecordSetsResponse><ResourceRecordSets></ResourceRecordSets></ListResourceRecordSetsResponse>";
+  }
+  const records = values
+    .map((value) => `<ResourceRecord><Value>${value.replace(/"/g, "&quot;")}</Value></ResourceRecord>`)
+    .join("");
+  return (
+    "<ListResourceRecordSetsResponse><ResourceRecordSets><ResourceRecordSet>" +
+    `<Name>${name}</Name><Type>TXT</Type><TTL>${ttl}</TTL>` +
+    `<ResourceRecords>${records}</ResourceRecords>` +
+    "</ResourceRecordSet></ResourceRecordSets></ListResourceRecordSetsResponse>"
+  );
+}
+
+test("route53: present lists the rrset then UPSERTs via ChangeResourceRecordSets", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return { status: 200, body: listRrsetsBody(null, null) };
+    }
+    return { status: 200 };
+  });
   const solver = createDnsSolver({
     provider: "route53",
     credentials: CREDENTIALS,
@@ -148,17 +170,59 @@ test("route53: present UPSERTs via ChangeResourceRecordSets on the configured zo
   const result = await solver.presentChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls.length, 1);
-  const call = fetchStub.calls[0];
-  assert.equal(call.url, `https://${API_HOST}/2013-04-01/hostedzone/Z123EXAMPLE/rrset`);
-  assert.equal(call.options.method, "POST");
-  assert.match(call.options.headers.Authorization, /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
-  assert.match(call.options.body, /<Action>UPSERT<\/Action>/);
-  assert.match(call.options.body, /&quot;token-value&quot;/);
+  assert.equal(fetchStub.calls.length, 2);
+
+  const listCall = fetchStub.calls[0];
+  assert.match(
+    listCall.url,
+    /\/2013-04-01\/hostedzone\/Z123EXAMPLE\/rrset\?name=_acme-challenge\.example\.com\.&type=TXT&maxitems=1$/,
+  );
+  assert.equal(listCall.options.method, "GET");
+
+  const changeCall = fetchStub.calls[1];
+  assert.equal(changeCall.url, `https://${API_HOST}/2013-04-01/hostedzone/Z123EXAMPLE/rrset`);
+  assert.equal(changeCall.options.method, "POST");
+  assert.match(changeCall.options.headers.Authorization, /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+  assert.match(changeCall.options.body, /<Action>UPSERT<\/Action>/);
+  assert.match(changeCall.options.body, /&quot;token-value&quot;/);
 });
 
-test("route53: cleanup sends a DELETE change for the same rrset", async () => {
-  const fetchStub = makeFetchStub(() => ({ status: 200 }));
+test("route53: present preserves pre-existing TXT values in the UPSERT", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: listRrsetsBody("_acme-challenge.example.com.", ['"sibling-value"'], 120),
+      };
+    }
+    return { status: 200 };
+  });
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.presentChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const body = fetchStub.calls[1].options.body;
+  assert.match(body, /<Action>UPSERT<\/Action>/);
+  assert.match(body, /&quot;sibling-value&quot;/);
+  assert.match(body, /&quot;token-value&quot;/);
+  assert.match(body, /<TTL>120<\/TTL>/);
+});
+
+test("route53: cleanup with remaining siblings UPSERTs only the leftovers", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: listRrsetsBody("_acme-challenge.example.com.", ['"sibling-value"', '"token-value"']),
+      };
+    }
+    return { status: 200 };
+  });
   const solver = createDnsSolver({
     provider: "route53",
     credentials: CREDENTIALS,
@@ -168,11 +232,62 @@ test("route53: cleanup sends a DELETE change for the same rrset", async () => {
   const result = await solver.cleanupChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.match(fetchStub.calls[0].options.body, /<Action>DELETE<\/Action>/);
+  const body = fetchStub.calls[1].options.body;
+  assert.match(body, /<Action>UPSERT<\/Action>/);
+  assert.match(body, /&quot;sibling-value&quot;/);
+  assert.doesNotMatch(body, /&quot;token-value&quot;/);
+});
+
+test("route53: cleanup of the last value sends a DELETE with the exact live set", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      return {
+        status: 200,
+        body: listRrsetsBody("_acme-challenge.example.com.", ['"token-value"']),
+      };
+    }
+    return { status: 200 };
+  });
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  const body = fetchStub.calls[1].options.body;
+  assert.match(body, /<Action>DELETE<\/Action>/);
+  assert.match(body, /&quot;token-value&quot;/);
+});
+
+test("route53: cleanup of an already-absent value is idempotent success", async () => {
+  const fetchStub = makeFetchStub((url, options) => {
+    if (options.method === "GET") {
+      // The list API returns the lexicographically NEXT record set when
+      // there is no exact match; a non-matching name must not count.
+      return {
+        status: 200,
+        body: listRrsetsBody("zzz.example.com.", ['"unrelated"']),
+      };
+    }
+    return { status: 500, body: "should never be called" };
+  });
+  const solver = createDnsSolver({
+    provider: "route53",
+    credentials: CREDENTIALS,
+    fetchImpl: fetchStub,
+  });
+
+  const result = await solver.cleanupChallenge(CHALLENGE);
+
+  assert.equal(result.ok, true);
+  assert.equal(fetchStub.calls.length, 1);
 });
 
 test("route53: hosted zone is looked up by name when hostedZoneId is absent", async () => {
-  const fetchStub = makeFetchStub((url) => {
+  const fetchStub = makeFetchStub((url, options) => {
     if (url.includes("/hostedzonebyname")) {
       return {
         status: 200,
@@ -181,6 +296,9 @@ test("route53: hosted zone is looked up by name when hostedZoneId is absent", as
           "<Id>/hostedzone/ZLOOKEDUP</Id><Name>example.com.</Name>" +
           "</HostedZone></HostedZones></ListHostedZonesByNameResponse>",
       };
+    }
+    if (options.method === "GET") {
+      return { status: 200, body: listRrsetsBody(null, null) };
     }
     return { status: 200 };
   });
@@ -193,9 +311,10 @@ test("route53: hosted zone is looked up by name when hostedZoneId is absent", as
   const result = await solver.presentChallenge(CHALLENGE);
 
   assert.equal(result.ok, true);
-  assert.equal(fetchStub.calls.length, 2);
+  assert.equal(fetchStub.calls.length, 3);
   assert.match(fetchStub.calls[0].url, /hostedzonebyname\?dnsname=example\.com&maxitems=1$/);
-  assert.match(fetchStub.calls[1].url, /\/hostedzone\/ZLOOKEDUP\/rrset$/);
+  assert.match(fetchStub.calls[1].url, /\/hostedzone\/ZLOOKEDUP\/rrset\?name=/);
+  assert.match(fetchStub.calls[2].url, /\/hostedzone\/ZLOOKEDUP\/rrset$/);
 });
 
 test("route53: a lookup returning a non-matching zone maps to ok:false", async () => {

--- a/packages/agent/src/exec-env.js
+++ b/packages/agent/src/exec-env.js
@@ -1,0 +1,63 @@
+"use strict";
+
+/**
+ * Minimal environment allowlist for agent-spawned subprocesses (ACME tools,
+ * reload/validate commands).
+ *
+ * The agent process environment can carry secrets: the single-use bootstrap
+ * token on first run (TOKENTIMER_AGENT_BOOTSTRAP_TOKEN via systemd
+ * EnvironmentFile) and any operator-exported material. Child processes must
+ * never inherit those, so instead of passing process.env through, every
+ * exec call builds an explicit environment containing only what external
+ * tools legitimately need:
+ *
+ *   - PATH / PATHEXT / SYSTEMROOT / WINDIR: binary resolution (POSIX + the
+ *     Windows entries that exist only there; absent vars are skipped).
+ *   - HOME / USERPROFILE: certbot/acme.sh default config + account dirs.
+ *   - TMPDIR / TEMP / TMP: scratch space.
+ *   - LANG / LC_ALL / TZ: locale and time, keeps tool output/parsing stable.
+ *   - TOKENTIMER_AGENT_CONFIG_DIR: the certops-dns-hook child that certbot
+ *     spawns resolves the agent config dir from this.
+ *
+ * TOKENTIMER_AGENT_BOOTSTRAP_TOKEN and every other TOKENTIMER_AGENT_* /
+ * arbitrary variable are deliberately NOT forwarded.
+ */
+
+const SUBPROCESS_ENV_ALLOWLIST = Object.freeze([
+  "PATH",
+  "PATHEXT",
+  "SYSTEMROOT",
+  "WINDIR",
+  "HOME",
+  "USERPROFILE",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "LANG",
+  "LC_ALL",
+  "TZ",
+  "TOKENTIMER_AGENT_CONFIG_DIR",
+]);
+
+/**
+ * Builds the explicit child-process environment from an allowlist over the
+ * given source environment.
+ *
+ * @param {NodeJS.ProcessEnv} [sourceEnv]
+ * @returns {Record<string, string>}
+ */
+function buildMinimalSubprocessEnv(sourceEnv = process.env) {
+  const env = {};
+  for (const name of SUBPROCESS_ENV_ALLOWLIST) {
+    const value = sourceEnv[name];
+    if (typeof value === "string" && value.length > 0) {
+      env[name] = value;
+    }
+  }
+  return env;
+}
+
+module.exports = {
+  SUBPROCESS_ENV_ALLOWLIST,
+  buildMinimalSubprocessEnv,
+};

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -66,6 +66,8 @@ const {
   persistRegistration,
   recoverPendingRegistration,
   readCaBundle,
+  createSequenceAllocator,
+  deleteBootstrapEnvFile,
 } = require("./config");
 const { loadPolicyConfig, createPolicyEngine } = require("./policy");
 const {
@@ -171,6 +173,32 @@ const EXECUTION_ERROR_MESSAGE_MAX_CHARS = 512;
 
 /** ACME adapter kinds executeJob accepts from a job payload. */
 const SUPPORTED_ACME_KINDS = ["certbot", "acme.sh"];
+
+/**
+ * Actions this agent build can actually execute (executeJob): "revoke" is
+ * deliberately absent (always blocked in this build). Sent as the claim's
+ * supportedActions when execution is enabled so the control plane's claim
+ * query only leases jobs this agent can run.
+ */
+const EXECUTABLE_JOB_ACTIONS = Object.freeze(["noop", "renew", "deploy", "reload"]);
+
+/**
+ * Claim scope in observe-only bootstrap mode (execution disabled): every
+ * action, including revoke, because this mode's documented contract is to
+ * claim jobs and report them back as explicit "blocked"/"rejected" terminal
+ * states rather than leaving them invisible. The control plane returns no
+ * jobs at all for an empty supportedActions list, which would silently
+ * disable that loop.
+ */
+const OBSERVE_ONLY_CLAIM_ACTIONS = Object.freeze(["noop", "renew", "deploy", "reload", "revoke"]);
+
+/**
+ * Exit code used when the control plane retires this agent. Paired with
+ * RestartPreventExitStatus in scripts/tokentimer-agent.service so systemd
+ * (Restart=on-failure/always) does not respawn a decommissioned agent into
+ * a heartbeat 410 loop (ADR-0002 clean retirement).
+ */
+const AGENT_RETIRED_EXIT_CODE = 86;
 
 /**
  * POSIX-or-Windows absolute path check (same rationale as the acme
@@ -1330,8 +1358,23 @@ async function runDiscoveryScan({ directories, client, log = null }) {
  * @returns {Promise<string>} the assigned agentId
  */
 async function registerIfNeeded({ client, config, configDir, env = process.env }) {
+  // Already-registered paths: an earlier run exchanged the bootstrap token,
+  // but systemd may still have re-exported it from a leftover bootstrap.env.
+  // Scrub it here too so a registered agent never keeps the (already spent)
+  // token in its environment or on disk.
+  const scrubBootstrapToken = () => {
+    if (env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN !== undefined) {
+      delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN;
+      delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID;
+    }
+    deleteBootstrapEnvFile(configDir);
+  };
+
   const recovered = recoverPendingRegistration(configDir);
-  if (recovered !== null) return recovered.agentId;
+  if (recovered !== null) {
+    scrubBootstrapToken();
+    return recovered.agentId;
+  }
 
   const existingCredential = readCredential(configDir);
   if (existingCredential !== null) {
@@ -1342,6 +1385,7 @@ async function registerIfNeeded({ client, config, configDir, env = process.env }
           "with a fresh bootstrap token or restore config.json.",
       );
     }
+    scrubBootstrapToken();
     return config.agentId;
   }
 
@@ -1369,6 +1413,14 @@ async function registerIfNeeded({ client, config, configDir, env = process.env }
     agentId: registration.agentId,
     credential: registration.credential,
   });
+  // The bootstrap token is single-use and has now been exchanged for a
+  // stored per-agent credential. Scrub it from this process's environment
+  // (so it can never leak into child processes or diagnostics) and remove
+  // the installer-written bootstrap.env file (so systemd stops re-exporting
+  // it on every later start).
+  delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN;
+  delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID;
+  deleteBootstrapEnvFile(configDir);
   // Trust-on-first-use pinning (ADR-0003): when the register response
   // carries the control plane's job-signing key info, persist it so every
   // later run verifies jobs against the same key. Public material only.
@@ -1506,6 +1558,12 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
         )
     : undefined;
 
+  // One persisted, crash-safe sequence stream shared by EVERY protocol
+  // client this process creates (candidate/registration client included):
+  // the control plane hard-rejects sequence regressions, so all outbound
+  // messages must draw from a single counter that survives restarts.
+  const sequenceAllocator = createSequenceAllocator(configDir);
+
   const clientForAgentId = (agentId) =>
     createProtocolClient({
       serverUrl: config.serverUrl,
@@ -1516,6 +1574,7 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       fetchImpl,
       allowInsecureLocalHttp: config.allowInsecureLocalHttp,
       onServerDate,
+      sequenceAllocator,
     });
 
   // For a not-yet-registered agent the envelope needs a client-generated
@@ -1567,6 +1626,9 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       });
       if (response && response.retired === true) {
         defaultAgentLogger.error("control plane retired this agent; exiting cleanly");
+        // Distinct exit status so systemd's RestartPreventExitStatus stops
+        // respawning a decommissioned agent into a heartbeat 410 loop.
+        process.exitCode = AGENT_RETIRED_EXIT_CODE;
         stop();
       }
     },
@@ -1577,7 +1639,12 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
     signal: controller.signal,
     startImmediately: true,
     onTick: async () => {
-      const jobs = await client.claim({ maxJobs: 1 });
+      const jobs = await client.claim({
+        maxJobs: 1,
+        supportedActions: executionContext
+          ? EXECUTABLE_JOB_ACTIONS
+          : OBSERVE_ONLY_CLAIM_ACTIONS,
+      });
       for (const job of jobs) {
         if (controller.signal.aborted) break;
         await handleClaimedJob({ job, policyEngine, client, executionContext });
@@ -1624,4 +1691,7 @@ module.exports = {
   registerIfNeeded,
   createCandidateAgentId,
   AGENT_VERSION,
+  AGENT_RETIRED_EXIT_CODE,
+  EXECUTABLE_JOB_ACTIONS,
+  OBSERVE_ONLY_CLAIM_ACTIONS,
 };

--- a/packages/agent/src/protocol/index.js
+++ b/packages/agent/src/protocol/index.js
@@ -575,50 +575,82 @@ async function resolveCredential(getCredential) {
   return typeof getCredential === "function" ? await getCredential() : null;
 }
 
-function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredential, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch, allowInsecureLocalHttp = false, onServerDate = null } = {}) {
+function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredential, signal, requestTimeoutMs = REQUEST_TIMEOUT_MS, fetchImpl = fetch, allowInsecureLocalHttp = false, onServerDate = null, sequenceAllocator = null } = {}) {
   const baseUrl = parseServerUrl(serverUrl, { allowInsecureLocalHttp });
   if (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs < 1 || requestTimeoutMs > 120_000) {
     throw new AgentProtocolError("requestTimeoutMs must be an integer between 1 and 120000", AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE);
   }
+  if (sequenceAllocator !== null && typeof sequenceAllocator?.next !== "function") {
+    throw new AgentProtocolError("sequenceAllocator must expose a next() function when provided", AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE);
+  }
   const routeUrl = (route) => `${baseUrl}${route}`;
   const send = (route, token, envelope) => postJson(routeUrl(route), { token, envelope, signal, requestTimeoutMs, fetchImpl, onServerDate });
 
-  // Per-client monotonically increasing message counter, included as the
+  // Per-agent monotonically increasing message counter, included as the
   // envelope's `sequence` field on every outbound message (register,
-  // heartbeat, claim, result, evidence). Deliberately NOT persisted: a
-  // process restart restarts the counter at 1, which is safe because the
-  // control plane only rejects regressions within the current registered
-  // agent generation and a successful register begins a new generation.
-  let lastSequence = 0;
+  // heartbeat, claim, result, evidence). The runtime injects a shared,
+  // crash-safe persisted allocator (config.createSequenceAllocator) so
+  // registration and steady-state clients draw from ONE stream and a
+  // process restart NEVER reuses a value (the control plane hard-rejects
+  // regressions). The in-memory fallback exists only for isolated
+  // unit-test clients.
+  let inMemorySequence = 0;
   function nextSequence() {
-    lastSequence += 1;
-    return lastSequence;
+    if (sequenceAllocator) return sequenceAllocator.next();
+    inMemorySequence += 1;
+    return inMemorySequence;
+  }
+
+  // Sequence-bearing requests are strictly serialized: the sequence value
+  // is allocated inside the queue immediately before its request is sent,
+  // and the next request cannot allocate until the current one settled.
+  // Without this, concurrent heartbeat/claim/discovery loops could deliver
+  // a higher sequence before a lower one and get the lower one rejected as
+  // a regression.
+  let sendQueue = Promise.resolve();
+  function enqueueSequencedSend(performSend) {
+    const run = sendQueue.then(() => performSend(nextSequence()));
+    // Keep the chain alive whether the send succeeds or fails; failures
+    // propagate to the caller through `run` itself.
+    sendQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   async function register({ bootstrapToken, bootstrapTokenId, agentVersion, hostname = null, platform = null, nodeVersion = null, declaredTargetSelectors = [], declaredCommandProfileNames = [] } = {}) {
     if (typeof bootstrapToken !== "string" || bootstrapToken.length === 0) {
       throw new AgentProtocolError("register requires a bootstrapToken", AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE);
     }
-    const { status, ok, json } = await send(ROUTES.REGISTER, bootstrapToken, buildEnvelope({
-      agentId,
-      protocolVersion,
-      messageType: MESSAGE_TYPES.REGISTER,
-      sequence: nextSequence(),
-      body: { bootstrapTokenId, agentVersion, hostname, platform, nodeVersion, declaredTargetSelectors, declaredCommandProfileNames },
-    }));
+    const { status, ok, json } = await enqueueSequencedSend((sequence) =>
+      send(ROUTES.REGISTER, bootstrapToken, buildEnvelope({
+        agentId,
+        protocolVersion,
+        messageType: MESSAGE_TYPES.REGISTER,
+        sequence,
+        body: { bootstrapTokenId, agentVersion, hostname, platform, nodeVersion, declaredTargetSelectors, declaredCommandProfileNames },
+      })),
+    );
     if (!ok) throw new AgentProtocolError(`agent registration failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return validateRegistrationResponse(json, protocolVersion);
   }
 
   async function heartbeat({ agentVersion, ntpSynced = null, uptimeSeconds = null, pinnedSigningKeyId = null, clockOffsetMs = null } = {}) {
-    const { status, ok, json } = await send(ROUTES.HEARTBEAT, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.HEARTBEAT, clockOffsetMs, sequence: nextSequence(), body: { agentVersion, ntpSynced, uptimeSeconds, pinnedSigningKeyId } }));
+    const token = await resolveCredential(getCredential);
+    const { status, ok, json } = await enqueueSequencedSend((sequence) =>
+      send(ROUTES.HEARTBEAT, token, buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.HEARTBEAT, clockOffsetMs, sequence, body: { agentVersion, ntpSynced, uptimeSeconds, pinnedSigningKeyId } })),
+    );
     if (status === 410) return { retired: true };
     if (!ok) throw new AgentProtocolError(`heartbeat failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }
 
   async function claim({ maxJobs = 1, supportedActions = [] } = {}) {
-    const { status, ok, json } = await send(ROUTES.CLAIM, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.CLAIM, sequence: nextSequence(), body: { maxJobs, supportedActions } }));
+    const token = await resolveCredential(getCredential);
+    const { status, ok, json } = await enqueueSequencedSend((sequence) =>
+      send(ROUTES.CLAIM, token, buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.CLAIM, sequence, body: { maxJobs, supportedActions } })),
+    );
     if (!ok) throw new AgentProtocolError(`claim failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     if (json !== null && !isPlainObject(json)) throw new AgentProtocolError("claim response must be an object", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
     if (json?.jobs !== undefined && !Array.isArray(json.jobs)) throw new AgentProtocolError("claim response jobs must be an array", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
@@ -647,13 +679,19 @@ function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredenti
       ...(claimId !== null ? { claimId } : {}),
       ...(nonce !== null ? { nonce } : {}),
     };
-    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.RESULT, clockOffsetMs, sequence: nextSequence(), body }));
+    const token = await resolveCredential(getCredential);
+    const { status, ok, json } = await enqueueSequencedSend((sequence) =>
+      send(ROUTES.RESULTS, token, buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.RESULT, clockOffsetMs, sequence, body })),
+    );
     if (!ok) throw new AgentProtocolError(`reportResult failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }
 
   async function reportEvidence({ jobId = null, evidenceItems } = {}) {
-    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.EVIDENCE, sequence: nextSequence(), body: { jobId, evidenceItems } }));
+    const token = await resolveCredential(getCredential);
+    const { status, ok, json } = await enqueueSequencedSend((sequence) =>
+      send(ROUTES.RESULTS, token, buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.EVIDENCE, sequence, body: { jobId, evidenceItems } })),
+    );
     if (!ok) throw new AgentProtocolError(`reportEvidence failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }

--- a/packages/agent/src/protocol/index.js
+++ b/packages/agent/src/protocol/index.js
@@ -154,6 +154,7 @@ function validateEnvelopeShape(message) {
     "workspaceId",
     "sentAt",
     "clockOffsetMs",
+    "sequence",
     "body",
   ]);
   if (!checkExactObject(message, envelopeKeys, ["schemaVersion", "protocolVersion", "messageType", "agentId", "sentAt"], "message", problems)) {
@@ -169,6 +170,9 @@ function validateEnvelopeShape(message) {
   }
   if (message.clockOffsetMs !== undefined && message.clockOffsetMs !== null && !Number.isInteger(message.clockOffsetMs)) {
     problems.push("clockOffsetMs must be an integer or null");
+  }
+  if (message.sequence !== undefined && (!Number.isInteger(message.sequence) || message.sequence < 1)) {
+    problems.push("sequence must be an integer >= 1 when present");
   }
 
   if (!MESSAGE_TYPE_VALUES.has(message.messageType)) return problems;
@@ -277,7 +281,7 @@ function prepareOutboundEnvelope(envelope) {
   return { envelope: sanitized, serialized };
 }
 
-function buildEnvelope({ agentId, protocolVersion, messageType, body = null, workspaceId = null, clockOffsetMs = null }) {
+function buildEnvelope({ agentId, protocolVersion, messageType, body = null, workspaceId = null, clockOffsetMs = null, sequence = null }) {
   const envelope = {
     schemaVersion: SCHEMA_VERSION,
     protocolVersion,
@@ -286,6 +290,9 @@ function buildEnvelope({ agentId, protocolVersion, messageType, body = null, wor
     workspaceId,
     sentAt: new Date().toISOString(),
     clockOffsetMs,
+    // Optional in the schema (plain integer, not nullable): carried only
+    // when the caller provides a valid counter value.
+    ...(Number.isInteger(sequence) && sequence >= 1 ? { sequence } : {}),
     body,
   };
   return prepareOutboundEnvelope(envelope).envelope;
@@ -576,6 +583,18 @@ function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredenti
   const routeUrl = (route) => `${baseUrl}${route}`;
   const send = (route, token, envelope) => postJson(routeUrl(route), { token, envelope, signal, requestTimeoutMs, fetchImpl, onServerDate });
 
+  // Per-client monotonically increasing message counter, included as the
+  // envelope's `sequence` field on every outbound message (register,
+  // heartbeat, claim, result, evidence). Deliberately NOT persisted: a
+  // process restart restarts the counter at 1, which is safe because the
+  // control plane only rejects regressions within the current registered
+  // agent generation and a successful register begins a new generation.
+  let lastSequence = 0;
+  function nextSequence() {
+    lastSequence += 1;
+    return lastSequence;
+  }
+
   async function register({ bootstrapToken, bootstrapTokenId, agentVersion, hostname = null, platform = null, nodeVersion = null, declaredTargetSelectors = [], declaredCommandProfileNames = [] } = {}) {
     if (typeof bootstrapToken !== "string" || bootstrapToken.length === 0) {
       throw new AgentProtocolError("register requires a bootstrapToken", AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE);
@@ -584,6 +603,7 @@ function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredenti
       agentId,
       protocolVersion,
       messageType: MESSAGE_TYPES.REGISTER,
+      sequence: nextSequence(),
       body: { bootstrapTokenId, agentVersion, hostname, platform, nodeVersion, declaredTargetSelectors, declaredCommandProfileNames },
     }));
     if (!ok) throw new AgentProtocolError(`agent registration failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
@@ -591,14 +611,14 @@ function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredenti
   }
 
   async function heartbeat({ agentVersion, ntpSynced = null, uptimeSeconds = null, pinnedSigningKeyId = null, clockOffsetMs = null } = {}) {
-    const { status, ok, json } = await send(ROUTES.HEARTBEAT, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.HEARTBEAT, clockOffsetMs, body: { agentVersion, ntpSynced, uptimeSeconds, pinnedSigningKeyId } }));
+    const { status, ok, json } = await send(ROUTES.HEARTBEAT, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.HEARTBEAT, clockOffsetMs, sequence: nextSequence(), body: { agentVersion, ntpSynced, uptimeSeconds, pinnedSigningKeyId } }));
     if (status === 410) return { retired: true };
     if (!ok) throw new AgentProtocolError(`heartbeat failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }
 
   async function claim({ maxJobs = 1, supportedActions = [] } = {}) {
-    const { status, ok, json } = await send(ROUTES.CLAIM, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.CLAIM, body: { maxJobs, supportedActions } }));
+    const { status, ok, json } = await send(ROUTES.CLAIM, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.CLAIM, sequence: nextSequence(), body: { maxJobs, supportedActions } }));
     if (!ok) throw new AgentProtocolError(`claim failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     if (json !== null && !isPlainObject(json)) throw new AgentProtocolError("claim response must be an object", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
     if (json?.jobs !== undefined && !Array.isArray(json.jobs)) throw new AgentProtocolError("claim response jobs must be an array", AGENT_PROTOCOL_ERROR_CODES.INVALID_RESPONSE);
@@ -627,13 +647,13 @@ function createProtocolClient({ serverUrl, agentId, protocolVersion, getCredenti
       ...(claimId !== null ? { claimId } : {}),
       ...(nonce !== null ? { nonce } : {}),
     };
-    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.RESULT, clockOffsetMs, body }));
+    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.RESULT, clockOffsetMs, sequence: nextSequence(), body }));
     if (!ok) throw new AgentProtocolError(`reportResult failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }
 
   async function reportEvidence({ jobId = null, evidenceItems } = {}) {
-    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.EVIDENCE, body: { jobId, evidenceItems } }));
+    const { status, ok, json } = await send(ROUTES.RESULTS, await resolveCredential(getCredential), buildEnvelope({ agentId, protocolVersion, messageType: MESSAGE_TYPES.EVIDENCE, sequence: nextSequence(), body: { jobId, evidenceItems } }));
     if (!ok) throw new AgentProtocolError(`reportEvidence failed with HTTP ${status}`, AGENT_PROTOCOL_ERROR_CODES.HTTP_ERROR, { status });
     return json ?? {};
   }

--- a/packages/agent/src/protocol/protocol.test.js
+++ b/packages/agent/src/protocol/protocol.test.js
@@ -7,13 +7,13 @@ const {
   ROUTES,
   AgentProtocolError,
   AGENT_PROTOCOL_ERROR_CODES,
+  validateEnvelopeShape,
   jitteredDelay,
   withRetry,
   startPollLoop,
   createCaAwareFetch,
   createProtocolClient,
   parseServerUrl,
-  validateEnvelopeShape,
 } = require("./index.js");
 
 const CREDENTIAL = "ttagent_agent-1_0123456789abcdef";
@@ -472,6 +472,109 @@ test("outbound boundary: rejects unknown/private fields and redacts allowed gene
     (err) => err.code === AGENT_PROTOCOL_ERROR_CODES.INVALID_MESSAGE,
   );
   assert.equal(calls.length, 1, "unsafe evidence must not reach fetch");
+});
+
+test("sequence: strictly increasing across every outbound message type", async () => {
+  const calls = stubFetch([
+    {
+      status: 201,
+      json: { agentId: "agent-1", credential: CREDENTIAL, protocolVersion: "1.0.0" },
+    },
+    { status: 200, json: {} },
+    { status: 200, json: { jobs: [] } },
+    { status: 202, json: { accepted: true } },
+    { status: 202, json: { accepted: true } },
+  ]);
+
+  const client = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-1",
+    protocolVersion: "1.0.0",
+    getCredential: () => CREDENTIAL,
+  });
+
+  await client.register({
+    bootstrapToken: "raw-bootstrap-token",
+    bootstrapTokenId: "bst_abc123",
+    agentVersion: "0.1.0",
+  });
+  await client.heartbeat({ agentVersion: "0.1.0" });
+  await client.claim({ maxJobs: 1 });
+  await client.reportResult({
+    jobId: "job-1",
+    attemptId: "attempt-1",
+    status: "succeeded",
+  });
+  await client.reportEvidence({
+    jobId: "job-1",
+    evidenceItems: [
+      { eventType: "certificate.observed", observedAt: new Date().toISOString() },
+    ],
+  });
+
+  assert.equal(calls.length, 5);
+  calls.forEach((call, index) => {
+    assert.equal(
+      call.parsedBody.sequence,
+      index + 1,
+      `expected envelope ${index} to carry sequence ${index + 1}`,
+    );
+  });
+});
+
+test("sequence: each client instance keeps its own counter starting at 1", async () => {
+  const calls = stubFetch([
+    { status: 200, json: {} },
+    { status: 200, json: {} },
+    { status: 200, json: {} },
+  ]);
+
+  const clientA = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-a",
+    protocolVersion: "1.0.0",
+    getCredential: () => "ttagent_agent-a_0123456789abcdef",
+  });
+  const clientB = createProtocolClient({
+    serverUrl: "https://example.test",
+    agentId: "agent-b",
+    protocolVersion: "1.0.0",
+    getCredential: () => "ttagent_agent-b_0123456789abcdef",
+  });
+
+  await clientA.heartbeat({ agentVersion: "0.1.0" });
+  await clientA.heartbeat({ agentVersion: "0.1.0" });
+  // A fresh client (e.g. after a process restart) restarts at 1; the
+  // control plane treats its register as a new generation.
+  await clientB.heartbeat({ agentVersion: "0.1.0" });
+
+  assert.equal(calls[0].parsedBody.sequence, 1);
+  assert.equal(calls[1].parsedBody.sequence, 2);
+  assert.equal(calls[2].parsedBody.sequence, 1);
+});
+
+test("validateEnvelopeShape: flags a non-positive or non-integer sequence, accepts absence", () => {
+  const base = {
+    schemaVersion: 1,
+    protocolVersion: "1.0.0",
+    messageType: "heartbeat",
+    agentId: "agent-1",
+    sentAt: new Date().toISOString(),
+    body: { agentVersion: "0.1.0", ntpSynced: null, uptimeSeconds: null },
+  };
+
+  assert.deepEqual(validateEnvelopeShape({ ...base }), []);
+  assert.deepEqual(validateEnvelopeShape({ ...base, sequence: 1 }), []);
+  assert.deepEqual(validateEnvelopeShape({ ...base, sequence: 999 }), []);
+
+  for (const bad of [0, -1, 1.5, "2", null]) {
+    const problems = validateEnvelopeShape({ ...base, sequence: bad });
+    assert.equal(
+      problems.some((p) => p.includes("sequence")),
+      true,
+      `expected sequence problem for ${JSON.stringify(bad)}`,
+    );
+  }
 });
 
 test("jitteredDelay: stays within expected bounds across many samples", () => {

--- a/packages/agent/src/reload/index.js
+++ b/packages/agent/src/reload/index.js
@@ -38,6 +38,7 @@
  */
 
 const { execFile } = require("node:child_process");
+const { buildMinimalSubprocessEnv } = require("../exec-env");
 
 /**
  * Same set as the policy module's SHELL_METACHARACTER_PATTERN, duplicated
@@ -118,8 +119,10 @@ function runCommand(execFileImpl, argv, timeoutMs) {
       argv.slice(1),
       // shell: false is execFile's default, but it is set explicitly so
       // the no-shell invariant is visible at the call site and assertable
-      // in tests via execFileImpl stubs.
-      { shell: false, timeout: timeoutMs },
+      // in tests via execFileImpl stubs. env is the explicit minimal
+      // allowlist so agent secrets (e.g. the bootstrap token) never reach
+      // reload/validate commands.
+      { shell: false, timeout: timeoutMs, env: buildMinimalSubprocessEnv() },
       (error, stdout, stderr) => {
         if (!error) {
           resolve({

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "status": "agent-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes. The controller lane added only narrow cert-manager observation, provisioning intent, cluster-bound command, and just-in-time mutation-authorization surfaces. The agent protocol is implemented server-side: the four /api/v1/certops/agent routes are now live control-plane endpoints (register, heartbeat, claim, results) with Ed25519-signed job dispatch, single-use result nonces, and claim-ownership re-proof.",
   "namespacePolicy": {
@@ -10,7 +10,8 @@
       "notes": [
         "Human/dashboard surface. Inherits global session + workspace membership + frozen-workspace guards.",
         "Subject to CSRF protection like other workspace mutations.",
-        "The workspace kill-switch settings GET and PUT routes require a human cookie/session user; internal worker bearer credentials are not accepted."
+        "The workspace kill-switch settings GET and PUT routes require a human cookie/session user; internal worker bearer credentials are not accepted.",
+        "POST /jobs/bulk-renew queues renewal jobs for up to 100 managed certificates in one request through the same manual job-creation path as POST /jobs (manager role, kill switch, approval gate, payload validation). It responds with a partial-failure envelope: per-certificate successes and failures are reported item by item and never abort the batch."
       ]
     },
     "executor": {
@@ -63,6 +64,7 @@
       { "path": "/api/v1/workspaces/{id}/certops/settings", "method": "PUT" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs", "method": "POST" },
+      { "path": "/api/v1/workspaces/{id}/certops/jobs/bulk-renew", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/provision-intents", "method": "POST" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs/{jobId}", "method": "GET" },
       { "path": "/api/v1/workspaces/{id}/certops/jobs/{jobId}/log", "method": "GET" },

--- a/packages/contracts/certops/agent-protocol.schema.json
+++ b/packages/contracts/certops/agent-protocol.schema.json
@@ -42,6 +42,11 @@
       "type": ["integer", "null"],
       "description": "Agent-reported offset vs control-plane time, used for clock-drift detection. Present on heartbeat and result; optional elsewhere."
     },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Per-agent monotonically increasing message counter, enforced server-side when present (defense in depth on top of the single-use nonce replay ledger): the control plane rejects any message whose sequence does not exceed the last accepted one for this agent. The counter is not persisted across agent restarts; a successful register begins a new generation, so enforcement only rejects regressions within the current registered generation. Optional for backward compatibility with already-deployed agents that do not send it."
+    },
     "body": {
       "description": "Message-type-specific payload. Structurally validated against the matching *Body definition below via the if/then rules in `allOf`; each body definition is additionalProperties:false, so unconstrained extra fields are rejected per messageType.",
       "type": ["object", "null"]

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -3705,6 +3705,74 @@ paths:
               example:
                 error: CertOps workspace state is unavailable
                 code: CERTOPS_WORKSPACE_STATE_UNAVAILABLE
+  /api/v1/workspaces/{id}/certops/jobs/bulk-renew:
+    post:
+      tags: [CertOps]
+      summary: Bulk-create CertOps renewal jobs
+      operationId: bulkRenewCertOpsCertificates
+      description: >-
+        Queues a renew job for up to 100 managed certificates in one request.
+        Each certificate goes through the same manual job-creation path as
+        POST /jobs (manager role, workspace kill switch, approval gate,
+        payload validation), and jobs are always recorded with source "api".
+        The response is a partial-failure envelope: per-certificate successes
+        and failures are reported item by item and never abort the batch, so
+        the request returns 200 even when some or all items fail. Only
+        whole-request shape problems (malformed body, more than 100 ids,
+        non-UUID or duplicate ids) fail with 400. Private key or secret
+        material in the request body is rejected.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertOpsBulkRenewRequest"
+      responses:
+        "200":
+          description: Partial-failure envelope with per-certificate outcomes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsBulkRenewResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Workspace CertOps is paused; no items are attempted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: CertOps is paused for this workspace
+                code: CERTOPS_WORKSPACE_PAUSED
+        "422":
+          description: The request contained private-key or forbidden secret material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          description: Workspace pause state could not be read; new CertOps work is denied fail-closed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: CertOps workspace state is unavailable
+                code: CERTOPS_WORKSPACE_STATE_UNAVAILABLE
   /api/v1/workspaces/{id}/certops/provision-intents:
     post:
       tags: [CertOps Controller]
@@ -5611,6 +5679,96 @@ components:
         idempotencyKey:
           type: string
           maxLength: 128
+    CertOpsBulkRenewRequest:
+      type: object
+      additionalProperties: false
+      required: [certificateIds]
+      description: >-
+        Bulk renewal request. Each certificate id becomes one renew job
+        created through the same manual creation path as POST /jobs; source
+        is always forced to "api" by the server.
+      properties:
+        certificateIds:
+          type: array
+          minItems: 1
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: string
+            format: uuid
+        dryRun:
+          type: boolean
+          default: false
+          description: >-
+            True validates each certificate and reports per-item outcomes
+            without creating any jobs.
+        requiresApproval:
+          type: boolean
+          default: false
+          description: >-
+            True makes every created job start at pending_approval, matching
+            the per-job approval gate of single manual job creation.
+        payload:
+          allOf:
+            - $ref: "#/components/schemas/CertOpsPublicObject"
+          description: >-
+            Optional shared public payload merged into every created renew
+            job, accepting the same optional execution fields as a single
+            renew job. The server sets certificateId per item.
+    CertOpsBulkRenewResultItem:
+      type: object
+      additionalProperties: false
+      required: [certificateId, ok]
+      properties:
+        certificateId:
+          type: string
+          format: uuid
+        ok:
+          type: boolean
+        jobId:
+          type: string
+          format: uuid
+          description: Present only when ok is true and the request was not a dry run.
+        errorCode:
+          type: string
+          description: >-
+            Present only when ok is false. Uses the existing CertOps error
+            vocabulary (for example CERTOPS_CERTIFICATE_NOT_FOUND,
+            CERTOPS_JOB_INVALID, CERTOPS_WORKSPACE_PAUSED).
+        message:
+          type: string
+          description: Present only when ok is false.
+    CertOpsBulkRenewResponse:
+      type: object
+      additionalProperties: false
+      required: [summary, results]
+      description: >-
+        Partial-failure envelope for bulk renewal. Returned with HTTP 200
+        even when some or all items fail; consumers must inspect per-item
+        results.
+      properties:
+        summary:
+          type: object
+          additionalProperties: false
+          required: [requested, succeeded, failed]
+          properties:
+            requested:
+              type: integer
+              minimum: 1
+              maximum: 100
+            succeeded:
+              type: integer
+              minimum: 0
+            failed:
+              type: integer
+              minimum: 0
+        dryRun:
+          type: boolean
+          description: Present and true only for dry-run requests.
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsBulkRenewResultItem"
     CertOpsWorkspacePauseUpdateRequest:
       type: object
       additionalProperties: false

--- a/tests/contract/certops-agent-openapi.test.js
+++ b/tests/contract/certops-agent-openapi.test.js
@@ -221,7 +221,7 @@ describe("CertOps agent routes OpenAPI contract", () => {
 
 describe("CertOps route-compat contract (agent runtime)", () => {
   it("carries the agent-runtime version and status", () => {
-    assert.strictEqual(routeCompat.version, "0.14.0");
+    assert.strictEqual(routeCompat.version, "0.15.0");
     assert.strictEqual(routeCompat.status, "agent-runtime-stable");
   });
 

--- a/tests/e2e/certops-agent-e2e.test.js
+++ b/tests/e2e/certops-agent-e2e.test.js
@@ -801,4 +801,111 @@ describe("CertOps agent surface E2E", () => {
     assert.equal(rows[0].status, "failed");
     assert.equal(rows[0].error_code, "agent_offline");
   });
+
+  it("sequence enforcement: monotonic accepted, regression 409, re-register resets the generation, sequence-less accepted", async (t) => {
+    if (!dbAvailable) return t.skip(skipReason);
+
+    const agentId = `e2e-agent-${RUN_ID}-seq`;
+    const lastSequenceOf = async () => {
+      const { rows } = await pool.query(
+        `SELECT last_sequence FROM certops_agents WHERE agent_id = $1`,
+        [agentId],
+      );
+      return Number(rows[0].last_sequence);
+    };
+
+    // Register with a sequence: the new generation starts at that value.
+    const boot1 = await createBootstrap();
+    const reg1 = await postAgent(
+      "register",
+      boot1.plaintextToken,
+      envelope(
+        "register",
+        agentId,
+        { bootstrapTokenId: String(boot1.token.id), agentVersion: "1.0.0" },
+        { sequence: 3 },
+      ),
+    );
+    assert.equal(reg1.status, 201, JSON.stringify(reg1.body));
+    assert.equal(await lastSequenceOf(), 3);
+
+    const heartbeatWith = (sequence) =>
+      postAgent(
+        "heartbeat",
+        reg1.body.credential,
+        envelope(
+          "heartbeat",
+          agentId,
+          { agentVersion: "1.0.0" },
+          sequence === undefined ? {} : { sequence },
+        ),
+      );
+
+    // Normal increasing sequence is accepted.
+    const hb4 = await heartbeatWith(4);
+    assert.equal(hb4.status, 200, JSON.stringify(hb4.body));
+    assert.equal(await lastSequenceOf(), 4);
+
+    // Replayed (equal) and lower sequences are rejected with 409 and do not
+    // move the high-water mark.
+    for (const stale of [4, 2]) {
+      const rejected = await heartbeatWith(stale);
+      assert.equal(rejected.status, 409, JSON.stringify(rejected.body));
+      assert.equal(rejected.body.code, "CERTOPS_AGENT_SEQUENCE_REGRESSION");
+    }
+    assert.equal(await lastSequenceOf(), 4);
+
+    // A claim poll also participates in the same per-agent counter.
+    const claim = await postAgent(
+      "jobs/claim",
+      reg1.body.credential,
+      envelope(
+        "claim",
+        agentId,
+        { maxJobs: 1, supportedActions: ["renew"] },
+        { sequence: 5 },
+      ),
+    );
+    assert.equal(claim.status, 200, JSON.stringify(claim.body));
+    assert.equal(await lastSequenceOf(), 5);
+
+    // Backward compatibility: an envelope without a sequence is processed
+    // as today and leaves last_sequence untouched.
+    const legacy = await heartbeatWith(undefined);
+    assert.equal(legacy.status, 200, JSON.stringify(legacy.body));
+    assert.equal(await lastSequenceOf(), 5);
+
+    // Re-register (decommission + fresh install with the same agentId):
+    // registration begins a new generation, so a low restarted counter is
+    // accepted again. All FKs to certops_agents are ON DELETE SET NULL.
+    await pool.query(`DELETE FROM certops_agents WHERE agent_id = $1`, [
+      agentId,
+    ]);
+    const boot2 = await createBootstrap();
+    const reg2 = await postAgent(
+      "register",
+      boot2.plaintextToken,
+      envelope(
+        "register",
+        agentId,
+        { bootstrapTokenId: String(boot2.token.id), agentVersion: "1.0.0" },
+        { sequence: 1 },
+      ),
+    );
+    assert.equal(reg2.status, 201, JSON.stringify(reg2.body));
+    assert.equal(await lastSequenceOf(), 1);
+
+    const restarted = await postAgent(
+      "heartbeat",
+      reg2.body.credential,
+      envelope(
+        "heartbeat",
+        agentId,
+        { agentVersion: "1.0.0" },
+        { sequence: 2 },
+      ),
+    );
+    assert.equal(restarted.status, 200, JSON.stringify(restarted.body));
+    assert.equal(await lastSequenceOf(), 2);
+  });
 });

--- a/tests/unit/certops-agent-dispatch.test.js
+++ b/tests/unit/certops-agent-dispatch.test.js
@@ -126,10 +126,11 @@ describe("agentDispatch.enforceAgentSequence", () => {
     );
   });
 
-  it("is a no-op for envelopes without a sequence (legacy agents)", async () => {
+  it("accepts a sequence-less envelope only while the agent has never sequenced", async () => {
     const client = {
-      query: async () => {
-        throw new Error("no query expected for a sequence-less envelope");
+      query: async (sql) => {
+        assert.match(sql, /SELECT last_sequence FROM certops_agents/);
+        return { rows: [{ last_sequence: 0 }] };
       },
     };
     await enforceAgentSequence({
@@ -142,6 +143,23 @@ describe("agentDispatch.enforceAgentSequence", () => {
       agentRowId: "agent-row-1",
       envelope: { sequence: 0 },
     });
+  });
+
+  it("rejects a sequence-less envelope once the agent has sent sequenced traffic (no-bypass)", async () => {
+    const client = {
+      query: async (sql) => {
+        assert.match(sql, /SELECT last_sequence FROM certops_agents/);
+        return { rows: [{ last_sequence: 12 }] };
+      },
+    };
+    await assert.rejects(
+      enforceAgentSequence({
+        client,
+        agentRowId: "agent-row-1",
+        envelope: {},
+      }),
+      (error) => error.code === CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
   });
 });
 
@@ -277,8 +295,7 @@ describe("agentDispatch.registerAgent", () => {
 describe("agentDispatch.recordHeartbeat", () => {
   it("recovers an offline agent to active and reports the signing key", async () => {
     const updates = [];
-    const dbPool = createMockPool(() => ({ rows: [] }));
-    dbPool.query = async (sql, params) => {
+    const dbPool = createMockPool((sql, params) => {
       updates.push({ sql, params });
       return {
         rows: [
@@ -289,7 +306,7 @@ describe("agentDispatch.recordHeartbeat", () => {
           },
         ],
       };
-    };
+    });
 
     const result = await recordHeartbeat({
       dbPool,
@@ -308,22 +325,26 @@ describe("agentDispatch.recordHeartbeat", () => {
     assert.equal(result.status, "active");
     assert.equal(result.signingKeyId, "key-1");
     assert.equal(result.signingPublicKeyPem, "pem");
-    assert.equal(updates.length, 1);
-    const sql = updates[0].sql;
+    const heartbeatWrites = updates.filter(({ sql }) =>
+      sql.includes("last_seen_at = NOW()"),
+    );
+    assert.equal(heartbeatWrites.length, 1);
+    const sql = heartbeatWrites[0].sql;
     assert.match(sql, /status = CASE WHEN status = 'offline' THEN 'active'/);
     assert.match(sql, /status <> 'retired'/);
     assert.match(sql, /last_seen_at = NOW\(\)/);
+    // The sequence bump and heartbeat write share one transaction.
+    assert.deepEqual(dbPool.state.transaction, ["BEGIN", "COMMIT"]);
   });
 
   it("rejects a sequence regression before any heartbeat write", async () => {
-    const dbPool = createMockPool(() => ({ rows: [] }));
-    dbPool.query = async (sql, params) => {
+    const dbPool = createMockPool((sql) => {
       if (sql.includes("SET last_sequence")) {
         // CAS matches zero rows: regression.
         return { rows: [] };
       }
       throw new Error(`no heartbeat write expected, got: ${sql}`);
-    };
+    });
 
     await assert.rejects(
       recordHeartbeat({
@@ -356,6 +377,10 @@ describe("agentDispatch.claimJobs", () => {
   it("claims pending jobs, sets lease fields, and returns signed payloads", async () => {
     let livenessUpdates = 0;
     const dbPool = createMockPool((sql, params) => {
+      if (sql.includes("SELECT last_sequence")) {
+        // Legacy (sequence-less) poll from an agent that never sequenced.
+        return { rows: [{ last_sequence: 0 }] };
+      }
       if (sql.includes("SET last_seen_at = NOW()")) {
         livenessUpdates += 1;
         assert.equal(params[0], "agent-row-1");
@@ -437,6 +462,9 @@ describe("agentDispatch.claimJobs", () => {
   it("honors CERTOPS_JOB_LEASE_SECONDS from env", async () => {
     let leaseParam = null;
     const dbPool = createMockPool((sql, params) => {
+      if (sql.includes("SELECT last_sequence")) {
+        return { rows: [{ last_sequence: 0 }] };
+      }
       if (sql.includes("SET last_seen_at = NOW()")) {
         return { rows: [] };
       }
@@ -475,6 +503,9 @@ describe("agentDispatch.claimJobs", () => {
 
   it("propagates the workspace kill switch and claims nothing", async () => {
     const dbPool = createMockPool((sql) => {
+      if (sql.includes("SELECT last_sequence")) {
+        return { rows: [{ last_sequence: 0 }] };
+      }
       throw new Error(`no job query expected, got: ${sql}`);
     });
     await assert.rejects(
@@ -499,6 +530,9 @@ describe("agentDispatch.claimJobs", () => {
 
   it("returns an empty set without selecting when supportedActions is empty", async () => {
     const dbPool = createMockPool((sql) => {
+      if (sql.includes("SELECT last_sequence")) {
+        return { rows: [{ last_sequence: 0 }] };
+      }
       if (sql.includes("SET last_seen_at = NOW()")) {
         return { rows: [] };
       }

--- a/tests/unit/certops-agent-dispatch.test.js
+++ b/tests/unit/certops-agent-dispatch.test.js
@@ -8,7 +8,9 @@ const {
   CERTOPS_AGENT_CLAIM_OWNERSHIP_MISMATCH,
   CERTOPS_AGENT_REGISTRATION_UNAUTHORIZED,
   CERTOPS_AGENT_RESULT_NONCE_REJECTED,
+  CERTOPS_AGENT_SEQUENCE_REGRESSION,
   claimJobs,
+  enforceAgentSequence,
   ingestResult,
   recordHeartbeat,
   registerAgent,
@@ -88,6 +90,60 @@ function registerBody() {
     declaredCommandProfileNames: ["nginx-reload"],
   };
 }
+
+describe("agentDispatch.enforceAgentSequence", () => {
+  it("accepts a strictly greater sequence via a single CAS UPDATE", async () => {
+    const queries = [];
+    const client = {
+      query: async (sql, params) => {
+        queries.push({ sql, params });
+        return { rows: [{ id: "agent-row-1" }] };
+      },
+    };
+    await enforceAgentSequence({
+      client,
+      agentRowId: "agent-row-1",
+      envelope: { sequence: 7 },
+    });
+    assert.equal(queries.length, 1);
+    assert.match(queries[0].sql, /SET last_sequence = \$2/);
+    assert.match(queries[0].sql, /last_sequence < \$2/);
+    assert.deepEqual(queries[0].params, ["agent-row-1", 7]);
+  });
+
+  it("rejects a replayed/lower sequence with CERTOPS_AGENT_SEQUENCE_REGRESSION", async () => {
+    const client = {
+      // Zero rows matched: stored last_sequence >= incoming sequence.
+      query: async () => ({ rows: [] }),
+    };
+    await assert.rejects(
+      enforceAgentSequence({
+        client,
+        agentRowId: "agent-row-1",
+        envelope: { sequence: 3 },
+      }),
+      (error) => error.code === CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
+  });
+
+  it("is a no-op for envelopes without a sequence (legacy agents)", async () => {
+    const client = {
+      query: async () => {
+        throw new Error("no query expected for a sequence-less envelope");
+      },
+    };
+    await enforceAgentSequence({
+      client,
+      agentRowId: "agent-row-1",
+      envelope: {},
+    });
+    await enforceAgentSequence({
+      client,
+      agentRowId: "agent-row-1",
+      envelope: { sequence: 0 },
+    });
+  });
+});
 
 describe("agentDispatch.registerAgent", () => {
   it("registers happy path: inserts row, consumes token, returns credential once", async () => {
@@ -172,6 +228,50 @@ describe("agentDispatch.registerAgent", () => {
     assert.deepEqual(dbPool.state.transaction, ["BEGIN", "ROLLBACK"]);
     assert.equal(dbPool.state.released, true);
   });
+
+  it("seeds last_sequence from the register envelope (new generation), 0 when absent", async () => {
+    const insertParams = [];
+    const makePool = () =>
+      createMockPool((sql, params) => {
+        if (sql.includes("INSERT INTO certops_agents")) {
+          insertParams.push(params);
+          return {
+            rows: [
+              { id: "agent-row-1", agent_id: "agent-01", protocol_version: "1.0.0" },
+            ],
+          };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+    const deps = {
+      ensureActiveSigningKey: async () => ({ signingKeyId: "key-1", publicKeyPem: "pem" }),
+      generateAgentCredential: () => ({
+        credentialPrefix: "ttagent_0123456789abcdef",
+        credentialHash: "hash",
+        plaintextCredential: "ttagent_x",
+      }),
+      consumeBootstrapToken: async () => ({ id: "boot-1" }),
+    };
+
+    await registerAgent({
+      dbPool: makePool(),
+      bootstrapToken: { id: "boot-1", workspaceId: WORKSPACE_A },
+      envelope: { ...registerEnvelope(), sequence: 5 },
+      body: registerBody(),
+      deps,
+    });
+    await registerAgent({
+      dbPool: makePool(),
+      bootstrapToken: { id: "boot-1", workspaceId: WORKSPACE_A },
+      envelope: registerEnvelope(),
+      body: registerBody(),
+      deps,
+    });
+
+    // last_sequence is the 14th insert parameter.
+    assert.equal(insertParams[0][13], 5);
+    assert.equal(insertParams[1][13], 0);
+  });
 });
 
 describe("agentDispatch.recordHeartbeat", () => {
@@ -213,6 +313,30 @@ describe("agentDispatch.recordHeartbeat", () => {
     assert.match(sql, /status = CASE WHEN status = 'offline' THEN 'active'/);
     assert.match(sql, /status <> 'retired'/);
     assert.match(sql, /last_seen_at = NOW\(\)/);
+  });
+
+  it("rejects a sequence regression before any heartbeat write", async () => {
+    const dbPool = createMockPool(() => ({ rows: [] }));
+    dbPool.query = async (sql, params) => {
+      if (sql.includes("SET last_sequence")) {
+        // CAS matches zero rows: regression.
+        return { rows: [] };
+      }
+      throw new Error(`no heartbeat write expected, got: ${sql}`);
+    };
+
+    await assert.rejects(
+      recordHeartbeat({
+        dbPool,
+        agent: agentFixture(),
+        envelope: { clockOffsetMs: null, sequence: 2 },
+        body: { agentVersion: "0.1.0" },
+        deps: {
+          getActiveSigningKeyPublicInfo: async () => null,
+        },
+      }),
+      (error) => error.code === CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
   });
 });
 
@@ -390,6 +514,63 @@ describe("agentDispatch.claimJobs", () => {
     assert.deepEqual(result, { jobs: [] });
     assert.deepEqual(dbPool.state.transaction, ["BEGIN", "COMMIT"]);
   });
+
+  it("rejects a sequence regression before locking the workspace or claiming", async () => {
+    let workspaceLocked = false;
+    const dbPool = createMockPool((sql) => {
+      if (sql.includes("SET last_sequence")) {
+        return { rows: [] };
+      }
+      throw new Error(`no job query expected, got: ${sql}`);
+    });
+    await assert.rejects(
+      claimJobs({
+        dbPool,
+        agent: agentFixture(),
+        envelope: { sequence: 1 },
+        body: { maxJobs: 1, supportedActions: ["renew"] },
+        env: {},
+        deps: {
+          ...CLAIM_DEPS_BASE,
+          lockWorkspaceForCertOpsSideEffect: async () => {
+            workspaceLocked = true;
+            return { locked: true };
+          },
+        },
+      }),
+      (error) => error.code === CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
+    assert.equal(workspaceLocked, false);
+    assert.deepEqual(dbPool.state.transaction, ["BEGIN", "ROLLBACK"]);
+  });
+
+  it("accepts an increasing sequence and proceeds with the claim", async () => {
+    let casParams = null;
+    const dbPool = createMockPool((sql, params) => {
+      if (sql.includes("SET last_sequence")) {
+        casParams = params;
+        return { rows: [{ id: "agent-row-1" }] };
+      }
+      if (sql.includes("SET last_seen_at = NOW()")) {
+        return { rows: [] };
+      }
+      if (sql.includes("FOR UPDATE SKIP LOCKED")) {
+        return { rows: [] };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const result = await claimJobs({
+      dbPool,
+      agent: agentFixture(),
+      envelope: { sequence: 9 },
+      body: { maxJobs: 1, supportedActions: ["renew"] },
+      env: {},
+      deps: CLAIM_DEPS_BASE,
+    });
+    assert.deepEqual(result, { jobs: [] });
+    assert.deepEqual(casParams, ["agent-row-1", 9]);
+    assert.deepEqual(dbPool.state.transaction, ["BEGIN", "COMMIT"]);
+  });
 });
 
 describe("agentDispatch.ingestResult", () => {
@@ -534,5 +715,69 @@ describe("agentDispatch.ingestResult", () => {
     assert.equal(result.errorCode, null);
     assert.equal(updateParams[2], null);
     assert.equal(updateParams[3], null);
+  });
+
+  it("rejects a sequence regression after nonce consumption and rolls the whole transaction back", async () => {
+    let nonceConsumed = false;
+    const dbPool = createMockPool((sql) => {
+      if (sql.includes("FOR UPDATE")) return { rows: [lockedJobRow()] };
+      if (sql.includes("SET last_sequence")) {
+        // Check ordering: auth (route), nonce replay, then sequence.
+        assert.equal(nonceConsumed, true, "nonce must be checked before sequence");
+        return { rows: [] };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    await assert.rejects(
+      ingestResult({
+        dbPool,
+        agent: agentFixture(),
+        envelope: { sequence: 4 },
+        body: resultBody(),
+        deps: {
+          consumeNonce: async () => {
+            nonceConsumed = true;
+            return { consumed: true };
+          },
+        },
+      }),
+      (error) => error.code === CERTOPS_AGENT_SEQUENCE_REGRESSION,
+    );
+    // Rollback also un-consumes the nonce ledger write for this message.
+    assert.deepEqual(dbPool.state.transaction, ["BEGIN", "ROLLBACK"]);
+  });
+
+  it("accepts an increasing sequence and completes result ingestion", async () => {
+    let casParams = null;
+    const dbPool = createMockPool((sql, params) => {
+      if (sql.includes("FOR UPDATE")) return { rows: [lockedJobRow()] };
+      if (sql.includes("SET last_sequence")) {
+        casParams = params;
+        return { rows: [{ id: "agent-row-1" }] };
+      }
+      if (sql.includes("UPDATE certificate_jobs")) {
+        return {
+          rows: [
+            {
+              id: 42,
+              status: "failed",
+              error_code: params[2],
+              completed_at: new Date(),
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const result = await ingestResult({
+      dbPool,
+      agent: agentFixture(),
+      envelope: { sequence: 11 },
+      body: resultBody(),
+      deps: { consumeNonce: async () => ({ consumed: true }) },
+    });
+    assert.equal(result.status, "failed");
+    assert.deepEqual(casParams, ["agent-row-1", 11]);
+    assert.deepEqual(dbPool.state.transaction, ["BEGIN", "COMMIT"]);
   });
 });

--- a/tests/unit/certops-agent-protocol-contracts.test.js
+++ b/tests/unit/certops-agent-protocol-contracts.test.js
@@ -310,6 +310,42 @@ describe("CertOps agent protocol contracts", () => {
     );
   });
 
+  it("treats the sequence counter as optional and bounded (integer >= 1)", () => {
+    const validate = createAjv().getSchema(agentProtocolSchema.$id);
+
+    for (const [messageType, build] of Object.entries(VALID_MESSAGES)) {
+      // Absent: backward compatible with already-deployed agents.
+      assert.equal(
+        validate(build()),
+        true,
+        `${messageType} without sequence must stay valid`,
+      );
+      assert.equal(
+        validate({ ...build(), sequence: 1 }),
+        true,
+        `${messageType} with sequence 1 must be valid`,
+      );
+    }
+
+    for (const badSequence of [0, -1, 1.5, "2", null]) {
+      assert.equal(
+        validate({ ...VALID_MESSAGES.heartbeat(), sequence: badSequence }),
+        false,
+        `sequence ${JSON.stringify(badSequence)} must be rejected`,
+      );
+    }
+
+    // The agent module's local envelope check must agree with the schema.
+    assert.deepEqual(
+      validateEnvelopeShape({ ...VALID_MESSAGES.claim(), sequence: 3 }),
+      [],
+    );
+    assert.ok(
+      validateEnvelopeShape({ ...VALID_MESSAGES.claim(), sequence: 0 }).length >
+        0,
+    );
+  });
+
   it("enforces per-messageType body required fields", () => {
     const validate = createAjv().getSchema(agentProtocolSchema.$id);
 

--- a/tests/unit/certops-agent-routes.test.js
+++ b/tests/unit/certops-agent-routes.test.js
@@ -462,6 +462,7 @@ describe("Results handler", () => {
       },
       res,
       {
+        enforceAgentSequence: async () => {},
         ingestResult: async () => {
           ingestCalled = true;
           throw new Error("must not be called for evidence");
@@ -507,6 +508,7 @@ describe("Results handler", () => {
       },
       res,
       {
+        enforceAgentSequence: async () => {},
         assertEvidenceClaimOwnership: async () => {
           const error = new Error(
             "Evidence does not match the claim for this job",

--- a/tests/unit/certops-agent-routes.test.js
+++ b/tests/unit/certops-agent-routes.test.js
@@ -283,6 +283,39 @@ describe("Heartbeat handler", () => {
     assert.equal(res.statusCode, 400);
     assert.equal(res.body.code, "CERTOPS_AGENT_MESSAGE_INVALID");
   });
+
+  it("rejects an invalid sequence field with 400 before the service runs", async () => {
+    let serviceCalled = false;
+    for (const badSequence of [0, -3, 1.5, "7", null]) {
+      const res = createResponse();
+      const body = envelope("heartbeat", { agentVersion: "0.1.0" });
+      body.sequence = badSequence;
+      await _test.heartbeatHandler({ certopsAgent: agentFixture(), body }, res, {
+        recordHeartbeat: async () => {
+          serviceCalled = true;
+          return { ok: true };
+        },
+      });
+      assert.equal(res.statusCode, 400, `sequence ${JSON.stringify(badSequence)}`);
+      assert.equal(res.body.code, "CERTOPS_AGENT_MESSAGE_INVALID");
+    }
+    assert.equal(serviceCalled, false);
+  });
+
+  it("maps a sequence regression from the service to 409", async () => {
+    const res = createResponse();
+    const body = envelope("heartbeat", { agentVersion: "0.1.0" });
+    body.sequence = 2;
+    await _test.heartbeatHandler({ certopsAgent: agentFixture(), body }, res, {
+      recordHeartbeat: async () => {
+        const error = new Error("regression");
+        error.code = "CERTOPS_AGENT_SEQUENCE_REGRESSION";
+        throw error;
+      },
+    });
+    assert.equal(res.statusCode, 409);
+    assert.equal(res.body.code, "CERTOPS_AGENT_SEQUENCE_REGRESSION");
+  });
 });
 
 describe("Claim handler", () => {
@@ -490,6 +523,58 @@ describe("Results handler", () => {
     assert.equal(res.statusCode, 409);
     assert.equal(res.body.code, "CERTOPS_AGENT_CLAIM_OWNERSHIP_MISMATCH");
     assert.equal(persisted, false);
+  });
+
+  it("evidence path enforces the sequence before appending and maps regression to 409", async () => {
+    const res = createResponse();
+    let evidenceAppended = false;
+    const body = envelope("evidence", {
+      jobId: "42",
+      evidenceItems: [
+        {
+          eventType: "certificate.observed",
+          observedAt: "2026-07-22T10:00:00.000Z",
+        },
+      ],
+    });
+    body.sequence = 5;
+    await _test.resultsHandler({ certopsAgent: agentFixture(), body }, res, {
+      enforceAgentSequence: async ({ agentRowId, envelope: seen }) => {
+        assert.equal(agentRowId, "agent-row-1");
+        assert.equal(seen.sequence, 5);
+        const error = new Error("regression");
+        error.code = "CERTOPS_AGENT_SEQUENCE_REGRESSION";
+        throw error;
+      },
+      createCertificateEvidence: async () => {
+        evidenceAppended = true;
+        return { id: "ev-1" };
+      },
+    });
+    assert.equal(res.statusCode, 409);
+    assert.equal(res.body.code, "CERTOPS_AGENT_SEQUENCE_REGRESSION");
+    assert.equal(evidenceAppended, false);
+  });
+
+  it("passes the envelope through to ingestResult for sequence enforcement", async () => {
+    const res = createResponse();
+    let seenEnvelope = null;
+    const body = envelope("result", {
+      jobId: "42",
+      attemptId: "claim-1",
+      claimId: "claim-1",
+      nonce: "n-1",
+      status: "succeeded",
+    });
+    body.sequence = 8;
+    await _test.resultsHandler({ certopsAgent: agentFixture(), body }, res, {
+      ingestResult: async ({ envelope: env }) => {
+        seenEnvelope = env;
+        return { ok: true, jobId: "42", status: "succeeded" };
+      },
+    });
+    assert.equal(res.statusCode, 200);
+    assert.equal(seenEnvelope.sequence, 8);
   });
 });
 

--- a/tests/unit/certops-bulk-renew-route.test.js
+++ b/tests/unit/certops-bulk-renew-route.test.js
@@ -182,6 +182,7 @@ describe("CertOps bulk-renew route", () => {
     const handler = bulkRenewCertificatesHandler({
       certificateLoader: async ({ certId }) =>
         certId === uuid(2) ? null : { id: certId },
+      activeJobFinder: async () => null,
       manualJobCreator: async () => {
         creatorCalls += 1;
         return { job: { id: "must-not-exist" } };

--- a/tests/unit/certops-bulk-renew-route.test.js
+++ b/tests/unit/certops-bulk-renew-route.test.js
@@ -1,0 +1,297 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const certOpsRouter = require(
+  path.resolve(__dirname, "../../apps/api/routes/certops.js"),
+);
+const { NOT_FOUND_RESPONSE } = require(
+  path.resolve(
+    __dirname,
+    "../../apps/api/middleware/require-certops-enabled.js",
+  ),
+);
+const { CERTOPS_DISABLED } = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/settings.js"),
+);
+const { CERTOPS_WORKSPACE_PAUSED } = require(
+  path.resolve(
+    __dirname,
+    "../../apps/api/services/certops/workspaceKillSwitch.js",
+  ),
+);
+const { CERTOPS_CERTIFICATE_NOT_FOUND } = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/inventory.js"),
+);
+const { CERTOPS_JOB_INVALID } = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+);
+
+const { bulkRenewCertificatesHandler, parseBulkRenewRequest } =
+  certOpsRouter._test;
+
+function uuid(n) {
+  return `aaaaaaaa-0000-4000-8000-${String(n).padStart(12, "0")}`;
+}
+
+function responseRecorder() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+function makeRequest(body) {
+  return {
+    workspace: { id: "workspace-1" },
+    user: { id: 42 },
+    body,
+  };
+}
+
+describe("CertOps bulk-renew route", () => {
+  it("creates a renew job per certificate and reports an all-success envelope", async () => {
+    const creatorCalls = [];
+    let jobCounter = 0;
+    const handler = bulkRenewCertificatesHandler({
+      certificateLoader: async () => ({ id: "found" }),
+      manualJobCreator: async (options) => {
+        creatorCalls.push(options);
+        jobCounter += 1;
+        return { job: { id: `job-${jobCounter}` } };
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({ certificateIds: [uuid(1), uuid(2), uuid(3)] }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body.summary, {
+      requested: 3,
+      succeeded: 3,
+      failed: 0,
+    });
+    assert.ok(!("dryRun" in res.body));
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true, jobId: "job-1" },
+      { certificateId: uuid(2), ok: true, jobId: "job-2" },
+      { certificateId: uuid(3), ok: true, jobId: "job-3" },
+    ]);
+
+    assert.strictEqual(creatorCalls.length, 3);
+    for (const [index, call] of creatorCalls.entries()) {
+      assert.strictEqual(call.workspaceId, "workspace-1");
+      assert.strictEqual(call.operation, "renew");
+      assert.strictEqual(call.subjectType, "managed_certificate");
+      assert.strictEqual(call.subjectId, uuid(index + 1));
+      assert.strictEqual(call.payload.certificateId, uuid(index + 1));
+      assert.strictEqual(call.source, "api");
+      assert.strictEqual(call.requiresApproval, false);
+      assert.strictEqual(call.requestedByUserId, 42);
+      assert.strictEqual(call.actorUserId, 42);
+    }
+  });
+
+  it("reports a mixed envelope where item failures never abort the batch", async () => {
+    const handler = bulkRenewCertificatesHandler({
+      certificateLoader: async ({ certId }) =>
+        certId === uuid(2) ? null : { id: certId },
+      manualJobCreator: async ({ subjectId }) => {
+        if (subjectId === uuid(3)) {
+          const err = new Error("CertOps is paused for this workspace");
+          err.code = CERTOPS_WORKSPACE_PAUSED;
+          throw err;
+        }
+        if (subjectId === uuid(4)) {
+          throw new Error("connection reset");
+        }
+        return { job: { id: "job-ok" } };
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({
+        certificateIds: [uuid(1), uuid(2), uuid(3), uuid(4), uuid(5)],
+      }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body.summary, {
+      requested: 5,
+      succeeded: 2,
+      failed: 3,
+    });
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true, jobId: "job-ok" },
+      {
+        certificateId: uuid(2),
+        ok: false,
+        errorCode: CERTOPS_CERTIFICATE_NOT_FOUND,
+        message: "Certificate not found",
+      },
+      {
+        certificateId: uuid(3),
+        ok: false,
+        errorCode: CERTOPS_WORKSPACE_PAUSED,
+        message: "CertOps is paused for this workspace",
+      },
+      {
+        certificateId: uuid(4),
+        ok: false,
+        errorCode: "INTERNAL_ERROR",
+        message: "Failed to create CertOps job",
+      },
+      { certificateId: uuid(5), ok: true, jobId: "job-ok" },
+    ]);
+  });
+
+  it("keeps the disabled-rollout 404 posture instead of a per-item failure", async () => {
+    const handler = bulkRenewCertificatesHandler({
+      certificateLoader: async () => ({ id: "found" }),
+      manualJobCreator: async () => {
+        const err = new Error("CertOps is not enabled");
+        err.code = CERTOPS_DISABLED;
+        throw err;
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(makeRequest({ certificateIds: [uuid(1)] }), res);
+
+    assert.strictEqual(res.statusCode, 404);
+    assert.deepStrictEqual(res.body, NOT_FOUND_RESPONSE);
+  });
+
+  it("validates and reports without creating jobs on dryRun", async () => {
+    let creatorCalls = 0;
+    const handler = bulkRenewCertificatesHandler({
+      certificateLoader: async ({ certId }) =>
+        certId === uuid(2) ? null : { id: certId },
+      manualJobCreator: async () => {
+        creatorCalls += 1;
+        return { job: { id: "must-not-exist" } };
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({ certificateIds: [uuid(1), uuid(2)], dryRun: true }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(creatorCalls, 0);
+    assert.strictEqual(res.body.dryRun, true);
+    assert.deepStrictEqual(res.body.summary, {
+      requested: 2,
+      succeeded: 1,
+      failed: 1,
+    });
+    assert.deepStrictEqual(res.body.results[0], {
+      certificateId: uuid(1),
+      ok: true,
+    });
+    assert.strictEqual(res.body.results[1].ok, false);
+  });
+
+  it("passes requiresApproval and shared payload through to the service path", async () => {
+    const creatorCalls = [];
+    const handler = bulkRenewCertificatesHandler({
+      certificateLoader: async () => ({ id: "found" }),
+      manualJobCreator: async (options) => {
+        creatorCalls.push(options);
+        return { job: { id: "job-1" } };
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({
+        certificateIds: [uuid(1)],
+        requiresApproval: true,
+        payload: { caEndpoint: "https://ca.example.com/acme" },
+      }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(creatorCalls[0].requiresApproval, true);
+    assert.deepStrictEqual(creatorCalls[0].payload, {
+      caEndpoint: "https://ca.example.com/acme",
+      certificateId: uuid(1),
+    });
+  });
+
+  it("rejects whole-request shape problems with 400 before any item runs", async () => {
+    const badBodies = [
+      undefined,
+      null,
+      [],
+      {},
+      { certificateIds: [] },
+      { certificateIds: "not-an-array" },
+      { certificateIds: [uuid(1), "not-a-uuid"] },
+      { certificateIds: [uuid(1), 7] },
+      { certificateIds: [uuid(1), uuid(1)] },
+      { certificateIds: Array.from({ length: 101 }, (_, i) => uuid(i + 1)) },
+      { certificateIds: [uuid(1)], dryRun: "yes" },
+      { certificateIds: [uuid(1)], requiresApproval: "yes" },
+      { certificateIds: [uuid(1)], payload: [] },
+      { certificateIds: [uuid(1)], payload: null },
+      { certificateIds: [uuid(1)], operation: "revoke" },
+    ];
+
+    for (const body of badBodies) {
+      const handler = bulkRenewCertificatesHandler({
+        certificateLoader: async () => {
+          throw new Error("loader must not run on a 400 request");
+        },
+        manualJobCreator: async () => {
+          throw new Error("creator must not run on a 400 request");
+        },
+      });
+      const res = responseRecorder();
+      await handler(makeRequest(body), res);
+
+      assert.strictEqual(
+        res.statusCode,
+        400,
+        `expected 400 for body ${JSON.stringify(body)}`,
+      );
+      assert.strictEqual(res.body.code, CERTOPS_JOB_INVALID);
+    }
+  });
+
+  it("dedupes case-insensitively and caps ids at 100", () => {
+    const duplicate = parseBulkRenewRequest({
+      certificateIds: [uuid(1), uuid(1).toUpperCase()],
+    });
+    assert.match(duplicate.error, /duplicates/);
+
+    const atCap = parseBulkRenewRequest({
+      certificateIds: Array.from({ length: 100 }, (_, i) => uuid(i + 1)),
+    });
+    assert.strictEqual(atCap.error, undefined);
+    assert.strictEqual(atCap.certificateIds.length, 100);
+
+    const mixedCase = parseBulkRenewRequest({
+      certificateIds: [uuid(1).toUpperCase()],
+    });
+    assert.deepStrictEqual(mixedCase.certificateIds, [uuid(1)]);
+  });
+});

--- a/tests/unit/certops-renewal-scheduler.test.js
+++ b/tests/unit/certops-renewal-scheduler.test.js
@@ -8,6 +8,7 @@ const {
   DEFAULT_RENEWAL_PER_CA_CAP,
   DEFAULT_RENEWAL_THRESHOLD_DAYS,
   UNKNOWN_CA_BUCKET,
+  caCapKey,
   certificateCaBucket,
   countInFlightRenewalJobsByCaEndpoint,
   findCertificatesDueForRenewal,
@@ -91,6 +92,12 @@ function createSchedulerPool({
             normalized === "ROLLBACK"
           ) {
             return { rows: [] };
+          }
+          if (normalized.includes("pg_try_advisory_lock")) {
+            return { rows: [{ acquired: true }] };
+          }
+          if (normalized.includes("pg_advisory_unlock")) {
+            return { rows: [{ pg_advisory_unlock: true }] };
           }
           if (normalized.startsWith("SELECT id, certops_paused FROM workspaces")) {
             return {
@@ -205,8 +212,9 @@ describe("certops renewal scheduler", () => {
     assert.ok(!("keyRotation" in job.payload));
 
     // The job creation transaction acquires the workspace kill-switch lock
-    // (FOR SHARE) before the insert and commits afterwards.
-    const client = pool.clients[0];
+    // (FOR SHARE) before the insert and commits afterwards. clients[0] is
+    // the sweep's advisory-lock client; clients[1] is the job transaction.
+    const client = pool.clients[1];
     const sqls = client.queries.map((q) => q.sql);
     assert.strictEqual(sqls[0], "BEGIN");
     assert.ok(
@@ -278,7 +286,9 @@ describe("certops renewal scheduler", () => {
       ["cert-ok"],
     );
 
-    const pausedClient = pool.clients[0];
+    // clients[0] is the advisory-lock client; the paused cert's transaction
+    // is the first job client after it.
+    const pausedClient = pool.clients[1];
     const pausedSqls = pausedClient.queries.map((q) => q.sql);
     assert.ok(pausedSqls.includes("ROLLBACK"));
     assert.ok(!pausedSqls.includes("COMMIT"));
@@ -396,8 +406,18 @@ describe("certops renewal scheduler", () => {
   it("counts in-flight renew jobs per payload caEndpoint with an unknown bucket", async () => {
     const pool = createSchedulerPool({
       inFlightRows: [
-        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 3 },
-        { ca_bucket: UNKNOWN_CA_BUCKET, in_flight: 2 },
+        {
+          workspace_id: "ws-1",
+          ca_endpoint: "https://ca-a.example.com/acme",
+          in_flight: 3,
+        },
+        { workspace_id: "ws-1", ca_endpoint: null, in_flight: 2 },
+        // Same CA, different representation: must merge into one bucket.
+        {
+          workspace_id: "ws-1",
+          ca_endpoint: "HTTPS://CA-A.example.com/acme/",
+          in_flight: 1,
+        },
       ],
     });
 
@@ -406,19 +426,22 @@ describe("certops renewal scheduler", () => {
       terminalStatuses: ["succeeded", "failed"],
     });
 
-    assert.strictEqual(counts.get("https://ca-a.example.com/acme"), 3);
-    assert.strictEqual(counts.get(UNKNOWN_CA_BUCKET), 2);
+    assert.strictEqual(
+      counts.get(caCapKey("ws-1", "https://ca-a.example.com/acme")),
+      4,
+    );
+    assert.strictEqual(counts.get(caCapKey("ws-1", UNKNOWN_CA_BUCKET)), 2);
 
     const countQuery = pool.scanQueries.find((entry) =>
       entry.sql.includes("COUNT(*)"),
     );
     assert.ok(countQuery, "in-flight count query must run");
     assert.match(countQuery.sql, /FROM certificate_jobs cj/);
+    assert.match(countQuery.sql, /cj\.workspace_id/);
     assert.match(countQuery.sql, /cj\.operation = 'renew'/);
     assert.match(countQuery.sql, /NOT \(cj\.status = ANY\(\$1::text\[\]\)\)/);
     assert.match(countQuery.sql, /payload->>'caEndpoint'/);
     assert.deepStrictEqual(countQuery.params[0], ["succeeded", "failed"]);
-    assert.strictEqual(countQuery.params[1], UNKNOWN_CA_BUCKET);
   });
 
   it("creates jobs while a CA is under its in-flight cap", async () => {
@@ -429,7 +452,11 @@ describe("certops renewal scheduler", () => {
         }),
       ],
       inFlightRows: [
-        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 4 },
+        {
+          workspace_id: "ws-1",
+          ca_endpoint: "https://ca-a.example.com/acme",
+          in_flight: 4,
+        },
       ],
     });
     const createdJobs = [];
@@ -467,7 +494,11 @@ describe("certops renewal scheduler", () => {
         }),
       ],
       inFlightRows: [
-        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 5 },
+        {
+          workspace_id: "ws-1",
+          ca_endpoint: "https://ca-a.example.com/acme",
+          in_flight: 5,
+        },
       ],
     });
     const createdJobs = [];
@@ -494,7 +525,9 @@ describe("certops renewal scheduler", () => {
   it("caps certificates without a resolvable caEndpoint in a shared unknown bucket", async () => {
     const pool = createSchedulerPool({
       dueRows: [dueCertificate({ id: "cert-no-ca" })],
-      inFlightRows: [{ ca_bucket: UNKNOWN_CA_BUCKET, in_flight: 5 }],
+      inFlightRows: [
+        { workspace_id: "ws-1", ca_endpoint: null, in_flight: 5 },
+      ],
     });
 
     const summary = await runRenewalSchedulerSweep({

--- a/tests/unit/certops-renewal-scheduler.test.js
+++ b/tests/unit/certops-renewal-scheduler.test.js
@@ -5,9 +5,14 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 
 const {
+  DEFAULT_RENEWAL_PER_CA_CAP,
   DEFAULT_RENEWAL_THRESHOLD_DAYS,
+  UNKNOWN_CA_BUCKET,
+  certificateCaBucket,
+  countInFlightRenewalJobsByCaEndpoint,
   findCertificatesDueForRenewal,
   renewalIdempotencyKey,
+  resolveRenewalPerCaCap,
   resolveRenewalThresholdDays,
   runRenewalSchedulerSweep,
 } = require(
@@ -51,10 +56,13 @@ function dueCertificate(overrides = {}) {
 /**
  * Fake pool whose connect() yields transaction-recording clients. The scan
  * query result is injectable; workspace pause state controls the FOR SHARE
- * gate inside lockWorkspaceForCertOpsSideEffect.
+ * gate inside lockWorkspaceForCertOpsSideEffect. The per-CA in-flight count
+ * query is dispatched separately so tests can seed pre-existing in-flight
+ * jobs per CA bucket.
  */
 function createSchedulerPool({
   dueRows = [],
+  inFlightRows = [],
   pausedWorkspaces = new Set(),
 } = {}) {
   const clients = [];
@@ -63,7 +71,11 @@ function createSchedulerPool({
     clients,
     scanQueries,
     async query(sql, params) {
-      scanQueries.push({ sql: normalizeSql(sql), params });
+      const normalized = normalizeSql(sql);
+      scanQueries.push({ sql: normalized, params });
+      if (normalized.includes("COUNT(*)")) {
+        return { rows: inFlightRows };
+      }
       return { rows: dueRows };
     },
     async connect() {
@@ -325,5 +337,230 @@ describe("certops renewal scheduler", () => {
   it("exposes the pause and disabled error codes it relies on", () => {
     assert.strictEqual(CERTOPS_WORKSPACE_PAUSED, "CERTOPS_WORKSPACE_PAUSED");
     assert.strictEqual(CERTOPS_DISABLED, "CERTOPS_DISABLED");
+  });
+
+  it("resolves the per-CA cap from env with a default of 5", () => {
+    assert.strictEqual(resolveRenewalPerCaCap({}), 5);
+    assert.strictEqual(DEFAULT_RENEWAL_PER_CA_CAP, 5);
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: "2" }),
+      2,
+    );
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: " 12 " }),
+      12,
+    );
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: "0" }),
+      5,
+    );
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: "-3" }),
+      5,
+    );
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: "junk" }),
+      5,
+    );
+    assert.strictEqual(
+      resolveRenewalPerCaCap({ CERTOPS_RENEWAL_PER_CA_CAP: "" }),
+      5,
+    );
+  });
+
+  it("buckets certificates by metadata caEndpoint with profile fallback", () => {
+    assert.strictEqual(
+      certificateCaBucket({
+        certificate_ca_endpoint: "https://ca-a.example.com/acme",
+        profile_ca_endpoint: "https://ca-b.example.com/acme",
+      }),
+      "https://ca-a.example.com/acme",
+    );
+    assert.strictEqual(
+      certificateCaBucket({
+        certificate_ca_endpoint: null,
+        profile_ca_endpoint: " https://ca-b.example.com/acme ",
+      }),
+      "https://ca-b.example.com/acme",
+    );
+    assert.strictEqual(
+      certificateCaBucket({
+        certificate_ca_endpoint: null,
+        profile_ca_endpoint: null,
+      }),
+      UNKNOWN_CA_BUCKET,
+    );
+    assert.strictEqual(certificateCaBucket({}), UNKNOWN_CA_BUCKET);
+  });
+
+  it("counts in-flight renew jobs per payload caEndpoint with an unknown bucket", async () => {
+    const pool = createSchedulerPool({
+      inFlightRows: [
+        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 3 },
+        { ca_bucket: UNKNOWN_CA_BUCKET, in_flight: 2 },
+      ],
+    });
+
+    const counts = await countInFlightRenewalJobsByCaEndpoint({
+      db: pool,
+      terminalStatuses: ["succeeded", "failed"],
+    });
+
+    assert.strictEqual(counts.get("https://ca-a.example.com/acme"), 3);
+    assert.strictEqual(counts.get(UNKNOWN_CA_BUCKET), 2);
+
+    const countQuery = pool.scanQueries.find((entry) =>
+      entry.sql.includes("COUNT(*)"),
+    );
+    assert.ok(countQuery, "in-flight count query must run");
+    assert.match(countQuery.sql, /FROM certificate_jobs cj/);
+    assert.match(countQuery.sql, /cj\.operation = 'renew'/);
+    assert.match(countQuery.sql, /NOT \(cj\.status = ANY\(\$1::text\[\]\)\)/);
+    assert.match(countQuery.sql, /payload->>'caEndpoint'/);
+    assert.deepStrictEqual(countQuery.params[0], ["succeeded", "failed"]);
+    assert.strictEqual(countQuery.params[1], UNKNOWN_CA_BUCKET);
+  });
+
+  it("creates jobs while a CA is under its in-flight cap", async () => {
+    const pool = createSchedulerPool({
+      dueRows: [
+        dueCertificate({
+          certificate_ca_endpoint: "https://ca-a.example.com/acme",
+        }),
+      ],
+      inFlightRows: [
+        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 4 },
+      ],
+    });
+    const createdJobs = [];
+
+    const summary = await runRenewalSchedulerSweep({
+      dbPool: pool,
+      env: {},
+      jobCreator: async (options) => {
+        createdJobs.push(options);
+        return { job: { id: "job-1" }, created: true };
+      },
+    });
+
+    assert.strictEqual(summary.perCaCap, 5);
+    assert.strictEqual(summary.created, 1);
+    assert.strictEqual(summary.skippedByCaCap, 0);
+    // The scheduler stamps the resolved caEndpoint onto the job payload so
+    // later sweeps bucket this job under the same CA.
+    assert.strictEqual(
+      createdJobs[0].payload.caEndpoint,
+      "https://ca-a.example.com/acme",
+    );
+  });
+
+  it("skips and reports certificates whose CA is at the cap", async () => {
+    const pool = createSchedulerPool({
+      dueRows: [
+        dueCertificate({
+          id: "cert-capped",
+          certificate_ca_endpoint: "https://ca-a.example.com/acme",
+        }),
+        dueCertificate({
+          id: "cert-other-ca",
+          certificate_ca_endpoint: "https://ca-b.example.com/acme",
+        }),
+      ],
+      inFlightRows: [
+        { ca_bucket: "https://ca-a.example.com/acme", in_flight: 5 },
+      ],
+    });
+    const createdJobs = [];
+
+    const summary = await runRenewalSchedulerSweep({
+      dbPool: pool,
+      env: {},
+      jobCreator: async (options) => {
+        createdJobs.push(options);
+        return { job: { id: "job-1" }, created: true };
+      },
+    });
+
+    assert.strictEqual(summary.scanned, 2);
+    assert.strictEqual(summary.skippedByCaCap, 1);
+    assert.strictEqual(summary.created, 1);
+    assert.deepStrictEqual(summary.errors, []);
+    assert.deepStrictEqual(
+      createdJobs.map((job) => job.subjectId),
+      ["cert-other-ca"],
+    );
+  });
+
+  it("caps certificates without a resolvable caEndpoint in a shared unknown bucket", async () => {
+    const pool = createSchedulerPool({
+      dueRows: [dueCertificate({ id: "cert-no-ca" })],
+      inFlightRows: [{ ca_bucket: UNKNOWN_CA_BUCKET, in_flight: 5 }],
+    });
+
+    const summary = await runRenewalSchedulerSweep({
+      dbPool: pool,
+      env: {},
+      jobCreator: async () => {
+        throw new Error("job creation must not run for a capped bucket");
+      },
+    });
+
+    assert.strictEqual(summary.skippedByCaCap, 1);
+    assert.strictEqual(summary.created, 0);
+    assert.deepStrictEqual(summary.errors, []);
+  });
+
+  it("counts jobs it creates in the same sweep against the cap", async () => {
+    const pool = createSchedulerPool({
+      dueRows: [
+        dueCertificate({
+          id: "cert-first",
+          certificate_ca_endpoint: "https://ca-a.example.com/acme",
+        }),
+        dueCertificate({
+          id: "cert-second",
+          certificate_ca_endpoint: "https://ca-a.example.com/acme",
+        }),
+      ],
+      inFlightRows: [],
+    });
+    const createdJobs = [];
+
+    const summary = await runRenewalSchedulerSweep({
+      dbPool: pool,
+      env: { CERTOPS_RENEWAL_PER_CA_CAP: "1" },
+      jobCreator: async (options) => {
+        createdJobs.push(options);
+        return { job: { id: "job-1" }, created: true };
+      },
+    });
+
+    assert.strictEqual(summary.perCaCap, 1);
+    assert.strictEqual(summary.created, 1);
+    assert.strictEqual(summary.skippedByCaCap, 1);
+    assert.deepStrictEqual(
+      createdJobs.map((job) => job.subjectId),
+      ["cert-first"],
+    );
+  });
+
+  it("never stamps a non-URL metadata caEndpoint onto the job payload", async () => {
+    const pool = createSchedulerPool({
+      dueRows: [
+        dueCertificate({ certificate_ca_endpoint: "not a url" }),
+      ],
+    });
+    const createdJobs = [];
+
+    await runRenewalSchedulerSweep({
+      dbPool: pool,
+      env: {},
+      jobCreator: async (options) => {
+        createdJobs.push(options);
+        return { job: { id: "job-1" }, created: true };
+      },
+    });
+
+    assert.ok(!("caEndpoint" in createdJobs[0].payload));
   });
 });

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -132,6 +132,7 @@ describe("CertOps route hardening", () => {
       "POST /api/v1/workspaces/:id/certops/jobs",
       "POST /api/v1/workspaces/:id/certops/jobs/:jobId/approve",
       "POST /api/v1/workspaces/:id/certops/jobs/:jobId/reject",
+      "POST /api/v1/workspaces/:id/certops/jobs/bulk-renew",
       "POST /api/v1/workspaces/:id/certops/provision-intents",
       "POST /api/v1/workspaces/:id/certops/tokens",
       "POST /api/v1/workspaces/:id/certops/tokens/:tokenId/revoke",
@@ -158,6 +159,7 @@ describe("CertOps route hardening", () => {
       ["post", "/api/v1/workspaces/:id/certops/imports"],
       ["get", "/api/v1/workspaces/:id/certops/jobs"],
       ["post", "/api/v1/workspaces/:id/certops/jobs"],
+      ["post", "/api/v1/workspaces/:id/certops/jobs/bulk-renew"],
       ["post", "/api/v1/workspaces/:id/certops/provision-intents"],
       ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/log"],
       ["get", "/api/v1/workspaces/:id/certops/jobs/:jobId/evidence"],
@@ -268,6 +270,7 @@ describe("CertOps route hardening", () => {
       ["post", "/api/v1/workspaces/:id/certops/imports"],
       ["put", "/api/v1/workspaces/:id/certops/settings"],
       ["post", "/api/v1/workspaces/:id/certops/jobs"],
+      ["post", "/api/v1/workspaces/:id/certops/jobs/bulk-renew"],
       ["post", "/api/v1/workspaces/:id/certops/tokens"],
       ["post", "/api/v1/workspaces/:id/certops/tokens/:tokenId/revoke"],
     ]) {
@@ -315,6 +318,18 @@ describe("CertOps route hardening", () => {
       createBlock.indexOf("requireCertOpsWriteRole") <
         createBlock.indexOf("requireWorkspaceCertOpsActive"),
       "role authorization must run before the pause gate",
+    );
+
+    const bulkRenewBlock = routeBlock(
+      "post",
+      "/api/v1/workspaces/:id/certops/jobs/bulk-renew",
+    );
+    assert.match(bulkRenewBlock, /requireWorkspaceCertOpsActive/);
+    assert.match(bulkRenewBlock, /bulkRenewCertificatesHandler/);
+    assert.ok(
+      bulkRenewBlock.indexOf("requireCertOpsWriteRole") <
+        bulkRenewBlock.indexOf("requireWorkspaceCertOpsActive"),
+      "bulk renew role authorization must run before the pause gate",
     );
 
     for (const [method, routePath] of [


### PR DESCRIPTION
## Summary

Productization wave for the CertOps agent, stacked on #91.

- **Native DNS-01 solvers (11 providers)**: wave 1 - Cloudflare, AWS Route 53 (hand-rolled SigV4), Azure DNS, Google Cloud DNS (service-account JWT), RFC 2136/TSIG (native wire format), acme-dns; wave 2 - OVHcloud, Hetzner DNS, Infomaniak, Exoscale (EXO2-HMAC-SHA256), PowerDNS. All zero-dependency agent-side modules; OVH and Exoscale signing pinned by vector tests; PowerDNS merges TXT rrsets so parallel challenges are safe. A new `certops-dns-hook` executable lets certbot/acme.sh manual hooks drive them. Agent-local policy (`allowedDnsProviders` / `allowedDnsZones`) is enforced before any credential read or network call; DNS credentials stay in 0600 agent-local files and never reach the control plane (zero-custody). Provider responses are bounded and redacted before they can reach logs or evidence.
- **Agent onboarding surface**: hardened `install-agent.sh` (OS/arch + Node checks, dedicated system user, systemd unit with `ProtectSystem=strict`, `--dry-run` / `--uninstall`), a dashboard Deploy-an-agent panel (show-once bootstrap token, copyable install command, waiting-for-agent polling), and an Agent fleet panel (status, version, last heartbeat, retire with confirmation) on the CertOps operations page.
- **Per-agent monotonic sequence enforcement**: agents stamp an optional `sequence` on every protocol envelope; the control plane enforces it via atomic CAS on `certops_agents.last_sequence` (409 `CERTOPS_AGENT_SEQUENCE_REGRESSION` on regression, generation reset on re-register, sequence-less envelopes stay accepted). Defense in depth on top of the nonce replay cache; no new migration needed.
- **Per-CA renewal caps + bulk renew**: the renewal scheduler caps in-flight renewal jobs per CA endpoint at sweep time (`CERTOPS_RENEWAL_PER_CA_CAP`, default 5), and `POST /api/v1/workspaces/:id/certops/jobs/bulk-renew` renews many certificates through the same creation path as single renew jobs (validation, approval gates, kill switch all apply) with a partial-failure envelope.

Contracts: `agent-protocol.schema.json` gains the optional `sequence` envelope field; the route-compat contract is bumped to 0.15.0 for the bulk-renew route; OpenAPI documents the new endpoint. Engineering docs (`docs/certops/agent.md`, `CONTEXT.md`) cover the 11 DNS providers, credential file formats, hook usage, the installer flow, and the sequence field.

## Testing

- Core unit suite: 813/813 pass
- Agent package: 517 pass / 10 expected win32 skips (includes 60 new wave-2 provider tests and the OVH/Exoscale signing vectors)
- Dashboard: 167/167 pass (24 new panel tests) + build
- Agent E2E against live Postgres: 11/11 pass, including the new sequence scenario
- Contract suite 37/37, OpenAPI runtime coverage, contracts integrity, keygen ban, and secret-logging guards all green
- Lint: 0 errors