### PR TITLE
fix(deps): revert react-router 8.3.0, incompatible with React 18

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -36,7 +36,7 @@
     "react-icons": "5.5.0",
     "react-joyride": "2.9.3",
     "react-query": "3.39.3",
-    "react-router": "8.3.0",
+    "react-router": "7.18.1",
     "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "devDependencies": {

--- a/packages/agent/scripts/pack-release.test.js
+++ b/packages/agent/scripts/pack-release.test.js
@@ -8,6 +8,9 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { main, sha256File, assertNoPrivateKeyMaterial } = require("./pack-release.js");
 
+const packageJsonPath = path.resolve(__dirname, "..", "package.json");
+const expectedVersion = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).version;
+
 describe("pack-release (H10)", () => {
   let outDir;
 
@@ -18,10 +21,13 @@ describe("pack-release (H10)", () => {
   it("builds a versioned tarball and matching sha256 sidecar", () => {
     outDir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentimer-agent-release-"));
     const result = main([`--out-dir=${outDir}`]);
-    assert.equal(result.version, "0.11.0");
+    assert.equal(result.version, expectedVersion);
     assert.ok(fs.existsSync(result.tarballPath));
     assert.ok(fs.existsSync(result.checksumPath));
-    assert.match(path.basename(result.tarballPath), /tokentimer-agent-0\.11\.0\.tgz$/);
+    assert.match(
+      path.basename(result.tarballPath),
+      new RegExp(`tokentimer-agent-${expectedVersion.replace(/\./g, "\\.")}\\.tgz$`),
+    );
 
     const checksum = fs.readFileSync(result.checksumPath, "utf8").trim();
     assert.equal(checksum, `${result.digest}  ${path.basename(result.tarballPath)}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
         specifier: 3.39.3
         version: 3.39.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router:
-        specifier: 8.3.0
-        version: 8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       xlsx:
         specifier: npm:@e965/xlsx@0.20.3
         version: '@e965/xlsx@0.20.3'
@@ -2227,9 +2227,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-es@3.1.1:
-    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
-
   cookie-parser@1.4.7:
     resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
     engines: {node: '>= 0.8.0'}
@@ -2247,6 +2244,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -3881,12 +3882,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@8.3.0:
-    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
-    engines: {node: '>=22.22.0'}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=19.2.7'
-      react-dom: '>=19.2.7'
+      react: '>=18'
+      react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -4047,6 +4048,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7048,8 +7052,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@3.1.1: {}
-
   cookie-parser@1.4.7:
     dependencies:
       cookie: 0.7.2
@@ -7062,6 +7064,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -8911,10 +8915,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-router@8.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.18.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      cookie-es: 3.1.1
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
@@ -9115,6 +9120,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
PR #103 (Dependabot) bumped \eact-router\ 7.18.1 -> 8.3.0 in \pps/dashboard\. react-router 8.3.0 declares a peer dependency on React >=19.2.7 and relies on React 19's \useOptimistic\ internally. The dashboard is still on React 18.3.1, so \itest run\ failed with \SyntaxError: The requested module 'react' does not provide an export named 'useOptimistic'\ across ~20 component test files (\AgentFleetPanel\, \ApiTokenList\, \ApiTokenModal\, \BootstrapTokenList\, \CertOpsCertificates\, etc). This broke main CI's Coverage Frontend job.

\ite build\ did not catch this because production builds don't execute component render logic, only \itest\'s actual component rendering does.

## Changes
- Revert \pps/dashboard/package.json\: \eact-router\ 8.3.0 -> 7.18.1 (+ \pnpm-lock.yaml\ sync).
- Fix \packages/agent/scripts/pack-release.test.js\: it hardcoded expected version \