### PR TITLE
fix(deps): migrate dashboard from react-router-dom v6 to react-router v7

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -36,7 +36,7 @@
     "react-icons": "5.5.0",
     "react-joyride": "2.9.3",
     "react-query": "3.39.3",
-    "react-router-dom": "6.30.4",
+    "react-router": "7.18.1",
     "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "devDependencies": {

--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -55,7 +55,7 @@ import {
   useSearchParams,
   useNavigate,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router';
 import toast, { Toaster } from 'react-hot-toast';
 import { HelmetProvider } from 'react-helmet-async';
 import { trackEvent } from './utils/analytics.js';

--- a/apps/dashboard/src/components/DashboardShell.jsx
+++ b/apps/dashboard/src/components/DashboardShell.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router';
 import {
   Box,
   Button,

--- a/apps/dashboard/src/components/Footer.jsx
+++ b/apps/dashboard/src/components/Footer.jsx
@@ -9,7 +9,7 @@ import {
   useColorModeValue,
   Icon,
 } from '@chakra-ui/react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { FiFileText, FiBookOpen } from 'react-icons/fi';
 import {
   useBrandColors,

--- a/apps/dashboard/src/components/ProductTour.jsx
+++ b/apps/dashboard/src/components/ProductTour.jsx
@@ -8,7 +8,7 @@ import {
   HStack,
   Box,
 } from '@chakra-ui/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { trackEvent } from '../utils/analytics';
 import { logger } from '../utils/logger';
 

--- a/apps/dashboard/src/components/RequireManagerRoute.jsx
+++ b/apps/dashboard/src/components/RequireManagerRoute.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { workspaceAPI } from '../utils/apiClient';
 import { useWorkspace } from '../utils/WorkspaceContext.jsx';
 

--- a/apps/dashboard/src/components/certops/CertOpsPreferencesEntry.jsx
+++ b/apps/dashboard/src/components/certops/CertOpsPreferencesEntry.jsx
@@ -1,4 +1,4 @@
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { HStack, Icon, Text } from '@chakra-ui/react';
 import { ArrowRight, ShieldCheck } from 'lucide-react';
 import {

--- a/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
+++ b/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
@@ -22,7 +22,7 @@ import {
   X,
   XCircle,
 } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { useDashboardTheme } from '../../hooks/useDashboardTheme';
 import CopyableId from '../CopyableId.jsx';
 import {

--- a/apps/dashboard/src/hooks/useDashboardShellProps.js
+++ b/apps/dashboard/src/hooks/useDashboardShellProps.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useDashboardTheme } from './useDashboardTheme';
 import { workspaceAPI } from '../utils/apiClient';
 import { useWorkspace } from '../utils/WorkspaceContext.jsx';

--- a/apps/dashboard/src/hooks/useInventoryUrlState.js
+++ b/apps/dashboard/src/hooks/useInventoryUrlState.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 /**
  * @typedef {object} InventoryUrlState

--- a/apps/dashboard/src/main.jsx
+++ b/apps/dashboard/src/main.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import './styles/brand.css';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 const RootTree = (
   <BrowserRouter>

--- a/apps/dashboard/src/pages/Account.jsx
+++ b/apps/dashboard/src/pages/Account.jsx
@@ -47,7 +47,7 @@ import { useDashboardTheme } from '../hooks/useDashboardTheme';
 import apiClient, { workspaceAPI } from '../utils/apiClient';
 import { showSuccess } from '../utils/toast.js';
 import { useWorkspace } from '../utils/WorkspaceContext.jsx';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { trackEvent } from '../utils/analytics.js';
 
 function resolveLoginMethodDisplay(session) {

--- a/apps/dashboard/src/pages/AlertPreferences.jsx
+++ b/apps/dashboard/src/pages/AlertPreferences.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
   Box,
   Text,

--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import {
   Box,
   Text,

--- a/apps/dashboard/src/pages/ControlCenter.jsx
+++ b/apps/dashboard/src/pages/ControlCenter.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router';
 import {
   Alert,
   AlertDescription,

--- a/apps/dashboard/src/pages/Login.jsx
+++ b/apps/dashboard/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import SEO from '../components/SEO.jsx';
 import { getLogoPath } from '../utils/logoUtils.js';
 import { logger } from '../utils/logger.js';

--- a/apps/dashboard/src/pages/NotFound.jsx
+++ b/apps/dashboard/src/pages/NotFound.jsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Text, Button, VStack } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import SEO from '../components/SEO.jsx';
 
 export default function NotFound() {

--- a/apps/dashboard/src/pages/Register.jsx
+++ b/apps/dashboard/src/pages/Register.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import axios from 'axios';
 import {
   Box,

--- a/apps/dashboard/src/pages/ResetPassword.jsx
+++ b/apps/dashboard/src/pages/ResetPassword.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import SEO from '../components/SEO.jsx';
 import { getLogoPath } from '../utils/logoUtils.js';
 import { logger } from '../utils/logger.js';

--- a/apps/dashboard/src/pages/Usage.jsx
+++ b/apps/dashboard/src/pages/Usage.jsx
@@ -1,7 +1,7 @@
 // Legacy Usage page stub. App.jsx redirects /usage to /control-center; this file
 // is not imported as a route element.
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 export default function Usage() {
   return <Navigate to='/control-center' replace />;

--- a/apps/dashboard/src/pages/UserPreferences.jsx
+++ b/apps/dashboard/src/pages/UserPreferences.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router';
 import {
   Box,
   Circle,

--- a/apps/dashboard/src/pages/VerifyEmail.jsx
+++ b/apps/dashboard/src/pages/VerifyEmail.jsx
@@ -13,7 +13,7 @@ import {
   Spinner,
   useColorModeValue,
 } from '@chakra-ui/react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import axios from 'axios';
 import { API_BASE_URL } from '../utils/apiClient';
 

--- a/apps/dashboard/src/pages/Workspaces.jsx
+++ b/apps/dashboard/src/pages/Workspaces.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Box,
   VStack,

--- a/apps/dashboard/src/pages/certops/CertOpsRoutes.jsx
+++ b/apps/dashboard/src/pages/certops/CertOpsRoutes.jsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import CertOpsOperations from './CertOpsOperations.jsx';
 
 /**

--- a/apps/dashboard/src/utils/WorkspaceContext.jsx
+++ b/apps/dashboard/src/utils/WorkspaceContext.jsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router';
 import { workspaceAPI } from './apiClient';
 
 const WorkspaceContext = createContext(null);

--- a/apps/dashboard/tests/unit/ApiTokenPanel.test.jsx
+++ b/apps/dashboard/tests/unit/ApiTokenPanel.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import ApiTokenPanel from '../../src/components/certops/ApiTokenPanel.jsx';

--- a/apps/dashboard/tests/unit/CertOpsOperations.test.jsx
+++ b/apps/dashboard/tests/unit/CertOpsOperations.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import CertOpsOperations from '../../src/pages/certops/CertOpsOperations.jsx';

--- a/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
+++ b/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import Workspaces from '../../src/pages/Workspaces.jsx';

--- a/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import EvidenceTimeline from '../../src/components/certops/EvidenceTimeline.jsx';

--- a/apps/dashboard/tests/unit/ImportForms.test.jsx
+++ b/apps/dashboard/tests/unit/ImportForms.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import ImportVaultForm from '../../src/components/imports/ImportVaultForm.jsx';

--- a/apps/dashboard/tests/unit/RequireManagerRoute.test.jsx
+++ b/apps/dashboard/tests/unit/RequireManagerRoute.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import RequireManagerRoute from '../../src/components/RequireManagerRoute.jsx';
 

--- a/apps/dashboard/tests/unit/TokenCertOpsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/TokenCertOpsPanel.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ChakraProvider, Grid } from '@chakra-ui/react';
 
 import TokenCertOpsPanel from '../../src/components/certops/TokenCertOpsPanel.jsx';

--- a/apps/dashboard/vite.config.js
+++ b/apps/dashboard/vite.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
         // Enable code splitting for lazy-loaded pages
         manualChunks: {
           // Core vendor libs that rarely change (good cache hits)
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-react': ['react', 'react-dom', 'react-router'],
           'vendor-chakra': [
             '@chakra-ui/react',
             '@emotion/react',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,9 @@ importers:
       react-query:
         specifier: 3.39.3
         version: 3.39.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom:
-        specifier: 6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router:
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       xlsx:
         specifier: npm:@e965/xlsx@0.20.3
         version: '@e965/xlsx@0.20.3'
@@ -1248,10 +1248,6 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -2130,6 +2126,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -3716,18 +3716,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -3877,6 +3874,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5764,8 +5764,6 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@remix-run/router@1.23.3': {}
-
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
@@ -6762,6 +6760,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -8567,17 +8567,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
-
-  react-router@6.30.4(react@18.3.1):
-    dependencies:
-      '@remix-run/router': 1.23.3
-      react: 18.3.1
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -8772,6 +8768,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   tar: 7.5.7
   fast-xml-builder: 1.2.0
   fast-xml-parser: 5.7.3
-  minimatch: 9.0.9
-  brace-expansion: 2.1.2
+  minimatch: 10.2.5
+  brace-expansion: 5.0.8
   path-to-regexp: 8.4.0
   yaml: 1.10.3
   js-yaml: 4.3.0
@@ -1926,8 +1926,9 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -1955,8 +1956,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3256,9 +3258,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -5492,7 +5494,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 9.0.9
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -5513,7 +5515,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -5527,7 +5529,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -5558,7 +5560,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3
-      minimatch: 9.0.9
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6273,7 +6275,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
@@ -6545,7 +6547,7 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -6573,9 +6575,9 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@2.1.2:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7103,7 +7105,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -7124,7 +7126,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -7192,7 +7194,7 @@ snapshots:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
       strip-ansi: 6.0.1
@@ -7233,7 +7235,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -7535,7 +7537,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -7545,7 +7547,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -7554,7 +7556,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -7563,7 +7565,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       once: 1.4.0
 
   globals@13.24.0:
@@ -8098,9 +8100,9 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@9.0.9:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -8130,7 +8132,7 @@ snapshots:
       he: 1.2.0
       js-yaml: 4.3.0
       log-symbols: 4.1.0
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       ms: 2.1.3
       serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
@@ -8169,7 +8171,7 @@ snapshots:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       pstree.remy: 1.1.8
       semver: 7.7.4
       simple-update-notifier: 2.0.0
@@ -9048,7 +9050,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 9.0.9
+      minimatch: 10.2.5
 
   text-hex@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ overrides:
   tar: 7.5.7
   fast-xml-builder: 1.2.0
   fast-xml-parser: 5.7.3
-  minimatch: 9.0.9
-  brace-expansion: 2.1.2
+  minimatch: 10.2.5
+  brace-expansion: 5.0.8
   path-to-regexp: 8.4.0
   yaml: 1.10.3
   js-yaml: 4.3.0

--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -18,8 +18,8 @@ const pkgPath = path.join(repoRoot, "package.json");
 const REQUIRED_PINS = {
   tar: { "*": "7.5.7" },
   "fast-xml-parser": { "*": "5.7.3" },
-  minimatch: { "*": "9.0.9" },
-  "brace-expansion": { "*": "2.1.2" },
+  minimatch: { "*": "10.2.5" },
+  "brace-expansion": { "*": "5.0.8" },
   "path-to-regexp": { "*": "8.4.0" },
   yaml: { "*": "1.10.3" },
   "js-yaml": { "*": "4.3.0" },


### PR DESCRIPTION
## Summary
- Stacked on #99 (needs that merged first, or merge this into that branch).
- react-router-dom v6 has no further security releases. `pnpm audit --prod` flagged 3 moderate CVEs (GHSA-jjmj-jmhj-qwj2, GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg: open redirect/XSS, SSR hydration constructor injection), all fixed only starting `react-router@7.18.0`. npm has no `react-router-dom@6.30.5` at all - the advisory's "patched >=6.30.5" is pnpm's generic last-affected+1 heuristic, not a real release.
- Dashboard only uses classic declarative routing (no data router / loader / action), which v7 keeps fully backward compatible. Clean package swap: `react-router-dom` -> `react-router@7.18.1`, updated every import across `apps/dashboard/src` and `apps/dashboard/tests`.
- `pnpm audit --prod` now surfaces one new unrelated High finding (GHSA-qwww-vcr4-c8h2) against `react-router@7.18.1`, but per the advisory it "only affects your application if you are using the unstable RSC APIs" - we use neither RSC nor any data router API, so it's unreachable here. Fully resolving it needs `react-router@8`, which requires React >=19.2.7 (we're on 18.3.1) - a much larger, separate migration out of scope for this PR.

## Test plan
- [x] `pnpm --filter @tokentimer/dashboard run lint` - 0 errors (same pre-existing warnings)
- [x] `pnpm --filter @tokentimer/dashboard run build` - succeeds
- [x] `pnpm --filter @tokentimer/dashboard run test` - 155/155 tests pass
- [x] `pnpm audit --prod --audit-level=moderate` - all 3 original react-router CVEs gone
