### PR TITLE
feat(certops): surface claim/lease/attempt metadata on job timeline

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -1081,6 +1081,23 @@ function jobDetail(job) {
     resultMetadata: job.resultMetadata || {},
     errorCode: job.errorCode,
     errorMessage: job.errorMessage,
+    // Claim/lease/attempt metadata: already computed by the service layer
+    // (mapJobRow in services/certops/jobs.js) but previously dropped at this
+    // projection boundary, so a human reviewing the job timeline had no
+    // visibility into which agent held the job, how long its lease was valid
+    // for, or which attempt this was. There is no per-attempt signing-key id
+    // anywhere in the schema or agent protocol (pinned_signing_key_id lives
+    // on certops_agents, not on a job/attempt), so that piece isn't included
+    // here - it would need new schema, not just a projection fix. The
+    // job-detail route below best-effort-resolves the claiming agent's
+    // current pinned key as the closest honest proxy.
+    claimId: job.claimId,
+    claimedByAgentId: job.claimedByAgentId,
+    claimedByControllerClusterId: job.claimedByControllerClusterId,
+    leaseExpiresAt: job.leaseExpiresAt,
+    leaseRenewedAt: job.leaseRenewedAt,
+    attemptCount: job.attemptCount,
+    maxAttempts: job.maxAttempts,
   };
 }
 
@@ -2050,7 +2067,31 @@ router.get(
         });
       }
 
-      return res.json({ job: jobDetail(job) });
+      // There is no per-attempt signing-key id anywhere in the schema, so
+      // the closest honest proxy for "which signing key backed this
+      // dispatch" is the claiming agent's own currently-pinned key. Best
+      // effort only: a lookup failure must not fail the job-detail response.
+      let claimedByAgentSigningKeyId = null;
+      if (job.claimedByAgentId) {
+        try {
+          const claimingAgent = await getAgentById({
+            workspaceId: req.workspace.id,
+            agentId: job.claimedByAgentId,
+          });
+          claimedByAgentSigningKeyId =
+            claimingAgent?.pinnedSigningKeyId ?? null;
+        } catch (lookupErr) {
+          logger.warn("CertOps job-detail signing-key lookup failed", {
+            error: lookupErr.message,
+            workspaceId: req.workspace?.id,
+            jobId,
+          });
+        }
+      }
+
+      return res.json({
+        job: { ...jobDetail(job), claimedByAgentSigningKeyId },
+      });
     } catch (err) {
       const handled = handleCertOpsError(res, err);
       if (handled) return handled;

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -200,6 +200,32 @@ function redactDeploymentPathForViewers(req, certificateOrList) {
     : strip(certificateOrList);
 }
 
+/**
+ * Strips `claimId` from a job-detail projection before it reaches anyone
+ * below admin/owner.
+ *
+ * claimId is the lease token an agent must reprove on every renew/report
+ * call before it can act on a host (see the agent claim/renew/report
+ * routes and lease_renewed_at handling in services/certops/jobs.js) - closer
+ * to a credential than to ordinary job metadata like status or timestamps.
+ * The job-detail read route is intentionally not manager-gated (any
+ * workspace member can follow a job's timeline), so this keeps the same
+ * viewer-can-read / value-can-be-sensitive split that
+ * `redactDeploymentPathForViewers` uses for deployment paths, but at the
+ * stricter admin threshold: unlike a filesystem path, this value is
+ * reusable proof of lease ownership for as long as the lease is open, so a
+ * manager who can create jobs still isn't the right audience for it.
+ */
+function redactClaimIdForNonAdmins(req, jobDetailProjection) {
+  if (!jobDetailProjection || !jobDetailProjection.claimId) {
+    return jobDetailProjection;
+  }
+  if (req.isWorkerCall || hasAtLeastRole(req.authz?.workspaceRole, "admin")) {
+    return jobDetailProjection;
+  }
+  return { ...jobDetailProjection, claimId: undefined };
+}
+
 function requireCertOpsTokenManager(req, res, next) {
   if (req.isWorkerCall || !req.user?.id) {
     return res.status(403).json({
@@ -669,7 +695,9 @@ function createManualCertificateJobHandler({
         actorUserId: req.user?.id || null,
         subjectUserId: req.user?.id || null,
       });
-      return res.status(201).json({ job: jobDetail(job) });
+      return res
+        .status(201)
+        .json({ job: redactClaimIdForNonAdmins(req, jobDetail(job)) });
     } catch (err) {
       const handled = handleCertOpsError(res, err);
       if (handled) return handled;
@@ -1011,7 +1039,7 @@ function createControllerProvisionIntentHandler({
         actorUserId: req.user?.id || null,
       });
       return res.status(result.duplicate ? 200 : 201).json({
-        job: jobDetail(result.job),
+        job: redactClaimIdForNonAdmins(req, jobDetail(result.job)),
         managedCertificateId: result.managedCertificateId,
         targetId: result.targetId,
         duplicate: Boolean(result.duplicate),
@@ -2090,7 +2118,10 @@ router.get(
       }
 
       return res.json({
-        job: { ...jobDetail(job), claimedByAgentSigningKeyId },
+        job: redactClaimIdForNonAdmins(req, {
+          ...jobDetail(job),
+          claimedByAgentSigningKeyId,
+        }),
       });
     } catch (err) {
       const handled = handleCertOpsError(res, err);
@@ -2901,7 +2932,9 @@ router.post(
         actorUserId: req.user?.id || null,
         subjectUserId: req.user?.id || null,
       });
-      return res.status(201).json({ job: jobDetail(job) });
+      return res
+        .status(201)
+        .json({ job: redactClaimIdForNonAdmins(req, jobDetail(job)) });
     } catch (err) {
       const handled = handleCertOpsError(res, err);
       if (handled) return handled;
@@ -3030,4 +3063,6 @@ module.exports._test = {
   loadRenewalSetupIntents,
   projectRenewalSetupState,
   apiTokenMetadata,
+  jobDetail,
+  redactClaimIdForNonAdmins,
 };

--- a/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
+++ b/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
@@ -331,7 +331,42 @@ export default function EvidenceTimeline({ jobId, onClose }) {
                 label={subjectTypeLabel(job.subjectType) || 'Subject'}
               />
             ) : null}
+            {job.claimId ? (
+              <CopyableId id={job.claimId} label='Claim ID' />
+            ) : null}
+            {job.claimedByAgentId ? (
+              <CopyableId id={job.claimedByAgentId} label='Claimed by agent' />
+            ) : null}
+            {job.claimedByControllerClusterId ? (
+              <CopyableId
+                id={job.claimedByControllerClusterId}
+                label='Claimed by controller'
+              />
+            ) : null}
+            {job.claimedByAgentSigningKeyId ? (
+              <CopyableId
+                id={job.claimedByAgentSigningKeyId}
+                label="Agent's pinned signing key"
+              />
+            ) : null}
           </HStack>
+          {job.claimId || job.leaseExpiresAt || job.attemptCount ? (
+            <HStack spacing={3} flexWrap='wrap'>
+              {job.leaseExpiresAt ? (
+                <Text fontSize='xs' color={muted}>
+                  Lease expires {formatDateTime(job.leaseExpiresAt)}
+                </Text>
+              ) : null}
+              {typeof job.attemptCount === 'number' ? (
+                <Text fontSize='xs' color={muted}>
+                  Attempt {job.attemptCount}
+                  {typeof job.maxAttempts === 'number'
+                    ? ` of ${job.maxAttempts}`
+                    : ''}
+                </Text>
+              ) : null}
+            </HStack>
+          ) : null}
         </VStack>
         {typeof onClose === 'function' ? (
           <IconButton

--- a/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
@@ -307,6 +307,40 @@ describe('EvidenceTimeline', () => {
     expect(screen.getAllByText('Redacted')).toHaveLength(1);
   });
 
+  it('shows the Claim ID chip when the API returns claimId (admin/owner viewer)', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob({ claimId: '22222222-2222-4222-8222-222222222222' }),
+      logEntries: [],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.getByText('Claim ID')).toBeInTheDocument();
+    expect(
+      screen.getByText('22222222-2222-4222-8222-222222222222')
+    ).toBeInTheDocument();
+  });
+
+  it('hides the Claim ID chip when the API omits claimId (non-admin viewer)', () => {
+    // The API omits `claimId` entirely for non-admin/owner workspace members;
+    // this mirrors that redacted response shape rather than sending it and
+    // hiding it client-side.
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.queryByText('Claim ID')).not.toBeInTheDocument();
+  });
+
   it('renders the failure reason for a failed job', () => {
     useCertOpsJobTimelineMock.mockReturnValue({
       job: baseJob({

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -7620,6 +7620,41 @@ components:
           type: string
           maxLength: 1024
           nullable: true
+        claimId:
+          type: string
+          format: uuid
+          nullable: true
+        claimedByAgentId:
+          type: string
+          format: uuid
+          nullable: true
+        claimedByControllerClusterId:
+          type: string
+          nullable: true
+        leaseExpiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        leaseRenewedAt:
+          type: string
+          format: date-time
+          nullable: true
+        attemptCount:
+          type: integer
+          minimum: 0
+        maxAttempts:
+          type: integer
+          minimum: 0
+        claimedByAgentSigningKeyId:
+          type: string
+          nullable: true
+          description: |-
+            Best-effort proxy for "which signing key backed this job's dispatch": the
+            claiming agent's *currently* pinned signing key, resolved by the single-job
+            GET .../certops/jobs/{jobId} route only (absent on job-creation responses).
+            There is no per-attempt signing-key column in the schema, so this reflects
+            the agent's key at read time, not necessarily the key pinned at the moment
+            of the specific claim being viewed.
     CertOpsJobDetailResponse:
       type: object
       additionalProperties: false

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -7624,6 +7624,12 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: |-
+            The current lease token an agent must reprove on every renew/report
+            call before it can act on this job. Only returned to workspace
+            admins/owners; other workspace members (who can still read this
+            endpoint) get this field omitted, since the raw value is reusable
+            proof of lease ownership for as long as the lease is open.
         claimedByAgentId:
           type: string
           format: uuid

--- a/tests/unit/certops-job-claim-id-visibility.test.js
+++ b/tests/unit/certops-job-claim-id-visibility.test.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  _test: { jobDetail, redactClaimIdForNonAdmins },
+} = require(path.resolve(__dirname, "../../apps/api/routes/certops.js"));
+
+const CLAIM_ID = "22222222-2222-4222-8222-222222222222";
+
+function claimedJob(overrides = {}) {
+  return {
+    id: "job-1",
+    workspaceId: "11111111-1111-4111-8111-111111111111",
+    operation: "renew",
+    status: "claimed",
+    source: "api",
+    subjectType: "managed_certificate",
+    subjectId: "cert-1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    claimId: CLAIM_ID,
+    claimedByAgentId: "agent-1",
+    leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+    attemptCount: 1,
+    maxAttempts: 3,
+    ...overrides,
+  };
+}
+
+describe("CertOps job-detail claimId visibility", () => {
+  it("keeps claimId for an admin workspace role", () => {
+    const req = { authz: { workspaceRole: "admin" } };
+    const projection = redactClaimIdForNonAdmins(req, jobDetail(claimedJob()));
+
+    assert.equal(projection.claimId, CLAIM_ID);
+  });
+
+  it("strips claimId for a workspace_manager role", () => {
+    const req = { authz: { workspaceRole: "workspace_manager" } };
+    const projection = redactClaimIdForNonAdmins(req, jobDetail(claimedJob()));
+
+    assert.equal(projection.claimId, undefined);
+  });
+
+  it("strips claimId for a viewer role", () => {
+    const req = { authz: { workspaceRole: "viewer" } };
+    const projection = redactClaimIdForNonAdmins(req, jobDetail(claimedJob()));
+
+    assert.equal(projection.claimId, undefined);
+  });
+
+  it("strips claimId when the caller has no resolved workspace role", () => {
+    const req = { authz: {} };
+    const projection = redactClaimIdForNonAdmins(req, jobDetail(claimedJob()));
+
+    assert.equal(projection.claimId, undefined);
+  });
+
+  it("keeps claimId for internal worker calls, which carry implicit admin", () => {
+    const req = { isWorkerCall: true, authz: {} };
+    const projection = redactClaimIdForNonAdmins(req, jobDetail(claimedJob()));
+
+    assert.equal(projection.claimId, CLAIM_ID);
+  });
+
+  it("is a no-op when the job has no claimId yet (unclaimed job)", () => {
+    const req = { authz: { workspaceRole: "viewer" } };
+    const projection = redactClaimIdForNonAdmins(
+      req,
+      jobDetail(claimedJob({ claimId: null })),
+    );
+
+    assert.equal(projection.claimId, null);
+  });
+
+  it("leaves every other job-detail field untouched for a non-admin", () => {
+    const req = { authz: { workspaceRole: "viewer" } };
+    const detail = jobDetail(claimedJob());
+    const projection = redactClaimIdForNonAdmins(req, detail);
+
+    for (const [key, value] of Object.entries(detail)) {
+      if (key === "claimId") continue;
+      assert.equal(projection[key], value, `${key} must be unchanged`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The job-detail API already computed `claimId`, `claimedByAgentId`, `claimedByControllerClusterId`, `leaseExpiresAt`, `leaseRenewedAt`, `attemptCount`, and `maxAttempts` in the service layer (`mapJobRow` in `services/certops/jobs.js`), but the route's `jobDetail()` projection dropped all of it, so a human reviewing the job timeline had no visibility into which agent held a job, how long its lease was valid, or which attempt was in progress.
- `jobDetail()` in `apps/api/routes/certops.js` now includes all seven fields.
- The single-job `GET /api/v1/workspaces/:id/certops/jobs/:jobId` route additionally best-effort resolves the claiming agent's currently-pinned signing key as `claimedByAgentSigningKeyId`, the closest honest proxy available since there is no per-attempt signing-key column in the schema; a lookup failure never fails the job-detail response.
- `EvidenceTimeline.jsx` renders all of this (claim id / claimed-by agent / claimed-by controller / pinned signing key as `CopyableId` chips, lease expiry and attempt count as plain text), each conditional so a job with no claim history shows none of it.
- `openapi.yaml`'s `CertOpsJobDetail` schema documents the new properties.

Ported from a fix already shipped in `tokentimer-cloud`, which forked these two files pre-pin (`fileOverride`/`derivedDivergence`+`coreParity`) and had diverged from core since. Core's `jobDetail()`/`EvidenceTimeline.jsx` were otherwise unchanged from the shape at the last re-pin, so this is an additive, backwards-compatible change (no fields removed, `additionalProperties: false` on `CertOpsJobDetail` already required documenting the new keys before runtime could return them without failing schema validation).

**Not included:** a genuine per-attempt signing-key column. `claimedByAgentSigningKeyId` reflects the claiming agent's *current* pinned key at read time, not necessarily the key pinned at the moment of that specific claim, a schema gap, not addressed here.

## Test plan

- [x] `node --check apps/api/routes/certops.js`
- [x] `pnpm --filter @tokentimer/api lint` — 0 errors, pre-existing unrelated warnings only
- [x] `pnpm --filter @tokentimer/dashboard exec prettier --check src/components/certops/EvidenceTimeline.jsx`
- [x] `pnpm --filter @tokentimer/dashboard lint` — 0 errors, pre-existing unrelated warnings only
- [x] `pnpm run test:unit` — 1268/1268 passing
- [x] `pnpm run check:contracts` / `check:contracts:integrity` — ok
- [x] Live integration run against `docker-compose.test.yml`: `tests/integration/certops-job-read-apis.test.js` — 5/5 passing, including "gets one sanitized job detail"
- [ ] Manual: open a claimed/completed CertOps job's timeline in the dashboard and confirm the new chips/labels render as expected
