### PR TITLE
test: fix worker-claim-lease fixture URL collision after v0.11.2 dedup constraint

### DIFF
--- a/tests/integration/worker-claim-lease.test.js
+++ b/tests/integration/worker-claim-lease.test.js
@@ -385,15 +385,19 @@ describe("Worker claim leases", function () {
 
   describe("endpoint check worker claim lease", () => {
     async function insertMonitor() {
+      // Unique URL per call: domain_monitors now enforces one row per
+      // (workspace_id, url) (uq_domain_monitors_workspace_url), so reusing a
+      // fixed URL across the tests in this describe block would collide.
+      const url = `http://127.0.0.1:9/${crypto.randomUUID()}`;
       const res = await pool.query(
         `INSERT INTO domain_monitors
            (workspace_id, url, token_id, health_check_enabled, check_interval,
             last_health_status, last_health_check_at, consecutive_failures,
             alert_after_failures, created_by)
-         VALUES ($1, 'http://127.0.0.1:9', $2, TRUE, '1min',
-                 'healthy', NOW() - INTERVAL '10 minutes', 0, 2, $3)
+         VALUES ($1, $2, $3, TRUE, '1min',
+                 'healthy', NOW() - INTERVAL '10 minutes', 0, 2, $4)
          RETURNING id`,
-        [workspaceId, tokenId, userId],
+        [workspaceId, url, tokenId, userId],
       );
       monitorIds.push(res.rows[0].id);
       return res.rows[0].id;


### PR DESCRIPTION
## Summary
`main` CI failed after the v0.11.2 release merge (#106): `Coverage Backend` and `Build and Integration Test` both failed with `duplicate key value violates unique constraint "uq_domain_monitors_workspace_url"`.

## Root cause
Migration 37 (`domain_monitors_workspace_url_dedup`, part of the v0.11.2 dedup fix) added a unique index on `domain_monitors (workspace_id, url)`. The `endpoint check worker claim lease` fixture in `tests/integration/worker-claim-lease.test.js` inserted every test monitor for the same workspace with the same hardcoded URL (`http://127.0.0.1:9`), so 3 of its 4 cases started colliding on the new constraint.

## Fix
Give each `insertMonitor()` call in that fixture a unique URL (`http://127.0.0.1:9/<uuid>`). None of the SQL under test filters by URL, only by `id`/`workspace_id`, so this does not change what is being exercised.

## Test plan
- [x] `tests/integration/worker-claim-lease.test.js` - 9/9 passing (was 3 failing)
- [x] Regression sweep against isolated Docker test stack: `worker-claim-lease`, `endpoint-monitor`, `certops-inventory`, `endpoint-check-worker.integration`, `endpoint-health-alerts` - 72/72 passing
- [x] `pnpm run test:unit` - 1268/1268 passing
