### PR TITLE
Release TokenTimer Core v0.10.2 with Auto-Sync Audit and Import Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-23
+
+### Added
+
+- **AUTO_SYNC_COMPLETED audit event for scheduled auto-sync runs** — the auto-sync worker now writes an audit event whenever a scheduled (planned) sync finishes with `success` or `partial` status, including provider, run status, scanned/imported item counts, and the config id. Previously only manual "run now" (`AUTO_SYNC_TRIGGERED`, written by the API) and failures (`AUTO_SYNC_FAILED`) left an audit trail, so worker-scheduled runs were invisible in the Audit log. The Audit page recognizes the new action in the action-type filter and renders its metadata (status, scanned, imported).
+
+### Fixed
+
+- **Import modal showed defaults instead of the saved auto-sync configuration** — reopening the GitLab or GitHub import view after configuring auto-sync now restores the saved base URL and all scan filters (token types, exclude regular-user PATs, include expired/revoked, GitHub include flags) from the stored `scan_params`, alongside the already-restored filter rules and cleanup setting. The token itself is never returned by the API and stays blank, with the "Credentials saved for auto-sync" placeholder. Previously only filter rules and the cleanup flag reached the form, so every other field silently fell back to its default.
+- **Revoked GitLab deploy tokens were still imported by scans** — GitLab hides revoked/deleted deploy tokens in its UI but the API still returns them (`revoked: true`), often with a still-valid `expires_at`, so they kept showing up in TokenTimer. The deploy-token scan now skips revoked entries unless the "Include revoked tokens" filter is enabled, matching PAT and project/group token behaviour.
+
+### Changed
+
+- Version metadata bumped to 0.10.2 across all manifests, contracts, and Helm chart.
+
 ## [0.10.1] - 2026-07-22
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/api/services/gitlabIntegration.js
+++ b/apps/api/services/gitlabIntegration.js
@@ -1088,6 +1088,16 @@ async function scanGitLab({
 
                 for (const dt of deployTokens) {
                   if (items.length >= maxItems) break;
+
+                  // GitLab hides revoked/deleted deploy tokens in its UI but
+                  // the API still returns them with revoked: true (their
+                  // expires_at can still be in the future). Skip them unless
+                  // the includeRevoked filter is enabled, matching PAT and
+                  // project/group token behaviour.
+                  if (dt.revoked === true && !filters.includeRevoked) {
+                    continue;
+                  }
+
                   const expiresAt = dt.expires_at
                     ? tryParseDate(dt.expires_at)
                     : null;

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -1017,6 +1017,7 @@ export default function ImportTokensModal({
 
   // Auto-sync state
   const [autoSyncConfig, setAutoSyncConfig] = React.useState(null); // null = not loaded, false = not exists, object = exists
+  const [restoredScanParams, setRestoredScanParams] = React.useState(null);
   const [restoredFilterRules, setRestoredFilterRules] = React.useState(null);
   const [restoredCleanupObsolete, setRestoredCleanupObsolete] =
     React.useState(null);
@@ -1071,6 +1072,10 @@ export default function ImportTokensModal({
         // Restore non-secret form fields from scan_params when auto-sync is already configured
         if (existing && existing.scan_params) {
           const sp = existing.scan_params;
+          // Forms (GitLab/GitHub) own their field state; hand them the full
+          // saved scan_params so reopening the modal shows the configured
+          // values instead of the defaults.
+          setRestoredScanParams(sp);
           setRestoredFilterRules(
             Array.isArray(sp.filterRules) ? sp.filterRules : null
           );
@@ -1159,9 +1164,11 @@ export default function ImportTokensModal({
           }
         } else if (source === 'aws') {
           setAwsAutoSyncScanParams(null);
+          setRestoredScanParams(null);
           setRestoredFilterRules(null);
           setRestoredCleanupObsolete(null);
         } else {
+          setRestoredScanParams(null);
           setRestoredFilterRules(null);
           setRestoredCleanupObsolete(null);
         }
@@ -2655,6 +2662,7 @@ export default function ImportTokensModal({
                   extractQuotaFromError={extractQuotaFromError}
                   autoSyncManageMode={autoSyncManageMode}
                   contactGroups={contactGroups}
+                  initialScanParams={restoredScanParams}
                   initialFilterRules={restoredFilterRules}
                   initialCleanupObsolete={restoredCleanupObsolete}
                 />
@@ -2686,6 +2694,7 @@ export default function ImportTokensModal({
                   formatQuotaError={formatQuotaError}
                   extractQuotaFromError={extractQuotaFromError}
                   contactGroups={contactGroups}
+                  initialScanParams={restoredScanParams}
                   initialFilterRules={restoredFilterRules}
                   initialCleanupObsolete={restoredCleanupObsolete}
                 />

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -98,6 +98,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
     contactGroups,
     onSelectionChange,
     autoSyncManageMode = false,
+    initialScanParams = null,
     initialFilterRules = null,
     initialCleanupObsolete = null,
   },
@@ -138,6 +139,22 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
       setFilterRules(initialFilterRules);
     }
   }, [initialFilterRules]);
+
+  // Restore base URL and include flags saved with the auto-sync config so
+  // reopening the modal shows the configured values instead of the defaults
+  // (the token itself is never returned by the API and stays blank).
+  React.useEffect(() => {
+    if (!initialScanParams) return;
+    const sp = initialScanParams;
+    if (sp.baseUrl) setGithubBaseUrl(sp.baseUrl);
+    const inc = sp.include;
+    if (!inc) return;
+    if (typeof inc.tokens === 'boolean') setGithubIncludeTokens(inc.tokens);
+    if (typeof inc.sshKeys === 'boolean') setGithubIncludeSSHKeys(inc.sshKeys);
+    if (typeof inc.deployKeys === 'boolean')
+      setGithubIncludeDeployKeys(inc.deployKeys);
+    if (typeof inc.secrets === 'boolean') setGithubIncludeSecrets(inc.secrets);
+  }, [initialScanParams]);
 
   React.useEffect(() => {
     if (typeof initialCleanupObsolete === 'boolean') {

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -93,6 +93,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
     contactGroups,
     onSelectionChange,
     autoSyncManageMode = false,
+    initialScanParams = null,
     initialFilterRules = null,
     initialCleanupObsolete = null,
   },
@@ -140,6 +141,34 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
       setFilterRules(initialFilterRules);
     }
   }, [initialFilterRules]);
+
+  // Restore base URL and scan filters saved with the auto-sync config so
+  // reopening the modal shows the configured values instead of the defaults
+  // (the token itself is never returned by the API and stays blank).
+  React.useEffect(() => {
+    if (!initialScanParams) return;
+    const sp = initialScanParams;
+    if (sp.baseUrl) setGitlabBaseUrl(sp.baseUrl);
+    const f = sp.filters;
+    if (!f) return;
+    if (typeof f.includePATs === 'boolean') setGitlabIncludePATs(f.includePATs);
+    if (typeof f.includeProjectTokens === 'boolean')
+      setGitlabIncludeProjectTokens(f.includeProjectTokens);
+    if (typeof f.includeGroupTokens === 'boolean')
+      setGitlabIncludeGroupTokens(f.includeGroupTokens);
+    if (typeof f.includeDeployTokens === 'boolean')
+      setGitlabIncludeDeployTokens(f.includeDeployTokens);
+    if (typeof f.includeTriggerTokens === 'boolean')
+      setGitlabIncludeTriggerTokens(f.includeTriggerTokens);
+    if (typeof f.includeSSHKeys === 'boolean')
+      setGitlabIncludeSSHKeys(f.includeSSHKeys);
+    if (typeof f.excludeUserPATs === 'boolean')
+      setGitlabExcludeUserPATs(f.excludeUserPATs);
+    if (typeof f.includeExpired === 'boolean')
+      setGitlabIncludeExpired(f.includeExpired);
+    if (typeof f.includeRevoked === 'boolean')
+      setGitlabIncludeRevoked(f.includeRevoked);
+  }, [initialScanParams]);
 
   React.useEffect(() => {
     if (typeof initialCleanupObsolete === 'boolean') {

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -159,6 +159,7 @@ const ALL_ACTION_TYPES = [
   'AUTO_SYNC_UPDATED',
   'AUTO_SYNC_DELETED',
   'AUTO_SYNC_TRIGGERED',
+  'AUTO_SYNC_COMPLETED',
   'AUTO_SYNC_FAILED',
   // WhatsApp
   'WHATSAPP_TEST_SENT',
@@ -1084,6 +1085,10 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       const md = ev?.metadata || {};
       const parts = [];
       if (md.provider) parts.push(`Provider: ${md.provider}`);
+      if (md.status) parts.push(`Status: ${md.status}`);
+      if (md.items_scanned != null) parts.push(`Scanned: ${md.items_scanned}`);
+      if (md.items_imported != null)
+        parts.push(`Imported: ${md.items_imported}`);
       if (md.error) parts.push(`Error: ${md.error}`);
       if (md.http_status != null) parts.push(`HTTP status: ${md.http_status}`);
       if (md.config_id) parts.push(`Config ID: ${md.config_id}`);
@@ -1269,6 +1274,7 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       action === 'AUTO_SYNC_UPDATED' ||
       action === 'AUTO_SYNC_DELETED' ||
       action === 'AUTO_SYNC_TRIGGERED' ||
+      action === 'AUTO_SYNC_COMPLETED' ||
       action === 'AUTO_SYNC_FAILED'
     ) {
       const formatted = formatAutoSyncMetadata(ev);

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -23,6 +23,7 @@ import axios from "axios";
 import { isAutoSyncProviderAllowed } from "./auto-sync-providers.js";
 import {
   formatAutoSyncError,
+  recordAutoSyncCompleted,
   recordAutoSyncFailure,
 } from "./shared/autoSyncFailure.js";
 
@@ -414,6 +415,19 @@ async function runAutoSync() {
              WHERE id = $5`,
             [syncStatus, syncError, importedCount, nextSync, id],
           );
+
+          // Scheduled runs must leave an audit trail like manual runs do
+          // (AUTO_SYNC_TRIGGERED is only written by the API "run now" path).
+          await recordAutoSyncCompleted(client, {
+            configId: id,
+            workspaceId: workspace_id,
+            provider,
+            createdBy,
+            status: syncStatus,
+            itemsScanned: itemsCount,
+            itemsImported: importedCount,
+            error: syncError,
+          });
 
           cAutoSync.inc({ provider, status: syncStatus });
           cAutoSyncItems.inc({ provider }, importedCount);

--- a/apps/worker/src/shared/autoSyncFailure.js
+++ b/apps/worker/src/shared/autoSyncFailure.js
@@ -46,6 +46,52 @@ async function writeAutoSyncAudit(
 }
 
 /**
+ * Emit AUTO_SYNC_COMPLETED audit after a scheduled worker run finishes with
+ * success or partial status. Manual runs write AUTO_SYNC_TRIGGERED from the
+ * API; without this, scheduled runs left no audit trail unless they failed.
+ */
+export async function recordAutoSyncCompleted(
+  client,
+  {
+    configId,
+    workspaceId,
+    provider,
+    createdBy = null,
+    status,
+    itemsScanned = null,
+    itemsImported = null,
+    error = null,
+  },
+) {
+  try {
+    const subjectUserId = await resolveAuditSubjectUserId(
+      client,
+      workspaceId,
+      createdBy,
+    );
+    await writeAutoSyncAudit(client, {
+      workspaceId,
+      subjectUserId,
+      action: "AUTO_SYNC_COMPLETED",
+      metadata: {
+        provider,
+        status,
+        items_scanned: itemsScanned,
+        items_imported: itemsImported,
+        ...(error ? { error } : {}),
+        config_id: configId,
+      },
+    });
+  } catch (err) {
+    logger.warn("Audit write failed (AUTO_SYNC_COMPLETED)", {
+      error: err.message,
+      workspace_id: workspaceId,
+      provider,
+    });
+  }
+}
+
+/**
  * Persist auto-sync failure and emit AUTO_SYNC_FAILED audit on first transition
  * into failed state (avoids hourly duplicate audit rows).
  */

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.10.1
-appVersion: "0.10.1"
+version: 0.10.2
+appVersion: "0.10.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.10.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "status": "m2-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes for M1/M2. M1/M2 Core workspace, machine-token executor, job read, job manual-create, evidence, and token-management routes are runtime-stable where implemented and documented in OpenAPI. This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn.",
   "namespacePolicy": {

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.10.1
+  version: 0.10.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/gitlab-integration-extended.unit.test.js
+++ b/tests/integration/gitlab-integration-extended.unit.test.js
@@ -324,4 +324,85 @@ describe("GitLab integration helper coverage", () => {
     expect(groupToken).to.exist;
     expect(groupToken.description).to.equal("real group token description");
   });
+
+  it("skips revoked deploy tokens unless includeRevoked is enabled (issue: deploy tokens revoked in GitLab, hence hidden from its UI, were still imported because the scan only checked expires_at)", async () => {
+    const deployTokensResponse = [
+      {
+        id: 1,
+        name: "active-deploy-token",
+        revoked: false,
+        expired: false,
+        expires_at: "2099-01-01T00:00:00Z",
+        scopes: ["read_repository"],
+      },
+      {
+        id: 2,
+        name: "revoked-deploy-token",
+        revoked: true,
+        expired: false,
+        // Revoked but still carries a valid future expiration date
+        expires_at: "2099-01-01T00:00:00Z",
+        scopes: ["read_repository"],
+      },
+    ];
+    const axiosMock = async (config) => {
+      const { pathname } = new URL(config.url);
+      if (pathname === "/api/v4/user") {
+        return { data: { id: 1, username: "alice", is_admin: false } };
+      }
+      if (pathname === "/api/v4/projects") {
+        return {
+          data: [{ id: 10, name: "proj", path_with_namespace: "g/proj" }],
+          headers: {},
+        };
+      }
+      if (pathname === "/api/v4/projects/10/deploy_tokens") {
+        return { data: deployTokensResponse };
+      }
+      return { data: [] };
+    };
+    const gitlab = requireWithMocks(resolveGitlabModule(), {
+      axios: axiosMock,
+    });
+
+    const baseFilters = {
+      includePATs: false,
+      includeProjectTokens: false,
+      includeGroupTokens: false,
+      includeDeployTokens: true,
+      includeTriggerTokens: false,
+      includeSSHKeys: false,
+      excludeUserPATs: false,
+      includeExpired: false,
+      includeRevoked: false,
+    };
+
+    const { items } = await gitlab.scanGitLab({
+      baseUrl: "https://gitlab.example.com",
+      token: "token",
+      include: { tokens: true, keys: false },
+      filters: baseFilters,
+    });
+    const names = items
+      .filter((i) => i.source === "gitlab-deploy-token")
+      .map((i) => i.name);
+    expect(names).to.deep.equal(["active-deploy-token"]);
+
+    const gitlabWithRevoked = requireWithMocks(resolveGitlabModule(), {
+      axios: axiosMock,
+    });
+    const { items: itemsWithRevoked } = await gitlabWithRevoked.scanGitLab({
+      baseUrl: "https://gitlab.example.com",
+      token: "token",
+      include: { tokens: true, keys: false },
+      filters: { ...baseFilters, includeRevoked: true },
+    });
+    const namesWithRevoked = itemsWithRevoked
+      .filter((i) => i.source === "gitlab-deploy-token")
+      .map((i) => i.name);
+    expect(namesWithRevoked).to.deep.equal([
+      "active-deploy-token",
+      "revoked-deploy-token",
+    ]);
+  });
 });

--- a/tests/unit/auto-sync-failure.unit.test.js
+++ b/tests/unit/auto-sync-failure.unit.test.js
@@ -37,4 +37,95 @@ describe("autoSyncFailure helpers", () => {
       "Network timeout",
     );
   });
+
+  it("recordAutoSyncCompleted writes an AUTO_SYNC_COMPLETED audit event for scheduled runs", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const calls = [];
+    const client = {
+      async query(sql, params) {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+
+    await mod.recordAutoSyncCompleted(client, {
+      configId: "cfg-1",
+      workspaceId: "ws-1",
+      provider: "gitlab",
+      createdBy: 42,
+      status: "success",
+      itemsScanned: 7,
+      itemsImported: 7,
+    });
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO audit_events"));
+    assert.ok(insert, "expected an audit_events INSERT");
+    const [subjectUserId, action, metadata, workspaceId] = insert.params;
+    assert.strictEqual(subjectUserId, 42);
+    assert.strictEqual(action, "AUTO_SYNC_COMPLETED");
+    assert.strictEqual(workspaceId, "ws-1");
+    assert.strictEqual(metadata.provider, "gitlab");
+    assert.strictEqual(metadata.status, "success");
+    assert.strictEqual(metadata.items_scanned, 7);
+    assert.strictEqual(metadata.items_imported, 7);
+    assert.strictEqual(metadata.config_id, "cfg-1");
+    assert.ok(!("error" in metadata));
+  });
+
+  it("recordAutoSyncCompleted includes the partial error and resolves the subject from workspace admins", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const calls = [];
+    const client = {
+      async query(sql, params) {
+        calls.push({ sql, params });
+        if (sql.includes("workspace_memberships") && sql.includes("'admin'")) {
+          return { rows: [{ user_id: 7 }] };
+        }
+        return { rows: [] };
+      },
+    };
+
+    await mod.recordAutoSyncCompleted(client, {
+      configId: "cfg-2",
+      workspaceId: "ws-2",
+      provider: "github",
+      createdBy: null,
+      status: "partial",
+      itemsScanned: 5,
+      itemsImported: 3,
+      error: "2 of 5 scanned item(s) failed to import.",
+    });
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO audit_events"));
+    assert.ok(insert, "expected an audit_events INSERT");
+    const [subjectUserId, action, metadata] = insert.params;
+    assert.strictEqual(subjectUserId, 7);
+    assert.strictEqual(action, "AUTO_SYNC_COMPLETED");
+    assert.strictEqual(metadata.status, "partial");
+    assert.strictEqual(metadata.error, "2 of 5 scanned item(s) failed to import.");
+  });
+
+  it("recordAutoSyncCompleted never throws when the audit insert fails", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const client = {
+      async query(sql) {
+        if (sql.includes("INSERT INTO audit_events")) {
+          throw new Error("insert failed");
+        }
+        return { rows: [] };
+      },
+    };
+
+    await assert.doesNotReject(() =>
+      mod.recordAutoSyncCompleted(client, {
+        configId: "cfg-3",
+        workspaceId: "ws-3",
+        provider: "gitlab",
+        createdBy: 1,
+        status: "success",
+        itemsScanned: 1,
+        itemsImported: 1,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Patch release fixing three anomalies reported across all TokenTimer editions. Scheduled auto-sync runs from the worker now leave an audit trail (new AUTO_SYNC_COMPLETED event), revoked GitLab deploy tokens are no longer imported by scans, and reopening the import modal restores the saved auto-sync configuration instead of showing defaults.

## Changes

### Worker
- New `recordAutoSyncCompleted` helper in `apps/worker/src/shared/autoSyncFailure.js` writes an `AUTO_SYNC_COMPLETED` audit event (provider, status, items scanned/imported, config id) after each scheduled sync finishes with success or partial status; previously only manual runs (`AUTO_SYNC_TRIGGERED`, API-side) and failures (`AUTO_SYNC_FAILED`) were audited.
- `auto-sync-worker.js` calls the helper in its success path, inside the same transaction as the config status update.

### API
- GitLab deploy-token scan now skips tokens with `revoked: true` unless the "Include revoked tokens" filter is enabled. GitLab hides revoked/deleted deploy tokens in its UI but still returns them from the API, often with a valid future `expires_at`, so they kept being detected.

### Dashboard
- Import modal passes the saved auto-sync `scan_params` down to the GitLab and GitHub forms (`initialScanParams` prop); the forms restore base URL and all scan filter checkboxes so the modal reflects the configured values instead of the defaults (token stays blank by design, placeholder indicates saved credentials).
- Audit page recognizes `AUTO_SYNC_COMPLETED` in the action filter and renders status/scanned/imported metadata for auto-sync events.

### Tests
- Unit tests for `recordAutoSyncCompleted` (audit insert, admin fallback subject resolution, never-throws-on-insert-failure).
- Scan test proving revoked deploy tokens are excluded by default and included with `includeRevoked: true`.

### Docs / metadata
- Version bumped to 0.10.2 across all manifests, contracts, and Helm chart.
- CHANGELOG entry for 0.10.2.

## Test plan
- [ ] CI job passes on main after squash-merge (link the run)
