### PR TITLE
Release TokenTimer Core v0.11.3 with Cross-Source Monitor Dedup Migration Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-08-01
+
+### Fixed
+
+- **Migration 38's own dedup pass could fail with `duplicate key value violates unique constraint "uq_certificate_instances_target_cert_fingerprint"` on upgrade, on exactly the data it was written to clean up.** Introduced in v0.11.2 to merge cross-source `managed_certificates` duplicates (see v0.11.2 entry above), migration 38's collision detection scanned only the *losing* `managed_certificate`'s `certificate_instances` rows when deciding which duplicates to drop before re-pointing survivors onto the keeper. Since Domain Checker and Endpoint Monitor share one `certificate_targets` row per `domain_monitor_id`, a workspace where both sources had already observed the same live certificate on the same target ended up with the keeper's own instance and a loser's instance already agreeing on `(target_id, observed_fingerprint_sha256)` *before* the migration ran - a collision the loser-only scan never checked for, so the later `UPDATE` that re-points loser rows onto the keeper's `managed_certificate_id` hit the unique constraint directly. The migration's `combined_instances` CTE now unions the keeper's own pre-existing instances into the same collision-detection partition as the losers', so the keeper's row is ranked first and the true duplicate is dropped up front instead of colliding mid-`UPDATE`. This was data-dependent - invisible on an empty database or on a workspace without that specific cross-source overlap - which is why it shipped undetected in v0.11.2 and then failed on `tokentimer-cloud`'s backend startup on upgrade. Added a dedicated upgrade-path integration test (`certops-migrations-37-38-upgrade.test.js`) that seeds this exact colliding shape, and documented the requirement in the release skill: any future migration that merges, dedupes, or backfills pre-existing rows must ship with a test seeded with the colliding legacy data it is meant to clean up, not just clean non-conflicting rows.
+
 ## [0.11.2] - 2026-07-31
 
 ### Fixed

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -2717,18 +2717,40 @@ const migrations = [
           ON k.workspace_id = g.workspace_id AND k.domain_monitor_id = g.domain_monitor_id
        WHERE g.mc_id <> k.keeper_mc_id;
 
-      WITH colliding_instances AS (
-        SELECT ci.id,
-               ROW_NUMBER() OVER (
-                 PARTITION BY ci.workspace_id, ci.target_id, cp.keeper_mc_id,
-                              ci.observed_fingerprint_sha256
-                 ORDER BY (ci.managed_certificate_id = cp.keeper_mc_id) DESC,
-                          ci.updated_at DESC, ci.created_at DESC, ci.id DESC
-               ) AS rn
+      -- Collision detection must also include the KEEPER's own pre-existing
+      -- instances, not just the losers': Domain Checker and Endpoint Monitor
+      -- share one certificate_targets row per domain_monitor_id
+      -- (findOrCreateTarget in monitorBridge.js keys the lookup on
+      -- domain_monitor_id), so when both sources observed the same live
+      -- certificate, the keeper's own instance and a loser's instance
+      -- already agree on (target_id, observed_fingerprint_sha256) before
+      -- this migration ever runs. Scanning losers alone missed that
+      -- collision, so the UPDATE below - which re-points loser rows onto the
+      -- keeper's managed_certificate_id - hit
+      -- uq_certificate_instances_target_cert_fingerprint the moment a loser
+      -- row collided with a keeper row nobody had checked against. Unioning
+      -- keeper + loser instances into one partition lets the ORDER BY
+      -- tiebreaker rank the keeper's own row first and drop the duplicate
+      -- loser row up front instead of during the re-point.
+      WITH combined_instances AS (
+        SELECT DISTINCT ci.id, ci.workspace_id, ci.target_id,
+               ci.observed_fingerprint_sha256, ci.managed_certificate_id,
+               ci.updated_at, ci.created_at, cp.keeper_mc_id
           FROM certificate_instances ci
           JOIN tmp_monitor_cert_pairs cp
-            ON cp.workspace_id = ci.workspace_id AND cp.loser_mc_id = ci.managed_certificate_id
+            ON cp.workspace_id = ci.workspace_id
+           AND ci.managed_certificate_id IN (cp.loser_mc_id, cp.keeper_mc_id)
          WHERE ci.observed_fingerprint_sha256 IS NOT NULL
+      ),
+      colliding_instances AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY workspace_id, target_id, keeper_mc_id,
+                              observed_fingerprint_sha256
+                 ORDER BY (managed_certificate_id = keeper_mc_id) DESC,
+                          updated_at DESC, created_at DESC, id DESC
+               ) AS rn
+          FROM combined_instances
       )
       DELETE FROM certificate_instances
        WHERE id IN (SELECT id FROM colliding_instances WHERE rn > 1);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/k8s-controller/package.json
+++ b/apps/k8s-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/k8s-controller",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "license": "BUSL-1.1",
   "main": "src/index.js",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.11.2
-appVersion: "0.11.2"
+version: 0.11.3
+appVersion: "0.11.3"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.11.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.11.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag; pin from release-manifest.json for reproducible deploys (:latest is not the source of truth)
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.11.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.11.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -158,7 +158,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.11.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.11.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -303,7 +303,7 @@ certops:
     image:
       registry: ""
       repository: tokentimer-core-k8s-controller
-      tag: "0.11.2"  # align with Chart.appVersion; release workflow updates this per tag
+      tag: "0.11.3"  # align with Chart.appVersion; release workflow updates this per tag
       digest: ""
       pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/agent",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "TokenTimer Agent - outbound-only execution-plane process for CertOps",
   "license": "BUSL-1.1",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.11.2
+  version: 0.11.3
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/tests/integration/certops-migrations-37-38-upgrade.test.js
+++ b/tests/integration/certops-migrations-37-38-upgrade.test.js
@@ -1,0 +1,267 @@
+/**
+ * CertOps migrations 37-38 (domain_monitors URL dedup, cross-source monitor
+ * dedup) - upgrade path test on a populated, MESSY database.
+ *
+ * Unlike a fresh-install test (which only proves migrations apply to an
+ * empty schema) or an upgrade test seeded with clean, non-conflicting rows
+ * (which only proves ordinary data survives), this seeds the exact
+ * *colliding* legacy shapes migrations 37 and 38 exist to clean up:
+ *   - two domain_monitors rows for the same (workspace_id, url)
+ *   - two managed_certificates rows (one per monitor source) for the same
+ *     domain_monitor_id, where the keeper already has its own
+ *     certificate_instances row that shares (target_id,
+ *     observed_fingerprint_sha256) with a loser's row - both sources
+ *     observed the same real certificate on the same target, so those rows
+ *     already collide on today's unique index *before* the migration
+ *     touches them.
+ *
+ * v0.11.2 shipped migration 38 without handling that last case: its dedup
+ * pass only scanned losers' own instances, missed the keeper's pre-existing
+ * one, and the later UPDATE that re-points loser rows onto the keeper hit
+ * uq_certificate_instances_target_cert_fingerprint - a data-dependent
+ * failure invisible on an empty DB or on non-colliding seed data, which is
+ * exactly why it shipped undetected and then broke a real deployment on
+ * upgrade. Any future migration that merges or dedupes pre-existing rows
+ * should get a test like this one (see release-tokentimer-core skill).
+ */
+
+const { expect } = require("chai");
+const { Client, Pool } = require("pg");
+const crypto = require("crypto");
+const path = require("path");
+
+const DB_HOST = process.env.DB_HOST || "localhost";
+const DB_PORT = Number(process.env.DB_PORT || process.env.TT_TEST_DB_PORT || 5432);
+const DB_USER = process.env.DB_USER || "tokentimer";
+const DB_PASSWORD = process.env.DB_PASSWORD || "password";
+const ADMIN_DB_NAME = process.env.DB_NAME || "tokentimer";
+const UPGRADE_DB_NAME = "tokentimer_certops_37_38_upgrade_test";
+
+const { migrations } = require(
+  path.join(__dirname, "..", "..", "apps", "api", "migrations", "migrate.js"),
+);
+
+async function adminClient() {
+  const client = new Client({
+    user: DB_USER,
+    host: DB_HOST,
+    database: ADMIN_DB_NAME,
+    password: DB_PASSWORD,
+    port: DB_PORT,
+  });
+  await client.connect();
+  return client;
+}
+
+async function dropDatabase(name) {
+  const admin = await adminClient();
+  try {
+    await admin.query(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [name],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS ${name}`);
+  } finally {
+    await admin.end();
+  }
+}
+
+async function applyMigrations(client, list) {
+  for (const migration of list) {
+    await client.query("BEGIN");
+    try {
+      await client.query(migration.sql);
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw new Error(
+        `Migration ${migration.version} (${migration.name}) failed: ${err.message}`,
+      );
+    }
+  }
+}
+
+describe("CertOps migrations 37-38 - upgrade path on a populated, colliding database", function () {
+  this.timeout(120000);
+
+  let pool;
+  let workspaceId;
+  let duplicateMonitorUrl;
+  let keeperMonitorId;
+  let loserMonitorId;
+  let keeperCertId;
+  let loserCertId;
+  let keeperInstanceId;
+  let loserCollidingInstanceId;
+  let loserRepointInstanceId;
+
+  before(async function () {
+    await dropDatabase(UPGRADE_DB_NAME);
+    const admin = await adminClient();
+    try {
+      await admin.query(`CREATE DATABASE ${UPGRADE_DB_NAME}`);
+    } finally {
+      await admin.end();
+    }
+
+    pool = new Pool({
+      user: DB_USER,
+      host: DB_HOST,
+      database: UPGRADE_DB_NAME,
+      password: DB_PASSWORD,
+      port: DB_PORT,
+      max: 4,
+    });
+
+    const client = await pool.connect();
+    try {
+      const pre37 = migrations.filter((m) => m.version <= 36);
+      const dedupBatch = migrations.filter((m) => m.version >= 37 && m.version <= 38);
+      expect(pre37.length).to.be.greaterThan(0);
+      expect(dedupBatch.length).to.equal(2);
+
+      await applyMigrations(client, pre37);
+
+      const userResult = await client.query(
+        `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+         VALUES ('upgrade-37-38-test@example.com', 'upgrade-37-38-test@example.com', 'Upgrade 37-38 Test User', 'x', 'local', TRUE)
+         RETURNING id`,
+      );
+      const userId = userResult.rows[0].id;
+
+      const ws = await client.query(
+        `INSERT INTO workspaces (id, name, created_by, plan)
+         VALUES (gen_random_uuid(), 'Upgrade 37-38 Test WS', $1, 'oss')
+         RETURNING id`,
+        [userId],
+      );
+      workspaceId = ws.rows[0].id;
+
+      // --- Legacy shape for migration 37: two domain_monitors rows for the
+      // same (workspace_id, url), predating the single-add endpoint's
+      // reuse-existing-monitor fix.
+      duplicateMonitorUrl = "https://cross-source-dedup.example.com";
+      const olderMonitor = await client.query(
+        `INSERT INTO domain_monitors (workspace_id, url, created_by, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days')
+         RETURNING id`,
+        [workspaceId, duplicateMonitorUrl, userId],
+      );
+      loserMonitorId = olderMonitor.rows[0].id;
+      const newerMonitor = await client.query(
+        `INSERT INTO domain_monitors (workspace_id, url, created_by, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day')
+         RETURNING id`,
+        [workspaceId, duplicateMonitorUrl, userId],
+      );
+      keeperMonitorId = newerMonitor.rows[0].id;
+
+      // --- Legacy shape for migration 38: Domain Checker discovered the
+      // host under the OLDER (loser) domain_monitors row; Endpoint Monitor
+      // was toggled on later, minting its own managed_certificates row tied
+      // to the NEWER (keeper) domain_monitors row - both point at the same
+      // real host once 37 merges the monitors.
+      loserCertId = crypto.randomUUID();
+      keeperCertId = crypto.randomUUID();
+      await client.query(
+        `INSERT INTO managed_certificates (id, workspace_id, source, updated_at)
+         VALUES
+           ($1, $3, 'domain_checker',   NOW() - INTERVAL '1 day'),
+           ($2, $3, 'endpoint_monitor', NOW())`,
+        [loserCertId, keeperCertId, workspaceId],
+      );
+
+      const target = await client.query(
+        `INSERT INTO certificate_targets
+           (workspace_id, domain_monitor_id, name, target_type, source)
+         VALUES ($1, $2, 'Cross-source dedup target', 'endpoint', 'endpoint_monitor')
+         RETURNING id`,
+        [workspaceId, keeperMonitorId],
+      );
+      const targetId = target.rows[0].id;
+
+      // keeperInstance and loserCollidingInstance already agree on (target,
+      // fingerprint) - the same live certificate observed by both sources -
+      // so they collide under today's schema before migration 38 ever runs.
+      // loserRepointInstance has a distinct fingerprint and must simply be
+      // re-pointed onto the keeper, not dropped.
+      keeperInstanceId = crypto.randomUUID();
+      loserCollidingInstanceId = crypto.randomUUID();
+      loserRepointInstanceId = crypto.randomUUID();
+      await client.query(
+        `INSERT INTO certificate_instances
+           (id, workspace_id, managed_certificate_id, target_id,
+            domain_monitor_id, observed_fingerprint_sha256, updated_at)
+         VALUES
+           ($1, $4, $7, $5, $6, 'deadbeef', NOW()),
+           ($2, $4, $8, $5, $6, 'deadbeef', NOW() - INTERVAL '1 day'),
+           ($3, $4, $8, $5, $6, 'cafefeed', NOW() - INTERVAL '1 day')`,
+        [
+          keeperInstanceId,
+          loserCollidingInstanceId,
+          loserRepointInstanceId,
+          workspaceId,
+          targetId,
+          keeperMonitorId,
+          keeperCertId,
+          loserCertId,
+        ],
+      );
+
+      // Now upgrade: apply 37-38 on top of this populated, colliding
+      // database. Must not throw
+      // uq_certificate_instances_target_cert_fingerprint.
+      await applyMigrations(client, dedupBatch);
+    } finally {
+      client.release();
+    }
+  });
+
+  after(async function () {
+    if (pool) await pool.end();
+    await dropDatabase(UPGRADE_DB_NAME);
+  });
+
+  it("merges the duplicate domain_monitors row for the same URL (migration 37)", async () => {
+    const monitors = await pool.query(
+      `SELECT id::text AS id FROM domain_monitors WHERE workspace_id = $1 AND url = $2`,
+      [workspaceId, duplicateMonitorUrl],
+    );
+    expect(monitors.rows.map((row) => row.id)).to.deep.equal([keeperMonitorId]);
+  });
+
+  it("merges the cross-source managed_certificates row onto the keeper (migration 38)", async () => {
+    const certs = await pool.query(
+      `SELECT id::text AS id FROM managed_certificates WHERE id = ANY($1::uuid[])`,
+      [[loserCertId, keeperCertId]],
+    );
+    expect(certs.rows.map((row) => row.id)).to.deep.equal([keeperCertId]);
+  });
+
+  it("drops the same-observation collision and re-points the non-colliding loser instance (migration 38)", async () => {
+    const instances = await pool.query(
+      `SELECT id::text AS id, managed_certificate_id::text AS managed_certificate_id
+         FROM certificate_instances
+        WHERE id = ANY($1::uuid[])`,
+      [[keeperInstanceId, loserCollidingInstanceId, loserRepointInstanceId]],
+    );
+    const byId = new Map(
+      instances.rows.map((row) => [row.id, row.managed_certificate_id]),
+    );
+    expect(byId.get(keeperInstanceId)).to.equal(keeperCertId);
+    expect(byId.has(loserCollidingInstanceId)).to.equal(false);
+    expect(byId.get(loserRepointInstanceId)).to.equal(keeperCertId);
+  });
+
+  it("leaves no duplicate (workspace_id, target_id, managed_certificate_id, observed_fingerprint_sha256) rows behind", async () => {
+    const dupes = await pool.query(
+      `SELECT workspace_id, target_id, managed_certificate_id, observed_fingerprint_sha256, COUNT(*)
+         FROM certificate_instances
+        WHERE workspace_id = $1
+        GROUP BY 1, 2, 3, 4
+       HAVING COUNT(*) > 1`,
+      [workspaceId],
+    );
+    expect(dupes.rows).to.have.length(0);
+  });
+});

--- a/tests/integration/suites/core.txt
+++ b/tests/integration/suites/core.txt
@@ -87,6 +87,7 @@ tests/integration/audit-system-admin-org-scope.test.js
 
 # Schema and utilities
 tests/integration/certops-migration.test.js
+tests/integration/certops-migrations-37-38-upgrade.test.js
 tests/integration/certops-inventory.test.js
 tests/integration/certops-inventory-import-helpers.test.js
 tests/integration/certops-controller-observations.test.js


### PR DESCRIPTION
﻿## Summary
Fixes a data-dependent bug in migration 38 (`managed_certificates_cross_source_monitor_dedup`, shipped in v0.11.2) that could fail on upgrade with `duplicate key value violates unique constraint "uq_certificate_instances_target_cert_fingerprint"` on databases where Domain Checker and Endpoint Monitor had already observed the same live certificate on the same target before the migration ran. Also adds a dedicated upgrade-path regression test and documents the requirement for future migrations in the release skill.

## Changes

### API
- `apps/api/migrations/migrate.js` - migration 38's `combined_instances` CTE now unions the keeper's own pre-existing `certificate_instances` rows into the same collision-detection partition as the losers', so a keeper/loser collision is caught and dropped before the re-point `UPDATE` instead of colliding mid-`UPDATE`.

### Tests
- `tests/integration/certops-migrations-37-38-upgrade.test.js` (new) - upgrade-path test that applies migrations 1-36, seeds the exact colliding legacy shape (duplicate `domain_monitors` for one URL, plus a keeper `certificate_instances` row colliding with a loser's on `(target_id, observed_fingerprint_sha256)`), then applies 37-38 and asserts clean dedup with no thrown error.
- Registered in `tests/integration/suites/core.txt` so `test:ci` picks it up automatically.

### Docs / metadata
- `CHANGELOG.md` - documents the bug (introduced in v0.11.2) and the fix.
- Version bumped to 0.11.3 across all manifests, contracts, and Helm chart.

## Test plan
- [ ] CI job passes (link the run)
- [x] New upgrade-path test verified locally: fails with the exact reported error against the pre-fix migration SQL, passes with the fix, and passes alongside the full existing `certops-migration.test.js` suite.
