### PR TITLE
fix: repair mojibake in import notes and surface import validation error details

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -491,7 +491,7 @@ app.post(
             (alert.error_message || "").toLowerCase().includes("webhooks") ||
             providerHint;
           const hint = isWebhookIssue
-            ? `Please put a valid ${providerHint || "webhook"} before retrying (Preferences Ã¢â€ â€™ Webhooks).`
+            ? `Please put a valid ${providerHint || "webhook"} before retrying (Preferences -> Webhooks).`
             : "No eligible channels to retry. Enable at least one channel in Preferences, then try again.";
           return res.status(400).json({
             error: hint,

--- a/apps/api/routes/account.js
+++ b/apps/api/routes/account.js
@@ -183,7 +183,7 @@ router.delete(
         "DELETE FROM workspace_memberships WHERE user_id = $1",
         [userId],
       );
-      // section_memberships legacy table removed Ã¢â‚¬â€œ no action needed
+      // section_memberships legacy table removed - no action needed
 
       // Delete alert artifacts owned by this user
       await client.query("DELETE FROM alert_delivery_log WHERE user_id = $1", [

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -50,6 +50,16 @@ function applyScanFilterRulesToResult(filterRules, result) {
   return result;
 }
 
+// Compact per-item error sample for audit metadata so validation failures
+// during import/sync are diagnosable from the audit log (bounded to avoid
+// oversized audit rows).
+function summarizeImportErrors(errors) {
+  return (Array.isArray(errors) ? errors : []).slice(0, 5).map((e) => ({
+    item: String(e?.item || "unknown").substring(0, 200),
+    error: String(e?.error || "unknown error").substring(0, 300),
+  }));
+}
+
 // --- Vault integration: scan mounts for inventory/expirations ---
 // Note: requireIntegrationQuota handles workspace validation, role check, and quota enforcement
 router.post(
@@ -413,7 +423,7 @@ router.post(
             `Imported from ${it?.source || "vault"}:${it?.mount || ""}${it?.path || ""}`;
           if (hasNoExpiration) {
             const sourceInfo = it?.source ? ` (${it.source})` : "";
-            notes = `Ã¢Å¡Â Ã¯Â¸Â This ${type} does not have an expiration date${sourceInfo}. Set to "Never expires" by default.\n${notes}`;
+            notes = `Warning: this ${type} does not have an expiration date${sourceInfo}. Set to "Never expires" by default.\n${notes}`;
           }
 
           // Build section value (robust split and flatten)
@@ -582,6 +592,9 @@ router.post(
             created_count: created.length,
             updated_count: updated.length,
             error_count: errors.length,
+            ...(errors.length > 0
+              ? { errors: summarizeImportErrors(errors) }
+              : {}),
             source: "vault",
           },
         });
@@ -763,9 +776,9 @@ router.post(
         // Connection timeout - likely firewall blocking or instance unreachable
         userMessage =
           "Connection timeout. The GitLab instance is not responding. This usually indicates:\n" +
-          "Ã¢â‚¬Â¢ Firewall blocking the connection\n" +
-          "Ã¢â‚¬Â¢ GitLab instance is unreachable or down\n" +
-          "Ã¢â‚¬Â¢ Network routing issues\n" +
+          "- Firewall blocking the connection\n" +
+          "- GitLab instance is unreachable or down\n" +
+          "- Network routing issues\n" +
           "Please verify the URL, check firewall rules, and ensure the instance is accessible from this server.";
       } else if (
         e?.code === "ENOTFOUND" ||
@@ -948,9 +961,9 @@ router.post(
         // Connection timeout - likely firewall blocking or instance unreachable
         userMessage =
           "Connection timeout. The GitHub instance is not responding. This usually indicates:\n" +
-          "Ã¢â‚¬Â¢ Firewall blocking the connection\n" +
-          "Ã¢â‚¬Â¢ GitHub instance is unreachable or down\n" +
-          "Ã¢â‚¬Â¢ Network routing issues\n" +
+          "- Firewall blocking the connection\n" +
+          "- GitHub instance is unreachable or down\n" +
+          "- Network routing issues\n" +
           "Please verify the URL, check firewall rules, and ensure the instance is accessible from this server.";
       } else if (
         e?.code === "ENOTFOUND" ||
@@ -1503,7 +1516,7 @@ router.post(
         e?.message?.includes("API_NOT_ACTIVATED")
       ) {
         userMessage =
-          'GCP Secret Manager API is not enabled. Enable it in Google Cloud Console: APIs & Services Ã¢â€ â€™ Enable "Secret Manager API".';
+          'GCP Secret Manager API is not enabled. Enable it in Google Cloud Console: APIs & Services -> Enable "Secret Manager API".';
       } else if (e?.code === "ENOTFOUND" || e?.code === "ECONNREFUSED") {
         userMessage = "Cannot connect to GCP. Check your network connectivity.";
       } else if (e?.message) {
@@ -2007,7 +2020,7 @@ router.post(
             it?.notes || `Imported from ${it?.source || "integration"}`;
           if (hasNoExpiration) {
             const sourceInfo = it?.source ? ` (${it.source})` : "";
-            notes = `Ã¢Å¡Â Ã¯Â¸Â This ${type} does not have an expiration date${sourceInfo}. Set to "Never expires" by default.\n${notes}`;
+            notes = `Warning: this ${type} does not have an expiration date${sourceInfo}. Set to "Never expires" by default.\n${notes}`;
           }
 
           // privileges from scopes or other source-specific fields
@@ -2238,6 +2251,9 @@ router.post(
             created_count: created.length,
             updated_count: updated.length,
             error_count: errors.length,
+            ...(errors.length > 0
+              ? { errors: summarizeImportErrors(errors) }
+              : {}),
             filtered_out_count: filteredOutCount,
             deleted_count: cleanupDeleted.length,
             source: "integration",

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -624,6 +624,15 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (md.contact_group_id)
         parts.push(`Contact group: ${md.contact_group_id}`);
       if (md.count) parts.push(`Count: ${md.count}`);
+      if (md.created_count != null) parts.push(`Created: ${md.created_count}`);
+      if (md.updated_count != null) parts.push(`Updated: ${md.updated_count}`);
+      if (md.error_count) parts.push(`Errors: ${md.error_count}`);
+      if (Array.isArray(md.errors) && md.errors.length > 0)
+        parts.push(
+          `Error details: ${md.errors
+            .map(e => `${e.item}: ${e.error}`)
+            .join('; ')}`
+        );
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {
       return '';
@@ -1090,6 +1099,12 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (md.items_imported != null)
         parts.push(`Imported: ${md.items_imported}`);
       if (md.error) parts.push(`Error: ${md.error}`);
+      if (Array.isArray(md.import_errors) && md.import_errors.length > 0)
+        parts.push(
+          `Import errors: ${md.import_errors
+            .map(e => `${e.item}: ${e.error}`)
+            .join('; ')}`
+        );
       if (md.http_status != null) parts.push(`HTTP status: ${md.http_status}`);
       if (md.config_id) parts.push(`Config ID: ${md.config_id}`);
       if (md.enabled != null)

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -23,8 +23,10 @@ import axios from "axios";
 import { isAutoSyncProviderAllowed } from "./auto-sync-providers.js";
 import {
   formatAutoSyncError,
+  formatImportErrorDetail,
   recordAutoSyncCompleted,
   recordAutoSyncFailure,
+  summarizeImportErrors,
 } from "./shared/autoSyncFailure.js";
 
 // Encryption helpers — must mirror systemSettings.js exactly
@@ -327,6 +329,7 @@ async function runAutoSync() {
           //    what a user gets when importing manually from the dashboard.
           let importedCount = 0;
           let importErrorCount = 0;
+          let importErrors = [];
           let deletedCount = 0;
           if (itemsCount > 0) {
             const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
@@ -381,6 +384,7 @@ async function runAutoSync() {
             importedCount =
               (importResult.created_count || 0) + (importResult.updated_count || 0);
             importErrorCount = importResult.error_count || 0;
+            importErrors = summarizeImportErrors(importResult.errors);
             deletedCount = importResult.deleted_count || 0;
             if (deletedCount > 0) {
               logger.info(
@@ -401,9 +405,14 @@ async function runAutoSync() {
                 : "success";
           const syncError =
             syncStatus === "partial"
-              ? itemsCount > 0 && importedCount === 0
-                ? `Scan found ${itemsCount} item(s) but none were imported (all failed validation or were rejected).`
-                : `${importErrorCount} of ${itemsCount} scanned item(s) failed to import.`
+              ? [
+                  itemsCount > 0 && importedCount === 0
+                    ? `Scan found ${itemsCount} item(s) but none were imported (all failed validation or were rejected).`
+                    : `${importErrorCount} of ${itemsCount} scanned item(s) failed to import.`,
+                  formatImportErrorDetail(importErrors, importErrorCount),
+                ]
+                  .filter(Boolean)
+                  .join(" ")
               : null;
 
           // Update config: success/partial
@@ -427,6 +436,7 @@ async function runAutoSync() {
             itemsScanned: itemsCount,
             itemsImported: importedCount,
             error: syncError,
+            importErrors,
           });
 
           cAutoSync.inc({ provider, status: syncStatus });

--- a/apps/worker/src/shared/autoSyncFailure.js
+++ b/apps/worker/src/shared/autoSyncFailure.js
@@ -14,6 +14,33 @@ export function formatAutoSyncError(err) {
   return String(err?.message || err).substring(0, 1000);
 }
 
+/**
+ * Bounded per-item error sample from the import endpoint response, suitable
+ * for audit metadata (mirrors summarizeImportErrors in the API import route).
+ */
+export function summarizeImportErrors(errors) {
+  return (Array.isArray(errors) ? errors : []).slice(0, 5).map((e) => ({
+    item: String(e?.item || "unknown").substring(0, 200),
+    error: String(e?.error || "unknown error").substring(0, 300),
+  }));
+}
+
+/**
+ * Human-readable "Details: ..." suffix for last_sync_error so partial runs
+ * explain which items failed validation and why, not just how many.
+ */
+export function formatImportErrorDetail(importErrors, totalErrorCount = 0) {
+  const sample = Array.isArray(importErrors) ? importErrors : [];
+  if (sample.length === 0) return "";
+  const shown = sample
+    .slice(0, 3)
+    .map((e) => `${e.item}: ${e.error}`)
+    .join("; ");
+  const remaining = Math.max(totalErrorCount, sample.length) - Math.min(3, sample.length);
+  const more = remaining > 0 ? ` (+${remaining} more)` : "";
+  return `Details: ${shown}${more}`.substring(0, 800);
+}
+
 async function resolveAuditSubjectUserId(client, workspaceId, createdBy) {
   if (createdBy) return createdBy;
   const adminRes = await client.query(
@@ -61,6 +88,7 @@ export async function recordAutoSyncCompleted(
     itemsScanned = null,
     itemsImported = null,
     error = null,
+    importErrors = null,
   },
 ) {
   try {
@@ -79,6 +107,9 @@ export async function recordAutoSyncCompleted(
         items_scanned: itemsScanned,
         items_imported: itemsImported,
         ...(error ? { error } : {}),
+        ...(Array.isArray(importErrors) && importErrors.length > 0
+          ? { import_errors: importErrors }
+          : {}),
         config_id: configId,
       },
     });

--- a/tests/unit/auto-sync-failure.unit.test.js
+++ b/tests/unit/auto-sync-failure.unit.test.js
@@ -128,4 +128,80 @@ describe("autoSyncFailure helpers", () => {
       }),
     );
   });
+
+  it("summarizeImportErrors bounds the sample to 5 items and truncates long fields", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const errors = Array.from({ length: 8 }, (_, i) => ({
+      item: `token-${i}`,
+      error: "x".repeat(500),
+    }));
+    const sample = mod.summarizeImportErrors(errors);
+    assert.strictEqual(sample.length, 5);
+    assert.strictEqual(sample[0].item, "token-0");
+    assert.strictEqual(sample[0].error.length, 300);
+  });
+
+  it("summarizeImportErrors tolerates missing/invalid input", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    assert.deepStrictEqual(mod.summarizeImportErrors(undefined), []);
+    assert.deepStrictEqual(mod.summarizeImportErrors("not-an-array"), []);
+    assert.deepStrictEqual(mod.summarizeImportErrors([{}]), [
+      { item: "unknown", error: "unknown error" },
+    ]);
+  });
+
+  it("formatImportErrorDetail lists up to 3 item errors and counts the rest", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const detail = mod.formatImportErrorDetail(
+      [
+        { item: "a", error: "missing name" },
+        { item: "b", error: "invalid category" },
+        { item: "c", error: "invalid type" },
+        { item: "d", error: "notes too long" },
+      ],
+      6,
+    );
+    assert.strictEqual(
+      detail,
+      "Details: a: missing name; b: invalid category; c: invalid type (+3 more)",
+    );
+    assert.strictEqual(mod.formatImportErrorDetail([], 0), "");
+    assert.strictEqual(mod.formatImportErrorDetail(null, 2), "");
+  });
+
+  it("recordAutoSyncCompleted includes the import_errors sample in the audit metadata", async () => {
+    const mod = await importFresh("apps/worker/src/shared/autoSyncFailure.js");
+    const calls = [];
+    const client = {
+      async query(sql, params) {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+
+    await mod.recordAutoSyncCompleted(client, {
+      configId: "cfg-4",
+      workspaceId: "ws-4",
+      provider: "gitlab",
+      createdBy: 42,
+      status: "partial",
+      itemsScanned: 3,
+      itemsImported: 1,
+      error:
+        "2 of 3 scanned item(s) failed to import. Details: t1: missing name; t2: invalid type",
+      importErrors: [
+        { item: "t1", error: "missing name" },
+        { item: "t2", error: "invalid type" },
+      ],
+    });
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO audit_events"));
+    assert.ok(insert, "expected an audit_events INSERT");
+    const metadata = insert.params[2];
+    assert.deepStrictEqual(metadata.import_errors, [
+      { item: "t1", error: "missing name" },
+      { item: "t2", error: "invalid type" },
+    ]);
+    assert.match(metadata.error, /Details: t1: missing name/);
+  });
 });

--- a/tests/unit/source-encoding.unit.test.js
+++ b/tests/unit/source-encoding.unit.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+
+// Signature of UTF-8 text that was decoded as Windows-1252/Latin-1 and
+// re-encoded: U+00C2/U+00C3 followed by a character in the UTF-8
+// continuation-byte range. Legitimate accented text never produces this
+// pair, so any match is corrupted source (e.g. the import-notes warning
+// prefix that surfaced as strange characters in imported token notes).
+const MOJIBAKE = /[\u00C2\u00C3][\u0080-\u00BF]/;
+
+const SCAN_DIRS = ["apps/api", "apps/worker/src", "apps/dashboard/src"];
+const SCAN_EXT = new Set([".js", ".jsx"]);
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", "coverage"]);
+
+function collectSourceFiles(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) {
+        collectSourceFiles(path.join(dir, entry.name), out);
+      }
+    } else if (SCAN_EXT.has(path.extname(entry.name))) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+describe("source encoding integrity", () => {
+  it("app source files contain no double-encoded (mojibake) characters", () => {
+    const root = path.join(__dirname, "..", "..");
+    const offenders = [];
+    for (const dir of SCAN_DIRS) {
+      const abs = path.join(root, dir);
+      if (!fs.existsSync(abs)) continue;
+      for (const file of collectSourceFiles(abs, [])) {
+        const text = fs.readFileSync(file, "utf8");
+        const lines = text.split("\n");
+        lines.forEach((line, i) => {
+          if (MOJIBAKE.test(line)) {
+            offenders.push(`${path.relative(root, file)}:${i + 1}`);
+          }
+        });
+      }
+    }
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `Mojibake found in: ${offenders.join(", ")}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two minor import issues reported after v0.10.2 (no release yet, PR only).

### 1. Strange characters in notes when importing tokens (e.g. `Å Ã`)

Root cause: the source code itself contained double-encoded UTF-8 (mojibake) baked into user-facing strings. The most visible one was the "no expiration date" warning prefix in import notes, which stored literal `Ã¢Å¡Â Ã¯Â¸Â` bytes into every imported token without an expiry.

- `apps/api/routes/integrations.js`: repaired the notes warning prefix (both the vault and integration import paths), the GitLab/GitHub connectivity troubleshooting bullets, and the GCP console arrow. All replaced with ASCII-safe equivalents (`Warning:`, `-`, `->`) so this class of corruption cannot recur in stored data.
- `apps/api/index.js`, `apps/api/routes/account.js`: same repair for the webhook retry hint and a comment.
- New regression test `tests/unit/source-encoding.unit.test.js` scans `apps/api`, `apps/worker/src`, and `apps/dashboard/src` for the mojibake signature (U+00C2/U+00C3 followed by a continuation-range character) and fails if any source file regresses.

Note: existing tokens that already have corrupted notes in the DB keep them; this fix stops new corruption at the source.

### 2. No detail on import validation errors during sync/autosync

The import endpoint already computed a per-item `errors` array (`{ item, error, field }`), but it was dropped everywhere except the HTTP response body:

- `TOKENS_IMPORTED` audit events (manual sync path) now include a bounded `errors` sample (up to 5 items, item/error truncated) in metadata, for both the vault and integration import endpoints.
- The auto-sync worker now captures `importResult.errors` and:
  - appends a human-readable `Details: item: reason; ... (+N more)` suffix to `last_sync_error` for partial runs, so the Import modal banner shows why items failed instead of only how many;
  - passes an `import_errors` sample into the `AUTO_SYNC_COMPLETED` audit event metadata.
- `apps/dashboard/src/pages/Audit.jsx` renders the new fields: created/updated/error counts and error details for `TOKENS_IMPORTED`, and `Import errors:` for auto-sync events.

## Testing

- `pnpm run test:unit`: 466 pass, 0 fail (includes 5 new tests for `summarizeImportErrors`, `formatImportErrorDetail`, `recordAutoSyncCompleted` with `import_errors`, and the source-encoding guard)
- `pnpm --filter @tokentimer/api lint`, `@tokentimer/worker lint`, `@tokentimer/dashboard lint`: 0 errors
- Dashboard prettier `--check`, `type-check`, `build`: pass
- `check:contracts`, `check:contracts:integrity`, `check:lockfile-overrides`, `check:secret-logging`, `test:contracts` (offline): pass
- `pnpm audit --prod --audit-level=moderate`: pass (1 low)

## Release

Not released. Do not tag; changes will ride in the next release train.
