### PR TITLE
Add Discord notification for new releases

### DIFF
--- a/.github/workflows/discord-release-backfill.yml
+++ b/.github/workflows/discord-release-backfill.yml
@@ -1,0 +1,115 @@
+name: Backfill Discord releases
+
+# Manual-only: one-time backfill for releases that were published before
+# Discord notifications existed in release.yml (which now handles all
+# future releases via its notify-discord job). Running this again re-posts
+# every non-draft release, so only use it for the initial backfill.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backfill-discord:
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Post every existing release to Discord
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "DISCORD_WEBHOOK_URL secret not set; aborting backfill."
+            exit 1
+          fi
+
+          post_release() {
+            local release_json="$1"
+            local payload
+
+            payload="$(
+              jq -n \
+                --arg repo "${{ github.repository }}" \
+                --argjson release "$release_json" \
+                '
+                def value_or($fallback):
+                  if . == null or . == "" then $fallback else . end;
+
+                {
+                  username: "GitHub Releases",
+                  allowed_mentions: {
+                    parse: []
+                  },
+                  embeds: [
+                    {
+                      title: (
+                        ($release.name | value_or($release.tag_name))[0:256]
+                      ),
+                      url: $release.html_url,
+                      description: (
+                        ($release.body | value_or("No release notes provided."))
+                        | if length > 3900
+                          then .[0:3897] + "..."
+                          else .
+                          end
+                      ),
+                      fields: [
+                        {
+                          name: "Repository",
+                          value: $repo,
+                          inline: true
+                        },
+                        {
+                          name: "Version",
+                          value: $release.tag_name,
+                          inline: true
+                        },
+                        {
+                          name: "Type",
+                          value: (
+                            if $release.prerelease
+                            then "Pre-release"
+                            else "Release"
+                            end
+                          ),
+                          inline: true
+                        }
+                      ],
+                      timestamp: (
+                        $release.published_at // $release.created_at
+                      )
+                    }
+                  ]
+                }
+                '
+            )"
+
+            curl \
+              --fail-with-body \
+              --retry 5 \
+              --retry-all-errors \
+              --retry-delay 2 \
+              --header "Content-Type: application/json" \
+              --data "$payload" \
+              "$DISCORD_WEBHOOK_URL"
+
+            # Avoid Discord rate limits during a large backfill.
+            sleep 1
+          }
+
+          gh api --paginate \
+            --header "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases?per_page=100" \
+          | jq -cs '
+              add
+              | map(select(.draft == false))
+              | sort_by(.published_at // .created_at)
+              | .[]
+            ' \
+          | while IFS= read -r release_json; do
+              post_release "$release_json"
+            done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,100 @@ jobs:
           draft: false
           prerelease: ${{ contains(steps.get_version.outputs.VERSION, 'alpha') || contains(steps.get_version.outputs.VERSION, 'beta') || contains(steps.get_version.outputs.VERSION, 'rc') }}
 
+  # Notify Discord once the release exists. Runs in parallel with the docker/helm
+  # publish jobs since the notification doesn't depend on them. Re-running this
+  # workflow for the same tag re-posts the notification (same idempotency
+  # trade-off as the release_lookup skip-create path above).
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Post release to Discord
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "DISCORD_WEBHOOK_URL secret not set; skipping Discord notification."
+            exit 0
+          fi
+
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          RELEASE_JSON="$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases/tags/${TAG_NAME}")"
+
+          PAYLOAD="$(
+            jq -n \
+              --arg repo "${{ github.repository }}" \
+              --argjson release "$RELEASE_JSON" \
+              '
+              def value_or($fallback):
+                if . == null or . == "" then $fallback else . end;
+
+              {
+                username: "GitHub Releases",
+                allowed_mentions: {
+                  parse: []
+                },
+                embeds: [
+                  {
+                    title: (
+                      ($release.name | value_or($release.tag_name))[0:256]
+                    ),
+                    url: $release.html_url,
+                    description: (
+                      ($release.body | value_or("No release notes provided."))
+                      | if length > 3900
+                        then .[0:3897] + "..."
+                        else .
+                        end
+                    ),
+                    fields: [
+                      {
+                        name: "Repository",
+                        value: $repo,
+                        inline: true
+                      },
+                      {
+                        name: "Version",
+                        value: $release.tag_name,
+                        inline: true
+                      },
+                      {
+                        name: "Type",
+                        value: (
+                          if $release.prerelease
+                          then "Pre-release"
+                          else "Release"
+                          end
+                        ),
+                        inline: true
+                      }
+                    ],
+                    timestamp: (
+                      $release.published_at // $release.created_at
+                    )
+                  }
+                ]
+              }
+              '
+          )"
+
+          curl \
+            --fail-with-body \
+            --retry 5 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --header "Content-Type: application/json" \
+            --data "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"
+
   build-and-push-docker:
     runs-on: ubuntu-latest
     needs: create-release


### PR DESCRIPTION
## Summary
- Adds a `notify-discord` job to `release.yml` that posts a Discord embed (title, URL, notes, repo/version/type fields) after `create-release` runs for a tagged release.
- Adds a manual-only `discord-release-backfill.yml` workflow to post existing published releases once (paginates all releases, skips drafts, oldest-to-newest, 1s delay between posts).
- No-ops cleanly if `DISCORD_WEBHOOK_URL` secret is not yet set, so it won't fail the release pipeline before the webhook is provisioned.

## Test plan
- [ ] CI passes on this PR/main
- [ ] `DISCORD_WEBHOOK_URL` secret provisioned in repo settings
- [ ] Run `discord-release-backfill` manually once to backfill history
- [ ] Confirm next tagged release posts to Discord automatically
