### PR TITLE
docs(certops): fix stale dashboard paths in executor-api.md

### DIFF
--- a/docs/certops/executor-api.md
+++ b/docs/certops/executor-api.md
@@ -16,7 +16,7 @@ goes stale.
 
 Machine tokens are scoped API keys for non-human callers (scripts, CI jobs,
 certbot/ACME hooks). Create one from the dashboard: workspace manager or
-admin role, `/certops/operations` page, "Machine API tokens" panel.
+admin role, `/certops/settings` page (Settings tab), "Machine API tokens" panel.
 
 - Format: `ttx_<id>_<secret>` (`apps/api/services/certops/apiTokens.js`).
 - The plaintext token is shown exactly once, in the create-token response.
@@ -310,13 +310,14 @@ should ever be sent to TokenTimer, and if it is, the request is rejected
 
 ## 8. Timeline in the dashboard
 
-Reported events and evidence show up under `/certops/operations` (Executor
-jobs panel + evidence timeline) for workspace managers/admins, with status
-badges, redaction markers, and audit links where available. See
+Reported events and evidence show up under `/certops/jobs` (`/certops/operations`
+permanently redirects there) - Executor jobs panel + evidence timeline - for
+workspace managers/admins, with status badges, redaction markers, and audit
+links where available. See
 `apps/dashboard/src/components/certops/{JobStatusBadge,EvidenceTimeline,CertificateTimeline}.jsx`.
 A job sitting at `pending_approval` shows inline **Approve**/**Reject**
-buttons on its row (manager/admin only, via the confirm modal in
-`apps/dashboard/src/pages/certops/CertOpsOperations.jsx`); see the
+buttons on its row (manager/admin only, via `ApprovalDecisionModal.jsx` inside
+`apps/dashboard/src/pages/certops/CertOpsJobs.jsx`); see the
 "Approval gates" runbook in `tokentimer-cloud`'s docs for the non-requester
 rule and what each decision does.
 


### PR DESCRIPTION
## Summary

- `docs/certops/executor-api.md` pointed machine-token creation at `/certops/operations`; the "Machine API tokens" panel actually lives on the Settings tab (`/certops/settings`, `CertOpsSettings.jsx`).
- The same doc referenced a nonexistent `CertOpsOperations.jsx` for the approval-decision modal. That filename only exists in `tokentimer-cloud` (which has no tab split yet); core's real chain is `CertOpsJobs.jsx` -> `ExecutorJobsPanel.jsx` -> `ApprovalDecisionModal.jsx`.

Found while auditing the equivalent (and more severe) drift in `tokentimer-cloud`'s docs against its actual dashboard routes.

## Test plan

- [x] Verified `/certops/settings` -> `CertOpsSettings.jsx` -> `ApiTokenList.jsx`/`ApiTokenModal.jsx` renders "Machine API tokens" (`CertOpsSettings.jsx`, `CertOpsRoutes.jsx`).
- [x] Verified `CertOpsJobs.jsx` -> `ExecutorJobsPanel.jsx` -> `ApprovalDecisionModal.jsx` is the real approve/reject chain.
- Docs-only change, no code/behavior touched.
