### PR TITLE
Release TokenTimer Core v0.10.3 with import notes encoding and error detail fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-07-23
+
+### Fixed
+
+- **Strange characters in imported token notes (mojibake)** — several source strings in the API (import warnings, autosync error notes, arrow separators) were double-encoded UTF-8 and ended up as sequences like `Å Ã` in token notes created by integration imports. All affected strings were repaired to ASCII-safe equivalents (`Warning:`, `-`, `->`), and a regression unit test now scans source files for double-encoded UTF-8 signatures so mojibake cannot silently reappear.
+- **Import validation errors had no detail in error messages or audit events** — when a sync/auto-sync import hit per-item validation errors, the UI and audit log only reported a count. The `TOKENS_IMPORTED` audit event now includes created/updated/error counts plus a bounded sample of per-item error details, the auto-sync worker appends the same detail to `last_sync_error` (visible in the auto-sync status banner), and the `AUTO_SYNC_COMPLETED` audit metadata carries an `import_errors` sample. The Audit page renders the new fields.
+
+### Changed
+
+- Version metadata bumped to 0.10.3 across all manifests, contracts, and Helm chart.
+
 ## [0.10.2] - 2026-07-23
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.10.2
-appVersion: "0.10.2"
+version: 0.10.3
+appVersion: "0.10.3"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,7 +19,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag
     pullPolicy: IfNotPresent
 
@@ -105,7 +105,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -152,7 +152,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.10.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.10.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/api/certops-route-compat.contract.json
+++ b/packages/contracts/api/certops-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.certops-route-compat",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "status": "m2-runtime-stable",
   "description": "Frozen CertOps route namespaces and stable routes for M1/M2. M1/M2 Core workspace, machine-token executor, job read, job manual-create, evidence, and token-management routes are runtime-stable where implemented and documented in OpenAPI. This contract freezes the namespace shape and auth model so cloud and enterprise overlays, the executor, and the agent can build in parallel without route churn.",
   "namespacePolicy": {

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.10.2
+  version: 0.10.3
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
Patch release bumping tokentimer-core to 0.10.3. Ships the two import fixes merged in #94: repaired mojibake (double-encoded UTF-8) in strings that end up in imported token notes, and detailed per-item import validation errors in error messages and audit events for sync/auto-sync.

## Changes

### API
- Mojibake repaired in `apps/api/routes/integrations.js`, `apps/api/routes/account.js`, `apps/api/index.js` (ASCII-safe `Warning:`, `-`, `->`)
- `TOKENS_IMPORTED` audit metadata now includes created/updated/error counts and a bounded per-item error sample

### Worker
- Auto-sync appends import error detail to `last_sync_error` and adds an `import_errors` sample to `AUTO_SYNC_COMPLETED` audit metadata

### Dashboard
- Audit page renders the new error detail fields

### Tests
- New `tests/unit/source-encoding.unit.test.js` regression test scanning source files for double-encoded UTF-8 signatures

### Docs / metadata
- Version bumped to 0.10.3 across all manifests, contracts (incl. `certops-route-compat.contract.json`), and Helm chart

## Test plan
- [ ] CI on main passes after merge (ci.yml has no pull_request trigger)
