### PR TITLE
feat(agent): enforce real Windows ACLs instead of best-effort chmod skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,52 @@ jobs:
       - name: Validate local dev postgres compose
         run: DB_PASSWORD=password docker compose -f deploy/compose/docker-compose.postgres.yml config -q
 
+  windows_agent_quality:
+    name: Windows Agent Quality Checks
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: "11.13.0"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint agent package
+        run: pnpm run lint:agent
+
+      - name: Validate shipped agent sources (includes install-agent.ps1 parse + UTF-8-no-BOM check)
+        run: pnpm run build:agent
+
+      - name: Run agent package tests (Windows ACL/durability/platform suite)
+        run: pnpm run test:agent
+
+      - name: Dry-run install-agent.ps1
+        shell: pwsh
+        run: |
+          ./packages/agent/scripts/install-agent.ps1 `
+            --api-url https://example.com `
+            --workspace-id ws_ci_dry_run `
+            --bootstrap-token ttboot_ci_dry_run_placeholder_token_value `
+            --write-path "C:\certs\ci-example" `
+            --reload-service nginx `
+            --dry-run
+
+      - name: Dry-run install-agent.ps1 --uninstall
+        shell: pwsh
+        run: ./packages/agent/scripts/install-agent.ps1 --uninstall --dry-run
+
   docker_build_and_scan:
     name: Docker Build & Security Scan
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dist/
 build/
 .next/
 out/
+# Windows service host binaries are built on demand by
+# packages/agent/scripts/build-windows-service-host.js (see pack:release);
+# never commit the compiled output.
+packages/agent/bin/*.exe
 
 # Environment files
 .env

--- a/docs/adr/0012-certops-windows-execution-surface-and-trust-anchors.md
+++ b/docs/adr/0012-certops-windows-execution-surface-and-trust-anchors.md
@@ -92,7 +92,15 @@ described below may now begin.** The PRs that implement this feature set
 follow this decision rather than re-deciding it; any future change to a
 decision here is a new, explicitly logged amendment, not a silent
 divergence in code.
-**An eighth amendment (2026-08-04, post-acceptance) corrects decision 1's
+**An eighth amendment (2026-08-03, post-acceptance) corrected decision 11**:
+the original decision assumed a plain native Windows Service was sufficient
+to run the Node.js agent, but a Node process cannot itself answer the
+Service Control Manager's start/stop protocol
+(`StartServiceCtrlDispatcher`), which would have made the service fail to
+start on a real host. Decision 11 now documents the small native service
+host that answers the SCM on the agent's behalf and runs the Node process
+as its supervised child.
+**A ninth amendment (2026-08-04, post-acceptance) corrects decision 1's
 numeric limits table.** The encoded-payload bound was originally set to
 65,536 characters, the tightest value that still decodes to at most the
 49,152-byte decoded-payload bound (`floor(65536/4)*3 = 49152` exactly).
@@ -1210,6 +1218,25 @@ protocol, not a narrower account:
   IIS-binding action produces evidence and an audit event, so `LocalSystem`
   breadth is paired with a durable trail of what it actually did, which is the
   control the account name cannot provide by itself.
+
+**Amended 2026-08-03: the service's binPath is a native host process, not
+node.exe directly.** A plain Node.js process never calls the Win32
+`StartServiceCtrlDispatcher` API, so the Service Control Manager cannot start
+it as a service at all (it fails the start after its startup timeout,
+Windows error 1053); this was an open gap in the original decision, not a
+choice it made. The install script now points the service's `binPath` at a
+small native host built from `packages/agent/windows-service-host` (Go,
+using `golang.org/x/sys/windows/svc`), which itself answers the SCM's
+start/stop/interrogate protocol, running under the same `LocalSystem`
+account, then launches `node.exe` plus the agent entry point as its child
+process. A stop or shutdown request is translated into a `CTRL_BREAK_EVENT`
+delivered to the child, giving the agent a chance to shut down gracefully,
+with a bounded wait before the host force-terminates the child. The host
+adds no new standing privilege: it runs in the same `LocalSystem` account
+this decision already established and performs no certificate, trust-store,
+or IIS operation itself. It is built, signed and shipped alongside the
+existing agent package, carrying the same provenance and ACL treatment
+already applied to that package's own files.
 
 ### 12. Rejected privilege models
 

--- a/docs/certops/agent.md
+++ b/docs/certops/agent.md
@@ -1107,6 +1107,33 @@ Windows:
 - The default config directory is `%APPDATA%\tokentimer-agent`.
 - Absolute-path detection accepts POSIX (`/...`), Windows drive (`C:\...`),
   and UNC (`\\...`) forms.
+- **Windows service host.** `install-agent.ps1` does not point the
+  `TokenTimerAgent` service's `binPath` directly at `node.exe`: a plain Node
+  process never calls `StartServiceCtrlDispatcher`, so the Service Control
+  Manager fails the start (error 1053) and the configured failure/restart
+  policy turns that into a restart loop. `binPath` instead points at a small
+  native host, `packages/agent/windows-service-host` (Go, cross-compiled for
+  both supported architectures by `build:windows-service-host`, shipped in
+  the package's own `bin/`), which answers the SCM's start/stop/interrogate
+  protocol on the agent's behalf, launches `node.exe` plus the agent entry
+  point as its child process, and translates a stop/shutdown request into a
+  graceful `CTRL_BREAK_EVENT` with a bounded wait before force-killing the
+  child. See ADR-0012 decision 11.
+- **Windows build-number floor.** `install-agent.ps1` fails closed before
+  doing anything else if `[System.Environment]::OSVersion.Version.Build` is
+  below 14393 (Windows Server 2016 / Windows 10 1607), the first widely-
+  deployed release with both WDAC (ADR-0012 decision 8's documented
+  hardened PowerShell-trust alternative) and CNG non-exportable key custody
+  (decision 1) generally available. This is a preflight check only; it does
+  not change what the agent itself requires at runtime.
+- **Registry-persisted bootstrap token is cleared after registration.** The
+  installer writes the bootstrap token into the service's own
+  `HKLM:\SYSTEM\CurrentControlSet\Services\TokenTimerAgent\Environment`
+  value so the service process inherits it as an environment variable, then
+  deletes the on-disk `bootstrap.env` file. The agent itself rewrites that
+  registry value (dropping the token, keeping the config-dir entry) once
+  registration succeeds, so the secret does not outlive its single-use
+  purpose by lingering in the registry after a successful exchange.
 
 ## 9. Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:controller": "pnpm --filter @tokentimer/k8s-controller build",
     "build:dashboard": "pnpm --filter @tokentimer/dashboard build",
     "build:agent": "pnpm --filter @tokentimer/agent build",
+    "build:agent:windows-service-host": "pnpm --filter @tokentimer/agent build:windows-service-host",
     "start": "pnpm run start:api",
     "start:api": "pnpm --filter @tokentimer/api start",
     "start:worker": "pnpm --filter @tokentimer/worker start",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "node bin/tokentimer-agent.js",
     "build": "node scripts/check-shipped-sources.js",
+    "build:windows-service-host": "node scripts/build-windows-service-host.js",
     "sync-vendor": "node scripts/sync-vendor.js",
     "pack:release": "node scripts/pack-release.js",
     "lint": "eslint .",
@@ -27,6 +28,7 @@
     "!src/verify/fixtures/**",
     "vendor",
     "scripts/install-agent.sh",
+    "scripts/install-agent.ps1",
     "scripts/tokentimer-agent.service",
     "scripts/host-sandbox.js",
     "scripts/validate-server-url.js",

--- a/packages/agent/scripts/build-windows-service-host.js
+++ b/packages/agent/scripts/build-windows-service-host.js
@@ -1,0 +1,109 @@
+"use strict";
+
+/**
+ * Cross-compiles the Windows service host binary (windows-service-host/)
+ * for both architectures install-agent.ps1 supports (see its OS/arch gate:
+ * AMD64, ARM64) and writes them to bin/ alongside the agent's own
+ * JavaScript entry points.
+ *
+ * Runs from any OS with a Go toolchain: the host has no cgo dependency
+ * (only golang.org/x/sys/windows, which is pure Go), so GOOS=windows
+ * cross-compilation works identically on the Linux release runner
+ * (release.yml's pack-agent job) and on a Windows dev machine.
+ *
+ * This is a separate script from check-shipped-sources.js (the agent's
+ * "build" step) rather than folded into it: check-shipped-sources.js
+ * validates JavaScript/PowerShell sources and intentionally has zero
+ * external tool dependencies; requiring a Go toolchain there would break
+ * that script everywhere it currently runs unconditionally.
+ *
+ *   node scripts/build-windows-service-host.js [--out-dir DIR]
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const packageRoot = path.resolve(__dirname, "..");
+const moduleDir = path.join(packageRoot, "windows-service-host");
+
+/** install-agent.ps1's OS/arch gate accepts exactly these two, and maps
+ * PROCESSOR_ARCHITECTURE values AMD64/ARM64 to these lowercase GOARCH
+ * names 1:1; keep this list and that gate in sync. */
+const TARGET_ARCHES = ["amd64", "arm64"];
+
+function parseArgs(argv) {
+  let outDir = path.join(packageRoot, "bin");
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--out-dir") {
+      outDir = path.resolve(argv[++i] || "");
+    } else if (arg.startsWith("--out-dir=")) {
+      outDir = path.resolve(arg.slice("--out-dir=".length));
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return { outDir };
+}
+
+function hostBinaryName(arch) {
+  return `tokentimer-agent-host-${arch}.exe`;
+}
+
+function buildOne(arch, outDir) {
+  const outputPath = path.join(outDir, hostBinaryName(arch));
+  const result = spawnSync(
+    "go",
+    ["build", "-trimpath", "-ldflags=-s -w", "-o", outputPath, "."],
+    {
+      cwd: moduleDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GOOS: "windows",
+        GOARCH: arch,
+        CGO_ENABLED: "0",
+      },
+    },
+  );
+  if (result.error) {
+    throw new Error(
+      `build-windows-service-host: could not run "go build" (is Go installed and on PATH?): ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `build-windows-service-host: "go build" for GOARCH=${arch} failed (exit ${result.status}):\n${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  }
+  if (!fs.existsSync(outputPath)) {
+    throw new Error(`build-windows-service-host: expected output missing after build: ${outputPath}`);
+  }
+  return outputPath;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const { outDir } = parseArgs(argv);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const built = TARGET_ARCHES.map((arch) => buildOne(arch, outDir));
+
+  process.stdout.write(
+    `Built the Windows service host for ${TARGET_ARCHES.join(", ")}:\n` +
+      built.map((p) => `  - ${p}`).join("\n") +
+      "\n",
+  );
+  return built;
+}
+
+module.exports = { main, TARGET_ARCHES, hostBinaryName };
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`build-windows-service-host: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/agent/scripts/check-shipped-sources.js
+++ b/packages/agent/scripts/check-shipped-sources.js
@@ -14,6 +14,14 @@
  * The installer copies only this package directory, so monorepo-relative
  * imports (packages/log-scrub, apps/api, packages/contracts, ...) are
  * release blockers. Keep shared helpers under packages/agent/vendor instead.
+ *
+ * Also validates install-agent.ps1 (the Windows installer) the same way
+ * node --check validates the shipped JavaScript: it must parse. This runs
+ * only where a PowerShell interpreter is available (Windows runners, and
+ * any host with PowerShell Core installed); elsewhere it is skipped with a
+ * printed note rather than failing a Linux/macOS build over a Windows-only
+ * tool being absent, since the dedicated Windows CI job (ci.yml) is the
+ * one that actually exercises install-agent.ps1 on every PR.
  */
 
 const fs = require("node:fs");
@@ -94,3 +102,91 @@ if (importErrors.length > 0) {
 process.stdout.write(
   `Validated ${files.length} shipped agent JavaScript files (syntax + self-contained imports).\n`,
 );
+
+/**
+ * Parses install-agent.ps1 with PowerShell's own language parser (the
+ * closest equivalent to `node --check` for a .ps1 file) so a syntax error
+ * introduced in either installer script is caught by `build`, not
+ * discovered later by an operator's `sc.exe create` failing partway
+ * through. UTF-8-without-BOM is checked too: Windows tools can silently
+ * emit UTF-16LE or a BOM, and either would still often "look right" in an
+ * editor while breaking a strict byte-for-byte release policy.
+ */
+function checkInstallAgentPs1() {
+  const ps1Path = path.join(packageRoot, "scripts", "install-agent.ps1");
+  if (!fs.existsSync(ps1Path)) {
+    process.stderr.write(
+      "check-shipped-sources: scripts/install-agent.ps1 not found; the Windows installer is missing.\n",
+    );
+    process.exit(1);
+  }
+
+  const bytes = fs.readFileSync(ps1Path);
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    process.stderr.write(
+      "check-shipped-sources: scripts/install-agent.ps1 has a UTF-8 BOM; it must be UTF-8 without BOM.\n",
+    );
+    process.exit(1);
+  }
+  let looksUtf16 = bytes.length > 32;
+  for (let i = 1; looksUtf16 && i < Math.min(200, bytes.length - 1); i += 2) {
+    if (bytes[i] !== 0) looksUtf16 = false;
+  }
+  if (looksUtf16) {
+    process.stderr.write(
+      "check-shipped-sources: scripts/install-agent.ps1 appears to be UTF-16LE; it must be UTF-8 without BOM.\n",
+    );
+    process.exit(1);
+  }
+
+  const parseScriptPath = path.join(
+    require("node:os").tmpdir(),
+    `tokentimer-ps1-check-${process.pid}-${Date.now()}.ps1`,
+  );
+  const parseScript =
+    "param([Parameter(Mandatory=$true)][string]$TargetPath)\n" +
+    "$parseErrors = $null\n" +
+    "$null = [System.Management.Automation.Language.Parser]::ParseFile($TargetPath, [ref]$null, [ref]$parseErrors)\n" +
+    "if ($parseErrors.Count -gt 0) {\n" +
+    "  $parseErrors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }\n" +
+    "  exit 1\n" +
+    "}\n" +
+    "exit 0\n";
+  const candidates = ["pwsh", "powershell"];
+  let ran = false;
+  try {
+    fs.writeFileSync(parseScriptPath, parseScript, "utf8");
+    for (const exe of candidates) {
+      const result = spawnSync(
+        exe,
+        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", parseScriptPath, ps1Path],
+        { encoding: "utf8" },
+      );
+      if (result.error) continue;
+      ran = true;
+      if (result.status !== 0) {
+        process.stderr.write(
+          `check-shipped-sources: scripts/install-agent.ps1 failed to parse under ${exe}:\n${result.stderr || result.stdout}\n`,
+        );
+        process.exit(1);
+      }
+      process.stdout.write(`Validated scripts/install-agent.ps1 (parses under ${exe}, UTF-8 without BOM).\n`);
+      break;
+    }
+  } finally {
+    try {
+      fs.unlinkSync(parseScriptPath);
+    } catch (_err) {
+      // Best effort cleanup.
+    }
+  }
+  if (!ran) {
+    process.stdout.write(
+      "Skipped scripts/install-agent.ps1 parse check: no PowerShell interpreter (pwsh/powershell) on this host. " +
+        "UTF-8-without-BOM was still verified. The dedicated Windows CI job exercises this script fully.\n",
+    );
+  }
+}
+
+checkInstallAgentPs1();
+

--- a/packages/agent/scripts/install-agent.ps1
+++ b/packages/agent/scripts/install-agent.ps1
@@ -1,0 +1,763 @@
+#Requires -Version 5.1
+# install-agent.ps1 - install the TokenTimer CertOps Agent as a native Windows Service.
+#
+# This script installs FROM THE LOCAL PACKAGE DIRECTORY it lives in
+# (packages/agent of a checked-out or unpacked release); it never downloads
+# remote artifacts. It mirrors install-agent.sh's contract flag-for-flag and
+# exit-code-for-exit-code so an operator who knows one script knows the
+# other. Any divergence from that contract is a defect, not a feature.
+#
+# What it does (see -h / --help for flags):
+#   1. Verifies the OS is 64-bit Windows (amd64/arm64) and that the
+#      installed Node satisfies the package.json "engines" range.
+#   2. Copies the agent package to C:\ProgramData\TokenTimerAgent\app and
+#      creates the state (config + credential) dir
+#      C:\ProgramData\TokenTimerAgent\state with a restricted ACL.
+#   3. Writes a config.json skeleton from flags/env, unless one already
+#      exists (a re-run never clobbers operator edits to config.json).
+#   4. Delivers the bootstrap token to the service's first run via the
+#      service's own registry Environment value (the native Windows
+#      mechanism for per-service environment variables; there is no
+#      Windows equivalent of a systemd EnvironmentFile). The token is
+#      single-use and is NEVER echoed back to the terminal by this script.
+#   5. Installs a native Windows Service (sc.exe / New-Service; no NSSM or
+#      other third-party service wrapper) running as LocalSystem per
+#      ADR-0012 decision 11, then starts it.
+#   6. On an upgrade (the service already exists), health-checks the
+#      restarted service and rolls back to the previous app version, with
+#      the credential and configuration preserved and its ACL re-asserted,
+#      if the health check fails.
+#
+# Security notes:
+#   - config.json and the credential file get a restricted ACL (see
+#     src/platform/index.js): the installing administrator's SID plus
+#     SYSTEM only, matching what the agent itself enforces on every write.
+#   - Prefer passing the bootstrap token via the
+#     TOKENTIMER_AGENT_BOOTSTRAP_TOKEN environment variable or the hidden
+#     interactive prompt over -BootstrapToken/--bootstrap-token: argv is
+#     visible in process listings.
+#
+# Known platform differences from install-agent.sh (documented, not
+# hidden, per ADR-0012's own policy that real-host gaps must be visible):
+#   - Windows has no equivalent of systemd's ProtectSystem=strict sandbox,
+#     so -WritePath/--write-path and -ReloadService/--reload-service are
+#     accepted and validated for CLI-contract parity, but there is no
+#     drop-in override to generate: a LocalSystem service already has
+#     ambient host-wide access (ADR-0012 decision 11), so the enforcement
+#     point on Windows is agent-local policy (config.json allowlists),
+#     not an OS-level sandbox.
+#   - certbot/acme.sh are POSIX shell tools; the acme/ state subdirectories
+#     install-agent.sh creates for them are not created here. Windows ACME
+#     integration (if any) is a separate, not-yet-scoped surface.
+#   - A plain Node.js process does not itself speak the Windows Service
+#     Control Manager's control protocol (StartServiceCtrlDispatcher), so
+#     the service's binPath does not point at node.exe directly. It points
+#     at a small native host, windows-service-host/ (built to
+#     bin\tokentimer-agent-host-<amd64|arm64>.exe by
+#     scripts/build-windows-service-host.js and shipped inside this same
+#     package), which answers the SCM's start/stop/interrogate requests
+#     and runs the Node agent as its child process, translating a stop
+#     request into a graceful shutdown signal (CTRL_BREAK_EVENT) before
+#     force-killing the child on a timeout. See ADR-0012 decision 11.
+
+# No [CmdletBinding()]/param() block: this script takes GNU-style
+# double-dash flags (--api-url, --dry-run, ...) via $args, the same
+# vocabulary as install-agent.sh, rather than PowerShell-style -ApiUrl
+# parameters. CmdletBinding's strict parameter binder would otherwise
+# reject any argument starting with a single dash before Parse-Arguments
+# ever runs (breaking -h and the double-dash-prefixed flags read as
+# unbound positionals).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$InstallRoot = "C:\ProgramData\TokenTimerAgent"
+$AppDir = Join-Path $InstallRoot "app"
+$StateDir = Join-Path $InstallRoot "state"
+$ServiceName = "TokenTimerAgent"
+$ServiceDisplayName = "TokenTimer CertOps Agent"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PackageDir = Split-Path -Parent $ScriptDir
+$ValidateServerUrlJs = Join-Path $ScriptDir "validate-server-url.js"
+$HostSandboxJs = Join-Path $ScriptDir "host-sandbox.js"
+
+$script:ApiUrl = ""
+$script:WorkspaceId = ""
+$script:BootstrapToken = $env:TOKENTIMER_AGENT_BOOTSTRAP_TOKEN
+if ($null -eq $script:BootstrapToken) { $script:BootstrapToken = "" }
+$script:CaBundle = ""
+$script:DryRun = $false
+$script:Uninstall = $false
+$script:WritePaths = New-Object System.Collections.Generic.List[string]
+$script:ReloadServices = New-Object System.Collections.Generic.List[string]
+$script:WritePathsFile = ""
+$script:AllowInsecureLocalHttp = $false
+
+function Write-Log {
+    param([string]$Message)
+    Write-Host "install-agent: $Message"
+}
+
+function Fail {
+    param([string]$Message)
+    [Console]::Error.WriteLine("install-agent: ERROR: $Message")
+    exit 1
+}
+
+# Runs (or prints, under -DryRun) a non-secret action. Never pass the
+# bootstrap token through this function: its description is printed.
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+    if ($script:DryRun) {
+        Write-Host "[dry-run] $Description"
+    } else {
+        & $Action
+    }
+}
+
+function Show-Usage {
+    @'
+Usage:
+  install-agent.ps1 --api-url URL --workspace-id ID [options]
+  install-agent.ps1 --uninstall [--dry-run]
+
+Installs the TokenTimer CertOps Agent from this local package directory as a
+native Windows Service (LocalSystem) named TokenTimerAgent. (No remote
+downloads; a hosted one-liner installer comes later.)
+
+Required for install:
+  --api-url URL          Control plane base URL (config.json serverUrl).
+                         Must be https:// unless --allow-insecure-local-http
+                         is set AND the host is loopback (localhost / 127/8 /
+                         ::1 / *.localhost), matching the agent runtime.
+  --workspace-id ID      Workspace the agent belongs to (recorded in
+                         config.json; the bootstrap token is already
+                         workspace-scoped server-side).
+  Bootstrap token        Supplied interactively: when neither the
+                         TOKENTIMER_AGENT_BOOTSTRAP_TOKEN environment
+                         variable nor --bootstrap-token is given, the
+                         installer reads the token from a hidden prompt
+                         (recommended; nothing lands in shell history or
+                         process listings). The environment variable is the
+                         non-interactive alternative. --bootstrap-token
+                         TOKEN still works but is discouraged: argv is
+                         visible in process listings. Single-use ttboot_
+                         token created in the dashboard (CertOps > Deploy an
+                         agent).
+
+Options:
+  --ca-bundle PATH       PEM CA bundle for a private-CA control plane
+                         (copied into the state dir, config.json
+                         caBundlePath).
+  --write-path PATH      Absolute directory the agent may write
+                         certificates into (repeatable). Accepted for
+                         parity with install-agent.sh; Windows has no
+                         sandbox to scope (the service runs as LocalSystem
+                         with ambient host-wide access), so this only
+                         appears in the post-install reminder about
+                         ACLing the target directories, and is not written
+                         to any drop-in file.
+  --write-paths-file F   File with one absolute write path per line (#
+                         comments and blank lines allowed). Merged with
+                         --write-path.
+  --reload-service NAME  Accepted for parity with install-agent.sh
+                         (allowed: nginx, apache/apache2/httpd, haproxy).
+                         Windows has no polkit/sudo boundary to work around
+                         (LocalSystem already has ambient access), so
+                         reload authorization on Windows is enforced purely
+                         by agent-local policy (config.json
+                         commandProfiles.reloadArgv), not by anything this
+                         installer configures.
+  --allow-insecure-local-http
+                         Permit plain http:// ONLY for loopback hosts,
+                         matching the runtime allowInsecureLocalHttp gate.
+                         Required for local development; never use for
+                         production. Also writes allowInsecureLocalHttp=true
+                         into config.json.
+  --dry-run              Print every action without executing anything.
+  --uninstall            Stop and remove the TokenTimerAgent service and
+                         the app dir. The state dir (credential, keys) is
+                         preserved; remove it manually once you are sure
+                         (Remove-Item -Recurse -Force
+                         C:\ProgramData\TokenTimerAgent).
+  -h, --help             Show this help.
+
+Layout created:
+  C:\ProgramData\TokenTimerAgent\app     agent package (read-only at
+                                          runtime)
+  C:\ProgramData\TokenTimerAgent\state   config dir: config.json,
+                                          credential (written by the agent
+                                          at registration), bootstrap.env
+                                          (deleted automatically by the
+                                          agent after its first successful
+                                          registration; kept here only for
+                                          a manual/dev run, since the
+                                          running service itself reads the
+                                          token from its own registry
+                                          Environment value)
+
+After install:
+  Get-Service TokenTimerAgent
+  Get-EventLog -LogName Application -Source TokenTimerAgent (if the agent
+  logs there) or inspect its own log output per the agent's logging config.
+
+Host permissions note:
+  The service runs as LocalSystem, which already has host-wide filesystem
+  access; --write-path/--write-paths-file only remind you which directories
+  the agent's own configured allowlist should include (see config.json).
+'@ | Write-Host
+}
+
+function Parse-Arguments {
+    param([string[]]$Arguments)
+    $i = 0
+    while ($i -lt $Arguments.Count) {
+        $arg = $Arguments[$i]
+        switch -Regex ($arg) {
+            '^--api-url$' { $script:ApiUrl = $Arguments[$i + 1]; $i += 2; continue }
+            '^--api-url=(.*)$' { $script:ApiUrl = $Matches[1]; $i += 1; continue }
+            '^--workspace-id$' { $script:WorkspaceId = $Arguments[$i + 1]; $i += 2; continue }
+            '^--workspace-id=(.*)$' { $script:WorkspaceId = $Matches[1]; $i += 1; continue }
+            '^--bootstrap-token$' { $script:BootstrapToken = $Arguments[$i + 1]; $i += 2; continue }
+            '^--bootstrap-token=(.*)$' { $script:BootstrapToken = $Matches[1]; $i += 1; continue }
+            '^--ca-bundle$' { $script:CaBundle = $Arguments[$i + 1]; $i += 2; continue }
+            '^--ca-bundle=(.*)$' { $script:CaBundle = $Matches[1]; $i += 1; continue }
+            '^--write-path$' {
+                $value = $Arguments[$i + 1]
+                if ([string]::IsNullOrEmpty($value)) { Fail "--write-path requires an absolute directory path" }
+                $script:WritePaths.Add($value)
+                $i += 2; continue
+            }
+            '^--write-path=(.*)$' { $script:WritePaths.Add($Matches[1]); $i += 1; continue }
+            '^--write-paths-file$' { $script:WritePathsFile = $Arguments[$i + 1]; $i += 2; continue }
+            '^--write-paths-file=(.*)$' { $script:WritePathsFile = $Matches[1]; $i += 1; continue }
+            '^--reload-service$' {
+                $value = $Arguments[$i + 1]
+                if ([string]::IsNullOrEmpty($value)) { Fail "--reload-service requires a service name" }
+                $script:ReloadServices.Add($value)
+                $i += 2; continue
+            }
+            '^--reload-service=(.*)$' { $script:ReloadServices.Add($Matches[1]); $i += 1; continue }
+            '^--allow-insecure-local-http$' { $script:AllowInsecureLocalHttp = $true; $i += 1; continue }
+            '^--dry-run$' { $script:DryRun = $true; $i += 1; continue }
+            '^--uninstall$' { $script:Uninstall = $true; $i += 1; continue }
+            '^(-h|--help)$' { Show-Usage; exit 0 }
+            default { Fail "unknown argument: $arg (see --help)" }
+        }
+    }
+}
+
+Parse-Arguments -Arguments $args
+
+# ------------------------------------------------------------- OS/arch gate
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($env:PROCESSOR_ARCHITEW6432) { $arch = $env:PROCESSOR_ARCHITEW6432 }
+if ($arch -notin @("AMD64", "ARM64")) {
+    Fail "unsupported architecture '$arch' (supported: AMD64, ARM64; 32-bit Windows is not supported)"
+}
+if (-not [System.Environment]::Is64BitOperatingSystem) {
+    Fail "a 64-bit Windows OS is required"
+}
+
+# Windows Server 2016 / Windows 10 1607 (build 14393) is the floor this
+# installer supports: it is the first widely-deployed release with WDAC
+# (decision 8's documented hardened PowerShell-trust alternative) and CNG
+# non-exportable key custody (decision 1) both generally available, and
+# every earlier Windows Server release is already past Microsoft's own
+# extended-support lifecycle. Without this check, install-agent.ps1 would
+# run to completion on an unsupported, pre-WDAC host and only reveal the
+# gap much later, if at all, the first time an operator tries to enable
+# the hardened PowerShell-trust alternative decision 8 documents.
+$MinimumSupportedBuild = 14393
+$osBuild = [System.Environment]::OSVersion.Version.Build
+if ($osBuild -lt $MinimumSupportedBuild) {
+    Fail "unsupported Windows build $osBuild (running: $([System.Environment]::OSVersion.VersionString)); this installer requires Windows Server 2016 / Windows 10 1607 (build $MinimumSupportedBuild) or later"
+}
+
+function Test-IsAdministrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# -------------------------------------------------------------- uninstall
+if ($script:Uninstall) {
+    if (-not $script:DryRun -and -not (Test-IsAdministrator)) {
+        Fail "uninstall must run from an elevated (Administrator) PowerShell session"
+    }
+    $serviceExists = [bool](Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)
+    if ($serviceExists) {
+        Invoke-Step "Stop-Service $ServiceName" { Get-Service -Name $ServiceName -ErrorAction SilentlyContinue | Where-Object { $_.Status -ne 'Stopped' } | Stop-Service -Force -ErrorAction SilentlyContinue }
+        Invoke-Step "sc.exe delete $ServiceName" { & sc.exe delete $ServiceName | Out-Null }
+    } else {
+        Write-Log "No $ServiceName service found; nothing to stop or delete."
+    }
+    Invoke-Step "Remove-Item -Recurse -Force $AppDir" {
+        if (Test-Path $AppDir) { Remove-Item -Recurse -Force $AppDir }
+    }
+    Write-Log ""
+    Write-Log "Uninstalled the service and app dir."
+    Write-Log "Preserved (remove manually once you are sure):"
+    Write-Log "  - $StateDir (agent credential, keys, replay store)"
+    exit 0
+}
+
+# ----------------------------------------------------------- validate input
+if ([string]::IsNullOrEmpty($script:ApiUrl)) { Fail "--api-url is required (control plane base URL)" }
+if ([string]::IsNullOrEmpty($script:WorkspaceId)) { Fail "--workspace-id is required" }
+
+# Hidden interactive prompt (preferred path): the dashboard's copyable
+# command carries no token; the operator pastes it here, with terminal echo
+# disabled (Read-Host -AsSecureString), so it never touches shell history or
+# process listings.
+if ([string]::IsNullOrEmpty($script:BootstrapToken) -and -not $script:DryRun) {
+    if ([System.Environment]::UserInteractive) {
+        $secure = Read-Host -Prompt "install-agent: paste the bootstrap token (input hidden)" -AsSecureString
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($secure)
+        try {
+            $script:BootstrapToken = [Runtime.InteropServices.Marshal]::PtrToStringUni($bstr)
+        } finally {
+            [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($bstr)
+        }
+    }
+}
+if ([string]::IsNullOrEmpty($script:BootstrapToken) -and $script:DryRun) {
+    Write-Log "dry-run: no bootstrap token supplied; a real install prompts for it interactively."
+} else {
+    if ([string]::IsNullOrEmpty($script:BootstrapToken)) {
+        Fail "bootstrap token is required: paste it at the interactive prompt, or set TOKENTIMER_AGENT_BOOTSTRAP_TOKEN"
+    }
+    if ($script:BootstrapToken -notlike "ttboot_*") {
+        Fail "bootstrap token does not look like a ttboot_ token (value not shown)"
+    }
+}
+if ($script:ApiUrl -notmatch '^(http|https)://') {
+    Fail "--api-url must start with http:// or https://"
+}
+# These values are interpolated into config.json below; refuse anything
+# that could break out of a JSON string instead of trying to escape it.
+if ($script:ApiUrl -match '["\\]') {
+    Fail "--api-url must not contain double quotes or backslashes"
+}
+if ($script:WorkspaceId -match '["\\]') {
+    Fail "--workspace-id must not contain double quotes or backslashes"
+}
+if (($script:ApiUrl + $script:WorkspaceId) -match '[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]') {
+    Fail "--api-url and --workspace-id must not contain control or non-printable characters"
+}
+
+# Match the agent runtime serverUrl gate exactly (src/protocol parseServerUrl):
+# https always ok; plain http only for loopback when --allow-insecure-local-http.
+if (-not (Test-Path $ValidateServerUrlJs)) { Fail "server URL validator not found: $ValidateServerUrlJs" }
+$validateArgs = @($script:ApiUrl)
+if ($script:AllowInsecureLocalHttp) { $validateArgs += "--allow-insecure-local-http" }
+$normalizedApiUrl = & node $ValidateServerUrlJs @validateArgs 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Fail "--api-url was rejected by the same rule the agent runtime uses (https required; http only for loopback with --allow-insecure-local-http)"
+}
+$script:ApiUrl = $normalizedApiUrl.Trim()
+
+if (-not [string]::IsNullOrEmpty($script:CaBundle)) {
+    if (-not (Test-Path $script:CaBundle -PathType Leaf)) { Fail "--ca-bundle file not found: $script:CaBundle" }
+    $caBundleContent = Get-Content -Raw $script:CaBundle
+    if ($caBundleContent -notmatch "BEGIN CERTIFICATE") { Fail "--ca-bundle contains no PEM certificate block" }
+    if ($caBundleContent -match "PRIVATE KEY") {
+        Fail "--ca-bundle contains private key material; a CA bundle must hold public certificates only"
+    }
+}
+
+if (-not (Test-Path (Join-Path $PackageDir "package.json"))) {
+    Fail "agent package.json not found next to this script (expected $PackageDir\package.json); run from an unpacked agent package"
+}
+if (-not (Test-Path (Join-Path $PackageDir "bin\tokentimer-agent.js"))) {
+    Fail "agent entrypoint bin\tokentimer-agent.js not found in $PackageDir"
+}
+if (-not (Test-Path $HostSandboxJs)) { Fail "host sandbox helper not found: $HostSandboxJs" }
+
+# Windows-native absolute path validator for --write-path: a drive-letter
+# rooted path (C:\...) or a UNC path (\\server\share\...), no ".." segments.
+# install-agent.sh's validateAbsolutePath (host-sandbox.js) requires a
+# POSIX leading "/", so it cannot validate a Windows path; this is a
+# deliberately separate, Windows-shaped check rather than forcing POSIX
+# path syntax onto Windows operators.
+function Test-WindowsAbsolutePath {
+    param([string]$Value)
+    if ([string]::IsNullOrEmpty($Value)) { Fail "write path must be a non-empty string" }
+    if ($Value.Trim() -ne $Value) { Fail "write path must not include leading/trailing whitespace: '$Value'" }
+    if ($Value -notmatch '^([A-Za-z]:\\|\\\\)') {
+        Fail "write path must be absolute (e.g. C:\path\to\dir or \\server\share\path): '$Value'"
+    }
+    if ($Value -match '[\x00-\x1F<>"|?*]') { Fail "write path contains disallowed characters: '$Value'" }
+    if ($Value -match '(^|\\)\.\.(\\|$)') { Fail "write path must not contain .. segments: '$Value'" }
+    return $Value.TrimEnd('\')
+}
+
+# Merge --write-paths-file into WritePaths, then validate every path.
+if (-not [string]::IsNullOrEmpty($script:WritePathsFile)) {
+    if (-not (Test-Path $script:WritePathsFile -PathType Leaf)) { Fail "--write-paths-file not found: $script:WritePathsFile" }
+    foreach ($line in Get-Content $script:WritePathsFile) {
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -eq 0 -or $trimmed.StartsWith("#")) { continue }
+        $script:WritePaths.Add($trimmed)
+    }
+}
+$validatedWritePaths = New-Object System.Collections.Generic.List[string]
+foreach ($writePath in $script:WritePaths) {
+    $validatedWritePaths.Add((Test-WindowsAbsolutePath $writePath))
+}
+$script:WritePaths = $validatedWritePaths
+
+$validatedReloadServices = New-Object System.Collections.Generic.List[string]
+foreach ($reloadService in $script:ReloadServices) {
+    & node $HostSandboxJs map-reload-service $reloadService | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "invalid --reload-service: $reloadService" }
+    $validatedReloadServices.Add($reloadService)
+}
+$script:ReloadServices = $validatedReloadServices
+
+if (-not $script:DryRun -and -not (Test-IsAdministrator)) {
+    Fail "install must run from an elevated (Administrator) PowerShell session"
+}
+
+# -------------------------------------------------------- node version gate
+# engines.node is a single ">=x.y.z <a.b.c" range in this package; a plain
+# regex parse of the lower bound avoids needing node before the node check
+# itself, mirroring install-agent.sh's sed parse.
+$packageJsonText = Get-Content -Raw (Join-Path $PackageDir "package.json")
+$engineMatch = [regex]::Match($packageJsonText, '"node"\s*:\s*"([^"]*)"')
+if (-not $engineMatch.Success) {
+    Fail "could not find engines.node in $PackageDir\package.json"
+}
+$requiredRange = $engineMatch.Groups[1].Value
+$requiredMajorMatch = [regex]::Match($requiredRange, '[0-9]+')
+if (-not $requiredMajorMatch.Success) {
+    Fail "could not parse required Node version from $PackageDir\package.json (engines.node='$requiredRange')"
+}
+$requiredMajor = [int]$requiredMajorMatch.Value
+
+$nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+if (-not $nodeCommand) {
+    Fail "node is not installed or not on PATH; the agent requires Node '$requiredRange'"
+}
+$nodeVersionRaw = (& node -v).Trim()
+$nodeMajorMatch = [regex]::Match($nodeVersionRaw, '^v([0-9]+)')
+if (-not $nodeMajorMatch.Success) {
+    Fail "could not parse installed Node version from 'node -v' (got '$nodeVersionRaw')"
+}
+$nodeMajor = [int]$nodeMajorMatch.Groups[1].Value
+if ($nodeMajor -lt $requiredMajor) {
+    Fail "Node $nodeVersionRaw is too old; the agent requires engines.node '$requiredRange'"
+}
+Write-Log "Node $nodeVersionRaw satisfies engines.node '$requiredRange'."
+$script:NodeExe = $nodeCommand.Source
+
+# --------------------------------------------------- platform module helper
+# Reuses the package's own src/platform module (already ACL-tested; see
+# platform.test.js) instead of re-implementing icacls logic in this script,
+# so the installer and the running agent enforce the exact same ACL matrix
+# (ADR-0012 decision 10), including the owner-SID check.
+function Invoke-PlatformAcl {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetPath,
+        [Parameter(Mandatory = $true)][ValidateSet("file", "directory")][string]$Kind
+    )
+    $platformModule = Join-Path $PackageDir "src\platform\index.js"
+    # ConvertTo-Json (built into PowerShell 5.1+) is used rather than a
+    # hand-rolled escape so a path containing a quote or backslash can never
+    # break out of the generated JS string literal. The script is written to
+    # a temp file rather than passed via `node -e "..."`: PowerShell 5.1's
+    # native-argument marshalling can strip embedded double quotes from a
+    # single command-line argument, which corrupts an inline -e script that
+    # itself contains quoted JS string literals.
+    $modulePathJson = $platformModule | ConvertTo-Json -Compress
+    $targetPathJson = $TargetPath | ConvertTo-Json -Compress
+    $kindJson = $Kind | ConvertTo-Json -Compress
+    $jsSource = "require($modulePathJson).applyRestrictivePermissions($targetPathJson, { kind: $kindJson });"
+    $scriptPath = Join-Path ([System.IO.Path]::GetTempPath()) "tokentimer-acl-$PID-$([guid]::NewGuid().ToString('N')).js"
+    try {
+        [System.IO.File]::WriteAllText($scriptPath, $jsSource, (New-Object System.Text.UTF8Encoding($false)))
+        & node $scriptPath
+        if ($LASTEXITCODE -ne 0) {
+            Fail "failed to apply a restricted ACL to $TargetPath (kind=$Kind)"
+        }
+    } finally {
+        Remove-Item -Force -ErrorAction SilentlyContinue $scriptPath
+    }
+}
+
+# ------------------------------------------------------------ install files
+# Staged, atomic-swap install: copy into a fresh staging dir next to the app
+# dir, then swap it into place. A failed copy can never leave a half-written
+# app dir behind, and a running service keeps its old files until the swap
+# (a subsequent service restart picks up the new tree). Mirrors
+# install-agent.sh's tar-pipe staging, using a plain recursive copy instead
+# of tar (not reliably present on Windows) that excludes node_modules and
+# .git the same way the tar pipe's --exclude does.
+function Copy-PackageTree {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+    $excludedDirNames = @("node_modules", ".git")
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Get-ChildItem -LiteralPath $Source -Force | ForEach-Object {
+        if ($_.PSIsContainer) {
+            if ($excludedDirNames -contains $_.Name) { return }
+            Copy-PackageTree -Source $_.FullName -Destination (Join-Path $Destination $_.Name)
+        } else {
+            Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $Destination $_.Name) -Force
+        }
+    }
+}
+
+Write-Log "Installing agent package from $PackageDir to $AppDir"
+if (-not $script:DryRun) {
+    New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+}
+
+$script:AppStaging = "$AppDir.staging.$PID"
+$script:AppPrevious = "$AppDir.previous.$PID"
+$script:IsUpgrade = (Test-Path $AppDir)
+
+if ($script:DryRun) {
+    Write-Host "[dry-run] copy $PackageDir into $($script:AppStaging) (excluding node_modules, .git), then atomically swap into $AppDir"
+} else {
+    if (Test-Path $script:AppStaging) { Remove-Item -Recurse -Force $script:AppStaging }
+    try {
+        Copy-PackageTree -Source $PackageDir -Destination $script:AppStaging
+    } catch {
+        if (Test-Path $script:AppStaging) { Remove-Item -Recurse -Force $script:AppStaging }
+        Fail "failed to stage the agent package; $AppDir was left untouched ($($_.Exception.Message))"
+    }
+    if (Test-Path $script:AppPrevious) { Remove-Item -Recurse -Force $script:AppPrevious }
+    if (Test-Path $AppDir) {
+        Rename-Item -LiteralPath $AppDir -NewName (Split-Path -Leaf $script:AppPrevious)
+    }
+    try {
+        Rename-Item -LiteralPath $script:AppStaging -NewName (Split-Path -Leaf $AppDir)
+    } catch {
+        if (Test-Path $script:AppPrevious) { Rename-Item -LiteralPath $script:AppPrevious -NewName (Split-Path -Leaf $AppDir) }
+        if (Test-Path $script:AppStaging) { Remove-Item -Recurse -Force $script:AppStaging }
+        Fail "failed to activate the staged agent package; the previous install was restored ($($_.Exception.Message))"
+    }
+}
+
+if (-not $script:DryRun) {
+    New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
+}
+Invoke-Step "apply restricted ACL to $StateDir" { Invoke-PlatformAcl -TargetPath $StateDir -Kind "directory" }
+
+# ------------------------------------------------------- config.json
+# Fields consumed by the agent's config loader (src/config/index.js):
+# serverUrl (required) and caBundlePath (optional). workspaceId is recorded
+# for operators; the loader ignores unknown fields and the bootstrap token
+# is already workspace-scoped server-side. agentId and the credential are
+# written by the agent itself at first-run registration.
+$configPath = Join-Path $StateDir "config.json"
+$caBundleDest = ""
+if (-not [string]::IsNullOrEmpty($script:CaBundle)) {
+    $caBundleDest = Join-Path $StateDir "ca-bundle.pem"
+    Invoke-Step "copy $($script:CaBundle) to $caBundleDest" { Copy-Item -Force $script:CaBundle $caBundleDest }
+}
+
+if ((Test-Path $configPath) -and -not $script:DryRun) {
+    Write-Log "Existing $configPath found; leaving it untouched (delete it to re-generate)."
+} elseif ($script:DryRun) {
+    $caNote = if ($caBundleDest) { " caBundlePath=$caBundleDest" } else { "" }
+    Write-Host "[dry-run] write $configPath with serverUrl=$($script:ApiUrl) workspaceId=$($script:WorkspaceId)$caNote"
+} else {
+    # Values were charset-validated above (no quotes/backslashes/control
+    # chars), so plain interpolation cannot produce malformed JSON. Written
+    # to a temp file first and renamed so a crash never leaves a torn file.
+    $configTmp = "$configPath.tmp.$PID"
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("{")
+    $lines.Add("  `"serverUrl`": `"$($script:ApiUrl)`",")
+    if ($caBundleDest -or $script:AllowInsecureLocalHttp) {
+        $lines.Add("  `"workspaceId`": `"$($script:WorkspaceId)`",")
+    } else {
+        $lines.Add("  `"workspaceId`": `"$($script:WorkspaceId)`"")
+    }
+    if ($caBundleDest) {
+        $caBundleDestJson = $caBundleDest.Replace('\', '\\')
+        if ($script:AllowInsecureLocalHttp) {
+            $lines.Add("  `"caBundlePath`": `"$caBundleDestJson`",")
+        } else {
+            $lines.Add("  `"caBundlePath`": `"$caBundleDestJson`"")
+        }
+    }
+    if ($script:AllowInsecureLocalHttp) {
+        $lines.Add("  `"allowInsecureLocalHttp`": true")
+    }
+    $lines.Add("}")
+    $configContent = ($lines -join "`n") + "`n"
+    [System.IO.File]::WriteAllText($configTmp, $configContent, (New-Object System.Text.UTF8Encoding($false)))
+    Move-Item -Force $configTmp $configPath
+    Invoke-PlatformAcl -TargetPath $configPath -Kind "file"
+    # Sanity-parse the result with the node we already verified, so a bad
+    # value can never install an unreadable config.
+    & node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" $configPath
+    if ($LASTEXITCODE -ne 0) {
+        Fail "generated $configPath is not valid JSON (unexpected characters in --api-url/--workspace-id?)"
+    }
+}
+
+# --------------------------------------- bootstrap token env file
+# Written for parity with install-agent.sh (documentation, and a manual/dev
+# run: "node bin\tokentimer-agent.js" with $env:TOKENTIMER_AGENT_CONFIG_DIR
+# set picks this up via a .env-style file only if the operator loads it
+# themselves; unlike systemd's EnvironmentFile, Windows has no service-level
+# equivalent). The single-use ttboot_ token is never printed by this script.
+# The agent deletes bootstrap.env itself right after a successful
+# registration. The service itself gets the token via its own registry
+# Environment value, set below.
+$bootstrapEnvPath = Join-Path $StateDir "bootstrap.env"
+if ($script:DryRun) {
+    Write-Host "[dry-run] write $bootstrapEnvPath with TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=<redacted>"
+} else {
+    $bootstrapEnvTmp = "$bootstrapEnvPath.tmp.$PID"
+    [System.IO.File]::WriteAllText(
+        $bootstrapEnvTmp,
+        "TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=$($script:BootstrapToken)`n",
+        (New-Object System.Text.UTF8Encoding($false)))
+    Move-Item -Force $bootstrapEnvTmp $bootstrapEnvPath
+    Invoke-PlatformAcl -TargetPath $bootstrapEnvPath -Kind "file"
+}
+
+# ------------------------------------------------------------- Windows service
+# Native tooling only (sc.exe): no NSSM or other third-party service
+# wrapper. LocalSystem per ADR-0012 decision 11.
+function Set-ServiceEnvironment {
+    param([string]$ConfigDir, [string]$Token)
+    $values = New-Object System.Collections.Generic.List[string]
+    $values.Add("TOKENTIMER_AGENT_CONFIG_DIR=$ConfigDir")
+    if (-not [string]::IsNullOrEmpty($Token)) {
+        $values.Add("TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=$Token")
+    }
+    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName" `
+        -Name "Environment" -PropertyType MultiString -Value $values.ToArray() -Force | Out-Null
+}
+
+function Test-ServiceHealthy {
+    param([int]$TimeoutSeconds = 20)
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+        if ($svc -and $svc.Status -eq 'Running') { return $true }
+        if ($svc -and $svc.Status -eq 'Stopped') { return $false }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+$quotedNode = '"' + $script:NodeExe + '"'
+$quotedEntry = '"' + (Join-Path $AppDir "bin\tokentimer-agent.js") + '"'
+
+# The service's binPath is the native host, not node.exe: node never calls
+# StartServiceCtrlDispatcher, so the SCM would otherwise fail the start
+# after 30s (error 1053) and, combined with the failure/restart policy
+# below, loop forever. The host answers the SCM directly and runs
+# node.exe + the agent entry point as its child (see windows-service-host/
+# and the header comment above). $arch (AMD64/ARM64, validated above)
+# selects which of the two binaries this OS can execute.
+$hostArchTag = $arch.ToLowerInvariant()
+$serviceHostExe = Join-Path $AppDir "bin\tokentimer-agent-host-$hostArchTag.exe"
+if (-not $script:DryRun -and -not (Test-Path $serviceHostExe)) {
+    Fail (
+        "service host binary not found at $serviceHostExe; the staged app dir looks incomplete " +
+        "or was not built with 'pnpm run build:windows-service-host' before packaging"
+    )
+}
+$quotedServiceHost = '"' + $serviceHostExe + '"'
+$binPath = "$quotedServiceHost $quotedNode $quotedEntry"
+
+if ($script:DryRun) {
+    Write-Host "[dry-run] sc.exe create/config $ServiceName binPath= $binPath start= auto obj= LocalSystem"
+    Write-Host "[dry-run] sc.exe failure $ServiceName reset= 86400 actions= restart/5000"
+    Write-Host "[dry-run] set HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName\Environment"
+    Write-Host "[dry-run] (re)start $ServiceName and health-check it"
+    Write-Log ""
+    Write-Log "Dry run complete. No changes were made."
+    exit 0
+}
+
+$serviceExisted = [bool](Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)
+if (-not $serviceExisted) {
+    & sc.exe create $ServiceName type= own start= auto obj= LocalSystem DisplayName= $ServiceDisplayName binPath= $binPath | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "sc.exe create failed for $ServiceName (exit $LASTEXITCODE)" }
+} else {
+    & sc.exe config $ServiceName binPath= $binPath obj= LocalSystem start= auto DisplayName= $ServiceDisplayName | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "sc.exe config failed to update $ServiceName (exit $LASTEXITCODE)" }
+}
+& sc.exe failureflag $ServiceName 1 | Out-Null
+& sc.exe failure $ServiceName reset= 86400 actions= restart/5000 | Out-Null
+
+Set-ServiceEnvironment -ConfigDir $StateDir -Token $script:BootstrapToken
+
+# restart, not start-if-stopped-only: on a re-run (upgrade) the service is
+# usually already running, and Start-Service is a no-op there, so the
+# freshly swapped app dir would keep being ignored while the old process
+# ran on. Restarting also starts a stopped/fresh service, so it is the
+# correct verb for both the install and the upgrade path (mirrors
+# install-agent.sh's use of `systemctl restart` for the same reason).
+$currentStatus = (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue).Status
+if ($currentStatus -eq 'Running') {
+    Restart-Service -Name $ServiceName -Force
+} else {
+    Start-Service -Name $ServiceName
+}
+
+$healthy = Test-ServiceHealthy -TimeoutSeconds 20
+
+if (-not $healthy -and $script:IsUpgrade -and (Test-Path $script:AppPrevious)) {
+    Write-Log "Health check failed after upgrade; rolling back to the previous version."
+    Stop-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $AppDir
+    Rename-Item -LiteralPath $script:AppPrevious -NewName (Split-Path -Leaf $AppDir)
+    $rollbackBinPath = $binPath
+    & sc.exe config $ServiceName binPath= $rollbackBinPath | Out-Null
+    Set-ServiceEnvironment -ConfigDir $StateDir -Token ""
+    Start-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    # The credential file's ACL must be re-asserted after rollback, not
+    # inherited from whatever the failed install left behind.
+    $credentialPath = Join-Path $StateDir "credential"
+    if (Test-Path $credentialPath) {
+        Invoke-PlatformAcl -TargetPath $credentialPath -Kind "file"
+    }
+    Fail "upgrade failed its post-install health check and was rolled back to the previous version; the agent credential and configuration were preserved and the credential file's ACL was re-asserted"
+}
+
+if (Test-Path $script:AppPrevious) { Remove-Item -Recurse -Force $script:AppPrevious }
+
+if (-not $healthy) {
+    Fail "the $ServiceName service did not reach the Running state within 20 seconds; check 'Get-Service $ServiceName' and the agent's own logs"
+}
+
+Write-Log ""
+Write-Log "Install complete. Next steps:"
+Write-Log "  1. Check the service:      Get-Service $ServiceName"
+Write-Log "  2. Confirm registration in the dashboard (CertOps > Agent fleet):"
+Write-Log "     the agent should appear as active within about a minute."
+Write-Log "     (The agent deletes the single-use $bootstrapEnvPath itself after"
+Write-Log "     registering; no manual cleanup is needed.)"
+Write-Log "  3. Configure agent-local policy and discovery in $configPath"
+Write-Log "     (allowlists are default-deny until you set them), then:"
+Write-Log "     Restart-Service $ServiceName"
+if ($script:WritePaths.Count -gt 0) {
+    Write-Log "  4. Ensure the LocalSystem service account can write the configured cert paths:"
+    foreach ($writePath in $script:WritePaths) {
+        Write-Log "       $writePath"
+    }
+    Write-Log "     (LocalSystem already has ambient access; this is a reminder to set"
+    Write-Log "     config.json's own write-path allowlist, not an OS-level grant.)"
+}
+if ($script:ReloadServices.Count -gt 0) {
+    Write-Log "  5. Reload authorization is enforced by agent-local policy on Windows"
+    Write-Log "     (no polkit/sudoers equivalent needed): configure policy"
+    Write-Log "     commandProfiles.reloadArgv for: $($script:ReloadServices -join ', ')"
+}
+exit 0

--- a/packages/agent/scripts/installer-smoke.test.js
+++ b/packages/agent/scripts/installer-smoke.test.js
@@ -215,3 +215,179 @@ describe("installer packaging smoke (B9)", () => {
     fs.rmSync(noInstallRoot, { recursive: true, force: true });
   });
 });
+
+/**
+ * Windows service lifecycle smoke test (H-blocker regression guard).
+ *
+ * Registers a *real* "TokenTimerAgent" service pointed at the built
+ * windows-service-host binary + a mock agent child, then asserts it
+ * actually reaches the Running state and survives a Stop-Service /
+ * Start-Service cycle. This is the regression the reviewer flagged: a
+ * plain node.exe binPath never calls StartServiceCtrlDispatcher, so the
+ * SCM fails the start (error 1053) after ~30s and the failure/restart
+ * policy in install-agent.ps1 turns that into a restart loop. Exercising
+ * the real SCM (not a mock) is the only way to catch that class of bug.
+ *
+ * Uses the mock agent (windows-service-host/testdata/mock-agent.js)
+ * rather than the real agent entrypoint so this test needs no network,
+ * API URL, or bootstrap token: it is scoped to the SCM handshake and
+ * process-lifecycle contract the host provides, which is exactly what
+ * regressed. install-agent.ps1's own binPath-construction logic is
+ * exercised indirectly, by hand-building the identical
+ * "<host.exe>" "<node.exe>" "<entry.js>" argv shape it produces.
+ *
+ * Requires: Windows + an elevated (Administrator) process, because
+ * creating/starting a LocalSystem service and writing HKLM requires
+ * elevation. Skips (does not fail) otherwise, e.g. on Linux/macOS CI
+ * runners or an unelevated local shell; the Windows-specific CI job is
+ * expected to run this as Administrator.
+ */
+describe("Windows service lifecycle smoke (H-blocker regression guard)", () => {
+  const SERVICE_NAME = "TokenTimerAgent";
+  const REG_KEY = `HKLM\\SYSTEM\\CurrentControlSet\\Services\\${SERVICE_NAME}`;
+
+  function isWindowsElevated() {
+    if (process.platform !== "win32") return false;
+    // `net session` requires Administrator and fails fast (no prompt) when
+    // run unelevated; this is the standard no-dependency elevation probe.
+    const probe = spawnSync("net", ["session"], { encoding: "utf8" });
+    return probe.status === 0;
+  }
+
+  function getServiceStatus() {
+    const result = spawnSync("sc.exe", ["query", SERVICE_NAME], { encoding: "utf8" });
+    if (result.status !== 0) return null;
+    const match = /STATE\s*:\s*\d+\s+(\w+)/.exec(result.stdout || "");
+    return match ? match[1] : null;
+  }
+
+  function waitForStatus(target, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (getServiceStatus() === target) return true;
+      // Deliberately synchronous polling: this test has no event loop
+      // work to interleave with, and node:test's own timeout is the
+      // real ceiling on total runtime.
+      spawnSync(process.execPath, ["-e", "setTimeout(()=>{}, 300)"], { timeout: 1000 });
+    }
+    return false;
+  }
+
+  let skipReason = null;
+  let hostExe;
+  let mockAgentJs;
+  let serviceConfigDir;
+
+  before(() => {
+    if (!isWindowsElevated()) {
+      skipReason = "requires an elevated (Administrator) Windows process";
+      return;
+    }
+    if (getServiceStatus() !== null) {
+      // Refuse to touch a pre-existing service of this name: it could be
+      // a real dev install on this machine, and this test deletes the
+      // service it creates when done.
+      skipReason = `a "${SERVICE_NAME}" service already exists on this host; skipping rather than risk clobbering it`;
+      return;
+    }
+
+    const { main: buildWindowsServiceHost, hostBinaryName } = require("./build-windows-service-host.js");
+    buildWindowsServiceHost();
+    const goarch = process.arch === "arm64" ? "arm64" : "amd64";
+    hostExe = path.join(packageRoot, "bin", hostBinaryName(goarch));
+    assert.ok(fs.existsSync(hostExe), `expected built host binary at ${hostExe}`);
+
+    mockAgentJs = path.join(packageRoot, "windows-service-host", "testdata", "mock-agent.js");
+    assert.ok(fs.existsSync(mockAgentJs), `expected mock agent fixture at ${mockAgentJs}`);
+
+    serviceConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentimer-agent-svc-state-"));
+  });
+
+  after(() => {
+    if (getServiceStatus() !== null) {
+      spawnSync("sc.exe", ["stop", SERVICE_NAME], { encoding: "utf8" });
+      spawnSync("sc.exe", ["delete", SERVICE_NAME], { encoding: "utf8" });
+    }
+    if (serviceConfigDir) fs.rmSync(serviceConfigDir, { recursive: true, force: true });
+  });
+
+  it("reaches Running and survives a Stop-Service / Start-Service cycle", (t) => {
+    if (skipReason) {
+      t.skip(skipReason);
+      return;
+    }
+
+    const quotedHost = `"${hostExe}"`;
+    const quotedNode = `"${process.execPath}"`;
+    const quotedEntry = `"${mockAgentJs}"`;
+    const binPath = `${quotedHost} ${quotedNode} ${quotedEntry}`;
+
+    const create = spawnSync("sc.exe", [
+      "create", SERVICE_NAME,
+      "type=", "own",
+      "start=", "demand",
+      "obj=", "LocalSystem",
+      "DisplayName=", "TokenTimer Agent Smoke Test",
+      "binPath=", binPath,
+    ], { encoding: "utf8" });
+    assert.equal(create.status, 0, `sc.exe create failed:\n${create.stdout}\n${create.stderr}`);
+
+    // Mirrors Set-ServiceEnvironment in install-agent.ps1, including a
+    // bootstrap-token-shaped value, so the Task 2 assertion below exercises
+    // the exact registry shape the real installer produces.
+    const setEnv = spawnSync("reg.exe", [
+      "add", REG_KEY,
+      "/v", "Environment",
+      "/t", "REG_MULTI_SZ",
+      "/d", `TOKENTIMER_AGENT_CONFIG_DIR=${serviceConfigDir}\\0TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=ttboot_smoketest`,
+      "/f",
+    ], { encoding: "utf8" });
+    assert.equal(setEnv.status, 0, `reg.exe add failed:\n${setEnv.stdout}\n${setEnv.stderr}`);
+
+    const start = spawnSync("sc.exe", ["start", SERVICE_NAME], { encoding: "utf8" });
+    assert.equal(start.status, 0, `sc.exe start failed:\n${start.stdout}\n${start.stderr}`);
+
+    assert.ok(
+      waitForStatus("RUNNING", 15000),
+      `service never reached RUNNING (last status: ${getServiceStatus()}); this is exactly the ` +
+        "error-1053 regression this test guards against if it fails",
+    );
+
+    // --- Task 2 (bootstrap token retention) integration assertion ---
+    // Exercise the real reg.exe path (not the mocked-spawn unit tests in
+    // platform.test.js) against the Environment value the service is
+    // actually running with.
+    const { clearWindowsServiceBootstrapToken } = require("../src/platform/index.js");
+    const scrubResult = clearWindowsServiceBootstrapToken({ configDir: serviceConfigDir });
+    assert.deepEqual(scrubResult, { attempted: true, cleared: true });
+
+    const queryAfterScrub = spawnSync(
+      "reg.exe",
+      ["query", REG_KEY, "/v", "Environment"],
+      { encoding: "utf8" },
+    );
+    assert.equal(queryAfterScrub.status, 0);
+    assert.doesNotMatch(
+      queryAfterScrub.stdout,
+      /TOKENTIMER_AGENT_BOOTSTRAP_TOKEN/,
+      "bootstrap token must not remain in the service Environment registry value after scrub",
+    );
+    assert.match(
+      queryAfterScrub.stdout,
+      /TOKENTIMER_AGENT_CONFIG_DIR/,
+      "scrub must preserve the non-secret config dir entry",
+    );
+
+    // --- Task 1 (SCM handshake) Stop/Start cycle assertion ---
+    const stop = spawnSync("sc.exe", ["stop", SERVICE_NAME], { encoding: "utf8" });
+    assert.equal(stop.status, 0, `sc.exe stop failed:\n${stop.stdout}\n${stop.stderr}`);
+    assert.ok(waitForStatus("STOPPED", 15000), `service never reached STOPPED (last status: ${getServiceStatus()})`);
+
+    const restart = spawnSync("sc.exe", ["start", SERVICE_NAME], { encoding: "utf8" });
+    assert.equal(restart.status, 0, `sc.exe start (restart) failed:\n${restart.stdout}\n${restart.stderr}`);
+    assert.ok(
+      waitForStatus("RUNNING", 15000),
+      `service did not come back RUNNING after Stop-Service/Start-Service (last status: ${getServiceStatus()})`,
+    );
+  });
+});

--- a/packages/agent/scripts/pack-release.js
+++ b/packages/agent/scripts/pack-release.js
@@ -14,6 +14,7 @@ const os = require("node:os");
 const path = require("node:path");
 const crypto = require("node:crypto");
 const { spawnSync } = require("node:child_process");
+const { main: buildWindowsServiceHost } = require("./build-windows-service-host.js");
 
 const packageRoot = path.resolve(__dirname, "..");
 const pkg = JSON.parse(
@@ -125,6 +126,12 @@ function main(argv = process.argv.slice(2)) {
 
   const { outDir } = parseArgs(argv);
   fs.mkdirSync(outDir, { recursive: true });
+
+  // The Windows service host binaries ship inside bin/ (see package.json's
+  // "files"), so they must exist before npm pack runs; build them fresh
+  // here rather than trusting a stale bin/*.exe left over from a previous
+  // run to still match the current windows-service-host/ source.
+  buildWindowsServiceHost();
 
   const pack = spawnSync(
     "npm",

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -29,8 +29,20 @@ const {
   resolveAcmeAccountCredentials,
   KNOWN_DNS_PROVIDER_IDS,
 } = require("./index.js");
+const {
+  applyRestrictivePermissions,
+  assertRestrictivePermissions,
+  readWindowsSddl,
+} = require("../platform/index.js");
 
 const IS_WIN32 = process.platform === "win32";
+const { spawnSync } = require("node:child_process");
+
+/** Asserts a directory's ACL grants nothing outside the agent allowlist. */
+function assertRestrictivePermissionsOnDir(dir) {
+  const sddl = readWindowsSddl(dir);
+  assert.doesNotMatch(sddl, /;WD\)|;BU\)|;AU\)/);
+}
 
 const tempDirs = [];
 
@@ -119,6 +131,24 @@ describe("ensureConfigDir", () => {
     ensureConfigDir(dir);
     const mode = fs.statSync(dir).mode & 0o777;
     assert.equal(mode, 0o700);
+  });
+
+  it("applies a real restricted ACL on win32", { skip: !IS_WIN32 }, () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    const sddl = readWindowsSddl(dir);
+    assert.match(sddl, /^D:P/);
+    assertRestrictivePermissionsOnDir(dir);
+  });
+
+  it("re-asserts the ACL when a foreign principal was granted (win32)", { skip: !IS_WIN32 }, () => {
+    const dir = makeTempConfigDir();
+    ensureConfigDir(dir);
+    spawnSync("icacls", [dir, "/grant", "*S-1-1-0:(F)"], { encoding: "utf8" });
+    // SDDL renders Everyone as the WD alias, which the parser maps to S-1-1-0.
+    assert.match(readWindowsSddl(dir), /;WD\)/);
+    ensureConfigDir(dir);
+    assert.doesNotMatch(readWindowsSddl(dir), /;WD\)/);
   });
 
   it("is idempotent and safe to call repeatedly", () => {
@@ -1105,6 +1135,24 @@ describe("readDnsCredentialsFile", () => {
       /readable by group\/other/,
     );
   });
+
+  it("refuses a credentials file whose ACL grants Everyone (win32)", { skip: !IS_WIN32 }, () => {
+    const credentialsPath = writeCredentialsFile('{"apiToken":"cf-token"}');
+    applyRestrictivePermissions(credentialsPath);
+    spawnSync("icacls", [credentialsPath, "/grant", "*S-1-1-0:(F)"], { encoding: "utf8" });
+    assert.throws(
+      () => readDnsCredentialsFile("cloudflare", configFor(credentialsPath)),
+      /grants access to S-1-1-0/,
+    );
+  });
+
+  it("accepts a credentials file restricted to the agent and SYSTEM (win32)", { skip: !IS_WIN32 }, () => {
+    const credentialsPath = writeCredentialsFile('{"apiToken":"cf-token"}');
+    applyRestrictivePermissions(credentialsPath);
+    assert.deepEqual(readDnsCredentialsFile("cloudflare", configFor(credentialsPath)), {
+      apiToken: "cf-token",
+    });
+  });
 });
 
 describe("validateAcmeAccountsObject", () => {
@@ -1180,6 +1228,32 @@ describe("resolveAcmeAccountCredentials", () => {
     assert.throws(
       () => resolveAcmeAccountCredentials("le-eab", configFor(credentialsPath)),
       /readable by group\/other/,
+    );
+  });
+
+  it("refuses an ACL granting Everyone and never falls back to a skip (win32)", { skip: !IS_WIN32 }, () => {
+    const credentialsPath = writeEabFile(
+      JSON.stringify({ eabKid: "kid-1", eabHmacKey: "hmac-1" }),
+    );
+    applyRestrictivePermissions(credentialsPath);
+    spawnSync("icacls", [credentialsPath, "/grant", "*S-1-1-0:(F)"], { encoding: "utf8" });
+    assert.throws(
+      () => resolveAcmeAccountCredentials("le-eab", configFor(credentialsPath)),
+      /grants access to S-1-1-0/,
+    );
+  });
+
+  it("fails closed when the ACL cannot be inspected at all (win32)", { skip: !IS_WIN32 }, () => {
+    const credentialsPath = writeEabFile(
+      JSON.stringify({ eabKid: "kid-1", eabHmacKey: "hmac-1" }),
+    );
+    assert.throws(
+      () =>
+        assertRestrictivePermissions(credentialsPath, {
+          label: "ACME account credentials file",
+          spawn: () => ({ status: 1, stdout: "", stderr: "" }),
+        }),
+      /icacls exited 1/,
     );
   });
 });

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -29,6 +29,11 @@ const path = require("node:path");
 const crypto = require("node:crypto");
 const { normalizePropagationConfig } = require("../dns/propagate.js");
 const {
+  applyRestrictivePermissions,
+  assertRestrictivePermissions,
+} = require("../platform/index.js");
+const { fsyncDirectorySync } = require("../platform/durability.js");
+const {
   assertNoPrivateKeyMaterial,
 } = require("../../vendor/log-scrub/secret-material.js");
 
@@ -83,23 +88,10 @@ const REDACTED_CREDENTIAL_PLACEHOLDER = "[AGENT_CREDENTIAL_REDACTED]";
 
 function fsyncParentDirectory(filePath) {
   // fsync on a directory is the durable part of an atomic rename on POSIX.
-  // Windows does not support opening directories this way, so this remains
-  // best effort there while the atomic rename still prevents torn files.
-  let directoryFd;
-  try {
-    directoryFd = fs.openSync(path.dirname(filePath), "r");
-    fs.fsyncSync(directoryFd);
-  } catch (_err) {
-    // Best effort across platforms/filesystems.
-  } finally {
-    if (directoryFd !== undefined) {
-      try {
-        fs.closeSync(directoryFd);
-      } catch (_err) {
-        // Best effort close.
-      }
-    }
-  }
+  // Windows cannot open a directory this way at all, so the fsync is recorded
+  // as a durability limit (see src/platform/durability.js) rather than being
+  // swallowed: the agent reports what it could not guarantee.
+  fsyncDirectorySync(path.dirname(filePath));
 }
 
 function writeFileAtomically(filePath, contents, mode) {
@@ -112,11 +104,10 @@ function writeFileAtomically(filePath, contents, mode) {
     fs.closeSync(fd);
     fd = undefined;
     fs.renameSync(temporaryPath, filePath);
-    try {
-      fs.chmodSync(filePath, mode);
-    } catch (_err) {
-      // Best effort on win32; see ensureConfigDir.
-    }
+    // POSIX re-asserts the mode; win32 gets a real restricted ACL. A failure
+    // here is fatal: an unprotected credential/config file is not an
+    // acceptable outcome of a successful write.
+    applyRestrictivePermissions(filePath, { kind: "file", mode });
     fsyncParentDirectory(filePath);
   } catch (err) {
     if (fd !== undefined) {
@@ -200,21 +191,16 @@ function resolveConfigDir(explicitDir) {
 }
 
 /**
- * Ensures the config directory exists with 0700 permissions, re-asserting
- * the mode on every call (defense in depth against a prior looser mode).
+ * Ensures the config directory exists with restrictive permissions,
+ * re-asserting them on every call (defense in depth against a prior looser
+ * mode). On win32 this is a real ACL: inheritance removed, owner plus SYSTEM
+ * only, inheritable so state files created inside start out restricted.
  * @param {string} configDir
  * @returns {void}
  */
 function ensureConfigDir(configDir) {
   fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
-  try {
-    fs.chmodSync(configDir, 0o700);
-  } catch (_err) {
-    // POSIX modes are not meaningful on win32 (no chmod-equivalent ACL model
-    // here), so enforcement is best-effort there. This is a defense-in-depth
-    // measure for the POSIX hosts the agent primarily runs on; nothing on
-    // win32 depends on this call succeeding.
-  }
+  applyRestrictivePermissions(configDir, { kind: "directory", mode: 0o700 });
 }
 
 function readConfigFile(configDir) {
@@ -455,41 +441,12 @@ function readDnsCredentialsFile(providerId, config) {
 
   const credentialsPath = entry.credentialsFile;
 
-  if (process.platform !== "win32") {
-    let stats;
-    try {
-      stats = fs.lstatSync(credentialsPath);
-    } catch (err) {
-      throw new Error(
-        `tokentimer-agent: failed to stat DNS credentials file ${credentialsPath}: ${err.message}`,
-      );
-    }
-    if (stats.isSymbolicLink() || !stats.isFile()) {
-      throw new Error(
-        `tokentimer-agent: DNS credentials file ${credentialsPath} must be a regular non-symlink file`,
-      );
-    }
-    // Same permission posture as the agent credential file: secrets are
-    // 0600. A group/other-readable credentials file is a misconfiguration
-    // the agent refuses to use rather than silently accepting.
-    if ((stats.mode & 0o077) !== 0) {
-      throw new Error(
-        `tokentimer-agent: refusing to read DNS credentials file ${credentialsPath}: ` +
-          "it is readable by group/other (chmod 600 it)",
-      );
-    }
-    // Must be owned by the agent user (or root, so operators can provision
-    // credentials without a login shell for the service account).
-    if (typeof process.getuid === "function") {
-      const uid = process.getuid();
-      if (stats.uid !== uid && stats.uid !== 0) {
-        throw new Error(
-          `tokentimer-agent: refusing to read DNS credentials file ${credentialsPath}: ` +
-            "it is not owned by the agent user or root",
-        );
-      }
-    }
-  }
+  // Cross-platform permission preflight: POSIX mode/ownership on POSIX, real
+  // ACL inspection on win32. Previously the whole check was skipped on win32,
+  // which meant a world-readable DNS credentials file was accepted there.
+  assertRestrictivePermissions(credentialsPath, {
+    label: "DNS credentials file",
+  });
 
   let raw;
   try {
@@ -600,36 +557,11 @@ function resolveAcmeAccountCredentials(accountRef, config) {
 
   const credentialsPath = entry.credentialsFile;
 
-  if (process.platform !== "win32") {
-    let stats;
-    try {
-      stats = fs.lstatSync(credentialsPath);
-    } catch (err) {
-      throw new Error(
-        `tokentimer-agent: failed to stat ACME account credentials file ${credentialsPath}: ${err.message}`,
-      );
-    }
-    if (stats.isSymbolicLink() || !stats.isFile()) {
-      throw new Error(
-        `tokentimer-agent: ACME account credentials file ${credentialsPath} must be a regular non-symlink file`,
-      );
-    }
-    if ((stats.mode & 0o077) !== 0) {
-      throw new Error(
-        `tokentimer-agent: refusing to read ACME account credentials file ${credentialsPath}: ` +
-          "it is readable by group/other (chmod 600 it)",
-      );
-    }
-    if (typeof process.getuid === "function") {
-      const uid = process.getuid();
-      if (stats.uid !== uid && stats.uid !== 0) {
-        throw new Error(
-          `tokentimer-agent: refusing to read ACME account credentials file ${credentialsPath}: ` +
-            "it is not owned by the agent user or root",
-        );
-      }
-    }
-  }
+  // Same cross-platform preflight as the DNS credentials file: enforced on
+  // win32 via ACL inspection rather than skipped.
+  assertRestrictivePermissions(credentialsPath, {
+    label: "ACME account credentials file",
+  });
 
   let raw;
   try {

--- a/packages/agent/src/deploy/deploy.test.js
+++ b/packages/agent/src/deploy/deploy.test.js
@@ -31,8 +31,21 @@ const tempDirs = [];
 
 function makeTempDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentimer-agent-deploy-test-"));
-  tempDirs.push(dir);
-  return dir;
+  // Canonicalize immediately: on some Windows hosts (notably GitHub-hosted
+  // runners) `os.tmpdir()` resolves through a short 8.3 alias component
+  // (e.g. `RUNNER~1`) while deployCertificate's symlink-aware containment
+  // re-check resolves through `fs.promises.realpath`, which Node documents
+  // as the promisified form of `fs.realpath.native` (the real Win32
+  // `GetFinalPathNameByHandle` call) and therefore expands 8.3 aliases to
+  // their long form (`runneradmin`). Plain `fs.realpathSync` is Node's own
+  // JS-based, cross-platform implementation: it resolves symlinks but does
+  // NOT perform that Win32-specific expansion, so it would silently leave
+  // the short form in place and reproduce the exact mismatch this is
+  // fixing. `.native` is required here to match what the production code
+  // actually compares against.
+  const realDir = fs.realpathSync.native(dir);
+  tempDirs.push(realDir);
+  return realDir;
 }
 
 /**

--- a/packages/agent/src/deploy/index.js
+++ b/packages/agent/src/deploy/index.js
@@ -45,16 +45,19 @@
  * etc.). Wiring is left to src/index.js.
  *
  * Windows note: directory fsync is not supported on win32 (fs.open on a
- * directory fails with EISDIR/EPERM), so the post-rename directory fsync is
- * best-effort and skipped there; the file-content fsync before rename still
- * runs on every platform. Likewise POSIX modes (0o600/0o644) are asserted
- * best-effort on win32, mirroring the config module's convention.
+ * directory fails with EISDIR/EPERM), so the post-rename directory fsync
+ * failure is recorded via src/platform/durability.js (never silently
+ * swallowed) rather than failing an otherwise-complete deploy; the
+ * file-content fsync before rename still runs on every platform. Likewise
+ * POSIX modes (0o600/0o644) are asserted best-effort on win32, mirroring
+ * the config module's convention.
  */
 
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
 const crypto = require("node:crypto");
+const { fsyncDirectory } = require("../platform/durability.js");
 
 // Mirrors discovery/index.js's PRIVATE_KEY_PEM_HEADER_PATTERN (which itself
 // mirrors apps/api/utils/secretMaterial.js). Duplicated, not imported, to
@@ -375,33 +378,18 @@ function validateTargetConfig(target, { checkPath, _fsOverrides } = {}) {
 
 /**
  * fsyncs a directory so a preceding rename in it becomes durable. On win32
- * directories cannot be opened for fsync (EISDIR/EPERM/EACCES), so this is
- * documented best-effort: it swallows the error there (and on any other
- * platform quirk) rather than failing an otherwise-complete deploy. The
+ * directories cannot be opened for fsync (EISDIR/EPERM/EACCES); that
+ * limitation is recorded via src/platform/durability.js (never silently
+ * swallowed) so it can be attached to deploy evidence, rather than being
+ * indistinguishable from a fully durable write in the evidence trail. The
  * file-content fsync before rename is NOT best-effort and runs everywhere.
  *
  * @param {typeof fsp} fspImpl
  * @param {string} dirPath
- * @returns {Promise<void>}
+ * @returns {Promise<{ durable: boolean, limit: null | object }>}
  */
 async function fsyncDirBestEffort(fspImpl, dirPath) {
-  let handle;
-  try {
-    handle = await fspImpl.open(dirPath, "r");
-    await handle.sync();
-  } catch (_err) {
-    // win32 (and some filesystems) cannot fsync a directory; the rename is
-    // still atomic on the same volume, just not guaranteed durable across
-    // an immediate power loss. Documented platform limitation.
-  } finally {
-    if (handle) {
-      try {
-        await handle.close();
-      } catch (_err) {
-        // best-effort close
-      }
-    }
-  }
+  return fsyncDirectory(fspImpl, dirPath);
 }
 
 /**

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -87,6 +87,7 @@ const {
   resolveAcmeAccountCredentials,
 } = require("./config");
 const { loadPolicyConfig, createPolicyEngine } = require("./policy");
+const { isWindows, clearWindowsServiceBootstrapToken } = require("./platform");
 const {
   createProtocolClient,
   createCaAwareFetch,
@@ -121,6 +122,7 @@ const {
   removeDeployedArtifacts,
   getDeployMetrics,
 } = require("./deploy");
+const { durabilityMetadataEntries } = require("./platform/durability.js");
 const {
   markSideEffectReached,
   scanUnresolvedJournalEntries,
@@ -3375,6 +3377,7 @@ async function runDeployReloadVerify({
         ...Object.entries(metricsForType)
           .filter(([, value]) => typeof value === "number")
           .map(([name, value]) => ({ name: `deployMetric_${name}`, value })),
+        ...durabilityMetadataEntries(),
       ],
     }),
   ]);
@@ -3827,19 +3830,41 @@ async function runDiscoveryScan({ directories, client, log = null }) {
  * @param {object} params.config from loadAgentConfig
  * @param {string} params.configDir
  * @param {NodeJS.ProcessEnv} [params.env]
+ * @param {(...args: unknown[]) => void} [params.log]
+ * @param {{ isWindows: Function, clearWindowsServiceBootstrapToken: Function }} [params.platformModule]
+ *   injection seam for tests; defaults to the real ./platform module.
  * @returns {Promise<string>} the assigned agentId
  */
-async function registerIfNeeded({ client, config, configDir, env = process.env }) {
+async function registerIfNeeded({
+  client,
+  config,
+  configDir,
+  env = process.env,
+  log = console.error,
+  platformModule = { isWindows, clearWindowsServiceBootstrapToken },
+}) {
   // Already-registered paths: an earlier run exchanged the bootstrap token,
   // but systemd may still have re-exported it from a leftover bootstrap.env.
   // Scrub it here too so a registered agent never keeps the (already spent)
-  // token in its environment or on disk.
+  // token in its environment, on disk, or (Windows service installs) in the
+  // service's own registry Environment value.
   const scrubBootstrapToken = () => {
     if (env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN !== undefined) {
       delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN;
       delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID;
     }
     deleteBootstrapEnvFile(configDir);
+    if (platformModule.isWindows()) {
+      const result = platformModule.clearWindowsServiceBootstrapToken({ configDir });
+      if (result.attempted && !result.cleared) {
+        log(
+          `tokentimer-agent: could not confirm the Windows service registry ` +
+            `Environment value no longer holds the bootstrap token (${result.reason}); ` +
+            "if this agent runs as the TokenTimerAgent service, check " +
+            "HKLM\\SYSTEM\\CurrentControlSet\\Services\\TokenTimerAgent\\Environment manually.",
+        );
+      }
+    }
   };
 
   const recovered = recoverPendingRegistration(configDir);
@@ -3898,12 +3923,12 @@ async function registerIfNeeded({ client, config, configDir, env = process.env }
   clearRegistrationId(configDir);
   // The bootstrap token is single-use and has now been exchanged for a
   // stored per-agent credential. Scrub it from this process's environment
-  // (so it can never leak into child processes or diagnostics) and remove
-  // the installer-written bootstrap.env file (so systemd stops re-exporting
-  // it on every later start).
-  delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN;
-  delete env.TOKENTIMER_AGENT_BOOTSTRAP_TOKEN_ID;
-  deleteBootstrapEnvFile(configDir);
+  // (so it can never leak into child processes or diagnostics), remove the
+  // installer-written bootstrap.env file (so systemd/the Windows service
+  // stop re-exporting it on every later start), and clear it out of the
+  // Windows service's own registry Environment value if this is a service
+  // install.
+  scrubBootstrapToken();
   // Trust-on-first-use pinning (ADR-0003): when the register response
   // carries the control plane's job-signing key info, persist it so every
   // later run verifies jobs against the same key. Public material only.

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -67,7 +67,17 @@ const {
 } = require("./protocol");
 
 function makeTempConfigDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "ttagent-index-test-"));
+  // .native is required on Windows: os.tmpdir() can resolve through a
+  // short 8.3 alias (e.g. GitHub-hosted runners' RUNNER~1), while
+  // deployCertificate's realpath-based containment re-check resolves
+  // through fs.promises.realpath (documented as the promisified form of
+  // fs.realpath.native). Plain fs.realpathSync does not perform that
+  // Win32 short-name expansion, so it would leave any checkPath allowlist
+  // built from this dir on a different spelling than what production
+  // code compares against.
+  return fs.realpathSync.native(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ttagent-index-test-")),
+  );
 }
 
 function createRecordingClient() {
@@ -392,6 +402,37 @@ describe("registerIfNeeded", () => {
     assert.equal(client.calls.register.length, 0);
   });
 
+  it("clears the Windows service registry Environment value on the already-registered path too", async () => {
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://cp.example.com", agentId: "agent-existing" }),
+      "utf8",
+    );
+    writeCredential(dir, "ttagent_agent-existing_0123456789abcdef");
+
+    const clearCalls = [];
+    const platformModule = {
+      isWindows: () => true,
+      clearWindowsServiceBootstrapToken: (options) => {
+        clearCalls.push(options);
+        return { attempted: true, cleared: true };
+      },
+    };
+
+    const client = createRecordingClient();
+    const agentId = await registerIfNeeded({
+      client,
+      config: loadConfigFrom(dir),
+      configDir: dir,
+      env: {},
+      platformModule,
+    });
+
+    assert.equal(agentId, "agent-existing");
+    assert.equal(clearCalls.length, 1);
+    assert.equal(clearCalls[0].configDir, dir);
+  });
+
   it("fails loudly when a credential exists but agentId is missing (inconsistent dir)", async () => {
     fs.writeFileSync(
       path.join(dir, "config.json"),
@@ -474,6 +515,95 @@ describe("registerIfNeeded", () => {
     const persisted = JSON.parse(fs.readFileSync(path.join(dir, "config.json"), "utf8"));
     assert.equal(persisted.agentId, "agent-assigned-1");
     assert.equal(readCredential(dir), "ttagent_agent-assigned-1_0123456789abcdef");
+  });
+
+  it("clears the Windows service registry Environment value after a successful registration", async () => {
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://cp.example.com" }),
+      "utf8",
+    );
+
+    const clearCalls = [];
+    const platformModule = {
+      isWindows: () => true,
+      clearWindowsServiceBootstrapToken: (options) => {
+        clearCalls.push(options);
+        return { attempted: true, cleared: true };
+      },
+    };
+
+    const client = createRecordingClient();
+    await registerIfNeeded({
+      client,
+      config: loadConfigFrom(dir),
+      configDir: dir,
+      env: { TOKENTIMER_AGENT_BOOTSTRAP_TOKEN: "bootstrap-raw-token" },
+      platformModule,
+    });
+
+    assert.equal(clearCalls.length, 1);
+    assert.equal(clearCalls[0].configDir, dir);
+  });
+
+  it("logs, but does not throw, when the Windows registry scrub cannot confirm success", async () => {
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://cp.example.com" }),
+      "utf8",
+    );
+
+    const logCalls = [];
+    const platformModule = {
+      isWindows: () => true,
+      clearWindowsServiceBootstrapToken: () => ({
+        attempted: true,
+        cleared: false,
+        reason: "reg.exe add exited 1",
+      }),
+    };
+
+    const client = createRecordingClient();
+    const agentId = await registerIfNeeded({
+      client,
+      config: loadConfigFrom(dir),
+      configDir: dir,
+      env: { TOKENTIMER_AGENT_BOOTSTRAP_TOKEN: "bootstrap-raw-token" },
+      platformModule,
+      log: (...args) => logCalls.push(args),
+    });
+
+    assert.equal(agentId, "agent-assigned-1");
+    assert.equal(logCalls.length, 1);
+    assert.match(logCalls[0][0], /reg\.exe add exited 1/);
+  });
+
+  it("never calls the Windows registry scrub on a non-Windows platform", async () => {
+    fs.writeFileSync(
+      path.join(dir, "config.json"),
+      JSON.stringify({ serverUrl: "https://cp.example.com" }),
+      "utf8",
+    );
+
+    const clearCalls = [];
+    const platformModule = {
+      isWindows: () => false,
+      clearWindowsServiceBootstrapToken: (options) => {
+        clearCalls.push(options);
+        return { attempted: false, cleared: false };
+      },
+    };
+
+    const client = createRecordingClient();
+    await registerIfNeeded({
+      client,
+      config: loadConfigFrom(dir),
+      configDir: dir,
+      env: { TOKENTIMER_AGENT_BOOTSTRAP_TOKEN: "bootstrap-raw-token" },
+      platformModule,
+    });
+
+    assert.equal(clearCalls.length, 0);
   });
 
   it("advertises configured DNS provider ids on register", async () => {

--- a/packages/agent/src/job-journal/index.js
+++ b/packages/agent/src/job-journal/index.js
@@ -14,6 +14,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { applyRestrictivePermissions } = require("../platform/index.js");
 
 const JOURNAL_DIR_NAME = "job-journal";
 const JOURNAL_FILE_MODE = 0o600;
@@ -59,17 +60,15 @@ function journalPathFor(stateDir, jobId, attemptId) {
 }
 
 /**
- * Ensures the journal directory exists with restrictive mode.
+ * Ensures the journal directory exists with restrictive permissions,
+ * re-asserting them on every call. POSIX: 0700. win32: a real ACL with
+ * inheritance removed, granting only the agent's own identity plus SYSTEM.
  * @param {string} stateDir
  */
 function ensureJournalDir(stateDir) {
   const dir = journalDirFor(stateDir);
   fs.mkdirSync(dir, { recursive: true, mode: JOURNAL_DIR_MODE });
-  try {
-    fs.chmodSync(dir, JOURNAL_DIR_MODE);
-  } catch (_err) {
-    // win32 may ignore mode bits
-  }
+  applyRestrictivePermissions(dir, { kind: "directory", mode: JOURNAL_DIR_MODE });
   return dir;
 }
 
@@ -113,11 +112,10 @@ function markSideEffectReached({
   };
   const tmp = `${filePath}.${process.pid}.tmp`;
   fs.writeFileSync(tmp, `${JSON.stringify(entry)}\n`, { mode: JOURNAL_FILE_MODE });
-  try {
-    fs.chmodSync(tmp, JOURNAL_FILE_MODE);
-  } catch (_err) {
-    // win32
-  }
+  // POSIX re-asserts the mode; win32 gets a real restricted ACL. A failure
+  // here is fatal: an unprotected journal entry is not an acceptable
+  // outcome of a successful write.
+  applyRestrictivePermissions(tmp, { kind: "file", mode: JOURNAL_FILE_MODE });
   fs.renameSync(tmp, filePath);
   return { path: filePath, created: true, entry };
 }

--- a/packages/agent/src/keys/index.js
+++ b/packages/agent/src/keys/index.js
@@ -23,13 +23,16 @@
  *
  * Module style follows the sibling policy/evidence modules: CommonJS,
  * node builtins only (node:crypto, node:fs, node:path), self-contained
- * plain-data functions with no sibling-module imports beyond the shared
- * detector seam already used by ../evidence.
+ * plain-data functions. The only sibling-module imports are the shared
+ * private-key-material detector (used by ../evidence too) and the shared
+ * platform permission module (used by ../config too) for cross-platform
+ * directory/file permission enforcement.
  */
 
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
+const { applyRestrictivePermissions } = require("../platform/index.js");
 
 // Single source of truth for content-based private-key-material detection.
 // Vendored from @tokentimer/log-scrub so the installed agent never depends
@@ -82,21 +85,18 @@ function guardReturnValue(value) {
 }
 
 /**
- * Ensures the parent directory of keyPath exists with 0700 permissions,
- * re-asserting the mode on every call (same defense-in-depth discipline as
- * config/ensureConfigDir; best-effort on win32 where POSIX modes are not
- * meaningful).
+ * Ensures the parent directory of keyPath exists with restrictive
+ * permissions, re-asserting them on every call (same defense-in-depth
+ * discipline as config/ensureConfigDir). POSIX: 0700. win32: a real ACL
+ * with inheritance removed, granting only the agent's own identity plus
+ * SYSTEM, verified against a trusted-owner allowlist.
  * @param {string} keyPath
  * @returns {void}
  */
 function ensureKeyDir(keyPath) {
   const dir = path.dirname(keyPath);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  try {
-    fs.chmodSync(dir, 0o700);
-  } catch (_err) {
-    // Best-effort on win32; see config/ensureConfigDir for rationale.
-  }
+  applyRestrictivePermissions(dir, { kind: "directory", mode: 0o700 });
 }
 
 /**
@@ -202,11 +202,10 @@ function generateKeyPairToFile({ keyPath, algorithm = "ec-p256", overwrite = fal
     // Exclusive create for both fresh and staging paths; never follows a
     // racing symlink into existence between classify and write.
     fs.writeFileSync(writePath, privatePemBuffer, { mode: 0o600, flag: "wx" });
-    try {
-      fs.chmodSync(writePath, 0o600);
-    } catch (_err) {
-      // Best-effort on win32; see ensureKeyDir.
-    }
+    // POSIX re-asserts the mode; win32 gets a real restricted ACL. A
+    // failure here is fatal: an unprotected private key file is not an
+    // acceptable outcome of a successful write.
+    applyRestrictivePermissions(writePath, { kind: "file", mode: 0o600 });
   } finally {
     // Zeroize what we can: the exported PEM bytes. The KeyObject's internal
     // OpenSSL memory and any engine-internal copies cannot be zeroized from

--- a/packages/agent/src/outbox/index.js
+++ b/packages/agent/src/outbox/index.js
@@ -13,33 +13,30 @@
  *
  * Storage conventions match src/config: 0700 directory, 0600 files,
  * atomic write + rename. Entries are public result/evidence payloads only
- * (never private keys).
+ * (never private keys). Permission enforcement is delegated to the shared
+ * src/platform module: POSIX chmod, or a real restricted ACL on win32
+ * (inheritance removed, owner-plus-SYSTEM only, verified against a
+ * trusted-owner allowlist), rather than a best-effort chmod that silently
+ * did nothing on win32.
  */
 
 const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
+const { applyRestrictivePermissions } = require("../platform/index.js");
+const { fsyncDirectorySync } = require("../platform/durability.js");
 
 const OUTBOX_DIR_NAME = "outbox";
 const ENTRY_FILE_SUFFIX = ".json";
 const MAX_ENTRY_BYTES = 512 * 1024;
 
 function fsyncParentDirectory(filePath) {
-  let directoryFd;
-  try {
-    directoryFd = fs.openSync(path.dirname(filePath), "r");
-    fs.fsyncSync(directoryFd);
-  } catch (_err) {
-    // Best effort across platforms/filesystems.
-  } finally {
-    if (directoryFd !== undefined) {
-      try {
-        fs.closeSync(directoryFd);
-      } catch (_err) {
-        // Best effort close.
-      }
-    }
-  }
+  // fsync on a directory is the durable part of an atomic rename on POSIX.
+  // Windows cannot open a directory this way at all, so the fsync is
+  // recorded as a durability limit (see src/platform/durability.js) rather
+  // than being swallowed by an empty catch: the agent reports what it
+  // could not guarantee instead of pretending it succeeded.
+  fsyncDirectorySync(path.dirname(filePath));
 }
 
 function writeFileAtomically(filePath, contents, mode) {
@@ -52,11 +49,10 @@ function writeFileAtomically(filePath, contents, mode) {
     fs.closeSync(fd);
     fd = undefined;
     fs.renameSync(temporaryPath, filePath);
-    try {
-      fs.chmodSync(filePath, mode);
-    } catch (_err) {
-      // Best effort on win32.
-    }
+    // POSIX re-asserts the mode; win32 gets a real restricted ACL. A
+    // failure here is fatal: an unprotected outbox entry is not an
+    // acceptable outcome of a successful write.
+    applyRestrictivePermissions(filePath, { kind: "file", mode });
     fsyncParentDirectory(filePath);
   } catch (err) {
     if (fd !== undefined) {
@@ -84,17 +80,15 @@ function resolveOutboxDir(configDir) {
 }
 
 /**
- * Ensures the outbox directory exists with 0700 permissions.
+ * Ensures the outbox directory exists with restrictive permissions,
+ * re-asserting them on every call. POSIX: 0700. win32: a real ACL with
+ * inheritance removed, granting only the agent's own identity plus SYSTEM.
  * @param {string} outboxDir
  * @returns {string} outboxDir
  */
 function ensureOutboxDir(outboxDir) {
   fs.mkdirSync(outboxDir, { recursive: true, mode: 0o700 });
-  try {
-    fs.chmodSync(outboxDir, 0o700);
-  } catch (_err) {
-    // Best effort on win32.
-  }
+  applyRestrictivePermissions(outboxDir, { kind: "directory", mode: 0o700 });
   return outboxDir;
 }
 

--- a/packages/agent/src/platform/durability.js
+++ b/packages/agent/src/platform/durability.js
@@ -1,0 +1,149 @@
+"use strict";
+
+/**
+ * Durability limits the host cannot satisfy.
+ *
+ * An atomic write is rename-plus-directory-fsync on POSIX. Windows cannot open
+ * a directory handle for fsync at all, so the directory fsync is impossible
+ * there: the rename is still atomic on the same volume, but its durability is
+ * not guaranteed across an immediate power loss. That was previously swallowed
+ * by an empty catch, which made a Windows deploy indistinguishable from a
+ * fully durable one in the evidence trail.
+ *
+ * This module keeps the swallow (failing a completed deploy over a missing
+ * directory fsync would be worse) but records the limitation so it can be
+ * attached to evidence. The agent states what it could not guarantee instead
+ * of implying a guarantee it never had.
+ */
+
+const DIRECTORY_FSYNC_UNSUPPORTED = "directory_fsync_unsupported";
+
+/** @type {Map<string, { code: string, platform: string, detail: string, occurrences: number }>} */
+const limits = new Map();
+
+/**
+ * @param {{ code: string, platform?: string, detail: string }} limit
+ * @returns {void}
+ */
+function noteDurabilityLimit({ code, platform = process.platform, detail }) {
+  const existing = limits.get(code);
+  if (existing) {
+    existing.occurrences += 1;
+    return;
+  }
+  limits.set(code, { code, platform, detail, occurrences: 1 });
+}
+
+/**
+ * Snapshot of the durability limitations observed so far. Values are public
+ * and non-secret, suitable for evidence metadata.
+ *
+ * @returns {Array<{ code: string, platform: string, detail: string, occurrences: number }>}
+ */
+function getDurabilityLimits() {
+  return [...limits.values()].map((limit) => ({ ...limit }));
+}
+
+/** Test helper. */
+function resetDurabilityLimits() {
+  limits.clear();
+}
+
+/**
+ * Flattens the recorded limits into scalar evidence metadata entries. Returns
+ * an empty array on a host with no limitations, so POSIX evidence is unchanged.
+ *
+ * @returns {Array<{ name: string, value: string|number|boolean }>}
+ */
+function durabilityMetadataEntries() {
+  return getDurabilityLimits().flatMap((limit) => [
+    { name: `durabilityLimit_${limit.code}`, value: true },
+    { name: `durabilityLimit_${limit.code}_platform`, value: limit.platform },
+  ]);
+}
+
+function describeDirectoryFsyncLimit(platform, err) {
+  return {
+    code: DIRECTORY_FSYNC_UNSUPPORTED,
+    platform,
+    detail:
+      platform === "win32"
+        ? "win32 cannot open a directory for fsync, so the rename that " +
+          "committed this write is atomic but not power-loss durable"
+        : `directory fsync failed (${err && err.code ? err.code : "unknown"}), ` +
+          "so the rename that committed this write is atomic but not " +
+          "power-loss durable",
+  };
+}
+
+/**
+ * fsyncs a directory so a preceding rename in it becomes durable, recording a
+ * durability limit instead of silently swallowing the failure.
+ *
+ * @param {string} dirPath
+ * @param {{ fsImpl?: typeof import("node:fs"), platform?: string }} [options]
+ * @returns {{ durable: boolean, limit: null | { code: string, platform: string, detail: string } }}
+ */
+function fsyncDirectorySync(
+  dirPath,
+  { fsImpl = require("node:fs"), platform = process.platform } = {},
+) {
+  let fd;
+  try {
+    fd = fsImpl.openSync(dirPath, "r");
+    fsImpl.fsyncSync(fd);
+    return { durable: true, limit: null };
+  } catch (err) {
+    const limit = describeDirectoryFsyncLimit(platform, err);
+    noteDurabilityLimit(limit);
+    return { durable: false, limit };
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fsImpl.closeSync(fd);
+      } catch (_err) {
+        // Best-effort close; the fsync outcome is already recorded.
+      }
+    }
+  }
+}
+
+/**
+ * Promise-based counterpart of fsyncDirectorySync for the deploy module's
+ * injected fs/promises implementation.
+ *
+ * @param {object} fspImpl node:fs/promises-compatible implementation
+ * @param {string} dirPath
+ * @param {{ platform?: string }} [options]
+ * @returns {Promise<{ durable: boolean, limit: null | object }>}
+ */
+async function fsyncDirectory(fspImpl, dirPath, { platform = process.platform } = {}) {
+  let handle;
+  try {
+    handle = await fspImpl.open(dirPath, "r");
+    await handle.sync();
+    return { durable: true, limit: null };
+  } catch (err) {
+    const limit = describeDirectoryFsyncLimit(platform, err);
+    noteDurabilityLimit(limit);
+    return { durable: false, limit };
+  } finally {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch (_err) {
+        // Best-effort close; the fsync outcome is already recorded.
+      }
+    }
+  }
+}
+
+module.exports = {
+  DIRECTORY_FSYNC_UNSUPPORTED,
+  durabilityMetadataEntries,
+  fsyncDirectory,
+  fsyncDirectorySync,
+  getDurabilityLimits,
+  noteDurabilityLimit,
+  resetDurabilityLimits,
+};

--- a/packages/agent/src/platform/index.js
+++ b/packages/agent/src/platform/index.js
@@ -1,0 +1,684 @@
+"use strict";
+
+/**
+ * Platform permission enforcement and durability limits.
+ *
+ * POSIX hosts express "only this identity may read this file" with chmod 0600
+ * / 0700, and the agent has always asserted those modes. Windows has no chmod
+ * equivalent, so before this module every chmod was wrapped in an empty catch
+ * and every permission preflight was skipped outright on win32. That is the
+ * one thing the agent must never do: treat "this platform cannot express the
+ * permission I need" as success.
+ *
+ * Enforcement on win32 uses `icacls`, which ships with Windows:
+ *
+ *   - apply: `icacls <path> /inheritance:r /grant:r <sid>:(F) ...` drops every
+ *     inherited ACE and leaves exactly the agent's own identity plus SYSTEM.
+ *     ADR-0012 decision 5 fixes the Windows agent service at `LocalSystem`, so
+ *     SYSTEM is the principal that must read these files; the ACL's job is
+ *     excluding everyone else, not excluding the service that owns the file.
+ *   - verify: `icacls <path> /save <file>` writes SDDL, which is SID-based and
+ *     therefore locale-independent. icacls' human-readable output is localized
+ *     ("AUTORITE NT\\Systeme" on a French host) and is never parsed here.
+ *
+ * Both operations fail loudly: a missing icacls, a non-zero exit, or an
+ * unparseable SDDL is an error, never a silent skip.
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { spawnSync } = require("node:child_process");
+
+/** Well-known SID of the local SYSTEM account (SDDL alias `SY`). */
+const SYSTEM_SID = "S-1-5-18";
+/** Well-known SID of the local Administrators group (SDDL alias `BA`). */
+const ADMINISTRATORS_SID = "S-1-5-32-544";
+
+/**
+ * SDDL two-letter aliases the parser resolves to SIDs. Only the aliases that
+ * can legitimately or dangerously appear on an agent state file are listed;
+ * anything unrecognized is surfaced verbatim so verification refuses it
+ * rather than silently ignoring it.
+ */
+const SDDL_ALIAS_SIDS = Object.freeze({
+  SY: SYSTEM_SID,
+  BA: ADMINISTRATORS_SID,
+  // `LA` (the built-in local Administrator account, RID 500) has no fixed
+  // well-known SID string: its real value is machine/domain-relative
+  // (<machine-or-domain-SID>-500), so it cannot be a literal constant here.
+  // It is mapped to the Administrators *group* SID instead, which is the
+  // correct outcome for this allowlist's purposes: the built-in Administrator
+  // account is always a member of Administrators and carries the identical
+  // "accepted but never granted" trust tier this module already applies to
+  // BA, for the identical reason (it can take ownership of any file on the
+  // machine, so excluding it from the DACL buys no confidentiality). A
+  // fabricated, syntactically invalid SID string was here before
+  // (`S-1-5-32-544-administrator`), which made `icacls` fail with exit code
+  // 1337 (ERROR_INVALID_SID) every time a DACL contained this alias, which
+  // real Windows hosts running as a built-in Administrator account (as
+  // GitHub-hosted Windows runners do) do by default.
+  LA: ADMINISTRATORS_SID,
+  BU: "S-1-5-32-545",
+  AU: "S-1-5-11",
+  WD: "S-1-1-0",
+  IU: "S-1-5-4",
+  AN: "S-1-5-7",
+  LS: "S-1-5-19",
+  NS: "S-1-5-20",
+  CO: "S-1-3-0",
+  OW: "S-1-3-4",
+});
+
+const FILE_MODE = 0o600;
+const DIRECTORY_MODE = 0o700;
+
+function isWindows(platform = process.platform) {
+  return platform === "win32";
+}
+
+function buildError(message) {
+  return new Error(`tokentimer-agent platform: ${message}`);
+}
+
+/**
+ * Runs a Windows utility and returns its exit status plus streams. Kept behind
+ * a single seam so tests can inject a fake without spawning processes.
+ *
+ * @param {string} file
+ * @param {string[]} args
+ * @param {(file: string, args: string[], options: object) => { status: number|null, stdout: string, stderr: string, error?: Error }} [spawn]
+ * @returns {{ status: number|null, stdout: string, stderr: string, error?: Error }}
+ */
+function runTool(file, args, spawn = spawnSync) {
+  const result = spawn(file, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 30000,
+  });
+  if (!result || (result.error && result.error.code === "ENOENT")) {
+    throw buildError(
+      `${file} is not available on this host, so file permissions cannot be ` +
+        "enforced; refusing to continue with unprotected state files",
+    );
+  }
+  if (result.error) {
+    throw buildError(`${file} failed to run: ${result.error.message}`);
+  }
+  return result;
+}
+
+let cachedUserSid = null;
+
+/**
+ * Resolves the SID of the identity this process runs as. `whoami /user` is
+ * used with CSV output so the SID is machine-readable and unaffected by the
+ * host language.
+ *
+ * @param {{ spawn?: Function, useCache?: boolean }} [options]
+ * @returns {string}
+ */
+function currentUserSid({ spawn = spawnSync, useCache = true } = {}) {
+  if (useCache && cachedUserSid !== null) return cachedUserSid;
+  const result = runTool("whoami", ["/user", "/fo", "csv", "/nh"], spawn);
+  if (result.status !== 0) {
+    throw buildError(
+      `whoami exited ${result.status} while resolving the agent's own SID`,
+    );
+  }
+  const match = /(S-1-[0-9-]+)/.exec(String(result.stdout || ""));
+  if (!match) {
+    throw buildError("could not parse a SID out of whoami /user output");
+  }
+  if (useCache) cachedUserSid = match[1];
+  return match[1];
+}
+
+/** Test helper: clears the memoized process SID. */
+function resetPlatformCaches() {
+  cachedUserSid = null;
+}
+
+/**
+ * The principals an agent-controlled sensitive file may grant.
+ *
+ * SYSTEM is required (the service runs as LocalSystem). The agent's own
+ * identity is required for a non-service, operator-run agent. Administrators
+ * is accepted but never granted by the agent: a member of Administrators can
+ * take ownership of any file on the machine, so excluding it from the DACL
+ * buys no confidentiality while breaking routine operator maintenance.
+ *
+ * @param {string} ownSid
+ * @returns {Set<string>}
+ */
+function allowedPrincipals(ownSid) {
+  return new Set([ownSid, SYSTEM_SID, ADMINISTRATORS_SID]);
+}
+
+/**
+ * Applies the restrictive ACL to a file or directory and verifies the result.
+ *
+ * `/grant:r` only replaces the entries of the principals it names, so a
+ * pre-existing explicit ACE for someone else (an operator who ran
+ * `icacls /grant`, a tool that added Everyone) survives it. Enforcement
+ * therefore grants, re-reads the resulting DACL, removes every principal
+ * outside the allowlist, and re-reads again. If anything foreign is still
+ * there the call raises: a partially restricted credential file is not an
+ * acceptable outcome of a successful write.
+ *
+ * Directories also get object/container inheritance so files created inside
+ * them (including the temp file of an atomic write, which is created fresh on
+ * every write) start out restricted instead of inheriting the parent's ACL.
+ *
+ * @param {string} targetPath
+ * @param {{ kind?: "file"|"directory", spawn?: Function, fsImpl?: typeof fs, tmpDir?: string }} [options]
+ * @returns {{ mechanism: "windows-acl", principals: string[], removed: string[], inheritance: "removed" }}
+ */
+function applyWindowsAcl(
+  targetPath,
+  { kind = "file", spawn = spawnSync, fsImpl = fs, tmpDir } = {},
+) {
+  const ownSid = currentUserSid({ spawn });
+  const rights = kind === "directory" ? "(OI)(CI)(F)" : "(F)";
+  const granted = [SYSTEM_SID, ownSid].filter(
+    (sid, index, all) => all.indexOf(sid) === index,
+  );
+  const grantResult = runTool(
+    "icacls",
+    [
+      targetPath,
+      "/inheritance:r",
+      "/grant:r",
+      ...granted.map((sid) => `*${sid}:${rights}`),
+    ],
+    spawn,
+  );
+  if (grantResult.status !== 0) {
+    throw buildError(
+      `icacls exited ${grantResult.status} while restricting ${targetPath}; ` +
+        "the file remains unprotected, so this is treated as a failure",
+    );
+  }
+
+  const allowed = allowedPrincipals(ownSid);
+  const foreign = parseDaclSddl(readWindowsSddl(targetPath, { spawn, fsImpl, tmpDir }))
+    .aces.map((ace) => ace.sid)
+    .filter((sid) => !allowed.has(sid))
+    .filter((sid, index, all) => all.indexOf(sid) === index);
+
+  if (foreign.length > 0) {
+    const removeResult = runTool(
+      "icacls",
+      [
+        targetPath,
+        ...foreign.flatMap((sid) => ["/remove:g", `*${sid}`, "/remove:d", `*${sid}`]),
+      ],
+      spawn,
+    );
+    if (removeResult.status !== 0) {
+      throw buildError(
+        `icacls exited ${removeResult.status} while removing ${foreign.join(", ")} ` +
+          `from ${targetPath}`,
+      );
+    }
+    const stillForeign = parseDaclSddl(
+      readWindowsSddl(targetPath, { spawn, fsImpl, tmpDir }),
+    )
+      .aces.map((ace) => ace.sid)
+      .filter((sid) => !allowed.has(sid));
+    if (stillForeign.length > 0) {
+      throw buildError(
+        `could not restrict ${targetPath}: it still grants ` +
+          `${stillForeign.join(", ")} after enforcement`,
+      );
+    }
+  }
+
+  assertTrustedOwner(targetPath, allowed, { label: targetPath, spawn });
+
+  return {
+    mechanism: "windows-acl",
+    principals: granted,
+    removed: foreign,
+    inheritance: "removed",
+  };
+}
+
+/**
+ * Reads a path's DACL as SDDL via `icacls /save`. The saved file is UTF-16LE
+ * and holds one `name` line followed by one SDDL line per processed path.
+ *
+ * @param {string} targetPath
+ * @param {{ spawn?: Function, fsImpl?: typeof fs, tmpDir?: string }} [options]
+ * @returns {string} the SDDL descriptor
+ */
+function readWindowsSddl(
+  targetPath,
+  { spawn = spawnSync, fsImpl = fs, tmpDir = os.tmpdir() } = {},
+) {
+  const savePath = path.join(
+    tmpDir,
+    `tokentimer-acl-${process.pid}-${crypto.randomBytes(6).toString("hex")}.sddl`,
+  );
+  try {
+    const result = runTool("icacls", [targetPath, "/save", savePath], spawn);
+    if (result.status !== 0) {
+      throw buildError(
+        `icacls exited ${result.status} while reading the ACL of ${targetPath}`,
+      );
+    }
+    const saved = fsImpl.readFileSync(savePath, "utf16le");
+    const sddl = /(D:[^\r\n]*)/.exec(String(saved).replace(/\uFEFF/g, ""));
+    if (!sddl) {
+      throw buildError(
+        `icacls did not report a DACL for ${targetPath}; refusing to assume ` +
+          "the path is protected",
+      );
+    }
+    return sddl[1].trim();
+  } finally {
+    try {
+      fsImpl.unlinkSync(savePath);
+    } catch (_err) {
+      // The save file may never have been created.
+    }
+  }
+}
+
+/**
+ * Parses the DACL portion of an SDDL string.
+ *
+ * @param {string} sddl
+ * @returns {{ protectedDacl: boolean, autoInherited: boolean, aces: Array<{ type: string, flags: string, sid: string, inherited: boolean }> }}
+ */
+function parseDaclSddl(sddl) {
+  const daclStart = sddl.indexOf("D:");
+  if (daclStart === -1) throw buildError(`SDDL has no DACL: ${sddl}`);
+  const body = sddl.slice(daclStart + 2);
+  const flagsEnd = body.indexOf("(");
+  const flags = (flagsEnd === -1 ? body : body.slice(0, flagsEnd)).trim();
+  const aces = [];
+  const acePattern = /\(([^)]*)\)/g;
+  let match;
+  while ((match = acePattern.exec(body))) {
+    const fields = match[1].split(";");
+    const rawSid = (fields[5] || "").trim();
+    if (rawSid.length === 0) continue;
+    const aceFlags = (fields[1] || "").trim().toUpperCase();
+    aces.push({
+      type: (fields[0] || "").trim().toUpperCase(),
+      flags: aceFlags,
+      sid: SDDL_ALIAS_SIDS[rawSid.toUpperCase()] || rawSid,
+      inherited: aceFlags.includes("ID"),
+    });
+  }
+  return {
+    protectedDacl: flags.toUpperCase().includes("P"),
+    autoInherited: flags.toUpperCase().includes("AI"),
+    aces,
+  };
+}
+
+/**
+ * Reads the owner SID of a path via .NET's `ObjectSecurity.GetOwner`,
+ * translated to a `SecurityIdentifier` rather than an `NTAccount`.
+ * Requesting the SID type directly (instead of reading the display name
+ * `Get-Acl` normally prints and translating it back) means the result is
+ * correct even on a localized host and even for an owner whose display
+ * name cannot be resolved (an orphaned SID from a deleted account).
+ *
+ * `icacls /save` was evaluated for this and rejected: its saved SDDL only
+ * ever contains the `D:` (DACL) component on this codebase's target OS
+ * versions, never `O:` (owner), so owner cannot be recovered from it.
+ *
+ * The path is passed through an environment variable rather than
+ * interpolated into the PowerShell command string, so a path containing
+ * quotes or `$` cannot affect what the script executes.
+ *
+ * That same environment is also where a subtler, host-dependent failure
+ * lives: Windows PowerShell 5.1 (`powershell.exe`) resolves `Get-Acl`
+ * through module auto-loading, and it trusts an inherited `PSModulePath`
+ * as-is rather than recomputing it the way `pwsh` (PowerShell 7+) does. On
+ * GitHub-hosted Windows runners (and any host where this process was
+ * itself launched from, or inherited environment from, a PowerShell 7
+ * parent), `PSModulePath` can list PowerShell 7's Core-edition module
+ * paths ahead of Windows PowerShell's own Desktop-edition ones. `Get-Acl`
+ * then autoloads the Core-edition `Microsoft.PowerShell.Security` binary
+ * module into the Desktop CLR, which cannot load it, and fails closed with
+ * `CouldNotAutoloadMatchingModule`. Deleting `PSModulePath` from the child
+ * environment (rather than trying to reorder or filter it) makes
+ * `powershell.exe` compute its own default, version-correct search path
+ * exactly as it would with no ancestor process at all.
+ *
+ * @param {string} targetPath
+ * @param {{ spawn?: Function }} [options]
+ * @returns {string} the owner SID
+ */
+function readWindowsOwnerSid(targetPath, { spawn = spawnSync } = {}) {
+  const script =
+    "$p = $env:TOKENTIMER_ACL_PATH; " +
+    "$acl = Get-Acl -LiteralPath $p; " +
+    "$acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value";
+  const env = { ...process.env, TOKENTIMER_ACL_PATH: targetPath };
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === "psmodulepath") delete env[key];
+  }
+  const result = spawn(
+    "powershell",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 30000,
+      env,
+    },
+  );
+  if (!result || (result.error && result.error.code === "ENOENT")) {
+    throw buildError(
+      "powershell is not available on this host, so the owner of " +
+        `${targetPath} cannot be verified; refusing to trust an unverifiable owner`,
+    );
+  }
+  if (result.error) {
+    throw buildError(
+      `powershell failed to run while reading the owner of ${targetPath}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw buildError(
+      `powershell exited ${result.status} while reading the owner of ${targetPath}: ` +
+        `${String(result.stderr || "").trim()}`,
+    );
+  }
+  const match = /(S-1-[0-9-]+)/.exec(String(result.stdout || ""));
+  if (!match) {
+    throw buildError(`could not parse an owner SID for ${targetPath}`);
+  }
+  return match[1];
+}
+
+/**
+ * Validates that a path's owner SID is inside the trusted allowlist,
+ * raising with the same fail-closed severity as a foreign DACL entry: an
+ * untrusted owner can rewrite the DACL at will (`WRITE_DAC`/`WRITE_OWNER`
+ * semantics), which makes a DACL check that ignores the owner no
+ * protection at all.
+ *
+ * @param {string} targetPath
+ * @param {Set<string>} allowed
+ * @param {{ label?: string, spawn?: Function }} [options]
+ * @returns {string} the validated owner SID
+ */
+function assertTrustedOwner(targetPath, allowed, { label = targetPath, spawn = spawnSync } = {}) {
+  const ownerSid = readWindowsOwnerSid(targetPath, { spawn });
+  if (!allowed.has(ownerSid)) {
+    throw buildError(
+      `refusing to use ${label}: its owner is ${ownerSid}, which is not one ` +
+        "of the trusted owners (the agent's own identity, SYSTEM, or " +
+        "Administrators); an untrusted owner can rewrite the ACL at will, " +
+        "which makes the DACL check above meaningless",
+    );
+  }
+  return ownerSid;
+}
+
+/**
+ * Verifies that a path's DACL grants nothing outside the allowlist. Every
+ * failure mode (unreadable ACL, unparseable SDDL, an extra principal) raises,
+ * so a caller can never mistake "could not check" for "checked and fine".
+ *
+ * `requireProtected` is for paths the agent creates itself, where inheritance
+ * removal is guaranteed. It stays off for operator-provided credential files:
+ * a file that inherits owner-plus-SYSTEM from a locked-down parent is exactly
+ * as confidential as one with an explicit DACL, and refusing it would be a
+ * false rejection. The principal allowlist is the security property; the
+ * protected flag is a durability-of-intent property.
+ *
+ * @param {string} targetPath
+ * @param {{ label?: string, requireProtected?: boolean, spawn?: Function, fsImpl?: typeof fs, tmpDir?: string }} [options]
+ * @returns {{ mechanism: "windows-acl", principals: string[], protectedDacl: boolean, sddl: string }}
+ */
+function assertWindowsAcl(
+  targetPath,
+  {
+    label = targetPath,
+    requireProtected = false,
+    spawn = spawnSync,
+    fsImpl = fs,
+    tmpDir,
+  } = {},
+) {
+  const sddl = readWindowsSddl(targetPath, { spawn, fsImpl, tmpDir });
+  const parsed = parseDaclSddl(sddl);
+  const allowed = allowedPrincipals(currentUserSid({ spawn }));
+
+  if (requireProtected && !parsed.protectedDacl) {
+    throw buildError(
+      `refusing to use ${label}: its ACL still inherits from its parent ` +
+        "directory (run icacls with /inheritance:r, or let the agent create it)",
+    );
+  }
+  if (parsed.aces.length === 0) {
+    throw buildError(
+      `refusing to use ${label}: its DACL is empty or could not be read, so ` +
+        "the agent cannot confirm who has access",
+    );
+  }
+  const foreign = parsed.aces
+    .filter((ace) => !allowed.has(ace.sid))
+    .map((ace) => ace.sid);
+  if (foreign.length > 0) {
+    throw buildError(
+      `refusing to use ${label}: its ACL grants access to ` +
+        `${foreign.join(", ")} (only the agent's own identity, SYSTEM and ` +
+        "Administrators are allowed)",
+    );
+  }
+  assertTrustedOwner(targetPath, allowed, { label, spawn });
+  return {
+    mechanism: "windows-acl",
+    principals: parsed.aces.map((ace) => ace.sid),
+    protectedDacl: parsed.protectedDacl,
+    sddl,
+  };
+}
+
+/**
+ * Applies the strongest permission the platform can express: POSIX modes on
+ * POSIX hosts, a restricted ACL on win32. Unlike the previous best-effort
+ * chmod, a failure here propagates.
+ *
+ * @param {string} targetPath
+ * @param {{ kind?: "file"|"directory", mode?: number, platform?: string, spawn?: Function, fsImpl?: typeof fs }} [options]
+ * @returns {{ mechanism: "posix-mode"|"windows-acl", principals?: string[], mode?: number }}
+ */
+function applyRestrictivePermissions(
+  targetPath,
+  {
+    kind = "file",
+    mode,
+    platform = process.platform,
+    spawn = spawnSync,
+    fsImpl = fs,
+    tmpDir,
+  } = {},
+) {
+  if (isWindows(platform)) {
+    return applyWindowsAcl(targetPath, { kind, spawn, fsImpl, tmpDir });
+  }
+  const posixMode =
+    typeof mode === "number" ? mode : kind === "directory" ? DIRECTORY_MODE : FILE_MODE;
+  fsImpl.chmodSync(targetPath, posixMode);
+  return { mechanism: "posix-mode", mode: posixMode };
+}
+
+/**
+ * Verifies that a path the agent is about to read secrets from is not exposed
+ * to other principals. POSIX: regular non-symlink file, no group/other bits,
+ * owned by this user or root. win32: allowlisted DACL.
+ *
+ * @param {string} targetPath
+ * @param {{ label: string, requireProtected?: boolean, platform?: string, spawn?: Function, fsImpl?: typeof fs, tmpDir?: string }} options
+ * @returns {{ mechanism: "posix-mode"|"windows-acl" }}
+ */
+function assertRestrictivePermissions(
+  targetPath,
+  {
+    label,
+    requireProtected = false,
+    platform = process.platform,
+    spawn = spawnSync,
+    fsImpl = fs,
+    tmpDir,
+  } = {},
+) {
+  const name = label || targetPath;
+  let stats;
+  try {
+    stats = fsImpl.lstatSync(targetPath);
+  } catch (err) {
+    throw new Error(
+      `tokentimer-agent: failed to stat ${name} ${targetPath}: ${err.message}`,
+    );
+  }
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(
+      `tokentimer-agent: ${name} ${targetPath} must be a regular non-symlink file`,
+    );
+  }
+
+  if (isWindows(platform)) {
+    assertWindowsAcl(targetPath, {
+      label: `${name} ${targetPath}`,
+      requireProtected,
+      spawn,
+      fsImpl,
+      tmpDir,
+    });
+    return { mechanism: "windows-acl" };
+  }
+
+  if ((stats.mode & 0o077) !== 0) {
+    throw new Error(
+      `tokentimer-agent: refusing to read ${name} ${targetPath}: ` +
+        "it is readable by group/other (chmod 600 it)",
+    );
+  }
+  if (typeof process.getuid === "function") {
+    const uid = process.getuid();
+    if (stats.uid !== uid && stats.uid !== 0) {
+      throw new Error(
+        `tokentimer-agent: refusing to read ${name} ${targetPath}: ` +
+          "it is not owned by the agent user or root",
+      );
+    }
+  }
+  return { mechanism: "posix-mode" };
+}
+
+/** Must exactly match install-agent.ps1's $ServiceName; a mismatch here
+ * would mean the scrub below silently touches nothing while the real
+ * spent token sits untouched in the registry. */
+const SERVICE_NAME = "TokenTimerAgent";
+const SERVICE_ENVIRONMENT_REGISTRY_KEY = `HKLM\\SYSTEM\\CurrentControlSet\\Services\\${SERVICE_NAME}`;
+
+/**
+ * Rewrites the Windows service's registry `Environment` value (written by
+ * install-agent.ps1's `Set-ServiceEnvironment`) to drop the single-use
+ * bootstrap token immediately after it has been exchanged for a stored
+ * credential, leaving only `TOKENTIMER_AGENT_CONFIG_DIR` behind. Without
+ * this, a secret documented and enforced everywhere else as single-use
+ * would otherwise sit in `HKLM` in cleartext for the entire lifetime of
+ * the install, readable by anything that can read a LocalSystem service's
+ * configuration (Administrators).
+ *
+ * Reuses reg.exe rather than a registry-editing npm dependency, matching
+ * this codebase's "native Windows tooling only" policy (see the icacls
+ * and sc.exe usage elsewhere) and check-shipped-sources.js's zero-runtime
+ * dependency rule.
+ *
+ * Queries before writing so this can never *create* a Services key that
+ * did not already exist: a `reg.exe add` alone would silently fabricate
+ * `HKLM\SYSTEM\CurrentControlSet\Services\TokenTimerAgent` on a host
+ * where the service was never installed (a manual/dev run of the agent),
+ * which is a strictly worse outcome than leaving an already-scrubbed
+ * environment (this process's own, and bootstrap.env) alone.
+ *
+ * Best-effort and Windows-only: clearing a bonus copy of an
+ * already-consumed, already-rotated-out secret must never be allowed to
+ * fail agent startup or registration, which is guarded by assertions with
+ * much higher stakes (the ACL checks elsewhere in this module). Every
+ * failure mode here is reported back to the caller for logging, never
+ * thrown.
+ *
+ * @param {{ configDir: string, spawn?: Function, platform?: string }} options
+ * @returns {{ attempted: boolean, cleared: boolean, reason?: string }}
+ */
+function clearWindowsServiceBootstrapToken({
+  configDir,
+  spawn = spawnSync,
+  platform = process.platform,
+} = {}) {
+  if (!isWindows(platform)) {
+    return { attempted: false, cleared: false, reason: "not running on Windows" };
+  }
+
+  const runRegExe = (args) =>
+    spawn("reg.exe", args, { encoding: "utf8", windowsHide: true, timeout: 30000 });
+
+  const queryResult = runRegExe(["query", SERVICE_ENVIRONMENT_REGISTRY_KEY, "/v", "Environment"]);
+  if (!queryResult || (queryResult.error && queryResult.error.code === "ENOENT")) {
+    return { attempted: true, cleared: false, reason: "reg.exe is not available on this host" };
+  }
+  if (queryResult.status !== 0) {
+    // No such key/value: this process is not running as the installed
+    // Windows service (a manual/dev run, or the service predates this
+    // registry value), so there is no registry copy of the token to clear.
+    return {
+      attempted: true,
+      cleared: false,
+      reason: "no service Environment registry value is present",
+    };
+  }
+  if (!/TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=/.test(String(queryResult.stdout || ""))) {
+    return { attempted: true, cleared: false, reason: "registry value already has no token" };
+  }
+
+  const addResult = runRegExe([
+    "add",
+    SERVICE_ENVIRONMENT_REGISTRY_KEY,
+    "/v",
+    "Environment",
+    "/t",
+    "REG_MULTI_SZ",
+    "/d",
+    `TOKENTIMER_AGENT_CONFIG_DIR=${configDir}`,
+    "/f",
+  ]);
+  if (!addResult || addResult.status !== 0) {
+    return {
+      attempted: true,
+      cleared: false,
+      reason: `reg.exe add exited ${addResult ? addResult.status : "(no result)"}`,
+    };
+  }
+  return { attempted: true, cleared: true };
+}
+
+module.exports = {
+  ADMINISTRATORS_SID,
+  SYSTEM_SID,
+  applyRestrictivePermissions,
+  applyWindowsAcl,
+  assertRestrictivePermissions,
+  assertTrustedOwner,
+  assertWindowsAcl,
+  clearWindowsServiceBootstrapToken,
+  currentUserSid,
+  isWindows,
+  parseDaclSddl,
+  readWindowsOwnerSid,
+  readWindowsSddl,
+  resetPlatformCaches,
+};

--- a/packages/agent/src/platform/platform.test.js
+++ b/packages/agent/src/platform/platform.test.js
@@ -1,0 +1,719 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { describe, it, beforeEach, afterEach } = require("node:test");
+
+const platform = require("./index.js");
+const durability = require("./durability.js");
+
+const IS_WIN32 = process.platform === "win32";
+const OWN_SID = "S-1-5-21-1-2-3-1001";
+
+/**
+ * Builds a spawn stub. Each entry maps an executable name to a handler that
+ * receives the arguments and returns { status, stdout, stderr } or an error.
+ * `powershell` defaults to reporting OWN_SID as the owner, since almost every
+ * test exercises a path the agent itself created and therefore legitimately
+ * owns; tests that care about a different owner override it explicitly.
+ */
+function fakeSpawn(handlers) {
+  const calls = [];
+  const merged = { powershell: () => ({ stdout: `${OWN_SID}\r\n` }), ...handlers };
+  const spawn = (file, args) => {
+    calls.push({ file, args });
+    const handler = merged[file];
+    if (!handler) return { error: Object.assign(new Error("nope"), { code: "ENOENT" }) };
+    return { status: 0, stdout: "", stderr: "", ...handler(args) };
+  };
+  spawn.calls = calls;
+  return spawn;
+}
+
+function whoamiHandler() {
+  return { stdout: `"host\\agent","${OWN_SID}"\r\n` };
+}
+
+/** Writes an icacls /save-shaped UTF-16LE file for the /save target path. */
+function icaclsSaveHandler(sddl) {
+  return (args) => {
+    const saveIndex = args.indexOf("/save");
+    if (saveIndex !== -1) {
+      fs.writeFileSync(args[saveIndex + 1], Buffer.from(`name\r\n${sddl}\r\n`, "utf16le"));
+    }
+    return { status: 0 };
+  };
+}
+
+describe("platform: SDDL parsing", () => {
+  it("reads the protected flag, aliases and inherited entries", () => {
+    const parsed = platform.parseDaclSddl(
+      `D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)(A;ID;0x1200a9;;;BU)`,
+    );
+    assert.equal(parsed.protectedDacl, true);
+    assert.deepEqual(
+      parsed.aces.map((ace) => ace.sid),
+      [OWN_SID, platform.SYSTEM_SID, "S-1-5-32-545"],
+    );
+    assert.deepEqual(
+      parsed.aces.map((ace) => ace.inherited),
+      [false, false, true],
+    );
+  });
+
+  it("does not report a protected DACL for an inheriting one", () => {
+    const parsed = platform.parseDaclSddl(`D:AI(A;ID;FA;;;${OWN_SID})`);
+    assert.equal(parsed.protectedDacl, false);
+    assert.equal(parsed.aces.length, 1);
+  });
+
+  it("refuses SDDL without a DACL", () => {
+    assert.throws(() => platform.parseDaclSddl("O:BAG:BA"), /SDDL has no DACL/);
+  });
+});
+
+describe("platform: permission application", () => {
+  beforeEach(() => platform.resetPlatformCaches());
+  afterEach(() => platform.resetPlatformCaches());
+
+  it("chmods on POSIX and never shells out", () => {
+    const chmodCalls = [];
+    const spawn = fakeSpawn({});
+    const result = platform.applyRestrictivePermissions("/state/credential", {
+      platform: "linux",
+      spawn,
+      fsImpl: { chmodSync: (p, mode) => chmodCalls.push([p, mode]) },
+    });
+    assert.deepEqual(result, { mechanism: "posix-mode", mode: 0o600 });
+    assert.deepEqual(chmodCalls, [["/state/credential", 0o600]]);
+    assert.equal(spawn.calls.length, 0);
+  });
+
+  it("uses 0700 for directories on POSIX", () => {
+    const chmodCalls = [];
+    platform.applyRestrictivePermissions("/state", {
+      kind: "directory",
+      platform: "linux",
+      fsImpl: { chmodSync: (p, mode) => chmodCalls.push([p, mode]) },
+    });
+    assert.deepEqual(chmodCalls, [["/state", 0o700]]);
+  });
+
+  it("removes inheritance and grants only SYSTEM plus its own identity on win32", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+    });
+    const result = platform.applyRestrictivePermissions("C:\\state\\credential", {
+      platform: "win32",
+      spawn,
+      tmpDir: os.tmpdir(),
+    });
+    assert.equal(result.mechanism, "windows-acl");
+    assert.equal(result.inheritance, "removed");
+    assert.deepEqual(result.removed, []);
+    const icacls = spawn.calls.find((call) => call.file === "icacls");
+    assert.deepEqual(icacls.args, [
+      "C:\\state\\credential",
+      "/inheritance:r",
+      "/grant:r",
+      `*${platform.SYSTEM_SID}:(F)`,
+      `*${OWN_SID}:(F)`,
+    ]);
+  });
+
+  it("removes a foreign ACE that survived /grant:r, then re-verifies", () => {
+    // icacls /grant:r only replaces the entries of the principals it names, so
+    // a pre-existing explicit Everyone ACE survives it.
+    const sddls = [
+      `D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)(A;;FA;;;WD)`,
+      `D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`,
+    ];
+    let read = 0;
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: (args) => {
+        const saveIndex = args.indexOf("/save");
+        if (saveIndex !== -1) {
+          fs.writeFileSync(
+            args[saveIndex + 1],
+            Buffer.from(`name\r\n${sddls[Math.min(read++, sddls.length - 1)]}\r\n`, "utf16le"),
+          );
+        }
+        return { status: 0 };
+      },
+    });
+    const result = platform.applyRestrictivePermissions("C:\\state\\credential", {
+      platform: "win32",
+      spawn,
+      tmpDir: os.tmpdir(),
+    });
+    assert.deepEqual(result.removed, ["S-1-1-0"]);
+    const removeCall = spawn.calls.find((call) => call.args.includes("/remove:g"));
+    assert.deepEqual(removeCall.args, [
+      "C:\\state\\credential",
+      "/remove:g",
+      "*S-1-1-0",
+      "/remove:d",
+      "*S-1-1-0",
+    ]);
+  });
+
+  it("fails when a foreign ACE is still present after enforcement", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)(A;;FA;;;WD)`),
+    });
+    assert.throws(
+      () =>
+        platform.applyRestrictivePermissions("C:\\state\\credential", {
+          platform: "win32",
+          spawn,
+          tmpDir: os.tmpdir(),
+        }),
+      /still grants S-1-1-0 after enforcement/,
+    );
+  });
+
+  it("grants inheritable rights on a directory so new files start restricted", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;OICI;FA;;;${OWN_SID})(A;OICI;FA;;;SY)`),
+    });
+    platform.applyRestrictivePermissions("C:\\state", {
+      kind: "directory",
+      platform: "win32",
+      spawn,
+      tmpDir: os.tmpdir(),
+    });
+    const icacls = spawn.calls.find((call) => call.file === "icacls");
+    assert.ok(icacls.args.includes(`*${platform.SYSTEM_SID}:(OI)(CI)(F)`));
+    assert.ok(icacls.args.includes(`*${OWN_SID}:(OI)(CI)(F)`));
+  });
+
+  it("collapses the grant list when the agent already runs as SYSTEM", () => {
+    const spawn = fakeSpawn({
+      whoami: () => ({ stdout: `"nt authority\\system","${platform.SYSTEM_SID}"\r\n` }),
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;SY)`),
+      powershell: () => ({ stdout: `${platform.SYSTEM_SID}\r\n` }),
+    });
+    const result = platform.applyRestrictivePermissions("C:\\state\\credential", {
+      platform: "win32",
+      spawn,
+      tmpDir: os.tmpdir(),
+    });
+    assert.deepEqual(result.principals, [platform.SYSTEM_SID]);
+  });
+
+  it("fails instead of continuing when icacls is unavailable", () => {
+    const spawn = fakeSpawn({ whoami: whoamiHandler });
+    assert.throws(
+      () =>
+        platform.applyRestrictivePermissions("C:\\state\\credential", {
+          platform: "win32",
+          spawn,
+        }),
+      /icacls is not available on this host/,
+    );
+  });
+
+  it("fails when icacls reports a non-zero exit", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: () => ({ status: 5, stderr: "Access is denied." }),
+    });
+    assert.throws(
+      () =>
+        platform.applyRestrictivePermissions("C:\\state\\credential", {
+          platform: "win32",
+          spawn,
+        }),
+      /icacls exited 5 .*remains unprotected/s,
+    );
+  });
+
+  it("fails when the agent's own SID cannot be resolved", () => {
+    const spawn = fakeSpawn({ whoami: () => ({ stdout: "no sid here" }) });
+    assert.throws(
+      () => platform.currentUserSid({ spawn, useCache: false }),
+      /could not parse a SID/,
+    );
+  });
+
+  it("fails closed when the resulting owner is not in the trusted allowlist", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+      powershell: () => ({ stdout: "S-1-5-21-9-9-9-9999\r\n" }),
+    });
+    assert.throws(
+      () =>
+        platform.applyRestrictivePermissions("C:\\state\\credential", {
+          platform: "win32",
+          spawn,
+          tmpDir: os.tmpdir(),
+        }),
+      /owner is S-1-5-21-9-9-9-9999.*not one of the trusted owners/s,
+    );
+  });
+
+  it("accepts SYSTEM or Administrators as a trusted owner", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+      powershell: () => ({ stdout: `${platform.ADMINISTRATORS_SID}\r\n` }),
+    });
+    const result = platform.applyRestrictivePermissions("C:\\state\\credential", {
+      platform: "win32",
+      spawn,
+      tmpDir: os.tmpdir(),
+    });
+    assert.equal(result.mechanism, "windows-acl");
+  });
+
+  it("fails closed when powershell is unavailable to verify the owner", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+    });
+    const bareSpawn = (file, args) => {
+      if (file === "powershell") return { error: Object.assign(new Error("nope"), { code: "ENOENT" }) };
+      return spawn(file, args);
+    };
+    assert.throws(
+      () =>
+        platform.applyRestrictivePermissions("C:\\state\\credential", {
+          platform: "win32",
+          spawn: bareSpawn,
+          tmpDir: os.tmpdir(),
+        }),
+      /powershell is not available on this host/,
+    );
+  });
+});
+
+describe("platform: permission verification", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    platform.resetPlatformCaches();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tt-platform-"));
+  });
+
+  afterEach(() => {
+    platform.resetPlatformCaches();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function targetFile() {
+    const filePath = path.join(tmpDir, "credential");
+    fs.writeFileSync(filePath, "secret");
+    return filePath;
+  }
+
+  it("accepts a DACL limited to the agent, SYSTEM and Administrators", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(
+        `D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)(A;;FA;;;BA)`,
+      ),
+    });
+    const result = platform.assertRestrictivePermissions(targetFile(), {
+      label: "credential file",
+      platform: "win32",
+      spawn,
+      tmpDir,
+    });
+    assert.equal(result.mechanism, "windows-acl");
+  });
+
+  it("refuses a DACL that grants any other principal", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;WD)`),
+    });
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(targetFile(), {
+          label: "credential file",
+          platform: "win32",
+          spawn,
+          tmpDir,
+        }),
+      /grants access to S-1-1-0/,
+    );
+  });
+
+  it("accepts an inheriting DACL whose inherited entries are all allowlisted", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:AI(A;ID;FA;;;${OWN_SID})(A;ID;FA;;;SY)`),
+    });
+    assert.equal(
+      platform.assertRestrictivePermissions(targetFile(), {
+        label: "credential file",
+        platform: "win32",
+        spawn,
+        tmpDir,
+      }).mechanism,
+      "windows-acl",
+    );
+  });
+
+  it("requires an explicitly protected DACL for state the agent creates itself", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:AI(A;ID;FA;;;${OWN_SID})(A;ID;FA;;;SY)`),
+    });
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(targetFile(), {
+          label: "agent state file",
+          requireProtected: true,
+          platform: "win32",
+          spawn,
+          tmpDir,
+        }),
+      /still inherits from its parent directory/,
+    );
+  });
+
+  it("refuses an empty DACL rather than reading it as harmless", () => {
+    const spawn = fakeSpawn({ whoami: whoamiHandler, icacls: icaclsSaveHandler("D:P") });
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(targetFile(), {
+          label: "credential file",
+          platform: "win32",
+          spawn,
+          tmpDir,
+        }),
+      /DACL is empty or could not be read/,
+    );
+  });
+
+  it("fails closed when icacls cannot report an ACL at all", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: (args) => {
+        const saveIndex = args.indexOf("/save");
+        if (saveIndex !== -1) fs.writeFileSync(args[saveIndex + 1], Buffer.from("", "utf16le"));
+        return { status: 0 };
+      },
+    });
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(targetFile(), {
+          label: "credential file",
+          platform: "win32",
+          spawn,
+          tmpDir,
+        }),
+      /did not report a DACL/,
+    );
+  });
+
+  it("refuses a symlink or non-regular path on every platform", () => {
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(tmpDir, {
+          label: "credential file",
+          platform: "linux",
+        }),
+      /must be a regular non-symlink file/,
+    );
+  });
+
+  it("reports a missing path as a stat failure", () => {
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(path.join(tmpDir, "absent"), {
+          label: "credential file",
+        }),
+      /failed to stat credential file/,
+    );
+  });
+
+  it("refuses a group/other-readable file on POSIX", { skip: IS_WIN32 }, () => {
+    const filePath = targetFile();
+    fs.chmodSync(filePath, 0o644);
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(filePath, {
+          label: "credential file",
+          platform: "linux",
+        }),
+      /readable by group\/other/,
+    );
+  });
+
+  it("enforces a real restricted ACL end to end on win32", { skip: !IS_WIN32 }, () => {
+    const filePath = targetFile();
+    platform.applyRestrictivePermissions(filePath);
+    const result = platform.assertRestrictivePermissions(filePath, {
+      label: "credential file",
+      requireProtected: true,
+    });
+    assert.equal(result.mechanism, "windows-acl");
+    assert.match(platform.readWindowsSddl(filePath), /^D:P/);
+  });
+
+  it("refuses a well-formed allowlisted DACL when the owner is untrusted", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+      powershell: () => ({ stdout: "S-1-5-21-9-9-9-9999\r\n" }),
+    });
+    assert.throws(
+      () =>
+        platform.assertRestrictivePermissions(targetFile(), {
+          label: "credential file",
+          platform: "win32",
+          spawn,
+          tmpDir,
+        }),
+      /owner is S-1-5-21-9-9-9-9999.*not one of the trusted owners/s,
+    );
+  });
+
+  it("reads the owner via .NET's SID-typed GetOwner rather than a localized display name", () => {
+    const spawn = fakeSpawn({
+      whoami: whoamiHandler,
+      icacls: icaclsSaveHandler(`D:PAI(A;;FA;;;${OWN_SID})(A;;FA;;;SY)`),
+      powershell: (args) => {
+        assert.ok(args.includes("-Command"));
+        assert.match(args[args.length - 1], /GetOwner\(\[System\.Security\.Principal\.SecurityIdentifier\]\)/);
+        return { stdout: `${OWN_SID}\r\n` };
+      },
+    });
+    const result = platform.assertRestrictivePermissions(targetFile(), {
+      label: "credential file",
+      platform: "win32",
+      spawn,
+      tmpDir,
+    });
+    assert.equal(result.mechanism, "windows-acl");
+  });
+});
+
+describe("platform: durability limits", () => {
+  beforeEach(() => durability.resetDurabilityLimits());
+  afterEach(() => durability.resetDurabilityLimits());
+
+  it("reports a successful directory fsync as durable with no limit", () => {
+    const result = durability.fsyncDirectorySync("/state", {
+      platform: "linux",
+      fsImpl: { openSync: () => 7, fsyncSync: () => {}, closeSync: () => {} },
+    });
+    assert.deepEqual(result, { durable: true, limit: null });
+    assert.deepEqual(durability.getDurabilityLimits(), []);
+    assert.deepEqual(durability.durabilityMetadataEntries(), []);
+  });
+
+  it("records the win32 directory-fsync limitation instead of swallowing it", () => {
+    const result = durability.fsyncDirectorySync("C:\\state", {
+      platform: "win32",
+      fsImpl: {
+        openSync: () => {
+          throw Object.assign(new Error("EISDIR"), { code: "EISDIR" });
+        },
+        fsyncSync: () => {},
+        closeSync: () => {},
+      },
+    });
+    assert.equal(result.durable, false);
+    assert.equal(result.limit.code, durability.DIRECTORY_FSYNC_UNSUPPORTED);
+    assert.match(result.limit.detail, /atomic but not power-loss durable/);
+    assert.deepEqual(durability.durabilityMetadataEntries(), [
+      { name: "durabilityLimit_directory_fsync_unsupported", value: true },
+      { name: "durabilityLimit_directory_fsync_unsupported_platform", value: "win32" },
+    ]);
+  });
+
+  it("counts repeat occurrences of one limitation once in metadata", () => {
+    const fsImpl = {
+      openSync: () => {
+        throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+      },
+      fsyncSync: () => {},
+      closeSync: () => {},
+    };
+    durability.fsyncDirectorySync("C:\\a", { platform: "win32", fsImpl });
+    durability.fsyncDirectorySync("C:\\b", { platform: "win32", fsImpl });
+    const limits = durability.getDurabilityLimits();
+    assert.equal(limits.length, 1);
+    assert.equal(limits[0].occurrences, 2);
+  });
+
+  it("records the limitation from the promise-based deploy path too", async () => {
+    const result = await durability.fsyncDirectory(
+      {
+        open: async () => {
+          throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+        },
+      },
+      "C:\\state",
+      { platform: "win32" },
+    );
+    assert.equal(result.durable, false);
+    assert.equal(result.limit.code, durability.DIRECTORY_FSYNC_UNSUPPORTED);
+  });
+
+  it("still closes the handle after a successful promise-based fsync", async () => {
+    let closed = false;
+    const result = await durability.fsyncDirectory(
+      {
+        open: async () => ({
+          sync: async () => {},
+          close: async () => {
+            closed = true;
+          },
+        }),
+      },
+      "/state",
+    );
+    assert.deepEqual(result, { durable: true, limit: null });
+    assert.equal(closed, true);
+  });
+});
+
+describe("platform: clearWindowsServiceBootstrapToken", () => {
+  const REG_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\TokenTimerAgent";
+
+  it("is a no-op on a non-Windows platform", () => {
+    const spawn = fakeSpawn({});
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "/state",
+      platform: "linux",
+      spawn,
+    });
+    assert.deepEqual(result, { attempted: false, cleared: false, reason: "not running on Windows" });
+    assert.deepEqual(spawn.calls, []);
+  });
+
+  it("rewrites the registry Environment value, dropping the token but keeping the config dir", () => {
+    const spawn = fakeSpawn({
+      "reg.exe": (args) => {
+        if (args[0] === "query") {
+          assert.deepEqual(args, [
+            "query",
+            REG_KEY,
+            "/v",
+            "Environment",
+          ]);
+          return {
+            status: 0,
+            stdout:
+              "    Environment    REG_MULTI_SZ    TOKENTIMER_AGENT_CONFIG_DIR=C:\\ProgramData\\TokenTimerAgent\\state\\0TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=ttboot_secret",
+          };
+        }
+        if (args[0] === "add") {
+          assert.deepEqual(args, [
+            "add",
+            REG_KEY,
+            "/v",
+            "Environment",
+            "/t",
+            "REG_MULTI_SZ",
+            "/d",
+            "TOKENTIMER_AGENT_CONFIG_DIR=C:\\ProgramData\\TokenTimerAgent\\state",
+            "/f",
+          ]);
+          return { status: 0 };
+        }
+        throw new Error(`unexpected reg.exe invocation: ${args.join(" ")}`);
+      },
+    });
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "C:\\ProgramData\\TokenTimerAgent\\state",
+      platform: "win32",
+      spawn,
+    });
+    assert.deepEqual(result, { attempted: true, cleared: true });
+    assert.equal(spawn.calls.length, 2);
+  });
+
+  it("does not write anything when the registry value already has no token", () => {
+    const spawn = fakeSpawn({
+      "reg.exe": (args) => {
+        assert.equal(args[0], "query");
+        return {
+          status: 0,
+          stdout: "    Environment    REG_MULTI_SZ    TOKENTIMER_AGENT_CONFIG_DIR=C:\\state",
+        };
+      },
+    });
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "C:\\state",
+      platform: "win32",
+      spawn,
+    });
+    assert.deepEqual(result, {
+      attempted: true,
+      cleared: false,
+      reason: "registry value already has no token",
+    });
+    assert.equal(spawn.calls.length, 1);
+  });
+
+  it("does not write anything, and does not create the key, when the service is not installed", () => {
+    const spawn = fakeSpawn({
+      "reg.exe": (args) => {
+        assert.equal(args[0], "query");
+        return { status: 1, stdout: "", stderr: "ERROR: The system was unable to find the specified registry key." };
+      },
+    });
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "C:\\state",
+      platform: "win32",
+      spawn,
+    });
+    assert.deepEqual(result, {
+      attempted: true,
+      cleared: false,
+      reason: "no service Environment registry value is present",
+    });
+    assert.equal(spawn.calls.length, 1);
+    assert.equal(spawn.calls[0].args[0], "query");
+  });
+
+  it("reports, rather than throws, when reg.exe is unavailable", () => {
+    const spawn = () => ({ error: Object.assign(new Error("nope"), { code: "ENOENT" }) });
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "C:\\state",
+      platform: "win32",
+      spawn,
+    });
+    assert.deepEqual(result, {
+      attempted: true,
+      cleared: false,
+      reason: "reg.exe is not available on this host",
+    });
+  });
+
+  it("reports, rather than throws, when the rewrite itself fails", () => {
+    const spawn = fakeSpawn({
+      "reg.exe": (args) => {
+        if (args[0] === "query") {
+          return {
+            status: 0,
+            stdout: "Environment REG_MULTI_SZ TOKENTIMER_AGENT_BOOTSTRAP_TOKEN=ttboot_secret",
+          };
+        }
+        return { status: 1, stderr: "access denied" };
+      },
+    });
+    const result = platform.clearWindowsServiceBootstrapToken({
+      configDir: "C:\\state",
+      platform: "win32",
+      spawn,
+    });
+    assert.deepEqual(result, {
+      attempted: true,
+      cleared: false,
+      reason: "reg.exe add exited 1",
+    });
+  });
+});

--- a/packages/agent/src/replay/index.js
+++ b/packages/agent/src/replay/index.js
@@ -9,9 +9,10 @@
  * (checkJobTimeWindow) so each can be tested in isolation.
  *
  * Persistence: the store is a JSON file written with mode 0o600, following
- * the config module's permission conventions (mode asserted at write time
- * and re-asserted via chmod; best-effort on win32, where POSIX modes are not
- * meaningful -- see packages/agent/src/config/index.js for the same caveat).
+ * the config module's permission conventions (POSIX: chmod; win32: a real
+ * restricted ACL via src/platform/index.js, verified against a
+ * trusted-owner allowlist -- see packages/agent/src/config/index.js for the
+ * cross-platform write path this module mirrors).
  * Persisting across restarts matters because a job's validity window can
  * outlive an agent process: without persistence, restarting the agent would
  * reopen the replay window for every not-yet-expired captured job.
@@ -42,6 +43,8 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
+const { applyRestrictivePermissions } = require("../platform/index.js");
+const { fsyncDirectorySync } = require("../platform/durability.js");
 
 const REPLAY_REJECTION_REASON = "job_replay_rejected";
 
@@ -174,7 +177,7 @@ function loadStore(storePath) {
  *
  * @param {object} params
  * @param {string} params.storePath JSON file path for the persisted store;
- *   written with mode 0o600 (config-module convention; best-effort on win32)
+ *   written with mode 0o600 (config-module convention; a real ACL on win32)
  * @param {number} [params.maxEntries=5000] hard bound on stored entries;
  *   when reached (after sweeping expired entries), new jobs are rejected
  *   rather than evicting unexpired nonces (see module doc for why)
@@ -224,9 +227,13 @@ function createReplayCache({
 
   function persist() {
     const dir = path.dirname(storePath);
-    // 0700 dir / 0600 file per the config module's conventions; chmod is
-    // best-effort on win32 (no POSIX mode semantics there).
+    // 0700 dir / 0600 file. POSIX: chmod. win32: a real ACL with
+    // inheritance removed, granting only the agent's own identity plus
+    // SYSTEM, verified against a trusted-owner allowlist (see
+    // src/platform/index.js) -- not the previous best-effort chmod that
+    // silently did nothing there.
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    applyRestrictivePermissions(dir, { kind: "directory", mode: 0o700 });
     const serialized = JSON.stringify({
       schemaVersion: STORE_SCHEMA_VERSION,
       entries: [...entries.values()],
@@ -261,11 +268,13 @@ function createReplayCache({
       }
       throw err;
     }
-    try {
-      fs.chmodSync(storePath, 0o600);
-    } catch (_err) {
-      // Best-effort on win32; see packages/agent/src/config/index.js.
-    }
+    // POSIX re-asserts the mode; win32 gets a real restricted ACL. A
+    // failure here is fatal, matching config/writeFileAtomically.
+    applyRestrictivePermissions(storePath, { kind: "file", mode: 0o600 });
+    // fsync on the directory is the durable part of the rename on POSIX.
+    // Windows cannot fsync a directory handle at all; that limitation is
+    // recorded (never swallowed) by durability.fsyncDirectorySync.
+    fsyncDirectorySync(dir);
   }
 
   /**

--- a/packages/agent/src/runtime/runtime.test.js
+++ b/packages/agent/src/runtime/runtime.test.js
@@ -33,7 +33,10 @@ const {
 } = require("../protocol");
 
 function makeTempConfigDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "ttagent-runtime-test-"));
+  // See index.test.js's makeTempConfigDir for why .native is required.
+  return fs.realpathSync.native(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ttagent-runtime-test-")),
+  );
 }
 
 function createRecordingClient() {

--- a/packages/agent/windows-service-host/.gitignore
+++ b/packages/agent/windows-service-host/.gitignore
@@ -1,0 +1,3 @@
+*.exe
+*.test
+/dist/

--- a/packages/agent/windows-service-host/console_windows.go
+++ b/packages/agent/windows-service-host/console_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package main
+
+// AttachConsole/FreeConsole/SetConsoleCtrlHandler are not exposed by
+// golang.org/x/sys/windows (only GenerateConsoleCtrlEvent is), so they are
+// bound here directly from kernel32.dll via the same LazyDLL/LazyProc
+// mechanism x/sys/windows itself uses internally. This keeps the only
+// dependency at build.go.mod's declared version (golang.org/x/sys) while
+// still reaching the three additional kernel32 exports this host needs.
+//
+// Why these three calls exist at all: GenerateConsoleCtrlEvent delivers
+// CTRL_BREAK_EVENT to every process in a console process group, but the
+// calling process must itself be attached to a console (or a pseudo-console
+// association) for the call to succeed. A Windows service runs in session 0
+// with no console of its own, so without this attach/detach dance every
+// GenerateConsoleCtrlEvent call from the service fails with
+// ERROR_INVALID_HANDLE. Attaching to the child's console group (the child
+// was started with CREATE_NEW_PROCESS_GROUP, so it has one even though
+// nothing ever allocated a visible window), sending the event, then
+// detaching again is the documented workaround and is the same technique
+// other Windows service wrappers use to deliver a soft-stop signal to a
+// console-subsystem child.
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modkernel32                   = windows.NewLazySystemDLL("kernel32.dll")
+	procAttachConsole             = modkernel32.NewProc("AttachConsole")
+	procFreeConsole               = modkernel32.NewProc("FreeConsole")
+	procSetConsoleCtrlHandlerProc = modkernel32.NewProc("SetConsoleCtrlHandler")
+)
+
+// attachConsole attaches the calling process to the console of the process
+// group identified by pid. Passing 0xFFFFFFFF (ATTACH_PARENT_PROCESS) is not
+// used here; this always attaches to a specific child's group.
+func attachConsole(pid uint32) error {
+	r1, _, err := procAttachConsole.Call(uintptr(pid))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+// freeConsole detaches the calling process from whatever console it is
+// currently attached to. Safe to call even if not attached to anything.
+func freeConsole() error {
+	r1, _, err := procFreeConsole.Call()
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+// ignoreOwnConsoleCtrlEvents installs the "no handler" ctrl handler for this
+// process (SetConsoleCtrlHandler(NULL, TRUE)), so the CTRL_BREAK_EVENT this
+// host is about to raise for the child's process group does not also cause
+// the host's own process to react to it while briefly attached to that
+// group's pseudo-console.
+func ignoreOwnConsoleCtrlEvents(ignore bool) error {
+	var setIgnore uintptr
+	if ignore {
+		setIgnore = 1
+	}
+	r1, _, err := procSetConsoleCtrlHandlerProc.Call(0, setIgnore)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/packages/agent/windows-service-host/go.mod
+++ b/packages/agent/windows-service-host/go.mod
@@ -1,0 +1,5 @@
+module github.com/tokentimerch/tokentimer-core/packages/agent/windows-service-host
+
+go 1.21
+
+require golang.org/x/sys v0.20.0

--- a/packages/agent/windows-service-host/go.sum
+++ b/packages/agent/windows-service-host/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/packages/agent/windows-service-host/host.go
+++ b/packages/agent/windows-service-host/host.go
@@ -1,0 +1,311 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// defaultStopTimeout bounds how long a graceful stop waits for the child
+// agent to drain outstanding work (job leases, outbox entries) before this
+// host forces termination. It matches the install script's own
+// Test-ServiceHealthy start horizon (20s) as a starting point that an
+// operator can override without a rebuild.
+const defaultStopTimeout = 20 * time.Second
+
+// stopTimeoutEnvVar overrides defaultStopTimeout. Read once at process
+// start (via resolveStopTimeout), never mutated afterward.
+const stopTimeoutEnvVar = "TOKENTIMER_AGENT_HOST_STOP_TIMEOUT_MS"
+
+// resolveStopTimeout parses stopTimeoutEnvVar out of the given environment
+// lookup function, falling back to defaultStopTimeout for an absent,
+// empty, non-numeric, or non-positive value. Kept as a pure function (no
+// direct os.Getenv call) so a test can supply a fake environment without
+// mutating process-global state.
+func resolveStopTimeout(getenv func(string) string) time.Duration {
+	raw := getenv(stopTimeoutEnvVar)
+	if raw == "" {
+		return defaultStopTimeout
+	}
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || ms <= 0 {
+		return defaultStopTimeout
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// agentHost owns the child agent process and the two operations the
+// service control handler and the interactive runner both need: start it,
+// and ask it to stop gracefully within a bounded window. It has no
+// dependency on svc.Handler or on any Windows Service Control Manager
+// concept, so both runService (main_windows.go) and the interactive
+// fallback can share and test it identically.
+type agentHost struct {
+	childExe  string
+	childArgs []string
+	env       []string
+	log       *hostLogger
+
+	mu  sync.Mutex
+	cmd *exec.Cmd
+	// exited is closed exactly once, when cmd.Wait() returns. Closing
+	// (rather than sending a value) lets every interested goroutine -
+	// the service handler's own exit-watcher and stopGracefully's timeout
+	// race - observe the same event without racing each other for the
+	// single delivery a buffered channel send would otherwise provide.
+	exited  chan struct{}
+	exitErr error
+}
+
+func newAgentHost(childExe string, childArgs []string, env []string, log *hostLogger) *agentHost {
+	return &agentHost{childExe: childExe, childArgs: childArgs, env: env, log: log}
+}
+
+// start launches the child in its own console process group
+// (CREATE_NEW_PROCESS_GROUP), which is required both for
+// GenerateConsoleCtrlEvent to target the child specifically (rather than
+// this host too) and to isolate the child's own Ctrl+Break handling from
+// this host's.
+func (h *agentHost) start() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.cmd != nil {
+		return fmt.Errorf("agentHost: start called twice")
+	}
+	cmd := exec.Command(h.childExe, h.childArgs...)
+	cmd.Env = h.env
+	cmd.Stdout = h.log.childWriter("stdout")
+	cmd.Stderr = h.log.childWriter("stderr")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// CREATE_NO_WINDOW gives the child its own dedicated (never
+		// visible) console rather than inheriting this host's - which,
+		// running as a Windows service, usually has none at all. Without
+		// an actual console object backing the child's process group,
+		// GenerateConsoleCtrlEvent below has nothing to deliver to.
+		// CREATE_NEW_PROCESS_GROUP makes the child the root of its own
+		// process group so the same event never also reaches this host.
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("agentHost: failed to start %s: %w", h.childExe, err)
+	}
+	h.cmd = cmd
+	h.exited = make(chan struct{})
+	go func() {
+		err := cmd.Wait()
+		h.mu.Lock()
+		h.exitErr = err
+		h.mu.Unlock()
+		close(h.exited)
+	}()
+	h.log.Printf("started child pid=%d exe=%s args=%v", cmd.Process.Pid, h.childExe, h.childArgs)
+	return nil
+}
+
+// wait blocks until the child exits on its own (crash or clean exit not
+// requested by stopGracefully) and returns its Wait() error. Used by the
+// caller to distinguish an unrequested child exit (which should propagate
+// as this host's own exit code, so SCM's existing failure/restart policy
+// on the service still fires) from a requested stop.
+func (h *agentHost) wait() error {
+	h.mu.Lock()
+	exited := h.exited
+	h.mu.Unlock()
+	if exited == nil {
+		return fmt.Errorf("agentHost: wait called before start")
+	}
+	<-exited
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.exitErr
+}
+
+// pid returns the child's process id, or 0 if not started.
+func (h *agentHost) pid() uint32 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.cmd == nil || h.cmd.Process == nil {
+		return 0
+	}
+	return uint32(h.cmd.Process.Pid)
+}
+
+// stopGracefully asks the child to shut itself down by delivering
+// CTRL_BREAK_EVENT to its process group (Node's libuv maps this to a
+// "SIGBREAK" process event the agent listens for, the same way it already
+// listens for SIGINT/SIGTERM on POSIX), waits up to timeout for it to exit
+// on its own, and force-terminates it if it does not. It never returns an
+// error for "child already exited" - that is success, not failure.
+func (h *agentHost) stopGracefully(timeout time.Duration) error {
+	h.mu.Lock()
+	cmd := h.cmd
+	exited := h.exited
+	h.mu.Unlock()
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	select {
+	case <-exited:
+		return nil // already exited before we got here
+	default:
+	}
+
+	pid := uint32(cmd.Process.Pid)
+	if err := h.sendCtrlBreak(pid); err != nil {
+		h.log.Printf("could not deliver a graceful stop signal to pid=%d: %v; forcing termination", pid, err)
+		return h.forceKill(cmd, exited)
+	}
+
+	select {
+	case <-exited:
+		h.mu.Lock()
+		err := h.exitErr
+		h.mu.Unlock()
+		h.log.Printf("child pid=%d exited gracefully: %v", pid, err)
+		return nil
+	case <-time.After(timeout):
+		h.log.Printf("child pid=%d did not exit within %s of the stop signal; forcing termination", pid, timeout)
+		return h.forceKill(cmd, exited)
+	}
+}
+
+// sendCtrlBreak performs the attach/raise/detach sequence described in
+// console_windows.go. It always frees the console again, even on error,
+// so this host never keeps a stray console attachment past the call.
+//
+// AttachConsole fails with ERROR_ACCESS_DENIED whenever the calling
+// process is already attached to a console of its own (documented Win32
+// behavior: a process may be attached to at most one console at a time).
+// A Windows service host running under SCM (session 0) has no console at
+// all, so this never triggers in production, but the interactive/test
+// runner inherits the launching terminal's console, so this host must
+// give that console up first. Losing it is safe here: this host's own
+// logging goes through hostLogger, which holds its output file/stderr
+// handle independently of console attachment state, and the interactive
+// runner never reads from stdin after startup.
+func (h *agentHost) sendCtrlBreak(pid uint32) error {
+	// Best-effort: only relevant when already attached to a console;
+	// ERROR_INVALID_PARAMETER when not attached to anything is expected
+	// and harmless here.
+	_ = freeConsole()
+	// AttachConsole against a just-created child's auto-allocated console
+	// is occasionally transiently unavailable (observed empirically as a
+	// spurious ERROR_INVALID_HANDLE/ERROR_ACCESS_DENIED immediately after
+	// a prior attach/detach cycle in the same process); a short bounded
+	// retry is the documented mitigation other implementations of this
+	// same technique use, rather than failing straight to a force-kill
+	// for what is usually a few-millisecond race.
+	var attachErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attachErr = attachConsole(pid); attachErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+		_ = freeConsole()
+	}
+	if attachErr != nil {
+		return fmt.Errorf("AttachConsole(%d): %w", pid, attachErr)
+	}
+	defer func() {
+		if err := freeConsole(); err != nil {
+			h.log.Printf("FreeConsole after signaling pid=%d failed (non-fatal): %v", pid, err)
+		}
+	}()
+	// Ignore the event in this host's own (temporarily attached) context;
+	// only the child's process group should react to it.
+	if err := ignoreOwnConsoleCtrlEvents(true); err != nil {
+		h.log.Printf("SetConsoleCtrlHandler(ignore) failed (non-fatal): %v", err)
+	}
+	defer func() {
+		if err := ignoreOwnConsoleCtrlEvents(false); err != nil {
+			h.log.Printf("SetConsoleCtrlHandler(restore) failed (non-fatal): %v", err)
+		}
+	}()
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, pid); err != nil {
+		return fmt.Errorf("GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, %d): %w", pid, err)
+	}
+	return nil
+}
+
+func (h *agentHost) forceKill(cmd *exec.Cmd, exited chan struct{}) error {
+	if err := cmd.Process.Kill(); err != nil {
+		h.log.Printf("TerminateProcess for pid=%d failed: %v", cmd.Process.Pid, err)
+	}
+	<-exited // Kill() only requests termination; wait for Wait() to observe it.
+	return nil
+}
+
+// hostLogger is a tiny best-effort logger: it writes lifecycle lines to a
+// file when TOKENTIMER_AGENT_CONFIG_DIR is set (the same directory the
+// installer already points the agent's own config/state at, via the
+// registry Environment value install-agent.ps1 writes), and falls back to
+// stderr otherwise (the useful case for interactive/dev runs, where stderr
+// is actually visible). A logger that cannot open its file never blocks
+// startup: it silently falls back to stderr instead.
+type hostLogger struct {
+	mu  sync.Mutex
+	out io.Writer
+	f   *os.File
+}
+
+func newHostLogger(configDir string) *hostLogger {
+	l := &hostLogger{out: os.Stderr}
+	if configDir == "" {
+		return l
+	}
+	f, err := os.OpenFile(configDir+string(os.PathSeparator)+"host.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return l
+	}
+	l.f = f
+	l.out = f
+	return l
+}
+
+func (l *hostLogger) Printf(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(l.out, "%s tokentimer-agent-host: %s\n", time.Now().UTC().Format(time.RFC3339), fmt.Sprintf(format, args...))
+}
+
+// childWriter returns a writer that prefixes each line the child writes to
+// stdout/stderr with a stream label, sharing the same destination as
+// Printf so operator-visible host and child lifecycle lines interleave in
+// one file/stream instead of two.
+func (l *hostLogger) childWriter(stream string) io.Writer {
+	return &prefixWriter{logger: l, stream: stream}
+}
+
+type prefixWriter struct {
+	logger *hostLogger
+	stream string
+}
+
+func (w *prefixWriter) Write(p []byte) (int, error) {
+	w.logger.mu.Lock()
+	defer w.logger.mu.Unlock()
+	fmt.Fprintf(w.logger.out, "%s tokentimer-agent (%s): %s", time.Now().UTC().Format(time.RFC3339), w.stream, p)
+	if len(p) == 0 || p[len(p)-1] != '\n' {
+		fmt.Fprintln(w.logger.out)
+	}
+	return len(p), nil
+}
+
+func (l *hostLogger) Close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.f != nil {
+		_ = l.f.Close()
+		l.f = nil
+	}
+}

--- a/packages/agent/windows-service-host/host_test.go
+++ b/packages/agent/windows-service-host/host_test.go
@@ -1,0 +1,195 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// nodeExe resolves the node.exe on PATH once per test binary run, skipping
+// every test in this file if Node is unavailable (this module has no
+// dependency on Node existing, but the behavior under test - graceful
+// shutdown of a Node child - is meaningless to verify without it).
+func nodeExe(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found on PATH; skipping agentHost lifecycle tests")
+	}
+	return p
+}
+
+// mockAgentPath returns the absolute path to testdata/mock-agent.js, a
+// throwaway Node script that behaves like the real agent only in the one
+// way these tests care about: it stays running until asked to stop, and
+// it exits promptly and cleanly on SIGBREAK (the same signal
+// stopGracefully delivers via CTRL_BREAK_EVENT), mirroring
+// packages/agent/src/index.js's own SIGINT/SIGTERM/SIGBREAK handling.
+func mockAgentPath(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("testdata", "mock-agent.js"))
+	if err != nil {
+		t.Fatalf("resolve mock-agent.js path: %v", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("mock-agent.js not found at %s: %v", abs, err)
+	}
+	return abs
+}
+
+func newTestLogger(t *testing.T) *hostLogger {
+	t.Helper()
+	return &hostLogger{out: &testWriter{t: t}}
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.t.Logf("%s", p)
+	return len(p), nil
+}
+
+func TestResolveStopTimeout(t *testing.T) {
+	cases := map[string]struct {
+		env  map[string]string
+		want time.Duration
+	}{
+		"absent":      {env: map[string]string{}, want: defaultStopTimeout},
+		"empty":       {env: map[string]string{stopTimeoutEnvVar: ""}, want: defaultStopTimeout},
+		"non-numeric": {env: map[string]string{stopTimeoutEnvVar: "not-a-number"}, want: defaultStopTimeout},
+		"zero":        {env: map[string]string{stopTimeoutEnvVar: "0"}, want: defaultStopTimeout},
+		"negative":    {env: map[string]string{stopTimeoutEnvVar: "-5"}, want: defaultStopTimeout},
+		"valid":       {env: map[string]string{stopTimeoutEnvVar: "1500"}, want: 1500 * time.Millisecond},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := resolveStopTimeout(func(key string) string { return tc.env[key] })
+			if got != tc.want {
+				t.Fatalf("resolveStopTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAgentHostGracefulStop is the core regression test for this whole
+// package: it proves a child started under CREATE_NEW_PROCESS_GROUP
+// actually receives and acts on the CTRL_BREAK_EVENT stopGracefully sends,
+// rather than always falling through to the force-kill path (which would
+// "work" for this test too, but would mean the agent's own outbox/lease
+// drain on SIGBREAK never runs in production).
+func TestAgentHostGracefulStop(t *testing.T) {
+	node := nodeExe(t)
+	entry := mockAgentPath(t)
+	log := newTestLogger(t)
+	host := newAgentHost(node, []string{entry}, os.Environ(), log)
+
+	if err := host.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := host.pid()
+	if pid == 0 {
+		t.Fatal("expected a non-zero child pid after start")
+	}
+
+	// Give the child a moment to install its SIGBREAK handler before
+	// signaling it, matching how a real agent would already be past
+	// startup by the time SCM ever asks it to stop.
+	time.Sleep(500 * time.Millisecond)
+
+	stopStart := time.Now()
+	if err := host.stopGracefully(5 * time.Second); err != nil {
+		t.Fatalf("stopGracefully: %v", err)
+	}
+	elapsed := time.Since(stopStart)
+
+	// mock-agent.js waits 500ms after SIGBREAK before exiting; a
+	// force-kill (the failure mode this test exists to catch) would
+	// instead return in well under 100ms because Kill() does not wait for
+	// any child-side cleanup at all. The lower bound below is what
+	// distinguishes "the child shut itself down" from "we just killed it
+	// immediately after signaling."
+	if elapsed < 300*time.Millisecond {
+		t.Fatalf("stopGracefully returned in %s, too fast to be the child's own 500ms graceful "+
+			"shutdown; the CTRL_BREAK_EVENT was likely never delivered and this fell through to force-kill", elapsed)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("stopGracefully took %s, suspiciously close to the 5s timeout; likely fell through to force-kill", elapsed)
+	}
+
+	select {
+	case <-host.exited:
+	default:
+		t.Fatal("expected agentHost.exited to be closed after stopGracefully returns")
+	}
+}
+
+// TestAgentHostForceKillOnTimeout proves the other half of the contract:
+// a child that ignores the graceful signal is still terminated, and
+// stopGracefully still returns, within a bounded time.
+func TestAgentHostForceKillOnTimeout(t *testing.T) {
+	node := nodeExe(t)
+	log := newTestLogger(t)
+	// This script ignores SIGBREAK entirely (no handler registered) and
+	// just runs forever, standing in for an agent that failed to drain.
+	stubbornScript := filepath.Join(t.TempDir(), "stubborn.js")
+	// Node's default action for an unhandled CTRL_BREAK_EVENT is to let
+	// Windows terminate the process outright, which would trivially
+	// "pass" this test for the wrong reason (immediate termination looks
+	// identical to a fast graceful exit). Registering a SIGBREAK listener
+	// that does nothing suppresses that default action while still never
+	// calling process.exit(), which is what actually exercises the
+	// timeout-then-force-kill path this test targets.
+	stubbornSrc := "process.on('SIGBREAK', () => {}); setInterval(() => {}, 1000);\n"
+	if err := os.WriteFile(stubbornScript, []byte(stubbornSrc), 0o600); err != nil {
+		t.Fatalf("write stubborn script: %v", err)
+	}
+	host := newAgentHost(node, []string{stubbornScript}, os.Environ(), log)
+	if err := host.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	stopStart := time.Now()
+	if err := host.stopGracefully(1 * time.Second); err != nil {
+		t.Fatalf("stopGracefully: %v", err)
+	}
+	elapsed := time.Since(stopStart)
+	if elapsed < 1*time.Second {
+		t.Fatalf("stopGracefully returned in %s, before its own 1s timeout should have elapsed", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("stopGracefully took %s to force-kill an unresponsive child; force-kill should be near-immediate once the timeout fires", elapsed)
+	}
+}
+
+// TestAgentHostWaitObservesUnrequestedExit proves the service handler's
+// crash-detection path: wait() returns as soon as the child exits on its
+// own, with no stop ever requested.
+func TestAgentHostWaitObservesUnrequestedExit(t *testing.T) {
+	node := nodeExe(t)
+	log := newTestLogger(t)
+	quickExitScript := filepath.Join(t.TempDir(), "quick-exit.js")
+	if err := os.WriteFile(quickExitScript, []byte("process.exit(3);\n"), 0o600); err != nil {
+		t.Fatalf("write quick-exit script: %v", err)
+	}
+	host := newAgentHost(node, []string{quickExitScript}, os.Environ(), log)
+	if err := host.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- host.wait() }()
+
+	select {
+	case err := <-waitDone:
+		if err == nil {
+			t.Fatal("expected a non-nil error for a child that exited with code 3")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("wait() did not observe the child's own exit within 5s")
+	}
+}

--- a/packages/agent/windows-service-host/main.go
+++ b/packages/agent/windows-service-host/main.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+// Command tokentimer-agent-host is the Windows Service Control Manager
+// (SCM) dispatcher for the TokenTimer CertOps Agent.
+//
+// Why this exists: the SCM start protocol requires the process named in a
+// service's binPath to call StartServiceCtrlDispatcher and answer
+// start/stop/interrogate control requests itself. A plain "node.exe
+// bin\tokentimer-agent.js" process never does that - Node has no SCM
+// awareness - so sc.exe create/start against that binPath directly starts
+// a service the SCM cannot confirm is alive, which fails after Windows'
+// own service-start timeout (error 1053) and then loops on whatever
+// failure/restart policy is configured. This binary is a small, purpose-
+// built host that speaks the SCM protocol on the agent's behalf: it is
+// what the installer's binPath now points at, and its only job is to
+// register with SCM, start the real Node agent as a child process,
+// forward SCM stop/shutdown requests to it as a graceful shutdown signal,
+// and propagate the child's own exit if it crashes on its own (so the
+// existing `sc.exe failure ... restart/5000` policy still restarts a
+// crashed agent exactly as it did before this host existed).
+//
+// Usage (what install-agent.ps1 puts in binPath):
+//
+//	tokentimer-agent-host.exe <node.exe path> <agent entrypoint .js path>
+//
+// Everything after the host's own argv[0] is passed through to the child
+// unchanged; this host has no flags of its own beyond that, on purpose -
+// it must never need its own separate configuration surface distinct from
+// the agent's.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "tokentimer-agent-host: usage: tokentimer-agent-host.exe <child-exe> [child-args...]")
+		os.Exit(2)
+	}
+	childExe := os.Args[1]
+	childArgs := os.Args[2:]
+
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tokentimer-agent-host: could not determine session type: %v\n", err)
+		os.Exit(1)
+	}
+
+	log := newHostLogger(os.Getenv("TOKENTIMER_AGENT_CONFIG_DIR"))
+	defer log.Close()
+	stopTimeout := resolveStopTimeout(os.Getenv)
+	host := newAgentHost(childExe, childArgs, os.Environ(), log)
+
+	if isService {
+		runAsService(host, stopTimeout, log)
+		return
+	}
+	os.Exit(runInteractive(host, stopTimeout, log))
+}
+
+// runInteractive supports `tokentimer-agent-host.exe <node> <entry.js>` run
+// directly from a console (manual testing, or an operator diagnosing a
+// service install without touching the SCM at all): it starts the child,
+// forwards this process's own Ctrl+C to the child as a graceful stop, and
+// exits with the child's exit status once it terminates either way.
+func runInteractive(host *agentHost, stopTimeout time.Duration, log *hostLogger) int {
+	if err := host.start(); err != nil {
+		log.Printf("%v", err)
+		return 1
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	childErrCh := make(chan error, 1)
+	go func() { childErrCh <- host.wait() }()
+
+	select {
+	case <-sigCh:
+		log.Printf("interactive mode: Ctrl+C received; requesting graceful child stop")
+		_ = host.stopGracefully(stopTimeout)
+		return 0
+	case err := <-childErrCh:
+		log.Printf("child exited on its own: %v", err)
+		if err == nil {
+			return 0
+		}
+		return 1
+	}
+}

--- a/packages/agent/windows-service-host/service_windows.go
+++ b/packages/agent/windows-service-host/service_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package main
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// serviceName must equal install-agent.ps1's $ServiceName exactly: the SCM
+// dispatcher table windows/svc builds from Execute's registration is keyed
+// by this string, and a mismatch here means StartServiceCtrlDispatcher
+// simply never routes control requests to this process at all - the exact
+// silent failure mode this host exists to eliminate.
+const serviceName = "TokenTimerAgent"
+
+// tokenTimerAgentService implements svc.Handler. It owns no state of its
+// own beyond the already-started agentHost and stop timeout; every actual
+// decision (how to signal the child, how long to wait) lives in host.go
+// so it stays unit-testable without a real SCM.
+type tokenTimerAgentService struct {
+	host        *agentHost
+	stopTimeout time.Duration
+	log         *hostLogger
+}
+
+// Execute implements svc.Handler. Its control flow follows the documented
+// SCM contract precisely:
+//  1. report StartPending immediately (the SCM already granted a startup
+//     window via the service's own start timeout; this host does not
+//     additionally manage that budget)
+//  2. start the child
+//  3. report Running, accepting Stop/Shutdown/Interrogate
+//  4. loop on the two events that can end the service: an SCM control
+//     request, or the child exiting on its own
+//  5. report StopPending, perform the graceful-then-forced stop, report
+//     Stopped
+func (s *tokenTimerAgentService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	if err := s.host.start(); err != nil {
+		s.log.Printf("service start failed: %v", err)
+		changes <- svc.Status{State: svc.Stopped}
+		return false, 1
+	}
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepted}
+
+	childExitCh := make(chan error, 1)
+	go func() { childExitCh <- s.host.wait() }()
+
+	for {
+		select {
+		case req := <-r:
+			switch req.Cmd {
+			case svc.Interrogate:
+				changes <- req.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending}
+				_ = s.host.stopGracefully(s.stopTimeout)
+				changes <- svc.Status{State: svc.Stopped}
+				return false, 0
+			default:
+				// Pause/Continue/ParamChange/etc. are not offered
+				// (Accepts above never advertises them), so the SCM
+				// should never deliver one; if it somehow does,
+				// reporting current status is the documented safe
+				// response rather than silently dropping it.
+				changes <- req.CurrentStatus
+			}
+		case err := <-childExitCh:
+			// The child exited without this host asking it to: a crash,
+			// or the agent's own clean self-exit. Report Stopped with a
+			// non-zero specific error so SCM's configured failure
+			// action (sc.exe failure ... actions= restart/5000) fires
+			// exactly as it would have for a bare node.exe binPath,
+			// which is the behavior the install script's failure
+			// policy was already written to expect.
+			exitCode := uint32(0)
+			if err != nil {
+				exitCode = 1
+			}
+			s.log.Printf("child exited without a stop request (err=%v); stopping service so the configured failure action can react", err)
+			changes <- svc.Status{State: svc.Stopped}
+			return false, exitCode
+		}
+	}
+}
+
+// runAsService blocks for the lifetime of the service by calling
+// svc.Run, which internally calls StartServiceCtrlDispatcher and blocks
+// until Execute returns.
+func runAsService(host *agentHost, stopTimeout time.Duration, log *hostLogger) {
+	handler := &tokenTimerAgentService{host: host, stopTimeout: stopTimeout, log: log}
+	if err := svc.Run(serviceName, handler); err != nil {
+		log.Printf("svc.Run failed: %v", err)
+	}
+}

--- a/packages/agent/windows-service-host/testdata/mock-agent.js
+++ b/packages/agent/windows-service-host/testdata/mock-agent.js
@@ -1,0 +1,13 @@
+console.log("mock-agent: started, pid=" + process.pid);
+let stopping = false;
+process.on("SIGBREAK", () => {
+  console.log("mock-agent: received SIGBREAK, shutting down gracefully");
+  stopping = true;
+  setTimeout(() => {
+    console.log("mock-agent: graceful shutdown complete");
+    process.exit(0);
+  }, 500);
+});
+setInterval(() => {
+  if (!stopping) console.log("mock-agent: heartbeat " + Date.now());
+}, 1000);


### PR DESCRIPTION
## Summary
- Enforce real Windows ACLs (`icacls`, `LocalSystem`/`BUILTIN\Administrators`) for CertOps agent private-key material on Windows, replacing the previous best-effort `chmod` no-op.
- See ADR-0012 (#120) for the normative Windows execution surface and trust-anchor decisions this closes out.

## Test plan
- [x] CI at exact head: https://github.com/tokentimerch/tokentimer-core/actions/runs/30767512174

## Stack
Base: #119. Independent of #118.
