### PR TITLE
feat(certops): diagnostic-agent isolation, protocol_smoke jobs, and orphan retirement

### DIFF
--- a/apps/api/middleware/machine-token-rate-limit.js
+++ b/apps/api/middleware/machine-token-rate-limit.js
@@ -14,6 +14,16 @@ const CERTOPS_MACHINE_RATE_LIMIT_STORE_REQUIRED =
 const DEFAULT_WINDOW_MS = 60_000;
 const DEFAULT_MAX = 120;
 const RAW_TOKEN_PATTERN = /^ttx_([a-f0-9]{16})_([a-f0-9]{64})$/;
+// Pre-auth traffic on the CertOps agent routes (register, heartbeat, claim,
+// lease, results) never carries a ttx_ workspace API token - it carries an
+// agent bootstrap token (ttboot_) or an agent credential (ttagent_), neither
+// of which RAW_TOKEN_PATTERN recognizes. Structural prefix extraction below
+// needs both shapes too, or every agent-route pre-auth request falls through
+// to the IP-only fallback and every caller behind the same IP collides on
+// one shared bucket, regardless of which distinct token each one is using.
+const RAW_AGENT_BOOTSTRAP_TOKEN_PATTERN =
+  /^ttboot_([a-f0-9]{16})_([a-f0-9]{64})$/;
+const RAW_AGENT_CREDENTIAL_PATTERN = /^ttagent_([a-f0-9]{16})_([a-f0-9]{64})$/;
 const UUID_SEGMENT_PATTERN =
   /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i;
 
@@ -166,13 +176,25 @@ function authorizationHeader(req) {
 }
 
 function tokenPrefixFromAuthorization(req) {
-  const match = /^Bearer\s+(ttx_[a-f0-9]{16}_[a-f0-9]{64})$/i.exec(
-    authorizationHeader(req),
-  );
-  if (!match || match[1] !== match[1].toLowerCase()) return null;
+  const match = /^Bearer\s+(\S+)$/i.exec(authorizationHeader(req));
+  if (!match) return null;
+  const rawToken = match[1];
+  if (rawToken !== rawToken.toLowerCase()) return null;
 
-  const tokenMatch = RAW_TOKEN_PATTERN.exec(match[1]);
-  return tokenMatch ? `ttx_${tokenMatch[1]}` : null;
+  // Try every machine-credential shape this server issues pre-auth callers
+  // may present here: workspace API tokens (ttx_) on executor routes, and
+  // agent bootstrap tokens (ttboot_) / agent credentials (ttagent_) on agent
+  // routes. Each match yields only the public prefix, never the secret half.
+  const apiTokenMatch = RAW_TOKEN_PATTERN.exec(rawToken);
+  if (apiTokenMatch) return `ttx_${apiTokenMatch[1]}`;
+
+  const bootstrapMatch = RAW_AGENT_BOOTSTRAP_TOKEN_PATTERN.exec(rawToken);
+  if (bootstrapMatch) return `ttboot_${bootstrapMatch[1]}`;
+
+  const credentialMatch = RAW_AGENT_CREDENTIAL_PATTERN.exec(rawToken);
+  if (credentialMatch) return `ttagent_${credentialMatch[1]}`;
+
+  return null;
 }
 
 function preAuthWorkspaceId(req, options = {}) {

--- a/apps/api/middleware/rateLimit.js
+++ b/apps/api/middleware/rateLimit.js
@@ -319,6 +319,62 @@ const domainCheckerLookupLimiter = rateLimit({
   },
 });
 
+// Per-workspace limit on diagnostic-bootstrap requests (ADR-0012 decision
+// 7). Keyed on workspace, not user or IP: the surface exists to gate how
+// many diagnostic agents+jobs a workspace can mint per window regardless of
+// which admin/owner is calling, mirroring domainCheckerLookupLimiter's
+// workspace-keyed shape above rather than the per-user API limiter's.
+const diagnosticBootstrapLimiter = rateLimit({
+  windowMs: intEnv(
+    "CERTOPS_DIAGNOSTIC_BOOTSTRAP_RATE_LIMIT_WINDOW_MS",
+    60 * 60 * 1000,
+  ),
+  max: Math.max(
+    1,
+    intEnv("CERTOPS_DIAGNOSTIC_BOOTSTRAP_RATE_LIMIT_MAX", isDevOrTest ? 1000 : 5),
+  ),
+  message:
+    "Diagnostic agent bootstrap is rate limited for this workspace. Please wait before trying again.",
+  standardHeaders: true,
+  legacyHeaders: false,
+  skipSuccessfulRequests: false,
+  keyGenerator: (req) => {
+    const workspaceId = req.workspace?.id || req.params?.id || "unknown";
+    return `certops-diagnostic-bootstrap:${workspaceId}`;
+  },
+  handler: (req, res) => {
+    const windowMs = intEnv(
+      "CERTOPS_DIAGNOSTIC_BOOTSTRAP_RATE_LIMIT_WINDOW_MS",
+      60 * 60 * 1000,
+    );
+    const fallbackRetrySec = Math.max(1, Math.ceil(windowMs / 1000));
+    const resetTime = req.rateLimit?.resetTime;
+    const retryAfterSeconds =
+      resetTime instanceof Date
+        ? Math.max(1, Math.ceil((resetTime.getTime() - Date.now()) / 1000))
+        : fallbackRetrySec;
+    logger.warn("RATE_LIMIT_EXCEEDED", {
+      type: "certops_diagnostic_bootstrap",
+      userId: req.user?.id || null,
+      workspaceId: req.workspace?.id || req.params?.id || null,
+      ip: resolveClientIp(req),
+      userAgent: req.get("User-Agent"),
+      retryAfterSeconds,
+    });
+    res.set("Retry-After", String(retryAfterSeconds));
+    res.status(429).json({
+      error:
+        "Diagnostic agent bootstrap is rate limited for this workspace. Please wait before trying again.",
+      code: "CERTOPS_DIAGNOSTIC_BOOTSTRAP_RATE_LIMITED",
+      retry_after_seconds: retryAfterSeconds,
+    });
+  },
+});
+
+function getDiagnosticBootstrapLimiter() {
+  return diagnosticBootstrapLimiter;
+}
+
 let resolvedApiLimiter;
 /**
  * Returns the API rate-limit middleware (resolved once per process).
@@ -386,6 +442,7 @@ module.exports = {
   planAwareApiLimiter,
   getApiLimiter,
   getDomainCheckerLookupLimiter,
+  getDiagnosticBootstrapLimiter,
   getTestApiLimiter,
   noRateLimit,
   applyGlobalRateLimit,

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -2898,6 +2898,97 @@ const migrations = [
         ADD COLUMN IF NOT EXISTS capabilities_updated_at TIMESTAMPTZ NULL;
     `,
   },
+  {
+    version: 41,
+    name: "certops_diagnostic_agent_isolation",
+    sql: `
+      -- Diagnostic-agent isolation surface (ADR-0012 decisions 2 and 7).
+      --
+      -- protocol_smoke is a dedicated wire action used only to test agent
+      -- protocol connectivity (claim/verify/report) without performing any
+      -- certificate work: no keygen, no ACME order, no filesystem write. It
+      -- is always dispatched with mode = 'dry_run' and, per the existing
+      -- mode/status guard above (certops_job_mode_and_dry_run_complete),
+      -- can therefore never terminate as 'succeeded' -- only
+      -- 'dry_run_complete' or 'rejected'.
+      ALTER TABLE certificate_jobs
+        DROP CONSTRAINT IF EXISTS certificate_jobs_operation_check;
+      ALTER TABLE certificate_jobs
+        ADD CONSTRAINT certificate_jobs_operation_check CHECK (
+          operation IN (
+            'issue', 'renew', 'deploy', 'reload', 'revoke', 'noop',
+            'protocol_smoke'
+          )
+        );
+
+      -- agent_kind is server-assigned exactly once, at row creation, and is
+      -- never updated afterward: there is deliberately no UPDATE path that
+      -- changes it for an existing agent. This makes it a trustworthy trust
+      -- boundary in a way declared_capabilities (client-supplied on every
+      -- register/heartbeat) can never be: dispatch keys the protocol_smoke
+      -- gate on this column, not on anything the agent itself asserts, so
+      -- a normal agent cannot make itself eligible for a diagnostic job (or
+      -- vice versa) by lying about what it supports.
+      ALTER TABLE certops_agents
+        ADD COLUMN IF NOT EXISTS agent_kind TEXT NOT NULL DEFAULT 'normal';
+      ALTER TABLE certops_agents
+        DROP CONSTRAINT IF EXISTS certops_agents_agent_kind_check;
+      ALTER TABLE certops_agents
+        ADD CONSTRAINT certops_agents_agent_kind_check CHECK (
+          agent_kind IN ('normal', 'diagnostic')
+        );
+      CREATE INDEX IF NOT EXISTS idx_certops_agents_workspace_agent_kind
+        ON certops_agents(workspace_id, agent_kind, status);
+    `,
+  },
+  {
+    version: 42,
+    name: "certops_diagnostic_bootstrap_requests",
+    sql: `
+      -- Single-use, non-replayable record for the session-authenticated
+      -- diagnostic-bootstrap endpoint (POST .../certops/agents/diagnostic-bootstrap).
+      --
+      -- Unlike certops_agent_registration_replays (which deliberately DOES
+      -- replay a lost response for a machine-credential register call),
+      -- a diagnostic bootstrap must never silently reissue
+      -- {agentId, credential, job}: a retried request with the same
+      -- request_id has to fail with diagnostic_bootstrap_already_consumed.
+      -- The UNIQUE(workspace_id, request_id) index below is what makes that
+      -- true: the row is inserted and the agent + smoke job are created in
+      -- the same transaction, so a second attempt with the same request_id
+      -- hits the unique constraint before anything else happens, and can
+      -- never observe (or create) a half-finished bootstrap.
+      --
+      -- expires_at is retained as a documented 15-minute request window and
+      -- as a future janitor-cleanup boundary for this audit trail; it is
+      -- not a re-arm mechanism, because a consumed row is never deleted and
+      -- the UNIQUE index makes single-use permanent, which is a strictly
+      -- stronger guarantee than "usable again after 15 minutes".
+      CREATE TABLE IF NOT EXISTS certops_diagnostic_bootstrap_requests (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        request_id TEXT NOT NULL
+          CHECK (char_length(btrim(request_id)) BETWEEN 1 AND 128),
+        requested_by_user_id INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        agent_row_id UUID NULL,
+        job_id UUID NULL,
+        expires_at TIMESTAMPTZ NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        CONSTRAINT fk_certops_diagnostic_bootstrap_agent
+          FOREIGN KEY (workspace_id, agent_row_id)
+          REFERENCES certops_agents(workspace_id, id)
+          ON DELETE SET NULL (agent_row_id),
+        CONSTRAINT fk_certops_diagnostic_bootstrap_job
+          FOREIGN KEY (workspace_id, job_id)
+          REFERENCES certificate_jobs(workspace_id, id)
+          ON DELETE SET NULL (job_id)
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_certops_diagnostic_bootstrap_workspace_request
+        ON certops_diagnostic_bootstrap_requests(workspace_id, request_id);
+      CREATE INDEX IF NOT EXISTS idx_certops_diagnostic_bootstrap_expires
+        ON certops_diagnostic_bootstrap_requests(expires_at);
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -3,7 +3,10 @@
 const router = require("express").Router();
 
 const { pool } = require("../db/database");
-const { getApiLimiter } = require("../middleware/rateLimit");
+const {
+  getApiLimiter,
+  getDiagnosticBootstrapLimiter,
+} = require("../middleware/rateLimit");
 const {
   PRIVATE_KEY_MATERIAL_REJECTED,
   rejectKeyMaterial,
@@ -64,6 +67,11 @@ const {
   normalizeRequiredRetireReason,
   retireAgent,
 } = require("../services/certops/agentRegistry");
+const {
+  CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED,
+  CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID,
+  createDiagnosticBootstrap,
+} = require("../services/certops/diagnosticBootstrap");
 const {
   CERTOPS_CERTIFICATE_NOT_AGENT_DEPLOYABLE,
   CERTOPS_RENEWAL_AUTO_RENEW_DISABLED,
@@ -435,6 +443,25 @@ function handleCertOpsError(res, err) {
     return res.status(404).json({
       error: "CertOps agent not found",
       code: CERTOPS_AGENT_NOT_FOUND,
+    });
+  }
+
+  if (err?.code === CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID) {
+    return res.status(400).json({
+      error: "requestId is required and must be at most 128 characters",
+      code: CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID,
+    });
+  }
+
+  // Deliberately not a 409/replay body: a retried bootstrap must never
+  // resemble a state the caller can recover from by retrying again, and it
+  // must never suggest the original {agentId, credential, job} might still
+  // be recoverable from the server (see ADR-0012 decision 7 and the
+  // diagnosticBootstrap.js module comment).
+  if (err?.code === CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED) {
+    return res.status(409).json({
+      error: "This diagnostic bootstrap request was already consumed",
+      code: CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED,
     });
   }
 
@@ -1692,6 +1719,41 @@ router.post(
       });
       return res.status(500).json({
         error: "Failed to revoke CertOps agent bootstrap token",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+router.post(
+  "/api/v1/workspaces/:id/certops/agents/diagnostic-bootstrap",
+  getDiagnosticBootstrapLimiter(),
+  getApiLimiter(),
+  rejectKeyMaterial,
+  requireCertOpsEnabled,
+  requireCertOpsSessionUser,
+  authorize("certops.agents.diagnose"),
+  async (req, res) => {
+    try {
+      const result = await createDiagnosticBootstrap({
+        workspaceId: req.workspace.id,
+        requestId: req.body?.requestId,
+        requestedByUserId: req.user.id,
+        env: process.env,
+      });
+      return res.status(201).json(result);
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps diagnostic agent bootstrap failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to bootstrap CertOps diagnostic agent",
         code: "INTERNAL_ERROR",
       });
     }

--- a/apps/api/services/certops/agentDispatch.js
+++ b/apps/api/services/certops/agentDispatch.js
@@ -993,13 +993,21 @@ async function claimJobs({
               declared_command_profile_names,
               supported_dns_providers,
               declared_capabilities,
-              capabilities_updated_at
+              capabilities_updated_at,
+              agent_kind
          FROM certops_agents
         WHERE id = $1
         FOR UPDATE`,
       [agent.id],
     );
     const caps = agentCaps.rows[0] || {};
+    // ADR-0012 decision 7: agent_kind is server-assigned at registration and
+    // never updated afterward, unlike declared_capabilities/supportedActions
+    // (both client-supplied on every call). The protocol_smoke gate below is
+    // keyed on this column alone, so a normal agent cannot make itself
+    // eligible for a diagnostic job (or vice versa) by declaring, or
+    // withholding, any capability.
+    const agentKind = caps.agent_kind === "diagnostic" ? "diagnostic" : "normal";
     const targetSelectors = jsonbTextArray(caps.declared_target_selectors);
     const commandProfiles = jsonbTextArray(caps.declared_command_profile_names);
     const dnsProviders =
@@ -1084,6 +1092,10 @@ async function claimJobs({
             required_command_profile IS NULL
             OR required_command_profile = ANY($6::text[])
           )
+          AND (
+            ($9::text = 'diagnostic' AND operation = 'protocol_smoke')
+            OR ($9::text <> 'diagnostic' AND operation <> 'protocol_smoke')
+          )
         ORDER BY created_at
         LIMIT $7
         FOR UPDATE SKIP LOCKED`,
@@ -1096,6 +1108,7 @@ async function claimJobs({
         commandProfiles,
         maxJobs,
         canBindEvidenceToClaim,
+        agentKind,
       ],
     );
 

--- a/apps/api/services/certops/agentRegistry.js
+++ b/apps/api/services/certops/agentRegistry.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("node:crypto");
 const { pool } = require("../../db/database");
 const { redactGenericSecrets } = require("../../utils/secretMaterial");
 const {
@@ -51,6 +52,30 @@ const DEFAULT_CLOCK_DRIFT_ALERT_MS = 30_000;
 // showing a crashed/unresponsive agent as "active" between sweeps.
 const DEFAULT_AGENT_OFFLINE_AFTER_MS = 10 * 60 * 1000;
 
+// ADR-0012 decision 7. agent_kind is server-assigned exactly once, at row
+// creation (registerAgent for 'normal', createDiagnosticBootstrap for
+// 'diagnostic'), and there is deliberately no code path that updates it on
+// an existing row.
+const AGENT_KIND_NORMAL = "normal";
+const AGENT_KIND_DIAGNOSTIC = "diagnostic";
+const AGENT_KINDS = Object.freeze([AGENT_KIND_NORMAL, AGENT_KIND_DIAGNOSTIC]);
+
+// ADR-0012 decision 7: a diagnostic agent that never heartbeats again (the
+// common case: an operator ran the reference client once to test
+// connectivity and closed it) must not linger in the fleet forever. Distinct
+// from DEFAULT_AGENT_OFFLINE_AFTER_MS, which only ever flips status to
+// 'offline' and never retires anything.
+const DEFAULT_DIAGNOSTIC_AGENT_INACTIVITY_TTL_MS = 24 * 60 * 60 * 1000;
+
+function diagnosticAgentInactivityTtlMs(env = process.env) {
+  const raw = Number.parseInt(
+    env.CERTOPS_DIAGNOSTIC_AGENT_INACTIVITY_TTL_MS,
+    10,
+  );
+  if (Number.isSafeInteger(raw) && raw > 0) return raw;
+  return DEFAULT_DIAGNOSTIC_AGENT_INACTIVITY_TTL_MS;
+}
+
 // ADR-0012 decision 17: capability-gated claim selection at
 // agentDispatch.js's claimJobs needs a freshness bound for
 // certops_agents.capabilities_updated_at. The bound is not an independently
@@ -85,6 +110,7 @@ const AGENT_SAFE_SELECT_FIELDS = `
   agent_version,
   protocol_version,
   status,
+  agent_kind,
   last_seen_at,
   clock_offset_ms,
   ntp_synced,
@@ -94,10 +120,42 @@ const AGENT_SAFE_SELECT_FIELDS = `
   retire_reason
 `;
 
+// Idempotent revocation guard for retireAgent below. Generates a fresh
+// cryptographically random value in Node (not SQL): gen_random_bytes()
+// needs the pgcrypto extension, which nothing in this schema's migrations
+// installs, whereas Node's own crypto module has no such dependency and the
+// value never needs to be derived from anything the database holds.
+function randomCredentialRevocationHash() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
 function serviceError(message, code) {
   const error = new Error(message);
   error.code = code;
   return error;
+}
+
+// Same BEGIN/COMMIT/ROLLBACK convention as agentDispatch.js and
+// diagnosticBootstrap.js's local helpers of the same name: a caller that
+// does not already hold a transaction (options.client) gets one of its own,
+// so reconcileDiagnosticAgentOrphan's writes commit or roll back together.
+async function withTransaction(dbPool, fn) {
+  const client = await dbPool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackError) {
+      // The original error is more useful to the caller.
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
 function dateToIso(value) {
@@ -304,6 +362,9 @@ function agentMetadataFromRow(row, env = process.env) {
     agentVersion: row.agent_version,
     protocolVersion: row.protocol_version,
     status: row.status,
+    agentKind: row.agent_kind === AGENT_KIND_DIAGNOSTIC
+      ? AGENT_KIND_DIAGNOSTIC
+      : AGENT_KIND_NORMAL,
     lastSeenAt: dateToIso(row.last_seen_at),
     clockOffsetMs: row.clock_offset_ms === null ? null : Number(row.clock_offset_ms),
     ntpSynced: typeof row.ntp_synced === "boolean" ? row.ntp_synced : null,
@@ -527,6 +588,24 @@ async function retireAgent(options) {
             retired_at = NOW(),
             retired_by_user_id = $3,
             retire_reason = $4,
+            -- ADR-0012 decision 7: a retired diagnostic agent must fail at
+            -- authentication, not merely at authorization on individual
+            -- routes afterward - unlike the frozen-retired rule that
+            -- deliberately still lets a retired *normal* agent authenticate
+            -- so the route layer can answer 410 (see agent-auth.js).
+            -- credential_hash is NOT NULL + unique, so revocation overwrites
+            -- it with a fresh cryptographically random value rather than
+            -- NULL: validateAgentCredential's timingSafeEqual comparison
+            -- against a candidate hash derived from the agent's real
+            -- (unrecoverable, sha256-hashed-at-source) plaintext credential
+            -- can then never match. Both the status flip and the hash
+            -- overwrite are written by this one UPDATE, so there is no row
+            -- state, and no window, where status already reads 'retired'
+            -- but credential_hash still matches the live credential.
+            credential_hash = CASE
+              WHEN agent_kind = 'diagnostic' THEN $5
+              ELSE credential_hash
+            END,
             updated_at = NOW()
       WHERE workspace_id = $1
         AND id = $2
@@ -537,6 +616,7 @@ async function retireAgent(options) {
       options.agentId,
       options.retiredBy || null,
       options.reason || null,
+      randomCredentialRevocationHash(),
     ],
   );
 
@@ -557,25 +637,274 @@ async function retireAgent(options) {
   return { agent: existing, retiredNow: false, fenced };
 }
 
+// ADR-0012 decision 7's four orphan-retirement branches, keyed on the
+// diagnostic agent's single protocol_smoke job. A lost registration
+// response, or an operator who ran the reference client once and never
+// heartbeated again, must not leave a permanently-active fleet row; but a
+// job that is genuinely mid-execution must not be yanked out from under a
+// live claim either. Exactly one of these four is safe to act on for any
+// given (agent, job) pair at the moment this function is called:
+//   pending_unclaimed  - nothing was ever leased: cancel the job and retire
+//                        the agent atomically, no claim to race.
+//   active_unexpired   - a client may be executing right now: defer.
+//   active_expired     - the lease reaper's terminalization, inlined here
+//                        instead of waited-for, then retire the agent.
+//   terminal           - the job already reached a terminal status (or the
+//                        transaction that would have created one never
+//                        happened): retire the agent normally.
+const DIAGNOSTIC_ORPHAN_BRANCH = Object.freeze({
+  PENDING_UNCLAIMED: "pending_unclaimed",
+  ACTIVE_UNEXPIRED: "active_unexpired",
+  ACTIVE_EXPIRED: "active_expired",
+  TERMINAL: "terminal",
+});
+
+const DIAGNOSTIC_AGENT_RETIRED_JOB_ERROR_CODE = "CERTOPS_DIAGNOSTIC_AGENT_RETIRED";
+
+function classifyDiagnosticOrphanBranch(job) {
+  if (!job) return DIAGNOSTIC_ORPHAN_BRANCH.TERMINAL;
+  if (job.status === "pending") {
+    return DIAGNOSTIC_ORPHAN_BRANCH.PENDING_UNCLAIMED;
+  }
+  if (job.status === "claimed" || job.status === "running") {
+    const leaseExpiresAt = job.lease_expires_at ? new Date(job.lease_expires_at) : null;
+    const leaseExpired = !leaseExpiresAt || leaseExpiresAt.getTime() <= Date.now();
+    return leaseExpired
+      ? DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_EXPIRED
+      : DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_UNEXPIRED;
+  }
+  return DIAGNOSTIC_ORPHAN_BRANCH.TERMINAL;
+}
+
+// Finds the one protocol_smoke job this diagnostic agent's bootstrap created.
+// FOR UPDATE so a concurrent claim (agentDispatch.js claimJobs) and this
+// reconciliation can never both believe they hold the deciding vote on the
+// same job row.
+async function loadAssignedProtocolSmokeJobForUpdate(db, workspaceId, agentId) {
+  const result = await db.query(
+    `SELECT id, status, lease_expires_at
+       FROM certificate_jobs
+      WHERE workspace_id = $1
+        AND assigned_agent_id = $2
+        AND operation = 'protocol_smoke'
+      ORDER BY created_at DESC
+      LIMIT 1
+      FOR UPDATE`,
+    [workspaceId, agentId],
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Reconciles exactly one diagnostic agent against the four-branch state
+ * machine above, then retires it unless the branch is active_unexpired.
+ * Callers (the inactivity sweep, or a test) are expected to have already
+ * decided *that* this agent is a retirement candidate (e.g. past the 24-hour
+ * inactivity TTL); this function only decides *how* to retire it safely.
+ *
+ * Runs inside options.client's transaction when provided (the inactivity
+ * sweep runs it inside its own per-agent transaction so one agent's
+ * reconciliation can never block or partially apply another's). When no
+ * client is supplied, this function opens and owns its own transaction via
+ * withTransaction, so a direct caller (a route, a one-off script, a test)
+ * still gets the cancel-job-then-retire-agent sequence atomically instead
+ * of as separate autocommitted statements: a crash or error partway through
+ * must never leave the job cancelled but the agent still active, or the
+ * agent retired but the job untouched.
+ */
+async function reconcileDiagnosticAgentOrphan(options) {
+  if (!options.client) {
+    const dbPool = options.dbPool || pool;
+    return withTransaction(dbPool, (client) =>
+      reconcileDiagnosticAgentOrphan({ ...options, client }),
+    );
+  }
+
+  const db = options.client;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+
+  const agentResult = await db.query(
+    `SELECT id, agent_kind, status
+       FROM certops_agents
+      WHERE workspace_id = $1
+        AND id = $2
+      FOR UPDATE`,
+    [workspaceId, options.agentId],
+  );
+  const agentRow = agentResult.rows[0];
+  if (!agentRow) return { notFound: true };
+  if (agentRow.agent_kind !== AGENT_KIND_DIAGNOSTIC) {
+    return { notApplicable: true, reason: "agent_kind is not diagnostic" };
+  }
+  if (agentRow.status === "retired") {
+    return { alreadyRetired: true };
+  }
+
+  const job = await loadAssignedProtocolSmokeJobForUpdate(
+    db,
+    workspaceId,
+    options.agentId,
+  );
+  const branch = classifyDiagnosticOrphanBranch(job);
+
+  if (branch === DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_UNEXPIRED) {
+    return { deferred: true, branch, jobId: job ? job.id : null };
+  }
+
+  const reason =
+    options.reason ||
+    "Diagnostic agent retired by the inactivity sweep (ADR-0012 decision 7)";
+
+  if (branch === DIAGNOSTIC_ORPHAN_BRANCH.PENDING_UNCLAIMED) {
+    // Nothing was ever leased, so there is no in-flight claim to race:
+    // cancel-and-retire is safe to do unconditionally in this transaction.
+    await db.query(
+      `UPDATE certificate_jobs
+          SET status = 'cancelled',
+              lease_expires_at = NOW(),
+              error_code = $2,
+              error_message = $3,
+              completed_at = COALESCE(completed_at, NOW()),
+              canceled_at = COALESCE(canceled_at, NOW()),
+              updated_at = NOW()
+        WHERE id = $1`,
+      [job.id, DIAGNOSTIC_AGENT_RETIRED_JOB_ERROR_CODE, reason],
+    );
+  } else if (branch === DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_EXPIRED) {
+    // Same terminalization the lease reaper applies to any expired lease
+    // (claimed -> cancelled, running -> orphaned_unknown_effect), inlined
+    // here rather than waited-for so retirement is not blocked on the next
+    // reaper pass. protocol_smoke is excluded from renewal alerting
+    // (RENEWAL_ALERTING_OPERATIONS), so no outbox alert is owed here.
+    const terminalStatus =
+      job.status === "running" ? "orphaned_unknown_effect" : "cancelled";
+    await db.query(
+      `UPDATE certificate_jobs
+          SET status = $2,
+              needs_operator_reconciliation = ($2 = 'orphaned_unknown_effect'),
+              reconciliation_reason = CASE WHEN $2 = 'orphaned_unknown_effect' THEN $3 ELSE NULL END,
+              lease_expires_at = NOW(),
+              error_code = $4,
+              error_message = $3,
+              completed_at = COALESCE(completed_at, NOW()),
+              canceled_at = CASE WHEN $2 = 'cancelled' THEN COALESCE(canceled_at, NOW()) ELSE canceled_at END,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [
+        job.id,
+        terminalStatus,
+        reason,
+        terminalStatus === "orphaned_unknown_effect"
+          ? "CERTOPS_DIAGNOSTIC_AGENT_RETIRED_UNKNOWN_EFFECT"
+          : DIAGNOSTIC_AGENT_RETIRED_JOB_ERROR_CODE,
+      ],
+    );
+  }
+  // TERMINAL: the job (if any) is already in a terminal status; nothing to
+  // do to it before retiring the agent.
+
+  const retireResult = await retireAgent({
+    client: db,
+    workspaceId,
+    agentId: options.agentId,
+    retiredBy: options.retiredBy ?? null,
+    reason,
+  });
+
+  return {
+    retired: true,
+    branch,
+    jobId: job ? job.id : null,
+    agent: retireResult.agent,
+  };
+}
+
+/**
+ * The 24-hour inactivity sweep itself: finds every non-retired diagnostic
+ * agent whose last_seen_at is older than the TTL and reconciles each one in
+ * its own transaction via reconcileDiagnosticAgentOrphan. A freshly
+ * registered diagnostic agent that has never heartbeated has last_seen_at
+ * set at INSERT time (see diagnosticBootstrap.js), so it is timed from
+ * registration, not left permanently exempt for lack of a heartbeat.
+ */
+async function sweepInactiveDiagnosticAgents(options = {}) {
+  const dbPool = options.dbPool || pool;
+  const ttlMs = diagnosticAgentInactivityTtlMs(options.env);
+  const batchSize = Number.isSafeInteger(options.batchSize) && options.batchSize > 0
+    ? options.batchSize
+    : 200;
+
+  const candidates = await dbPool.query(
+    `SELECT id, workspace_id
+       FROM certops_agents
+      WHERE agent_kind = 'diagnostic'
+        AND status <> 'retired'
+        AND last_seen_at < NOW() - make_interval(secs => $1)
+      ORDER BY last_seen_at ASC
+      LIMIT $2`,
+    [Math.floor(ttlMs / 1000), batchSize],
+  );
+
+  const results = [];
+  for (const row of candidates.rows) {
+    const client = await dbPool.connect();
+    try {
+      await client.query("BEGIN");
+      const outcome = await reconcileDiagnosticAgentOrphan({
+        client,
+        workspaceId: row.workspace_id,
+        agentId: row.id,
+        reason:
+          "Diagnostic agent exceeded its 24-hour inactivity TTL (ADR-0012 decision 7)",
+      });
+      await client.query("COMMIT");
+      results.push({ agentId: row.id, workspaceId: row.workspace_id, ...outcome });
+    } catch (error) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (_rollbackError) {
+        // The original error is more useful to the caller.
+      }
+      results.push({
+        agentId: row.id,
+        workspaceId: row.workspace_id,
+        error: error.message,
+      });
+    } finally {
+      client.release();
+    }
+  }
+  return results;
+}
+
 module.exports = {
+  AGENT_KIND_DIAGNOSTIC,
+  AGENT_KIND_NORMAL,
+  AGENT_KINDS,
   CERTOPS_AGENT_INVALID,
   CERTOPS_AGENT_NOT_FOUND,
   CERTOPS_AGENT_RETIRE_REASON_INVALID,
   CERTOPS_AGENT_WORKSPACE_REQUIRED,
   DEFAULT_CERTOPS_CAPABILITY_FRESHNESS_MS,
+  DEFAULT_DIAGNOSTIC_AGENT_INACTIVITY_TTL_MS,
+  DIAGNOSTIC_ORPHAN_BRANCH,
   certopsCapabilityFreshnessMs,
   computeAgentCompatibility,
   countActivelyLeasedJobs,
+  diagnosticAgentInactivityTtlMs,
   fenceAgentInFlightWork,
   getAgentById,
   listAgents,
   normalizeRequiredRetireReason,
   readCompatibilityConfig,
+  reconcileDiagnosticAgentOrphan,
   retireAgent,
+  sweepInactiveDiagnosticAgents,
 };
 
 module.exports._test = {
   agentMetadataFromRow,
+  classifyDiagnosticOrphanBranch,
   compareSemver,
   computeAgentCompatibility,
   normalizeRequiredRetireReason,

--- a/apps/api/services/certops/diagnosticBootstrap.js
+++ b/apps/api/services/certops/diagnosticBootstrap.js
@@ -1,0 +1,276 @@
+"use strict";
+
+/**
+ * Diagnostic-agent bootstrap service (ADR-0012 decision 7).
+ *
+ * POST /api/v1/workspaces/:id/certops/agents/diagnostic-bootstrap is
+ * session-authenticated (an operator, not a machine credential) and behind
+ * the certops.agents.diagnose permission. This module is the one
+ * transaction the route calls into: consume the single-use bootstrap
+ * request row, create the diagnostic agent, and create its protocol_smoke
+ * job, all three or none. There is no interval in which the agent row
+ * exists with no job, and no interval in which a second call with the same
+ * requestId can observe (or create) a half-finished bootstrap.
+ */
+
+const crypto = require("node:crypto");
+
+const { pool } = require("../../db/database");
+const { generateAgentCredential } = require("./agentCredentials");
+const { ensureActiveSigningKey } = require("./jobSigning");
+const { createCertificateJob } = require("./jobs");
+const { writeAudit } = require("../audit");
+
+const CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED =
+  "diagnostic_bootstrap_already_consumed";
+const CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID =
+  "CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID";
+
+// 15-minute single-use bootstrap window (ADR-0012 decision 7). This is a
+// documented request window and a future janitor-cleanup boundary for the
+// audit trail, not a re-arm mechanism: a consumed row is never deleted or
+// reset, so the UNIQUE(workspace_id, request_id) index (migration
+// certops_diagnostic_bootstrap_requests) makes single-use permanent
+// regardless of this TTL.
+const DEFAULT_DIAGNOSTIC_BOOTSTRAP_TTL_MS = 15 * 60 * 1000;
+
+// Placeholder wire identity for a diagnostic reference client. It is not an
+// agent build, so there is no real agentVersion/protocolVersion to report;
+// these satisfy the certops_agents CHECK constraints (protocol_version must
+// be x.y.z; agent_version 1-32 chars) without claiming compatibility with
+// any real agent release.
+const DIAGNOSTIC_AGENT_VERSION = "diagnostic-client";
+const DIAGNOSTIC_PROTOCOL_VERSION = "1.0.0";
+
+function serviceError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function diagnosticBootstrapTtlMs(env = process.env) {
+  const raw = Number.parseInt(env.CERTOPS_DIAGNOSTIC_BOOTSTRAP_TTL_MS, 10);
+  if (Number.isSafeInteger(raw) && raw > 0) return raw;
+  return DEFAULT_DIAGNOSTIC_BOOTSTRAP_TTL_MS;
+}
+
+function normalizeWorkspaceId(value) {
+  const workspaceId = typeof value === "string" ? value.trim() : "";
+  if (!workspaceId) {
+    throw serviceError(
+      "Workspace id is required",
+      "CERTOPS_AGENT_WORKSPACE_REQUIRED",
+    );
+  }
+  return workspaceId;
+}
+
+function normalizeRequestId(value) {
+  const requestId = typeof value === "string" ? value.trim() : "";
+  if (!requestId || requestId.length > 128) {
+    throw serviceError(
+      "requestId is required and must be at most 128 characters",
+      CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID,
+    );
+  }
+  return requestId;
+}
+
+function generateDiagnosticAgentId() {
+  // "diag-" + a UUID satisfies certops_agents.agent_id's
+  // ^[A-Za-z0-9_.:-]{1,128}$ CHECK and is unmistakable in the fleet list.
+  return `diag-${crypto.randomUUID()}`;
+}
+
+async function withTransaction(dbPool, fn) {
+  const client = await dbPool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackError) {
+      // The original error is more useful to the caller.
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Runs the whole diagnostic bootstrap in one transaction:
+ *   1. Insert the single-use request row (workspace_id, request_id). A
+ *      unique-violation on this insert means a prior call already consumed
+ *      this exact requestId, so the transaction is rolled back and the
+ *      caller sees diagnostic_bootstrap_already_consumed rather than a
+ *      replayed {agentId, credential, job}.
+ *   2. Create the certops_agents row with agent_kind = 'diagnostic'.
+ *   3. Create its protocol_smoke job (mode: dry_run) via the same
+ *      createCertificateJob used everywhere else, passing
+ *      allowDiagnosticOperation so the operation-name guard in jobs.js
+ *      lets it through.
+ *   4. Stamp the request row with the new agent/job ids (for audit and
+ *      for the orphan-retirement sweep to find this agent's job).
+ */
+async function createDiagnosticBootstrap({
+  dbPool = pool,
+  workspaceId,
+  requestId,
+  requestedByUserId = null,
+  env = process.env,
+  deps = {},
+} = {}) {
+  const ensureKey = deps.ensureActiveSigningKey || ensureActiveSigningKey;
+  const generateCredential =
+    deps.generateAgentCredential || generateAgentCredential;
+  const createJob = deps.createCertificateJob || createCertificateJob;
+  const auditWriter = deps.writeAudit || writeAudit;
+
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+  const normalizedRequestId = normalizeRequestId(requestId);
+  const ttlMs = diagnosticBootstrapTtlMs(env);
+
+  return await withTransaction(dbPool, async (client) => {
+    let requestRow;
+    try {
+      const inserted = await client.query(
+        `INSERT INTO certops_diagnostic_bootstrap_requests (
+           workspace_id, request_id, requested_by_user_id, expires_at
+         )
+         VALUES ($1, $2, $3, NOW() + make_interval(secs => $4))
+         RETURNING id`,
+        [
+          normalizedWorkspaceId,
+          normalizedRequestId,
+          requestedByUserId,
+          Math.floor(ttlMs / 1000),
+        ],
+      );
+      requestRow = inserted.rows[0];
+    } catch (error) {
+      if (
+        error?.code === "23505" &&
+        String(error.constraint || "").includes(
+          "uq_certops_diagnostic_bootstrap_workspace_request",
+        )
+      ) {
+        throw serviceError(
+          "This diagnostic bootstrap request was already consumed",
+          CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED,
+        );
+      }
+      throw error;
+    }
+
+    const signingKey = await ensureKey({ client });
+    const credential = generateCredential();
+    const agentId = generateDiagnosticAgentId();
+
+    const insertedAgent = await client.query(
+      `INSERT INTO certops_agents (
+         workspace_id,
+         agent_id,
+         name,
+         agent_version,
+         protocol_version,
+         credential_prefix,
+         credential_hash,
+         agent_kind,
+         status,
+         last_sequence,
+         capabilities_updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'diagnostic', 'active', 0, NOW())
+       RETURNING id, agent_id, protocol_version`,
+      [
+        normalizedWorkspaceId,
+        agentId,
+        "Diagnostic bootstrap client",
+        DIAGNOSTIC_AGENT_VERSION,
+        DIAGNOSTIC_PROTOCOL_VERSION,
+        credential.credentialPrefix,
+        credential.credentialHash,
+      ],
+    );
+    const agentRow = insertedAgent.rows[0];
+
+    // assignedAgentId pins the smoke job to this exact diagnostic agent so
+    // it can never be claimed by a different diagnostic agent in the same
+    // workspace; the agent_kind gate in agentDispatch.js claimJobs is the
+    // real security boundary, this is just correct routing on top of it.
+    const job = await createJob({
+      client,
+      workspaceId: normalizedWorkspaceId,
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      source: "api",
+      status: "pending",
+      executorKind: "agent",
+      assignedAgentId: agentRow.id,
+      requestedByUserId,
+      allowDiagnosticOperation: true,
+    });
+
+    await client.query(
+      `UPDATE certops_diagnostic_bootstrap_requests
+          SET agent_row_id = $2,
+              job_id = $3
+        WHERE id = $1`,
+      [requestRow.id, agentRow.id, job.id],
+    );
+
+    // The bootstrap is the moment a diagnostic client gains the right to
+    // authenticate against this workspace's agent protocol (a low-privilege
+    // right, but a real one: it can occupy the fleet list and the
+    // per-workspace rate limit), and it is the only record of who requested
+    // it. Written inside this transaction, so the agent cannot exist
+    // unaudited.
+    await auditWriter({
+      client,
+      actorUserId: requestedByUserId,
+      subjectUserId: null,
+      action: "CERTOPS_DIAGNOSTIC_AGENT_BOOTSTRAPPED",
+      targetType: "certops_agent",
+      targetId: null,
+      workspaceId: normalizedWorkspaceId,
+      metadata: {
+        agentId: agentRow.agent_id,
+        requestId: normalizedRequestId,
+        jobId: String(job.id),
+        credentialPrefix: credential.credentialPrefix,
+        signingKeyId: signingKey?.signingKeyId ?? null,
+      },
+    });
+
+    return {
+      agentId: agentRow.agent_id,
+      credential: credential.plaintextCredential,
+      protocolVersion: agentRow.protocol_version,
+      signingKeyId: signingKey?.signingKeyId ?? null,
+      signingPublicKeyPem: signingKey?.publicKeyPem ?? null,
+      job: {
+        id: String(job.id),
+        operation: job.operation,
+        mode: job.mode,
+        status: job.status,
+      },
+    };
+  });
+}
+
+module.exports = {
+  CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED,
+  CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID,
+  DEFAULT_DIAGNOSTIC_BOOTSTRAP_TTL_MS,
+  createDiagnosticBootstrap,
+  diagnosticBootstrapTtlMs,
+  _test: {
+    generateDiagnosticAgentId,
+    normalizeRequestId,
+    normalizeWorkspaceId,
+  },
+};

--- a/apps/api/services/certops/jobSigning.js
+++ b/apps/api/services/certops/jobSigning.js
@@ -351,6 +351,10 @@ async function acknowledgeSigningKey(options = {}) {
  * Retire the previous (retiring) signing key once the active fleet has
  * acknowledged the replacement, or when an operator forces incomplete
  * rotation after a grace period.
+ *
+ * The fleet count excludes diagnostic-kind agents (ADR-0012 decision 7):
+ * they are not part of production certificate work, so they must not be
+ * able to stall or distort a real rotation's completion gate.
  */
 async function completeSigningKeyRotation(options = {}) {
   const db = options.client || pool;
@@ -371,7 +375,8 @@ async function completeSigningKeyRotation(options = {}) {
   const fleet = await db.query(
     `SELECT COUNT(*)::int AS active_agents
        FROM certops_agents
-      WHERE status = 'active'`,
+      WHERE status = 'active'
+        AND agent_kind <> 'diagnostic'`,
   );
   const acks = await db.query(
     `SELECT COUNT(DISTINCT agent_id)::int AS ack_count
@@ -441,7 +446,8 @@ async function getSigningKeyRotationStatus(options = {}) {
     const fleet = await db.query(
       `SELECT COUNT(*)::int AS active_agents
          FROM certops_agents
-        WHERE status = 'active'`,
+        WHERE status = 'active'
+          AND agent_kind <> 'diagnostic'`,
     );
     const acks = await db.query(
       `SELECT COUNT(DISTINCT agent_id)::int AS ack_count

--- a/apps/api/services/certops/jobs.js
+++ b/apps/api/services/certops/jobs.js
@@ -149,6 +149,14 @@ const JOB_STATUS_TRANSITIONS = Object.freeze({
 // yet. It is a control-plane-only operation: the agent never sees it, because
 // signed dispatch translates it to the wire-level action "renew" (identical
 // execution). See docs/adr/0008-certops-upfront-issuance.md.
+// "protocol_smoke" is a diagnostic-only operation (ADR-0012 decisions 2 and
+// 7): it never touches certificate material, is only ever assigned to an
+// agent whose server-assigned agent_kind is 'diagnostic' (see
+// agentDispatch.js claimJobs), and can only be created by the dedicated
+// diagnostic-bootstrap service (createCertificateJob refuses it below), so
+// it is excluded from certificate quotas, per-CA limits, approval flows,
+// and renewal alerts by construction rather than by an operation-name
+// exclusion list scattered across those subsystems.
 const JOB_OPERATIONS = Object.freeze([
   "issue",
   "renew",
@@ -156,6 +164,7 @@ const JOB_OPERATIONS = Object.freeze([
   "reload",
   "revoke",
   "noop",
+  "protocol_smoke",
 ]);
 const JOB_OPERATION_SET = new Set(JOB_OPERATIONS);
 
@@ -637,6 +646,10 @@ const EXECUTION_FIELDS_BY_OPERATION = Object.freeze({
   reload: new Set(["reloadService", "verifyHost", "verifyPort"]),
   revoke: new Set(),
   noop: new Set(),
+  // Adds nothing certificate-shaped (packages/contracts/certops/
+  // protocol-smoke-payload.schema.json): a smoke job can never be mistaken
+  // for, or grown into, a certificate job.
+  protocol_smoke: new Set(),
 });
 
 // Fields an operation cannot function without. Only `issue` is covered today:
@@ -1338,6 +1351,40 @@ async function createCertificateJob(options) {
     CERTOPS_JOB_OPERATION_INVALID,
     "operation",
   );
+  // protocol_smoke is diagnostic-only and must never enter through the
+  // general-purpose job-creation path: allowing it here would let a
+  // protocol_smoke job pick up an approval gate, a per-CA cap check, a
+  // renewal-profile requirement, or a managed-certificate default the way
+  // any other operation can, defeating the exclusion this operation exists
+  // to have by construction. Only the diagnostic-bootstrap service
+  // (services/certops/diagnosticBootstrap.js) creates these jobs, via its
+  // own dedicated insert, and passes this flag explicitly.
+  if (operation === "protocol_smoke" && options.allowDiagnosticOperation !== true) {
+    throw serviceError(
+      "protocol_smoke jobs can only be created by the CertOps diagnostic-bootstrap service",
+      CERTOPS_JOB_OPERATION_INVALID,
+    );
+  }
+  // protocol_smoke is always dispatched dry-run (ADR-0012 decision 7): this
+  // is what makes assertModeAllowsTerminalStatus below reject a later
+  // "succeeded" report for this job, the same guard that already stops any
+  // other dry_run job from terminating that way. A caller cannot opt a
+  // smoke job into mode: "real" and reach a code path that never runs a
+  // real ACME order or filesystem write anyway.
+  if (
+    operation === "protocol_smoke" &&
+    options.mode !== undefined &&
+    options.mode !== null &&
+    options.mode !== "dry_run"
+  ) {
+    throw serviceError(
+      "protocol_smoke jobs must use mode: dry_run",
+      CERTOPS_JOB_MODE_INVALID,
+    );
+  }
+  if (operation === "protocol_smoke") {
+    options = { ...options, mode: "dry_run" };
+  }
   // Per-job approval gate: a job that requires human approval starts at
   // pending_approval and only reaches the claimable 'pending' status through
   // services/certops/jobApprovals.approveJob. The flag only chooses the

--- a/apps/api/services/rbac.js
+++ b/apps/api/services/rbac.js
@@ -46,6 +46,13 @@ const actionPolicy = {
   // host at the next renewal, so it sits above ordinary CertOps job creation
   // (workspace_manager) and alongside the kill switch.
   "certops.renewal_profile.manage": "admin",
+  // Diagnostic bootstrap mints a new machine credential and lets a
+  // reference client authenticate against this workspace's agent protocol
+  // (ADR-0012 decision 7). Low blast radius by construction (protocol_smoke
+  // only, no certificate access), but it is still credential issuance, so
+  // it sits at admin alongside the kill switch and renewal profile rather
+  // than at the workspace_manager level ordinary job creation uses.
+  "certops.agents.diagnose": "admin",
 };
 
 /**

--- a/apps/worker/src/certops-metrics.js
+++ b/apps/worker/src/certops-metrics.js
@@ -52,3 +52,10 @@ export const gCertopsRenewalScheduler = new client.Gauge({
   labelNames: ["outcome"],
   registers: [metricsRegister],
 });
+
+export const gCertopsDiagnosticAgentsRetired = new client.Gauge({
+  name: "certops_diagnostic_agents_retired",
+  help: "Diagnostic agents processed by the last inactivity-TTL sweep, by outcome",
+  labelNames: ["outcome"],
+  registers: [metricsRegister],
+});

--- a/apps/worker/src/certops-worker.js
+++ b/apps/worker/src/certops-worker.js
@@ -22,6 +22,10 @@
  *      rows (registrationCredentialCrypto.js).
  *   5. Renewal scheduler: plan renew jobs for expiring certificates
  *      (apps/api/services/certops/renewalScheduler.js).
+ *   6. Diagnostic-agent inactivity sweep: retire diagnostic agents past their
+ *      24-hour inactivity TTL via the four-branch orphan-retirement state
+ *      machine (apps/api/services/certops/agentRegistry.js, ADR-0012
+ *      decision 7).
  *
  * Zero-custody: nothing here reads or writes private key material.
  */
@@ -38,6 +42,7 @@ import {
   gCertopsRegistrationReplaysSwept,
   gCertopsRenewalJobsCreated,
   gCertopsRenewalScheduler,
+  gCertopsDiagnosticAgentsRetired,
 } from "./certops-metrics.js";
 import { safeInc } from "./shared/safeMetrics.js";
 import { createRequire } from "module";
@@ -77,6 +82,10 @@ const {
   JOB_STATUSES,
   isTerminalJobStatus,
 } = require("../../api/services/certops/jobs.js");
+
+const {
+  sweepInactiveDiagnosticAgents,
+} = require("../../api/services/certops/agentRegistry.js");
 
 const TERMINAL_JOB_STATUSES = new Set(
   JOB_STATUSES.filter((status) => isTerminalJobStatus(status)),
@@ -127,6 +136,10 @@ export const CERTOPS_SWEEP_CONFIG = Object.freeze({
   "outbox-drain": Object.freeze({
     enableEnv: "CERTOPS_SWEEP_OUTBOX_DRAIN_ENABLED",
     timeoutEnv: "CERTOPS_SWEEP_OUTBOX_DRAIN_TIMEOUT_MS",
+  }),
+  "diagnostic-agent-inactivity-sweep": Object.freeze({
+    enableEnv: "CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_ENABLED",
+    timeoutEnv: "CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_TIMEOUT_MS",
   }),
 });
 
@@ -1138,6 +1151,7 @@ export async function runCertOpsMaintenance({
   registrationReplaySweeper = sweepExpiredRegistrationReplays,
   renewalSweeper = runRenewalSchedulerSweep,
   outboxDrainer = drainCertOpsOutbox,
+  diagnosticAgentSweeper = sweepInactiveDiagnosticAgents,
   pushMetricsFn = pushMetrics,
 } = {}) {
   log.info("CertOps maintenance worker started");
@@ -1260,6 +1274,36 @@ export async function runCertOpsMaintenance({
     },
   );
 
+  // ADR-0012 decision 7: this sweep is the only path that retires a
+  // diagnostic agent past its 24-hour inactivity TTL. It is deliberately
+  // separate from the stale-agents sweep above: that one only ever flips
+  // status to 'offline' and never retires anything, for any agent kind.
+  results.diagnosticAgentInactivitySweep = await runIsolated(
+    "diagnostic-agent-inactivity-sweep",
+    log,
+    async () => {
+      const outcomes = await diagnosticAgentSweeper({ dbPool, env });
+      const retired = outcomes.filter((o) => o.retired).length;
+      const deferred = outcomes.filter((o) => o.deferred).length;
+      const errors = outcomes.filter((o) => o.error).length;
+      return { candidates: outcomes.length, retired, deferred, errors };
+    },
+    {
+      enabled: isSweepEnabled("diagnostic-agent-inactivity-sweep", env),
+      timeoutMs: resolveSweepTimeoutMs(
+        "diagnostic-agent-inactivity-sweep",
+        env,
+      ),
+    },
+  );
+  if (results.diagnosticAgentInactivitySweep.status === "success") {
+    const { retired, deferred, errors } =
+      results.diagnosticAgentInactivitySweep.result;
+    safeGaugeSet(gCertopsDiagnosticAgentsRetired, { outcome: "retired" }, retired);
+    safeGaugeSet(gCertopsDiagnosticAgentsRetired, { outcome: "deferred" }, deferred);
+    safeGaugeSet(gCertopsDiagnosticAgentsRetired, { outcome: "error" }, errors);
+  }
+
   log.info("CertOps maintenance worker finished", {
     leaseReaper:
       results.leaseReaper.status === "success"
@@ -1285,6 +1329,10 @@ export async function runCertOpsMaintenance({
       results.outboxDrain.status === "success"
         ? results.outboxDrain.result
         : results.outboxDrain.status,
+    diagnosticAgentInactivitySweep:
+      results.diagnosticAgentInactivitySweep.status === "success"
+        ? results.diagnosticAgentInactivitySweep.result
+        : results.diagnosticAgentInactivitySweep.status,
   });
 
   await pushMetricsFn("certops").catch((e) =>

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -5365,6 +5365,90 @@ paths:
                 code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/agents/diagnostic-bootstrap:
+    post:
+      tags: [CertOps]
+      summary: Bootstrap a CertOps diagnostic agent
+      operationId: createCertOpsDiagnosticBootstrap
+      description: >-
+        Session-authenticated (requires certops.agents.diagnose, admin-only).
+        Atomically consumes a single-use requestId, creates an agent with
+        agent_kind "diagnostic", and creates its protocol_smoke job, all in
+        one transaction. The response's credential is returned exactly once
+        and is not recoverable afterward. Retrying with the same requestId
+        never replays the original agentId/credential/job; it fails with
+        diagnostic_bootstrap_already_consumed. Requests are rate limited per
+        workspace. Diagnostic agents that stay inactive for 24 hours are
+        retired automatically; retirement revokes the credential in the same
+        transaction that marks the agent retired, so a retired diagnostic
+        agent's credential fails authentication immediately, not just
+        authorization.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CertOpsDiagnosticBootstrapRequest"
+      responses:
+        "201":
+          description: Diagnostic agent and its protocol_smoke job were created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsDiagnosticBootstrapResponse"
+        "400":
+          description: requestId is missing or too long
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: requestId is required and must be at most 128 characters
+                code: CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: CertOps is disabled for this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Endpoint not found
+                code: NOT_FOUND
+        "409":
+          description: This exact requestId was already consumed by a prior bootstrap call
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: This diagnostic bootstrap request was already consumed
+                code: diagnostic_bootstrap_already_consumed
+        "422":
+          description: Request rejected because it contained private key material
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Private key material is not accepted in CertOps requests
+                code: PRIVATE_KEY_MATERIAL_REJECTED
+        "429":
+          description: Diagnostic bootstrap is rate limited for this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Diagnostic agent bootstrap is rate limited for this workspace. Please wait before trying again.
+                code: CERTOPS_DIAGNOSTIC_BOOTSTRAP_RATE_LIMITED
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/certops/jobs/{jobId}/events:
     post:
       tags: [CertOps Agent]
@@ -9061,6 +9145,10 @@ components:
         status:
           type: string
           enum: [active, offline, retired]
+        agentKind:
+          type: string
+          enum: [normal, diagnostic]
+          description: Server-assigned at creation and never client-settable. A "diagnostic" agent can only ever be offered protocol_smoke jobs, regardless of what it declares in its capabilities (ADR-0012 decision 7).
         lastSeenAt:
           type: string
           format: date-time
@@ -9109,6 +9197,50 @@ components:
       properties:
         agent:
           $ref: "#/components/schemas/CertOpsWorkspaceAgent"
+    CertOpsDiagnosticBootstrapRequest:
+      type: object
+      additionalProperties: false
+      required: [requestId]
+      properties:
+        requestId:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Caller-chosen idempotency key. The same requestId can only ever succeed once; every retry after the first fails with diagnostic_bootstrap_already_consumed rather than replaying the original agent/credential/job.
+    CertOpsDiagnosticBootstrapResponse:
+      type: object
+      additionalProperties: false
+      required: [agentId, credential, protocolVersion, job]
+      properties:
+        agentId:
+          type: string
+          description: Stable protocol-level agent identifier for the new diagnostic agent.
+        credential:
+          type: string
+          description: Plaintext bearer credential for the diagnostic agent. Returned exactly once; the server stores only its hash and cannot recover it later.
+        protocolVersion:
+          type: string
+        signingKeyId:
+          type: string
+          nullable: true
+        signingPublicKeyPem:
+          type: string
+          nullable: true
+        job:
+          type: object
+          additionalProperties: false
+          required: [id, operation, mode, status]
+          properties:
+            id:
+              type: string
+            operation:
+              type: string
+              enum: [protocol_smoke]
+            mode:
+              type: string
+              enum: [dry_run]
+            status:
+              type: string
     CertOpsAgentProtocolEnvelope:
       type: object
       description: Agent-protocol message envelope. Mirrors packages/contracts/certops/agent-protocol.schema.json (the authoritative schema, additionalProperties false there); the per-messageType body is constrained in the operation-specific request schemas below. Messages never carry private key material.

--- a/tests/integration/certops-diagnostic-agent-orphan-retirement.test.js
+++ b/tests/integration/certops-diagnostic-agent-orphan-retirement.test.js
@@ -1,0 +1,501 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+
+const { pool } = require("../../apps/api/db/database");
+const {
+  claimJobs,
+} = require("../../apps/api/services/certops/agentDispatch");
+const {
+  AGENT_KIND_DIAGNOSTIC,
+  AGENT_KIND_NORMAL,
+  DIAGNOSTIC_ORPHAN_BRANCH,
+  reconcileDiagnosticAgentOrphan,
+  retireAgent,
+} = require("../../apps/api/services/certops/agentRegistry");
+const {
+  generateAgentCredential,
+  validateAgentCredential,
+} = require("../../apps/api/services/certops/agentCredentials");
+
+/**
+ * ADR-0012 decision 7 covers two boundaries that only mean something against
+ * a real database:
+ *   - the agent_kind dispatch gate (a normal agent must never be offered a
+ *     protocol_smoke job, and a diagnostic agent must never be offered a
+ *     real one, regardless of what it declares in supportedActions);
+ *   - the four-branch orphan-retirement state machine and the atomicity of
+ *     credential revocation on retire.
+ * Both live in SQL predicates (agentDispatch.js's claim query, and the
+ * single UPDATE in agentRegistry.js's retireAgent), so, like
+ * certops-issuance-claim-gating.test.js, these run against real PostgreSQL
+ * rather than a mocked pool.
+ */
+describe("CertOps diagnostic-agent isolation (real database)", function () {
+  this.timeout(60000);
+
+  let ownerId;
+  let workspaceId;
+
+  before(async () => {
+    await runMigrations();
+
+    const email = `diag-isolation-${Date.now()}-${crypto.randomUUID()}@example.com`;
+    const owner = await TestUtils.execQuery(
+      `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+       VALUES ($1, $2, 'Diagnostic Isolation', 'unused', 'local', TRUE)
+       RETURNING id`,
+      [email.toLowerCase(), email],
+    );
+    ownerId = owner.rows[0].id;
+
+    workspaceId = crypto.randomUUID();
+    await TestUtils.execQuery(
+      `INSERT INTO workspaces (id, name, created_by, plan)
+       VALUES ($1, 'Diagnostic Isolation WS', $2, 'oss')`,
+      [workspaceId, ownerId],
+    );
+  });
+
+  after(async () => {
+    if (workspaceId) {
+      await TestUtils.execQuery("DELETE FROM workspaces WHERE id = $1", [
+        workspaceId,
+      ]);
+    }
+    if (ownerId) {
+      await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+    }
+  });
+
+  async function createAgent({
+    agentKind = AGENT_KIND_NORMAL,
+    capabilities = [],
+  } = {}) {
+    const agentId = `agent-${crypto.randomUUID()}`;
+    const credential = generateAgentCredential();
+    const inserted = await TestUtils.execQuery(
+      `INSERT INTO certops_agents (
+         workspace_id, agent_id, name, agent_version, protocol_version,
+         credential_prefix, credential_hash, agent_kind, status,
+         declared_capabilities, capabilities_updated_at, last_seen_at
+       )
+       VALUES ($1, $2, 'diag-isolation-agent', '0.11.1', '1.0.0', $3, $4, $5,
+               'active', $6::jsonb, NOW(), NOW())
+       RETURNING id`,
+      [
+        workspaceId,
+        agentId,
+        credential.credentialPrefix,
+        credential.credentialHash,
+        agentKind,
+        JSON.stringify(capabilities),
+      ],
+    );
+    return {
+      id: inserted.rows[0].id,
+      agentId,
+      workspaceId,
+      agentVersion: "0.11.1",
+      protocolVersion: "1.0.0",
+      status: "active",
+      credential: credential.plaintextCredential,
+    };
+  }
+
+  async function createJob({
+    operation,
+    mode = "real",
+    status = "pending",
+    assignedAgentId = null,
+    leaseExpiresAt = null,
+  }) {
+    const inserted = await TestUtils.execQuery(
+      `INSERT INTO certificate_jobs
+         (workspace_id, operation, status, executor_kind, mode,
+          subject_type, subject_id, payload, requested_by_user_id,
+          assigned_agent_id, lease_expires_at)
+       VALUES ($1, $2, $3, 'agent', $4,
+               'managed_certificate', NULL, '{}'::jsonb, $5, $6, $7)
+       RETURNING id`,
+      [
+        workspaceId,
+        operation,
+        status,
+        mode,
+        ownerId,
+        assignedAgentId,
+        leaseExpiresAt,
+      ],
+    );
+    return inserted.rows[0].id;
+  }
+
+  async function claimJobsFull(agent, supportedActions) {
+    const result = await claimJobs({
+      dbPool: pool,
+      agent,
+      envelope: { agentId: agent.agentId, protocolVersion: "1.0.0" },
+      body: { supportedActions, maxJobs: 10 },
+      deps: {
+        enforceAgentSequence: async () => ({ sequence: 1 }),
+        signJobForDispatch: async ({ job, envelopeVersion }) => ({
+          ...job,
+          envelopeVersion,
+        }),
+      },
+    });
+    return result.jobs || [];
+  }
+
+  async function claimFor(agent, supportedActions) {
+    const jobs = await claimJobsFull(agent, supportedActions);
+    return jobs.map((job) => String(job.jobId ?? job.id));
+  }
+
+  async function jobStatus(jobId) {
+    const result = await TestUtils.execQuery(
+      `SELECT status FROM certificate_jobs WHERE id = $1`,
+      [jobId],
+    );
+    return result.rows[0]?.status || null;
+  }
+
+  async function agentRow(agentId) {
+    const result = await TestUtils.execQuery(
+      `SELECT status, credential_hash FROM certops_agents WHERE id = $1`,
+      [agentId],
+    );
+    return result.rows[0];
+  }
+
+  // --- agent_kind dispatch gate --------------------------------------------
+
+  it("never offers a protocol_smoke job to a normal agent, even declaring a matching capability", async () => {
+    const normalAgent = await createAgent({ agentKind: AGENT_KIND_NORMAL });
+    const jobId = await createJob({ operation: "protocol_smoke", mode: "dry_run" });
+
+    // supportedActions is client-supplied on every claim call; a normal agent
+    // declaring "protocol_smoke" must still never be offered the job, because
+    // the gate is agent_kind (server-assigned), not declared capabilities.
+    expect(await claimFor(normalAgent, ["protocol_smoke", "renew"])).to.not.include(
+      String(jobId),
+    );
+  });
+
+  it("never offers a real job to a diagnostic agent that clears its declaredCapabilities", async () => {
+    const diagnosticAgent = await createAgent({
+      agentKind: AGENT_KIND_DIAGNOSTIC,
+      capabilities: [],
+    });
+    const jobId = await createJob({ operation: "renew", mode: "real" });
+
+    // A diagnostic agent declaring every action it can think of, with an
+    // empty declaredCapabilities, must still never be offered a real job:
+    // agent_kind is the only thing that decides this, not what it claims.
+    expect(
+      await claimFor(diagnosticAgent, ["renew", "deploy", "reload", "revoke"]),
+    ).to.not.include(String(jobId));
+  });
+
+  it("offers a protocol_smoke job only to the diagnostic agent that declares it", async () => {
+    const diagnosticAgent = await createAgent({
+      agentKind: AGENT_KIND_DIAGNOSTIC,
+    });
+    const jobId = await createJob({ operation: "protocol_smoke", mode: "dry_run" });
+
+    expect(await claimFor(diagnosticAgent, ["protocol_smoke"])).to.include(
+      String(jobId),
+    );
+  });
+
+  // --- four-branch orphan retirement (ADR-0012 decision 7) -----------------
+
+  it("branch pending_unclaimed: cancels the job and retires the agent atomically", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "pending",
+      assignedAgentId: agent.id,
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: pending_unclaimed branch",
+    });
+
+    expect(outcome.retired).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.PENDING_UNCLAIMED);
+    expect(await jobStatus(jobId)).to.equal("cancelled");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("retired");
+  });
+
+  it("branch active_unexpired: defers and leaves the agent active", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "claimed",
+      assignedAgentId: agent.id,
+      leaseExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: active_unexpired branch",
+    });
+
+    expect(outcome.deferred).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_UNEXPIRED);
+    // Neither the job nor the agent is touched while a lease may still be
+    // held by a live client.
+    expect(await jobStatus(jobId)).to.equal("claimed");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("active");
+  });
+
+  it("branch active_expired: terminalizes the job then retires the agent", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "claimed",
+      assignedAgentId: agent.id,
+      leaseExpiresAt: new Date(Date.now() - 60 * 1000),
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: active_expired branch",
+    });
+
+    expect(outcome.retired).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_EXPIRED);
+    // A "claimed" (never reported "running") job with an expired lease is
+    // safe to cancel outright: no in-flight effect was ever reported.
+    expect(await jobStatus(jobId)).to.equal("cancelled");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("retired");
+  });
+
+  it("branch active_expired on a running job: flags needs_operator_reconciliation instead of a plain cancel", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "running",
+      assignedAgentId: agent.id,
+      leaseExpiresAt: new Date(Date.now() - 60 * 1000),
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: active_expired running branch",
+    });
+
+    expect(outcome.retired).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.ACTIVE_EXPIRED);
+    expect(await jobStatus(jobId)).to.equal("orphaned_unknown_effect");
+    const result = await TestUtils.execQuery(
+      `SELECT needs_operator_reconciliation FROM certificate_jobs WHERE id = $1`,
+      [jobId],
+    );
+    expect(result.rows[0].needs_operator_reconciliation).to.equal(true);
+  });
+
+  it("branch terminal: retires the agent normally without touching an already-terminal job", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "dry_run_complete",
+      assignedAgentId: agent.id,
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: terminal branch",
+    });
+
+    expect(outcome.retired).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.TERMINAL);
+    expect(await jobStatus(jobId)).to.equal("dry_run_complete");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("retired");
+  });
+
+  // --- reconcile atomicity (no client passed in) ---------------------------
+
+  // node-postgres' pool hands out and reuses the *same* client object across
+  // connect() calls, so patching client.query in place would leak the
+  // injected failure into whichever later test happens to draw this same
+  // client back out of the pool. Restore the original query (and release)
+  // before the client goes back to the pool, so the patch is scoped to this
+  // one checkout only.
+  function createFailingDbPool(realPool, { failOnQueryIncluding }) {
+    return {
+      async connect() {
+        const client = await realPool.connect();
+        const originalQuery = client.query.bind(client);
+        const originalRelease = client.release.bind(client);
+        client.query = (text, params) => {
+          const sql = typeof text === "string" ? text : text?.text || "";
+          if (sql.includes(failOnQueryIncluding)) {
+            return Promise.reject(
+              new Error("Injected failure for rollback test"),
+            );
+          }
+          return originalQuery(text, params);
+        };
+        client.release = (...args) => {
+          client.query = originalQuery;
+          client.release = originalRelease;
+          return originalRelease(...args);
+        };
+        return client;
+      },
+    };
+  }
+
+  it("reconcileDiagnosticAgentOrphan with no caller-supplied client still runs atomically: a failure retiring the agent rolls back the job cancellation too", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "pending",
+      assignedAgentId: agent.id,
+    });
+
+    // Fails the retireAgent UPDATE (the second write in the sequence), after
+    // the job-cancellation UPDATE has already run on the same client. If
+    // reconcileDiagnosticAgentOrphan opened its own transaction (the fix),
+    // that first write is rolled back along with the failed second one; if
+    // it did not (the bug), the job-cancellation write would have already
+    // committed on its own and would survive this failure.
+    const failingPool = createFailingDbPool(pool, {
+      failOnQueryIncluding: "SET status = 'retired'",
+    });
+
+    let caughtError = null;
+    try {
+      await reconcileDiagnosticAgentOrphan({
+        dbPool: failingPool,
+        workspaceId,
+        agentId: agent.id,
+        reason: "test: rollback on partial failure",
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).to.not.equal(null);
+    expect(caughtError.message).to.include("Injected failure");
+
+    expect(await jobStatus(jobId)).to.equal("pending");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("active");
+  });
+
+  it("reconcileDiagnosticAgentOrphan with no caller-supplied client commits both writes together on success", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+    const jobId = await createJob({
+      operation: "protocol_smoke",
+      mode: "dry_run",
+      status: "pending",
+      assignedAgentId: agent.id,
+    });
+
+    const outcome = await reconcileDiagnosticAgentOrphan({
+      dbPool: pool,
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: no-client caller still commits",
+    });
+
+    expect(outcome.retired).to.equal(true);
+    expect(outcome.branch).to.equal(DIAGNOSTIC_ORPHAN_BRANCH.PENDING_UNCLAIMED);
+    expect(await jobStatus(jobId)).to.equal("cancelled");
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("retired");
+  });
+
+  // --- credential revocation on retire (no window) --------------------------
+
+  it("fails authentication for a retired diagnostic agent's credential, not merely authorization", async () => {
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+
+    const beforeRetire = await validateAgentCredential({
+      rawCredential: agent.credential,
+    });
+    expect(beforeRetire.valid).to.equal(true);
+
+    await retireAgent({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: credential revocation on retire",
+    });
+
+    const afterRetire = await validateAgentCredential({
+      rawCredential: agent.credential,
+    });
+    expect(afterRetire.valid).to.equal(false);
+  });
+
+  it("has no window where the row reads retired but the credential still authenticates", async () => {
+    // Both the status flip and the credential_hash overwrite happen in the
+    // single UPDATE inside retireAgent (agentRegistry.js). Asserting this
+    // directly (not just by code inspection): read status and re-derive the
+    // credential validity from the same post-retire row snapshot, and prove
+    // they agree in the direction that matters (retired implies invalid).
+    const agent = await createAgent({ agentKind: AGENT_KIND_DIAGNOSTIC });
+
+    await retireAgent({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: no window between retired and credential invalid",
+    });
+
+    const row = await agentRow(agent.id);
+    expect(row.status).to.equal("retired");
+
+    const validation = await validateAgentCredential({
+      rawCredential: agent.credential,
+    });
+    expect(validation.valid).to.equal(false);
+  });
+
+  it("does not revoke a normal agent's credential on retire (frozen-retired rule)", async () => {
+    // Unlike diagnostic agents, a retired *normal* agent's credential must
+    // still authenticate (so heartbeat/claim routes can answer 410 instead
+    // of a generic 401). This pins that the diagnostic-only revocation branch
+    // in retireAgent's UPDATE ... CASE does not regress the normal-agent path.
+    const agent = await createAgent({ agentKind: AGENT_KIND_NORMAL });
+
+    await retireAgent({
+      workspaceId,
+      agentId: agent.id,
+      reason: "test: normal agent retire keeps credential",
+    });
+
+    const validation = await validateAgentCredential({
+      rawCredential: agent.credential,
+    });
+    expect(validation.valid).to.equal(true);
+    expect(validation.agent.status).to.equal("retired");
+  });
+});

--- a/tests/unit/certops-agent-lifecycle.test.js
+++ b/tests/unit/certops-agent-lifecycle.test.js
@@ -479,6 +479,10 @@ describe("CertOps agents list route", () => {
       agentVersion: "1.2.3",
       protocolVersion: "1.0.0",
       status: "active",
+      // Server-assigned, defaults to normal for every pre-existing and
+      // ordinarily-registered agent (ADR-0012 decision 7); only the
+      // diagnostic-bootstrap service ever sets this to 'diagnostic'.
+      agentKind: "normal",
       lastSeenAt: "2026-07-01T12:00:00.000Z",
       clockOffsetMs: 25,
       ntpSynced: null,

--- a/tests/unit/certops-diagnostic-agent-isolation.test.js
+++ b/tests/unit/certops-diagnostic-agent-isolation.test.js
@@ -1,0 +1,264 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { can, authorize } = require("../../apps/api/services/rbac");
+const {
+  CERTOPS_JOB_MODE_INVALID,
+  CERTOPS_JOB_MODE_TERMINAL_INVALID,
+  CERTOPS_JOB_OPERATION_INVALID,
+  assertModeAllowsTerminalStatus,
+  createCertificateJob,
+} = require("../../apps/api/services/certops/jobs");
+const {
+  CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED,
+  createDiagnosticBootstrap,
+} = require("../../apps/api/services/certops/diagnosticBootstrap");
+
+// --- certops.agents.diagnose RBAC -----------------------------------------
+//
+// The diagnostic-bootstrap route mints a new machine credential, so it is
+// admin-gated like the kill switch and renewal-profile permissions (see
+// rbac.js and certops-routes-hardening.test.js for the route-wiring half of
+// this coverage). These tests exercise the actual can()/authorize() runtime
+// behavior rather than just the route's middleware ordering.
+
+describe("certops.agents.diagnose permission", () => {
+  it("denies viewer and workspace_manager, allows admin", () => {
+    assert.equal(can("viewer", "certops.agents.diagnose"), false);
+    assert.equal(can("workspace_manager", "certops.agents.diagnose"), false);
+    assert.equal(can("admin", "certops.agents.diagnose"), true);
+  });
+
+  it("rejects a viewer-role diagnostic-bootstrap request with 403 via authorize()", () => {
+    const middleware = authorize("certops.agents.diagnose");
+    let statusCode = null;
+    let body = null;
+    const req = { authz: { workspaceRole: "viewer" } };
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        body = payload;
+        return this;
+      },
+    };
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(statusCode, 403);
+    assert.ok(body && typeof body.error === "string");
+    assert.equal(nextCalled, false);
+  });
+
+  it("lets an admin-role request through authorize()", () => {
+    const middleware = authorize("certops.agents.diagnose");
+    const req = { authz: { workspaceRole: "admin" } };
+    let nextCalled = false;
+
+    middleware(req, {}, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+  });
+});
+
+// --- protocol_smoke job creation and terminal-status guards ---------------
+
+describe("protocol_smoke job creation guard", () => {
+  it("rejects protocol_smoke through the general job-creation path", async () => {
+    await assert.rejects(
+      createCertificateJob({
+        workspaceId: "11111111-1111-1111-1111-111111111111",
+        operation: "protocol_smoke",
+      }),
+      (err) => {
+        assert.equal(err.code, CERTOPS_JOB_OPERATION_INVALID);
+        return true;
+      },
+    );
+  });
+
+  it("rejects mode: real for protocol_smoke even with allowDiagnosticOperation", async () => {
+    // This also proves allowDiagnosticOperation actually lifted the operation
+    // guard above: the rejection here is CERTOPS_JOB_MODE_INVALID, not
+    // CERTOPS_JOB_OPERATION_INVALID, so the code path reached the mode check.
+    await assert.rejects(
+      createCertificateJob({
+        workspaceId: "11111111-1111-1111-1111-111111111111",
+        operation: "protocol_smoke",
+        allowDiagnosticOperation: true,
+        mode: "real",
+      }),
+      (err) => {
+        assert.equal(err.code, CERTOPS_JOB_MODE_INVALID);
+        return true;
+      },
+    );
+  });
+});
+
+describe("protocol_smoke terminal status (always mode: dry_run)", () => {
+  it("never allows a dry_run job (protocol_smoke's only mode) to terminate as succeeded", () => {
+    assert.throws(
+      () => assertModeAllowsTerminalStatus("dry_run", "succeeded"),
+      (err) => {
+        assert.equal(err.code, CERTOPS_JOB_MODE_TERMINAL_INVALID);
+        return true;
+      },
+    );
+  });
+
+  it("allows dry_run_complete and rejected as protocol_smoke terminal outcomes", () => {
+    assert.doesNotThrow(() =>
+      assertModeAllowsTerminalStatus("dry_run", "dry_run_complete"),
+    );
+    assert.doesNotThrow(() =>
+      assertModeAllowsTerminalStatus("dry_run", "rejected"),
+    );
+  });
+});
+
+// --- diagnostic-bootstrap single-use replay --------------------------------
+//
+// createDiagnosticBootstrap runs the request-row insert, the agent insert,
+// the smoke-job insert, and the audit write inside one transaction on one
+// client (see diagnosticBootstrap.js). This mock proves the *shape* of that
+// contract at the JS level: a second call with the same requestId must hit
+// the unique-violation branch before it can create a second agent/job pair,
+// and the caller must see diagnostic_bootstrap_already_consumed, never a
+// replayed {agentId, credential, job}.
+
+function createMockDiagnosticBootstrapPool() {
+  let requestInsertCount = 0;
+  const agentInsertCalls = [];
+  const jobCreateCalls = [];
+  const queries = [];
+
+  const client = {
+    query: async (sql, params) => {
+      queries.push(sql);
+      if (/^\s*BEGIN\s*$/i.test(sql) || /^\s*COMMIT\s*$/i.test(sql) || /^\s*ROLLBACK\s*$/i.test(sql)) {
+        return { rows: [] };
+      }
+      if (sql.includes("INSERT INTO certops_diagnostic_bootstrap_requests")) {
+        requestInsertCount += 1;
+        if (requestInsertCount > 1) {
+          const error = new Error(
+            'duplicate key value violates unique constraint "uq_certops_diagnostic_bootstrap_workspace_request"',
+          );
+          error.code = "23505";
+          error.constraint = "uq_certops_diagnostic_bootstrap_workspace_request";
+          throw error;
+        }
+        return { rows: [{ id: "req-row-1" }] };
+      }
+      if (sql.includes("INSERT INTO certops_agents")) {
+        agentInsertCalls.push(params);
+        return {
+          rows: [
+            {
+              id: "agent-row-1",
+              agent_id: params[1],
+              protocol_version: params[4],
+            },
+          ],
+        };
+      }
+      if (sql.includes("UPDATE certops_diagnostic_bootstrap_requests")) {
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query in mock pool: ${sql}`);
+    },
+    release: () => {},
+  };
+
+  const dbPool = {
+    connect: async () => client,
+  };
+
+  return {
+    dbPool,
+    agentInsertCalls,
+    jobCreateCalls,
+    getRequestInsertCount: () => requestInsertCount,
+  };
+}
+
+describe("diagnostic-bootstrap single-use consumption", () => {
+  it("fails a consumed-bootstrap retry with diagnostic_bootstrap_already_consumed, without replaying agent/credential/job", async () => {
+    const mock = createMockDiagnosticBootstrapPool();
+    const deps = {
+      ensureActiveSigningKey: async () => ({
+        signingKeyId: "key-1",
+        publicKeyPem: "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----",
+      }),
+      createCertificateJob: async (options) => {
+        mock.jobCreateCalls.push(options);
+        return {
+          id: "job-1",
+          operation: "protocol_smoke",
+          mode: "dry_run",
+          status: "pending",
+        };
+      },
+      writeAudit: async () => {},
+    };
+
+    const first = await createDiagnosticBootstrap({
+      dbPool: mock.dbPool,
+      workspaceId: "22222222-2222-2222-2222-222222222222",
+      requestId: "req-abc",
+      requestedByUserId: 1,
+      deps,
+    });
+
+    assert.ok(first.agentId);
+    assert.ok(first.credential);
+    assert.equal(mock.agentInsertCalls.length, 1);
+    assert.equal(mock.jobCreateCalls.length, 1);
+
+    await assert.rejects(
+      createDiagnosticBootstrap({
+        dbPool: mock.dbPool,
+        workspaceId: "22222222-2222-2222-2222-222222222222",
+        requestId: "req-abc",
+        requestedByUserId: 1,
+        deps,
+      }),
+      (err) => {
+        assert.equal(err.code, CERTOPS_DIAGNOSTIC_BOOTSTRAP_ALREADY_CONSUMED);
+        return true;
+      },
+    );
+
+    // The retry must never reach the agent/job insert path at all: the
+    // unique violation on the request-row insert is what stops it, before
+    // any second credential could be minted.
+    assert.equal(mock.agentInsertCalls.length, 1);
+    assert.equal(mock.jobCreateCalls.length, 1);
+  });
+
+  it("rejects a requestId over 128 characters before touching the database", async () => {
+    const mock = createMockDiagnosticBootstrapPool();
+    await assert.rejects(
+      createDiagnosticBootstrap({
+        dbPool: mock.dbPool,
+        workspaceId: "22222222-2222-2222-2222-222222222222",
+        requestId: "x".repeat(129),
+      }),
+      (err) => {
+        assert.equal(err.code, "CERTOPS_DIAGNOSTIC_BOOTSTRAP_REQUEST_ID_INVALID");
+        return true;
+      },
+    );
+    assert.equal(mock.getRequestInsertCount(), 0);
+  });
+});

--- a/tests/unit/certops-issuance.test.js
+++ b/tests/unit/certops-issuance.test.js
@@ -968,12 +968,22 @@ describe("migration 34 issue job operation", () => {
     }
   });
 
-  it("accepts exactly the operations the service layer declares", () => {
+  it("accepts exactly the operations the service layer declared at the time", () => {
+    // Migration 34 is a historical snapshot: it widened the constraint to the
+    // operations the service layer declared as of that migration. Migration
+    // 40 widens the same constraint again for protocol_smoke (ADR-0012
+    // decision 7), so this assertion excludes operations introduced by later
+    // migrations rather than comparing against the current live
+    // JOB_OPERATIONS, which would make this historical test fail every time
+    // a later migration adds a new operation.
     const declared = migration.sql.match(/operation IN \(([^)]+)\)/);
     assert.ok(declared, "operation IN (...) list expected");
     const values = declared[1]
       .split(",")
       .map((entry) => entry.trim().replace(/^'|'$/g, ""));
-    assert.deepEqual([...values].sort(), [...JOB_OPERATIONS].sort());
+    const operationsAsOfMigration34 = JOB_OPERATIONS.filter(
+      (operation) => operation !== "protocol_smoke",
+    );
+    assert.deepEqual([...values].sort(), [...operationsAsOfMigration34].sort());
   });
 });

--- a/tests/unit/certops-job-signing.test.js
+++ b/tests/unit/certops-job-signing.test.js
@@ -430,6 +430,27 @@ describe("certops job signing service", () => {
       assert.equal(old.status, "retiring");
     });
 
+    it("excludes diagnostic agents from the fleet count backing the rotation gate (ADR-0012 decision 7)", async () => {
+      const client = createMemoryClient();
+      await ensureActiveSigningKey({ client });
+      await beginSigningKeyRotation({ client });
+
+      await getSigningKeyRotationStatus({ client });
+      await completeSigningKeyRotation({ client, force: true });
+
+      const fleetQueries = client.queries.filter((entry) =>
+        entry.sql.includes("FROM certops_agents"),
+      );
+      assert.ok(fleetQueries.length > 0, "expected at least one fleet query");
+      for (const entry of fleetQueries) {
+        assert.match(
+          entry.sql,
+          /agent_kind\s*<>\s*'diagnostic'/,
+          `fleet query must exclude diagnostic agents: ${entry.sql}`,
+        );
+      }
+    });
+
     it("completes once the whole fleet acknowledged the new key", async () => {
       const client = createMemoryClient();
       await ensureActiveSigningKey({ client });

--- a/tests/unit/certops-machine-token-rate-limit.test.js
+++ b/tests/unit/certops-machine-token-rate-limit.test.js
@@ -424,6 +424,81 @@ describe("CertOps machine-token rate limiter", () => {
     }
   });
 
+  it("extracts the public prefix from agent bootstrap tokens and agent credentials, not just ttx_", () => {
+    const bootstrapToken = `ttboot_${TOKEN_ID}_${TOKEN_SECRET}`;
+    const credentialToken = `ttagent_${TOKEN_ID}_${TOKEN_SECRET}`;
+
+    assert.equal(
+      tokenPrefixFromAuthorization(
+        createRequest({ authorization: `Bearer ${bootstrapToken}` }),
+      ),
+      `ttboot_${TOKEN_ID}`,
+    );
+    assert.equal(
+      tokenPrefixFromAuthorization(
+        createRequest({ authorization: `Bearer ${credentialToken}` }),
+      ),
+      `ttagent_${TOKEN_ID}`,
+    );
+
+    for (const authorization of [
+      `Bearer ttboot__${TOKEN_SECRET}`,
+      `Bearer ttagent_${TOKEN_ID}_`,
+      `Bearer TTBOOT_${TOKEN_ID}_${TOKEN_SECRET}`,
+      `Bearer ttagent_${TOKEN_ID}_${"A".repeat(64)}`,
+    ]) {
+      assert.equal(
+        tokenPrefixFromAuthorization(createRequest({ authorization })),
+        null,
+      );
+    }
+  });
+
+  // Regression for the CertOps agent register/claim lockout: those routes
+  // authenticate with a bootstrap token (ttboot_) or an agent credential
+  // (ttagent_), never a workspace API token (ttx_), and never carry a
+  // :workspaceId route param. Before tokenPrefixFromAuthorization recognized
+  // those two token shapes, every pre-auth call on those routes fell through
+  // to the IP-only fallback, so two entirely different agents (different
+  // bootstrap tokens, different workspaces) calling register from behind the
+  // same IP collided on one shared bucket and could lock each other out
+  // despite neither one having exceeded its own budget.
+  it("does not let two different agent bootstrap tokens behind the same IP lock each other out", async () => {
+    const middleware = createCertOpsMachineTokenPreAuthRateLimit({ max: 1 });
+    const sharedIp = "203.0.113.55";
+    const firstAgentRegister = createRequest({
+      authorization: `Bearer ttboot_${TOKEN_ID}_${TOKEN_SECRET}`,
+      ip: sharedIp,
+      path: "/api/v1/certops/agent/register",
+      originalUrl: "/api/v1/certops/agent/register",
+      baseUrl: "",
+      route: { path: "/api/v1/certops/agent/register" },
+    });
+    const secondAgentRegister = createRequest({
+      authorization: `Bearer ttboot_fedcba9876543210_${TOKEN_SECRET}`,
+      ip: sharedIp,
+      path: "/api/v1/certops/agent/register",
+      originalUrl: "/api/v1/certops/agent/register",
+      baseUrl: "",
+      route: { path: "/api/v1/certops/agent/register" },
+    });
+
+    assert.equal(
+      (await runMiddleware(middleware, firstAgentRegister)).nextCalled,
+      true,
+    );
+    // A second, distinct bootstrap token from the same IP must still get
+    // through: it is a different caller, not a retry of the first one.
+    assert.equal(
+      (await runMiddleware(middleware, secondAgentRegister)).nextCalled,
+      true,
+    );
+
+    // The first token's own retry is still correctly rate limited once it
+    // is over its own budget (real protection is preserved).
+    assertRateLimited(await runMiddleware(middleware, firstAgentRegister));
+  });
+
   it("uses public prefix or IP fallback for pre-auth keys without retaining raw authorization", () => {
     const validKey = machineTokenPreAuthRateLimitKey(
       createRequest({

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -166,6 +166,7 @@ describe("CertOps route hardening", () => {
       "POST /api/v1/workspaces/:id/certops/agent-bootstrap-tokens",
       "POST /api/v1/workspaces/:id/certops/agent-bootstrap-tokens/:tokenId/revoke",
       "POST /api/v1/workspaces/:id/certops/agents/:agentId/retire",
+      "POST /api/v1/workspaces/:id/certops/agents/diagnostic-bootstrap",
       "POST /api/v1/workspaces/:id/certops/certificates",
       "POST /api/v1/workspaces/:id/certops/certificates/:certId/renewal-setup",
       "POST /api/v1/workspaces/:id/certops/certificates/:certId/retire",
@@ -838,6 +839,61 @@ describe("CertOps route hardening", () => {
         `${routePath} is a passive read and must remain available while paused`,
       );
     }
+  });
+
+  it("gates diagnostic-bootstrap on admin role, a human session, and its own rate limiter", () => {
+    // Bootstrap mints a new machine credential (ADR-0012 decision 7), so it
+    // needs the same "human session, not a worker credential" posture as the
+    // kill switch and renewal profile, plus a workspace-scoped rate limiter
+    // dedicated to this route (not the general API limiter alone).
+    const block = routeBlock(
+      "post",
+      "/api/v1/workspaces/:id/certops/agents/diagnostic-bootstrap",
+    );
+    assert.match(block, /authorize\("certops\.agents\.diagnose"\)/);
+    assert.match(block, /requireCertOpsSessionUser/);
+    assert.match(block, /getDiagnosticBootstrapLimiter\(\)/);
+    assert.ok(
+      block.indexOf("rejectKeyMaterial") <
+        block.indexOf("requireCertOpsSessionUser"),
+      "diagnostic-bootstrap must reject private key material before session-user denial",
+    );
+    assert.ok(
+      block.indexOf("requireCertOpsEnabled") <
+        block.indexOf("requireCertOpsSessionUser"),
+      "diagnostic-bootstrap must check the rollout gate before session-user denial",
+    );
+    assert.ok(
+      block.indexOf("requireCertOpsSessionUser") <
+        block.indexOf('authorize("certops.agents.diagnose")'),
+      "diagnostic-bootstrap must require a human session before role authorization",
+    );
+  });
+
+  it("documents diagnostic-bootstrap and the admin RBAC entry backing it", () => {
+    assertOpenApiRoute(
+      "/api/v1/workspaces/{id}/certops/agents/diagnostic-bootstrap",
+      "POST",
+    );
+    for (const schemaName of [
+      "CertOpsDiagnosticBootstrapRequest",
+      "CertOpsDiagnosticBootstrapResponse",
+    ]) {
+      assert.ok(
+        openApiSource.includes(`    ${schemaName}:`),
+        `${schemaName} must be defined under components.schemas`,
+      );
+    }
+
+    const rbacSource = fs.readFileSync(
+      path.resolve(__dirname, "../../apps/api/services/rbac.js"),
+      "utf8",
+    );
+    assert.match(
+      rbacSource,
+      /"certops\.agents\.diagnose":\s*"admin"/,
+      "diagnostic bootstrap mints a new machine credential, so it must be admin-gated",
+    );
   });
 
   it("keeps token and agent-bootstrap-token revoke/retire available while paused", () => {


### PR DESCRIPTION
## Summary
- Diagnostic-agent isolation (ADR-0012 decisions 2 and 7): a dedicated `protocol_smoke` job operation and `certops_agents.agent_kind` (`normal` | `diagnostic`), server-assigned exactly once at row creation with no update path afterward.
- `POST .../certops/agents/diagnostic-bootstrap`: session-authenticated, single-use, non-replayable route (`certops_diagnostic_bootstrap_requests`, unique on `(workspace_id, request_id)`) that mints a diagnostic agent, a credential, and its one `protocol_smoke` job in a single transaction. A consumed retry fails with `diagnostic_bootstrap_already_consumed` rather than replaying.
- Four-branch orphan retirement sweep in the worker: a diagnostic agent that never heartbeats again is retired, its credential revoked, and its bootstrap record's `agent_row_id`/`job_id` cleared.
- `certops.agents.diagnose` RBAC permission at the `admin` level (credential issuance, same tier as the kill switch and renewal-profile management), plus rate limiting on the bootstrap route.
- `protocol_smoke` jobs are excluded by construction from certificate quotas, per-CA limits, approval flows, renewal alerts, and fleet-health metrics, since `createCertificateJob` refuses the operation outside the dedicated bootstrap path.

## Test plan
- [x] Unit tests: diagnostic-agent isolation, single-use bootstrap consumption, orphan-retirement state machine.
- [x] Integration tests: four-branch orphan retirement, including credential revocation on retire.
- [x] `pnpm run test:unit` passes.
- [x] `pnpm run lint:api` passes (0 errors).
- [x] `pnpm run verify:ci-guards` passes.

## Stack
Base: #118 (`certops/signed-dispatch-envelope-v2`). Independent of #121 (`certops/agent-id-required`) and of #117   neither touches this branch's migrations. `certops/windows-target-schemas` stacks on top of this branch instead, since it reuses migration numbers 40-41.
