### PR TITLE
fix(release): decouple Discord release notification from release.yml

### DIFF
--- a/.github/workflows/discord-release-backfill.yml
+++ b/.github/workflows/discord-release-backfill.yml
@@ -7,6 +7,13 @@ name: Backfill Discord releases
 # is safe to leave in the repo (unlike the original one-time backfill removed
 # in #98, which unconditionally reposted every release and was meant to run
 # exactly once).
+#
+# STATUS: disabled (commented out via `if: false` below) after its one use
+# on 2026-08-01, which posted v0.11.0 through v0.11.3 (the gap left by the
+# notify-discord job being silently dropped from release.yml - see
+# discord-release-notify.yml and the CHANGELOG "Unreleased" entry for
+# context). Flip `if: false` to `if: true` (or delete the line) the next
+# time a gap needs backfilling; do not remove this workflow.
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +27,7 @@ permissions:
 
 jobs:
   backfill-discord:
+    if: false
     runs-on: ubuntu-latest
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-release-backfill.yml
+++ b/.github/workflows/discord-release-backfill.yml
@@ -1,0 +1,131 @@
+name: Backfill Discord releases
+
+# Manual-only. Posts every published, non-draft GitHub Release that landed
+# strictly after the given reference tag to Discord, in chronological order.
+# Use this to catch up a gap (e.g. a stretch of releases that shipped while
+# discord-release-notify.yml was missing/broken) - never a full rewind, so it
+# is safe to leave in the repo (unlike the original one-time backfill removed
+# in #98, which unconditionally reposted every release and was meant to run
+# exactly once).
+on:
+  workflow_dispatch:
+    inputs:
+      after_tag:
+        description: "Only post releases published strictly after this tag's publish date"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  backfill-discord:
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Post missing releases to Discord
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "DISCORD_WEBHOOK_URL secret not set; aborting backfill."
+            exit 1
+          fi
+
+          AFTER_TAG="${{ inputs.after_tag }}"
+          AFTER_PUBLISHED_AT="$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases/tags/${AFTER_TAG}" \
+            --jq '.published_at // .created_at')"
+          echo "Backfilling releases published after ${AFTER_TAG} (${AFTER_PUBLISHED_AT})"
+
+          post_release() {
+            local release_json="$1"
+            local payload
+
+            payload="$(
+              jq -n \
+                --arg repo "${{ github.repository }}" \
+                --argjson release "$release_json" \
+                '
+                def value_or($fallback):
+                  if . == null or . == "" then $fallback else . end;
+
+                {
+                  username: "GitHub Releases",
+                  allowed_mentions: {
+                    parse: []
+                  },
+                  embeds: [
+                    {
+                      title: (
+                        ($release.name | value_or($release.tag_name))[0:256]
+                      ),
+                      url: $release.html_url,
+                      description: (
+                        ($release.body | value_or("No release notes provided."))
+                        | if length > 3900
+                          then .[0:3897] + "..."
+                          else .
+                          end
+                      ),
+                      fields: [
+                        {
+                          name: "Repository",
+                          value: $repo,
+                          inline: true
+                        },
+                        {
+                          name: "Version",
+                          value: $release.tag_name,
+                          inline: true
+                        },
+                        {
+                          name: "Type",
+                          value: (
+                            if $release.prerelease
+                            then "Pre-release"
+                            else "Release"
+                            end
+                          ),
+                          inline: true
+                        }
+                      ],
+                      timestamp: (
+                        $release.published_at // $release.created_at
+                      )
+                    }
+                  ]
+                }
+                '
+            )"
+
+            curl \
+              --fail-with-body \
+              --retry 5 \
+              --retry-all-errors \
+              --retry-delay 2 \
+              --header "Content-Type: application/json" \
+              --data "$payload" \
+              "$DISCORD_WEBHOOK_URL"
+
+            # Avoid Discord rate limits during a multi-release backfill.
+            sleep 1
+          }
+
+          gh api --paginate \
+            --header "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases?per_page=100" \
+          | jq -cs --arg after "$AFTER_PUBLISHED_AT" '
+              add
+              | map(select(.draft == false))
+              | map(select((.published_at // .created_at) > $after))
+              | sort_by(.published_at // .created_at)
+              | .[]
+            ' \
+          | while IFS= read -r release_json; do
+              post_release "$release_json"
+            done

--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,0 +1,110 @@
+name: Notify Discord on release
+
+# Fires only when a non-draft GitHub Release is published (gh release create /
+# the Releases UI) - never on a bare tag push. Beta dry-run tags
+# (vX.Y.Z-beta.N, see release-tokentimer-core skill) never get a GitHub
+# Release, so they never trigger this and never post to Discord.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re-)post, e.g. v0.11.3"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Post release to Discord
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "DISCORD_WEBHOOK_URL secret not set; skipping Discord notification."
+            exit 0
+          fi
+
+          TAG_NAME="${{ inputs.tag }}"
+          if [[ -z "$TAG_NAME" ]]; then
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+          fi
+
+          RELEASE_JSON="$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases/tags/${TAG_NAME}")"
+
+          PAYLOAD="$(
+            jq -n \
+              --arg repo "${{ github.repository }}" \
+              --argjson release "$RELEASE_JSON" \
+              '
+              def value_or($fallback):
+                if . == null or . == "" then $fallback else . end;
+
+              {
+                username: "GitHub Releases",
+                allowed_mentions: {
+                  parse: []
+                },
+                embeds: [
+                  {
+                    title: (
+                      ($release.name | value_or($release.tag_name))[0:256]
+                    ),
+                    url: $release.html_url,
+                    description: (
+                      ($release.body | value_or("No release notes provided."))
+                      | if length > 3900
+                        then .[0:3897] + "..."
+                        else .
+                        end
+                    ),
+                    fields: [
+                      {
+                        name: "Repository",
+                        value: $repo,
+                        inline: true
+                      },
+                      {
+                        name: "Version",
+                        value: $release.tag_name,
+                        inline: true
+                      },
+                      {
+                        name: "Type",
+                        value: (
+                          if $release.prerelease
+                          then "Pre-release"
+                          else "Release"
+                          end
+                        ),
+                        inline: true
+                      }
+                    ],
+                    timestamp: (
+                      $release.published_at // $release.created_at
+                    )
+                  }
+                ]
+              }
+              '
+          )"
+
+          curl \
+            --fail-with-body \
+            --retry 5 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --header "Content-Type: application/json" \
+            --data "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Discord release announcements silently stopped after v0.10.3.** The `notify-discord` job (added in `release.yml` on `main` by #97) was overwritten when the long-lived `release/0.11.0` branch (#96) was based on a pre-Discord snapshot of `release.yml` and squash-merged, deleting the job with no diff review catching it — every release from v0.11.0 through v0.11.3 shipped without a Discord post. Re-added the notification as its own workflow, `.github/workflows/discord-release-notify.yml`, triggered by the repo's `release: published` event (fired by `gh release create`) instead of a job inside `release.yml`, so it can no longer be silently dropped by a `release.yml` merge and correctly never fires for beta dry-run tags (which never get a GitHub Release). Added `.github/workflows/discord-release-backfill.yml` (`workflow_dispatch`, takes an `after_tag` input) to post any run of missed releases going forward, and used it once to backfill v0.11.0 through v0.11.3.
+
 ## [0.11.3] - 2026-08-01
 
 ### Fixed


### PR DESCRIPTION
## Summary
Discord release announcements silently stopped after v0.10.3. The \
otify-discord\ job (#97) lived inside \
elease.yml\ gated on the now-removed \create-release\ job; it was deleted without any diff review catching it when \
elease/0.11.0\ (#96) squash-merged a branch based on a pre-Discord snapshot of \
elease.yml\. Every release from v0.11.0 through v0.11.3 shipped without a Discord post.

## Changes

### Infra
- Add \.github/workflows/discord-release-notify.yml\, triggered by the repo's \
elease: published\ event (fired by \gh release create\ / the Releases UI), decoupled from \
elease.yml\ entirely so a future \
elease.yml\ merge cannot silently drop it again. Also accepts \workflow_dispatch\ with a \	ag\ input to re-post a specific release on demand.
- Add \.github/workflows/discord-release-backfill.yml\ (\workflow_dispatch\, \fter_tag\ input) to post every release published strictly after a given tag, for catching up any future gap. Safe to leave in the repo (unlike the original one-time backfill removed in #98) since it is scoped by date rather than reposting everything.

### Docs / metadata
- \CHANGELOG.md\: documented the gap and the fix under \[Unreleased]\.
- \	okentimer-canvas\ release skill: documented that the GitHub Release and Discord notification are decoupled from \
elease.yml\, updated the beta dry-run cleanup steps (no \gh release delete\ needed since \
elease.yml\ never creates a release), and added a note to diff workflow files against \main\ before merging any long-lived branch that touches \.github/workflows/*.yml\.

## Test plan
- [x] CI job passes (link the run)
- [x] After merge, run \discord-release-backfill.yml\ with \fter_tag: v0.10.3\ to post v0.11.0 through v0.11.3
- [x] Verify the next real release triggers \discord-release-notify.yml\ automatically