### PR TITLE
chore(release): drop GitHub Release and :latest promotion jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           path: .helm-pkg/tokentimer-${{ steps.get_version.outputs.VERSION }}.tgz
           if-no-files-found: error
 
-  # Stage 1c: build agent release tarball + checksum (not attached yet).
+  # Stage 1c: build agent release tarball + checksum (verified in verify-release).
   pack-agent:
     runs-on: ubuntu-latest
     permissions:
@@ -134,7 +134,7 @@ jobs:
             agent-dist/*.sha256
           if-no-files-found: error
 
-  # Stage 2: verify all artifacts before any public release / :latest / Helm OCI publish.
+  # Stage 2: verify all artifacts before Helm OCI publish.
   verify-release:
     runs-on: ubuntu-latest
     needs:
@@ -209,7 +209,7 @@ jobs:
           test -n "$(ls *.sha256 2>/dev/null)"
           sha256sum -c ./*.sha256
 
-  # Stage 3a: publish Helm to OCI only after verification (chart refs versioned images).
+  # Stage 3: publish Helm to OCI only after verification (chart refs versioned images).
   publish-helm-chart:
     runs-on: ubuntu-latest
     needs: verify-release
@@ -240,240 +240,3 @@ jobs:
 
       - name: Push chart to OCI registry
         run: helm push .helm-pkg/tokentimer-${{ steps.get_version.outputs.VERSION }}.tgz oci://${{ env.HELM_OCI_REPO }}
-
-  # Stage 3b: create the public GitHub Release only after verify + Helm publish succeed.
-  create-release:
-    runs-on: ubuntu-latest
-    needs:
-      - verify-release
-      - publish-helm-chart
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Extract version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Download agent release artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: agent-release
-          path: agent-dist
-
-      - name: Detect existing GitHub Release for tag
-        id: release_lookup
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          if gh release view "$TAG_NAME" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Release already exists for ${TAG_NAME}; skipping create so UI title and body are kept."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create Release
-        if: steps.release_lookup.outputs.exists != 'true'
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          name: Release ${{ steps.get_version.outputs.VERSION }}
-          body: |
-            ## TokenTimer Core ${{ steps.get_version.outputs.VERSION }}
-
-            See [CHANGELOG.md](https://github.com/tokentimerch/tokentimer-core/blob/main/CHANGELOG.md) for details.
-
-            ### Installation
-
-            **Helm (OCI):**
-            ```bash
-            helm install tokentimer oci://ghcr.io/${{ github.repository_owner }}/charts/tokentimer \
-              --version ${{ steps.get_version.outputs.VERSION }} \
-              --namespace tokentimer --create-namespace \
-              --set config.adminEmail=admin@example.com
-            ```
-
-            **Docker Compose:**
-            ```bash
-            docker compose -f deploy/compose/docker-compose.yml up -d
-            ```
-          draft: false
-          prerelease: ${{ contains(steps.get_version.outputs.VERSION, 'alpha') || contains(steps.get_version.outputs.VERSION, 'beta') || contains(steps.get_version.outputs.VERSION, 'rc') }}
-          files: |
-            agent-dist/*.tgz
-            agent-dist/*.sha256
-
-      - name: Upload release assets to existing release
-        if: steps.release_lookup.outputs.exists == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          gh release upload "$TAG_NAME" agent-dist/*.tgz agent-dist/*.sha256 \
-            --repo "${{ github.repository }}" --clobber
-
-  # Stage 4: promote all components to :latest together after the public release exists.
-  # :latest is a convenience/dev channel only. Reproducible deploys must use versioned
-  # tags or digests from release-manifest.json (attached to the GitHub Release and
-  # uploaded as a workflow artifact). Helm chart defaults pin appVersion tags (not
-  # :latest); see deploy/helm/values.yaml image.digest notes.
-  #
-  # Skipped for prerelease tags (alpha/beta/rc) so a beta dry-run tag (see
-  # release-tokentimer-core skill) never clobbers :latest with an unreleased build.
-  #
-  # Note: main added a notify-discord job here (#97); release/0.11.0 reverted that
-  # feature (see the "Revert" commit), so it is intentionally not carried forward.
-  promote-latest:
-    runs-on: ubuntu-latest
-    needs: create-release
-    if: >-
-      !contains(github.ref_name, 'alpha') &&
-      !contains(github.ref_name, 'beta') &&
-      !contains(github.ref_name, 'rc')
-    permissions:
-      packages: write
-      contents: write
-    steps:
-      - name: Extract version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Fail the whole job before any :latest mutation if any versioned image is missing.
-      - name: Verify versioned image digests
-        id: verify_digests
-        run: |
-          set -euo pipefail
-          VER='${{ steps.get_version.outputs.VERSION }}'
-          OWNER='${{ github.repository_owner }}'
-          echo '{}' > digests.json
-
-          for component in api worker dashboard k8s-controller; do
-            IMAGE="ghcr.io/${OWNER}/tokentimer-core-${component}:${VER}"
-            echo "Inspecting ${IMAGE}"
-            # Existence check: non-zero exit fails the job before any promotion.
-            docker buildx imagetools inspect "$IMAGE" >/dev/null
-
-            DIGEST="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$IMAGE" 2>/dev/null || true)"
-            if [[ -z "${DIGEST}" || "${DIGEST}" == "<no value>" || "${DIGEST}" != sha256:* ]]; then
-              DIGEST="$(docker buildx imagetools inspect --format '{{.Digest}}' "$IMAGE" 2>/dev/null || true)"
-            fi
-            if [[ -z "${DIGEST}" || "${DIGEST}" == "<no value>" || "${DIGEST}" != sha256:* ]]; then
-              echo "::error::Failed to resolve digest for ${IMAGE}"
-              docker buildx imagetools inspect "$IMAGE" || true
-              exit 1
-            fi
-
-            echo "Resolved ${component} -> ${DIGEST}"
-            KEY="$component"
-            if [ "$component" = "k8s-controller" ]; then
-              KEY="k8sController"
-            fi
-            jq --arg k "$KEY" --arg d "$DIGEST" --arg img "$IMAGE" \
-              '.[$k] = {digest: $d, image: $img}' digests.json > digests.json.tmp
-            mv digests.json.tmp digests.json
-          done
-
-          echo "All versioned image digests resolved:"
-          cat digests.json
-
-      - name: Build release manifest
-        run: |
-          set -euo pipefail
-          VER='${{ steps.get_version.outputs.VERSION }}'
-          PROMOTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          test -f digests.json
-          jq -n \
-            --arg version "$VER" \
-            --arg promotedAt "$PROMOTED_AT" \
-            --slurpfile digests digests.json \
-            '{
-              version: $version,
-              components: {
-                api: { digest: $digests[0].api.digest },
-                worker: { digest: $digests[0].worker.digest },
-                dashboard: { digest: $digests[0].dashboard.digest },
-                k8sController: { digest: $digests[0].k8sController.digest }
-              },
-              promotedAt: $promotedAt
-            }' > release-manifest.json
-
-          for key in api worker dashboard k8sController; do
-            DIGEST="$(jq -r --arg k "$key" '.components[$k].digest' release-manifest.json)"
-            case "$DIGEST" in
-              sha256:*) ;;
-              *)
-                echo "::error::release-manifest.json missing digest for ${key}"
-                exit 1
-                ;;
-            esac
-          done
-
-          echo "Wrote release-manifest.json:"
-          cat release-manifest.json
-
-      - name: Upload release manifest artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: release-manifest
-          path: release-manifest.json
-          if-no-files-found: error
-
-      - name: Attach release manifest to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          test -f release-manifest.json
-          gh release upload "$TAG_NAME" release-manifest.json \
-            --repo "${{ github.repository }}" --clobber
-
-      # Promote from the verified digests captured above (not by re-resolving :${VERSION}).
-      # Idempotent: re-running retags the same digests onto :latest.
-      - name: Promote verified digests to :latest
-        run: |
-          set -euo pipefail
-          OWNER='${{ github.repository_owner }}'
-          test -f release-manifest.json
-
-          promote_one() {
-            local component="$1"
-            local key="$2"
-            local digest
-            digest="$(jq -r --arg k "$key" '.components[$k].digest' release-manifest.json)"
-            case "$digest" in
-              sha256:*) ;;
-              *)
-                echo "::error::Missing digest for ${key} in release-manifest.json"
-                exit 1
-                ;;
-            esac
-            local repo="ghcr.io/${OWNER}/tokentimer-core-${component}"
-            local src="${repo}@${digest}"
-            local dst="${repo}:latest"
-            echo "Promoting ${src} -> ${dst}"
-            if ! docker buildx imagetools create -t "$dst" "$src"; then
-              echo "::error::Failed promoting ${component} to :latest from ${src}"
-              exit 1
-            fi
-          }
-
-          promote_one api api
-          promote_one worker worker
-          promote_one dashboard dashboard
-          promote_one k8s-controller k8sController
-
-          echo "All components promoted to :latest from release-manifest.json digests"


### PR DESCRIPTION
## Summary
Simplify `release.yml` so tag pushes only build and publish release artifacts (Docker images, Helm OCI chart, verified agent tarball). GitHub Releases and `:latest` image promotion are handled manually outside CI, which avoids immutable-release asset upload failures and keeps release notes under human control.

## Changes

### Infra
- Remove `create-release` job (softprops/action-gh-release, agent tarball upload to GitHub Releases).
- Remove `promote-latest` job (`:latest` tag promotion, `release-manifest.json` build/upload).
- Pipeline now ends at `publish-helm-chart` after `verify-release`.
- Update stage comments to match the slimmer workflow.

## Test plan
- [ ] Merge PR
- [ ] Next tag push runs green through `publish-helm-chart` with no downstream jobs
- [ ] Create GitHub Release and attach agent assets manually via `gh release create` / `gh release upload` as today
