### PR TITLE
fix(certops): add visible focus indicator to CertOps sub-nav tabs

### DIFF
--- a/apps/dashboard/src/pages/certops/CertOpsLayout.jsx
+++ b/apps/dashboard/src/pages/certops/CertOpsLayout.jsx
@@ -74,6 +74,11 @@ function CertOpsSubNav() {
             borderColor={border}
             _hover={{ bg: hoverBg, textDecoration: 'none' }}
             _activeLink={{ bg: activeBg, color: 'white' }}
+            _focusVisible={{
+              boxShadow: 'outline',
+              zIndex: 1,
+              textDecoration: 'none',
+            }}
           >
             {tab.label}
           </Box>

--- a/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
@@ -104,7 +104,7 @@ describe('EvidenceTimeline', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders an unknown future evidence/event type as a safe fallback without a raw JSON dump or secret leak (ARC-19)', () => {
+  it('renders an unknown future evidence/event type as a safe fallback without a raw JSON dump or secret leak', () => {
     useCertOpsJobTimelineMock.mockReturnValue({
       job: baseJob(),
       logEntries: [

--- a/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
@@ -104,6 +104,63 @@ describe('EvidenceTimeline', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders an unknown future evidence/event type as a safe fallback without a raw JSON dump or secret leak (ARC-19)', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [
+        {
+          id: 'log-1',
+          eventType: 'job.some_future_event_type_v9',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          message: 'Unrecognized event occurred',
+          metadata: {
+            apiKey: 'sk_live_should_never_render_1234567890',
+            nested: { password: 'super-secret-password' },
+          },
+        },
+      ],
+      evidence: [
+        {
+          id: 'ev-1',
+          evidenceType: 'future.unknown_evidence_kind',
+          observedAt: '2026-01-02T00:00:00.000Z',
+          subjectType: 'certificate',
+          subjectId: 'cert-1',
+          metadata: {
+            token: 'ttagent_should_never_render_abcdef',
+            credential: { secret: 'do-not-leak-me' },
+          },
+        },
+      ],
+      loading: false,
+      error: '',
+    });
+
+    // Must not throw for an unrecognized type.
+    expect(() =>
+      renderWithProviders(<EvidenceTimeline jobId='job-1' />)
+    ).not.toThrow();
+
+    // Falls back to the raw type string as a label (bounded fallback), not a crash or blank render.
+    expect(
+      screen.getAllByText('job.some_future_event_type_v9').length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('future.unknown_evidence_kind').length
+    ).toBeGreaterThan(0);
+
+    // Never dumps the raw metadata object (which would include the key names/JSON braces).
+    expect(screen.queryByText(/apiKey/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/credential/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\{.*apiKey.*\}/)).not.toBeInTheDocument();
+
+    // Never leaks the actual secret values anywhere in the rendered output.
+    expect(screen.queryByText(/sk_live_should_never_render/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/super-secret-password/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ttagent_should_never_render/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/do-not-leak-me/)).not.toBeInTheDocument();
+  });
+
   it('renders merged log and evidence items in chronological order', () => {
     useCertOpsJobTimelineMock.mockReturnValue({
       job: baseJob(),


### PR DESCRIPTION
## What

Two fixes found while verifying CertOps dashboard accessibility and UI-residue behavior:

1. **CertOps sub-nav tabs had no visible keyboard-focus indicator** (WCAG 2.4.7 violation). `CertOpsSubNav` in `apps/dashboard/src/pages/certops/CertOpsLayout.jsx` styled `_hover` and `_activeLink` but never `_focusVisible`, so keyboard users got no indication of which tab was focused, unlike every other interactive control in the app (buttons, selects) which already carry Chakra's `:focus-visible` outline ring. Fixed by adding the same `_focusVisible={{ boxShadow: 'outline', zIndex: 1, textDecoration: 'none' }}` pattern already used elsewhere.
2. **Strengthened the `EvidenceTimeline` unknown-event-type test.** Added an explicit assertion that an unrecognized event/evidence type renders a bounded fallback label rather than dumping raw metadata or leaking a secret value.

## Why

Found via a live CDP accessibility audit (before/after focus-ring comparison); no existing automated a11y gate in this repo would have caught it (searched CI config and `package.json` for axe/pa11y/lighthouse -- none exist, a separate infrastructure gap noted but out of scope for this PR).

## Test plan

- [x] Full dashboard suite (398 tests, 39 files) passes with no regressions
- [x] Verified via CDP that the generated CSS now carries a `:focus-visible` rule matching the rest of the app
- [ ] CI green on this branch
