### PR TITLE
fix(certops): close ARC-01..ARC-10 zero-custody detector and redaction gaps

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -27,6 +27,7 @@ const {
   CERTOPS_CERTIFICATE_STATUS_INVALID,
   CERTOPS_KEY_MODE_INVALID,
   CERTOPS_KEY_REFERENCE_INVALID,
+  CERTOPS_SOURCE_REF_INVALID,
   getManagedCertificate,
   importPublicCertificates,
   listCertificateInstances,
@@ -354,6 +355,13 @@ function handleCertOpsError(res, err) {
     return res.status(400).json({
       error: "keyReference must be a non-secret reference",
       code: CERTOPS_KEY_REFERENCE_INVALID,
+    });
+  }
+
+  if (err?.code === CERTOPS_SOURCE_REF_INVALID) {
+    return res.status(400).json({
+      error: "sourceRef must be a non-secret reference",
+      code: CERTOPS_SOURCE_REF_INVALID,
     });
   }
 

--- a/apps/api/services/certops/inventory.js
+++ b/apps/api/services/certops/inventory.js
@@ -6,7 +6,7 @@ const {
   PRIVATE_KEY_MATERIAL_REJECTED,
   parsePublicCertificateMaterial,
 } = require("./parser");
-const { containsPrivateKeyMaterial } = require("../../utils/secretMaterial");
+const { containsPrivateKeyMaterial, containsGenericSecretMaterial } = require("../../utils/secretMaterial");
 
 const CERTOPS_CERTIFICATE_NOT_FOUND = "CERTOPS_CERTIFICATE_NOT_FOUND";
 const CERTOPS_CERTIFICATE_RETIRE_REASON_INVALID =
@@ -63,6 +63,78 @@ const PEM_MARKER_PATTERN = /-----\s*(?:BEGIN|END)\b/i;
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(?:password|secret|token|credential|private_key|privatekey|key_material)\s*=/i;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+// C2 (zero-custody): keyReference is a material-locality pointer, not free
+// text -- it answers which execution plane holds the key, never where to
+// open it. A bare credential (GitHub PAT, AWS access key, Slack token, JWT,
+// high-entropy password) has none of these scheme prefixes, so allow-listing
+// them rejects most bare-credential shapes outright without needing the
+// secret detector at all. Every prefix here is evidenced elsewhere in this
+// codebase: `file://` and `k8s:` are emitted by the shipped agent/controller
+// observation writers (agentObservations.js, controllerProvisioning.js,
+// controllerObservations.js); `vault:`, `hsm:`, and `external-unknown:` are
+// exercised by tests/integration/certops-inventory.test.js; `pkcs11:` is the
+// URI format the import UI documents (ImportCertificateForm.jsx).
+const KEY_REFERENCE_ALLOWED_SCHEME_PREFIXES = Object.freeze([
+  "file://",
+  "k8s:",
+  "vault:",
+  "hsm:",
+  "external-unknown:",
+  "pkcs11:",
+]);
+
+// RFC 7512 PKCS#11 URI attribute keys. All of them are structural
+// identifiers (a token label, a slot number, an object label, a module
+// path...) and none of them ever carries the key material itself. This
+// allow-list intentionally omits `pin-value`: RFC 7512 defines that query
+// attribute as an inline PIN, which is exactly the kind of secret this
+// validator must keep rejecting even inside an otherwise well-formed URI.
+const PKCS11_URI_SAFE_ATTRIBUTE_KEYS = new Set([
+  "token",
+  "manufacturer",
+  "serial",
+  "model",
+  "library-manufacturer",
+  "library-description",
+  "library-version",
+  "object",
+  "type",
+  "id",
+  "slot-id",
+  "slot-manufacturer",
+  "slot-description",
+  "module-name",
+  "module-path",
+  "pin-source",
+]);
+
+/**
+ * True if `value` is a `pkcs11:` URI built exclusively from RFC 7512
+ * attribute keys that never carry secret material. Used to exempt the
+ * generic secret-assignment checks from firing on the URI's own structural
+ * syntax (its `token=<label>` attribute textually matches a "token
+ * assignment," but the label is not a credential).
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isSafePkcs11Uri(value) {
+  const body = value.slice("pkcs11:".length);
+  const [pathPart, queryPart] = body.split("?");
+  const segments = [
+    ...(pathPart ? pathPart.split(";") : []),
+    ...(queryPart ? queryPart.split("&") : []),
+  ];
+  let sawAttribute = false;
+  for (const segment of segments) {
+    if (!segment) continue;
+    const separatorIndex = segment.indexOf("=");
+    if (separatorIndex <= 0) return false;
+    const key = segment.slice(0, separatorIndex).toLowerCase();
+    if (!PKCS11_URI_SAFE_ATTRIBUTE_KEYS.has(key)) return false;
+    sawAttribute = true;
+  }
+  return sawAttribute;
+}
 const RETIRE_STATUSES = new Set(["revoked", "decommissioned"]);
 const RETIRE_STATUS_SQL_LIST = "'revoked', 'decommissioned'";
 
@@ -203,6 +275,46 @@ function keyReferenceError() {
   return err;
 }
 
+// sourceRef is documented in the OpenAPI contract as an "opaque non-secret
+// source reference" (packages/contracts/openapi/openapi.yaml), but unlike
+// keyReference it has no scheme allow-list: it is free text describing where
+// an observation came from (an import job id, a monitor URL, a
+// cert-manager resource name...), not a material-locality pointer. It still
+// gets persisted verbatim and echoed back in API responses, so the same
+// content-based private-key and generic-secret checks that guard
+// keyReference apply here too, just without the scheme requirement.
+const SOURCE_REF_MAX_LENGTH = 512;
+const CERTOPS_SOURCE_REF_INVALID = "CERTOPS_SOURCE_REF_INVALID";
+
+function sourceRefError() {
+  const err = new Error("CertOps sourceRef must be a non-secret reference");
+  err.code = CERTOPS_SOURCE_REF_INVALID;
+  return err;
+}
+
+function normalizeSourceRef(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw sourceRefError();
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > SOURCE_REF_MAX_LENGTH) throw sourceRefError();
+  if (containsPrivateKeyMaterial(trimmed)) throw sourceRefError();
+  if (PEM_MARKER_PATTERN.test(trimmed)) throw sourceRefError();
+  if (CONTROL_CHARACTER_PATTERN.test(trimmed)) throw sourceRefError();
+  if (SECRET_ASSIGNMENT_PATTERN.test(trimmed)) throw sourceRefError();
+  if (containsGenericSecretMaterial(trimmed)) throw sourceRefError();
+
+  return trimmed;
+}
+
+function keyReferenceSchemePrefix(value) {
+  return (
+    KEY_REFERENCE_ALLOWED_SCHEME_PREFIXES.find((prefix) => value.startsWith(prefix)) ||
+    null
+  );
+}
+
 function normalizeKeyReference(value) {
   if (value === undefined || value === null) return null;
   if (typeof value !== "string") throw keyReferenceError();
@@ -212,8 +324,30 @@ function normalizeKeyReference(value) {
   if (trimmed.length > KEY_REFERENCE_MAX_LENGTH) throw keyReferenceError();
   if (containsPrivateKeyMaterial(trimmed)) throw keyReferenceError();
   if (PEM_MARKER_PATTERN.test(trimmed)) throw keyReferenceError();
-  if (SECRET_ASSIGNMENT_PATTERN.test(trimmed)) throw keyReferenceError();
   if (CONTROL_CHARACTER_PATTERN.test(trimmed)) throw keyReferenceError();
+
+  const schemePrefix = keyReferenceSchemePrefix(trimmed);
+  if (!schemePrefix) throw keyReferenceError();
+
+  // A well-formed `pkcs11:` URI textually contains `token=<label>` (RFC
+  // 7512), which otherwise reads exactly like the "secret assignment" shape
+  // both checks below exist to catch. Recognizing the URI structurally, and
+  // requiring every one of its attributes to come from the safe RFC 7512 set
+  // (never `pin-value`), lets a real PKCS#11 reference through without
+  // weakening those checks for anything else.
+  if (schemePrefix === "pkcs11:" && isSafePkcs11Uri(trimmed)) {
+    return trimmed;
+  }
+
+  // Scheme-allowlisting and the generic-secret checks are not alternatives;
+  // both apply, in that order. A value can be scheme-valid and still carry a
+  // credential-shaped payload after the prefix (for example
+  // "vault://pki/Authorization: Bearer <token>"), so both the narrow
+  // assignment pattern and the full generic-secret detector run against the
+  // portion after the scheme, without ever echoing the rejected value back.
+  const remainder = trimmed.slice(schemePrefix.length);
+  if (SECRET_ASSIGNMENT_PATTERN.test(remainder)) throw keyReferenceError();
+  if (containsGenericSecretMaterial(remainder)) throw keyReferenceError();
 
   return trimmed;
 }
@@ -640,7 +774,7 @@ async function upsertManagedCertificate(client, certificate, options, chainIndex
     options.tokenId || null,
     options.status || "discovered",
     options.source || "import",
-    options.sourceRef || null,
+    normalizeSourceRef(options.sourceRef),
     chooseCertificateName(certificate, options.name),
     certificate.commonName || null,
     certificate.subjectAltNames || [],
@@ -754,7 +888,7 @@ async function upsertManagedCertificateByMonitorSource(
   options,
   chainIndex,
 ) {
-  const sourceRef = options.sourceRef || null;
+  const sourceRef = normalizeSourceRef(options.sourceRef);
   if (!sourceRef) {
     throw new Error("sourceRef is required for monitor-source upsert");
   }
@@ -876,7 +1010,7 @@ async function upsertManagedCertificateByMonitorSource(
  * Mirrors cert-manager target upsert identity semantics.
  */
 async function upsertAgentFilesystemTarget(client, options) {
-  const sourceRef = options.sourceRef || null;
+  const sourceRef = normalizeSourceRef(options.sourceRef);
   if (!sourceRef) {
     throw new Error("sourceRef is required for agent filesystem target upsert");
   }
@@ -934,7 +1068,7 @@ async function upsertAgentFilesystemInstance(client, options) {
       options.managedCertificateId,
       options.targetId,
       options.status || "discovered",
-      options.sourceRef || null,
+      normalizeSourceRef(options.sourceRef),
       options.fingerprintSha256,
       options.serialNumber || null,
       options.subject || null,
@@ -955,7 +1089,7 @@ async function upsertAgentFilesystemInstance(client, options) {
  * or observation metadata that a cert-manager observer has already recorded.
  */
 async function upsertManagedCertificateForControllerProvisioning(client, options) {
-  const sourceRef = options.sourceRef || null;
+  const sourceRef = normalizeSourceRef(options.sourceRef);
   if (!sourceRef) {
     throw new Error("sourceRef is required for controller provisioning upsert");
   }
@@ -1447,6 +1581,9 @@ module.exports = {
   CERTOPS_CERTIFICATE_STATUS_INVALID,
   CERTOPS_KEY_MODE_INVALID,
   CERTOPS_KEY_REFERENCE_INVALID,
+  CERTOPS_SOURCE_REF_INVALID,
+  KEY_REFERENCE_MAX_LENGTH,
+  SOURCE_REF_MAX_LENGTH,
   MANAGED_CERTIFICATE_SOURCES,
   MANAGED_CERTIFICATE_STATUSES,
   PRIVATE_KEY_MATERIAL_REJECTED,
@@ -1470,6 +1607,7 @@ module.exports = {
   managedCertificateFilterSql,
   normalizeKeyMode,
   normalizeKeyReference,
+  normalizeSourceRef,
   normalizeLimit,
   normalizeOffset,
   retireManagedCertificate,

--- a/apps/dashboard/src/components/certops/ImportCertificateForm.jsx
+++ b/apps/dashboard/src/components/certops/ImportCertificateForm.jsx
@@ -224,7 +224,7 @@ const ImportCertificateForm = forwardRef(function ImportCertificateForm(
             setKeyReference(event.target.value);
             if (scanError) setScanError('');
           }}
-          placeholder='e.g. agent-id:/etc/ssl/private/wildcard.key or pkcs11 URI'
+          placeholder='e.g. vault://pki/web-wildcard or pkcs11:token=HSM-1;object=web-wildcard'
           rows={2}
           fontFamily='mono'
           fontSize='sm'

--- a/docs/certops/CONTEXT.md
+++ b/docs/certops/CONTEXT.md
@@ -21,6 +21,18 @@ Field-name redaction and explicit sanitized logging are wired for the current
 inventory boundary paths. A broader logger content-scrub layer for arbitrary log
 message content is a follow-up, not something the inventory assumes globally.
 
+Content-based detection also covers compressed input: a base64/hex-decoded or
+raw buffer that begins with a recognized gzip/zlib header is decompressed once
+and the result is scanned in its place, subject to compressed-length and
+decompressed-output ceilings (`classifyCompressedBuffer` in
+`packages/log-scrub/secret-material.js`). If that decompressed output is
+itself gzip/zlib-shaped (nested compression), the detector fails closed and
+rejects the input outright rather than unwrapping a second time and treating
+the result as ordinary scannable plaintext. Silently unwrapping nested
+compression would let an attacker hide key material below the ratio/size
+ceilings applied to the outer layer, which is exactly the kind of silent
+fall-through this invariant does not allow.
+
 The one private key the platform does hold is the platform operational signing
 key (Ed25519) used to sign jobs. It is never used for certificate issuance and
 never holds customer key material. See ADR-0003.

--- a/packages/agent/src/claimed-job/index.js
+++ b/packages/agent/src/claimed-job/index.js
@@ -110,7 +110,7 @@ function validateClaimedJob(job) {
   requireDate(job.requestedAt, "requestedAt");
 
   if (job.tokenId !== undefined && job.tokenId !== null && (!Number.isInteger(job.tokenId) || job.tokenId < 1)) fail("tokenId is invalid");
-  if (job.keyReference !== undefined && job.keyReference !== null) requireString(job.keyReference, "keyReference", { max: 512 });
+  if (job.keyReference !== undefined && job.keyReference !== null) requireString(job.keyReference, "keyReference", { max: 256 });
   if (job.requestedBy !== undefined && job.requestedBy !== null) {
     requireExactKeys(job.requestedBy, new Set(["actorType", "actorId", "displayName"]), ["actorType"], "requestedBy");
     if (!["user", "system", "automation"].includes(job.requestedBy.actorType)) fail("requestedBy.actorType is invalid");

--- a/packages/agent/vendor/log-scrub/secret-material.js
+++ b/packages/agent/vendor/log-scrub/secret-material.js
@@ -34,23 +34,29 @@ const zlib = require("zlib");
  *
  * Compressed input: a base64/base64url/hex-decoded (or raw) buffer that begins
  * with a recognized gzip (`1F 8B`) or RFC 1950 zlib header is decompressed
- * exactly once (never recursively) and the result is scanned in its place.
- * Recognition of a zlib header is algorithmic against the two-byte header
- * (CMF, FLG), not an enumerated allow-list of common compression-level byte
- * pairs, so a smaller window size or a set preset-dictionary flag is still
- * recognized as compressed input. Two independent bounds apply once a
- * recognized header is found: the compressed buffer itself must not exceed
+ * exactly once and the result is scanned in its place. Recognition of a zlib
+ * header is algorithmic against the two-byte header (CMF, FLG), not an
+ * enumerated allow-list of common compression-level byte pairs, so a smaller
+ * window size or a set preset-dictionary flag is still recognized as
+ * compressed input. Two independent bounds apply once a recognized header is
+ * found: the compressed buffer itself must not exceed
  * `MAX_COMPRESSED_INPUT_LENGTH`, and the decompression call's own output-size
  * parameter is capped to `min(MAX_DECOMPRESSED_OUTPUT_LENGTH, compressedLength
  * * DECOMPRESSED_OUTPUT_RATIO)` so the library itself refuses to materialize a
  * decompression bomb. A stream with the preset-dictionary flag (`FDICT`) set,
- * a stream whose compressed length or decoded-output bound is exceeded, and a
- * stream that presents a valid header but fails to decompress cleanly all
- * report the same fail-closed outcome as detected key material, never a
- * silent fall-through to the ordinary content scan. A buffer with neither
- * recognized header proceeds directly to the ordinary scan: that is the
- * default path for the overwhelming majority of legitimate, uncompressed
- * base64 traffic and is not itself a failure mode.
+ * a stream whose compressed length or decoded-output bound is exceeded, a
+ * stream that presents a valid header but fails to decompress cleanly, and a
+ * stream whose decompressed output is itself gzip/zlib-shaped (nested
+ * compression) all report the same fail-closed outcome as detected key
+ * material, never a silent fall-through to the ordinary content scan.
+ * Rejecting nested compression outright (rather than unwrapping a second
+ * time) closes an evasion path where an attacker gzips a payload twice to
+ * slip key material past the ratio/size ceilings on the outer layer while
+ * the inner layer, which actually holds the material, never gets bounds-
+ * checked or scanned. A buffer with neither recognized header proceeds
+ * directly to the ordinary scan: that is the default path for the
+ * overwhelming majority of legitimate, uncompressed base64 traffic and is
+ * not itself a failure mode.
  */
 
 const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
@@ -583,11 +589,16 @@ const COMPRESSION_CLASSIFICATION = Object.freeze({
 
 /**
  * Classifies a buffer for the compressed-input branch. Two outcomes besides
- * "not compressed": a single successful decompression pass (never re-fed
- * into this function, closing the bomb-inside-bomb vector), or a fail-closed
- * rejection covering an oversized compressed buffer, a preset-dictionary
- * (`FDICT`) stream, a bound-exceeding decompression, and a stream that
- * presents a valid header but fails to decompress. `FDICT` is external
+ * "not compressed": a single successful decompression pass whose output is
+ * itself not compressed, or a fail-closed rejection covering an oversized
+ * compressed buffer, a preset-dictionary (`FDICT`) stream, a bound-exceeding
+ * decompression, a stream that presents a valid header but fails to
+ * decompress, and a stream whose decompressed output is itself gzip/zlib-
+ * shaped. That last case is deliberate: unwrapping a second time would let
+ * an attacker nest compression to hide key material below the ratio/size
+ * ceilings applied to the outer layer, or simply to waste CPU, so nested
+ * compression is treated the same as any other suspicious input and
+ * rejected rather than recursively decompressed. `FDICT` is external
  * material this detector does not have, so decompression is never attempted
  * for it; the caller must not treat REJECTED as "not found."
  * @param {Buffer} buffer
@@ -621,6 +632,11 @@ function classifyCompressedBuffer(buffer) {
     const decoded = isGzip
       ? zlib.gunzipSync(buffer, { maxOutputLength })
       : zlib.inflateSync(buffer, { maxOutputLength });
+    if (looksGzipHeader(decoded) || looksZlibHeader(decoded)) {
+      // Nested compression (gzip-of-gzip, zlib-of-gzip, etc.): fail closed
+      // instead of unwrapping again. See the function-level note above.
+      return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+    }
     return { classification: COMPRESSION_CLASSIFICATION.DECOMPRESSED, decoded };
   } catch (_err) {
     // Covers both a corrupt/truncated stream and the library refusing to

--- a/packages/agent/vendor/log-scrub/secret-material.js
+++ b/packages/agent/vendor/log-scrub/secret-material.js
@@ -6,6 +6,8 @@
  */
 "use strict";
 
+const zlib = require("zlib");
+
 /**
  * TokenTimer shared secret-material detector.
  *
@@ -21,14 +23,34 @@
  *   - private key material  -> REJECT (hard 422 at the API boundary)
  *   - other generic secrets -> REDACT (so legitimate operational output is kept)
  *
- * Scope note: PEM private-key blocks (all common variants), base64-wrapped PEM,
- * PKCS#8/PKCS#1/SEC1 DER private keys, PKCS#12/PFX-like DER bundles, and JKS
- * keystores (by magic header) are detected here. PKCS#12/PFX detection is
- * intentionally a conservative structural sniff for the PFX version field, not
- * a full ASN.1 parser; JKS detection is likewise a magic-header sniff rather
- * than a full keystore parser; a JKS container is rejected outright since its
- * entire purpose is to hold private key material. Do not weaken these
+ * Scope note: PEM private-key blocks (all common variants), base64- and
+ * base64url-wrapped PEM, PKCS#8/PKCS#1/SEC1 DER private keys, PKCS#12/PFX-like
+ * DER bundles, and JKS keystores (by magic header) are detected here. PKCS#12/PFX
+ * detection is intentionally a conservative structural sniff for the PFX version
+ * field, not a full ASN.1 parser; JKS detection is likewise a magic-header sniff
+ * rather than a full keystore parser; a JKS container is rejected outright since
+ * its entire purpose is to hold private key material. Do not weaken these
  * patterns without updating tests/unit/secretMaterial.test.js.
+ *
+ * Compressed input: a base64/base64url/hex-decoded (or raw) buffer that begins
+ * with a recognized gzip (`1F 8B`) or RFC 1950 zlib header is decompressed
+ * exactly once (never recursively) and the result is scanned in its place.
+ * Recognition of a zlib header is algorithmic against the two-byte header
+ * (CMF, FLG), not an enumerated allow-list of common compression-level byte
+ * pairs, so a smaller window size or a set preset-dictionary flag is still
+ * recognized as compressed input. Two independent bounds apply once a
+ * recognized header is found: the compressed buffer itself must not exceed
+ * `MAX_COMPRESSED_INPUT_LENGTH`, and the decompression call's own output-size
+ * parameter is capped to `min(MAX_DECOMPRESSED_OUTPUT_LENGTH, compressedLength
+ * * DECOMPRESSED_OUTPUT_RATIO)` so the library itself refuses to materialize a
+ * decompression bomb. A stream with the preset-dictionary flag (`FDICT`) set,
+ * a stream whose compressed length or decoded-output bound is exceeded, and a
+ * stream that presents a valid header but fails to decompress cleanly all
+ * report the same fail-closed outcome as detected key material, never a
+ * silent fall-through to the ordinary content scan. A buffer with neither
+ * recognized header proceeds directly to the ordinary scan: that is the
+ * default path for the overwhelming majority of legitimate, uncompressed
+ * base64 traffic and is not itself a failure mode.
  */
 
 const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
@@ -194,9 +216,17 @@ function fieldNameLooksGenericSecret(fieldName) {
   );
 }
 
+// Standard base64 uses `+`/`/`; base64url uses `-`/`_` in the same
+// positions. An attacker who controls the plaintext can always pad a PEM to
+// force at least one of the four variant characters to appear, so both
+// alphabets must decode, not just the standard one (C1: base64url evasion).
+const BASE64_STANDARD_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]+={0,2}$/;
+
 /**
- * Returns true if the string looks like base64 and is long enough to plausibly
- * wrap a bounded DER envelope or PEM block. Whitespace is tolerated.
+ * Returns true if the string looks like base64 or base64url and is long
+ * enough to plausibly wrap a bounded DER envelope or PEM block. Whitespace is
+ * tolerated.
  * @param {string} value
  * @returns {boolean}
  */
@@ -204,7 +234,21 @@ function looksBase64(value) {
   if (typeof value !== "string") return false;
   const compact = value.replace(/\s+/g, "");
   if (compact.length < 16) return false;
-  return /^[A-Za-z0-9+/]+={0,2}$/.test(compact);
+  return (
+    BASE64_STANDARD_PATTERN.test(compact) || BASE64_URL_PATTERN.test(compact)
+  );
+}
+
+/**
+ * A string using the base64url alphabet (`-`/`_`) is never valid standard
+ * base64 input to Node's decoder in the same pass, so the two alphabets must
+ * be told apart before decoding rather than decoded with a single fixed
+ * encoding name.
+ * @param {string} compact
+ * @returns {"base64url"|"base64"}
+ */
+function base64VariantFor(compact) {
+  return /[-_]/.test(compact) ? "base64url" : "base64";
 }
 
 /**
@@ -466,8 +510,9 @@ function looksJksKeystore(value) {
 
 function base64DecodeIfLikely(value) {
   if (!looksBase64(value)) return null;
+  const compact = value.replace(/\s+/g, "");
   try {
-    return Buffer.from(value.replace(/\s+/g, ""), "base64");
+    return Buffer.from(compact, base64VariantFor(compact));
   } catch (_err) {
     return null;
   }
@@ -485,7 +530,108 @@ function hexDecodeIfLikely(value) {
   }
 }
 
-function bufferContainsPrivateKey(value) {
+// Bounds for the compressed-input branch (C1). Both apply once a recognized
+// gzip/zlib header is found; neither is optional. The compressed buffer
+// itself must not exceed this many bytes before decompression is even
+// attempted (an oversized "compressed" blob is rejected outright, never
+// decompressed).
+const MAX_COMPRESSED_INPUT_LENGTH = 1024 * 1024; // 1 MiB
+// The decoded-output bound is a ratio check, not a flat cap on its own: a
+// small compressed input is bounded to a small multiple of its own size, and
+// only an input already close to MAX_COMPRESSED_INPUT_LENGTH can reach this
+// absolute ceiling.
+const MAX_DECOMPRESSED_OUTPUT_LENGTH = 4 * 1024 * 1024; // 4 MiB
+const DECOMPRESSED_OUTPUT_RATIO = 4;
+
+function looksGzipHeader(buffer) {
+  return (
+    Buffer.isBuffer(buffer) &&
+    buffer.length >= 2 &&
+    buffer[0] === 0x1f &&
+    buffer[1] === 0x8b
+  );
+}
+
+/**
+ * RFC 1950 zlib header recognition, checked algorithmically against the
+ * two-byte header (CMF, FLG) rather than matched against the four common
+ * compression-level byte pairs (`78 01`/`78 5E`/`78 9C`/`78 DA`): a valid
+ * zlib stream may use a smaller window size (encoded in the CMF nibble) or
+ * set the preset-dictionary flag (encoded in FLG), either of which produces
+ * a header outside those four presets while remaining fully decodable.
+ * @param {Buffer} buffer
+ * @returns {boolean}
+ */
+function looksZlibHeader(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 2) return false;
+  const cmf = buffer[0];
+  const flg = buffer[1];
+  if ((cmf & 0x0f) !== 8) return false; // compression method must be "deflate"
+  if (cmf >> 4 > 7) return false; // windowBits - 8 must be at most 7
+  return ((cmf << 8) | flg) % 31 === 0; // RFC 1950 header self-check
+}
+
+function zlibHeaderHasPresetDictionary(buffer) {
+  return Buffer.isBuffer(buffer) && buffer.length >= 2 && (buffer[1] & 0x20) !== 0;
+}
+
+const COMPRESSION_CLASSIFICATION = Object.freeze({
+  NOT_COMPRESSED: "not_compressed",
+  DECOMPRESSED: "decompressed",
+  REJECTED: "rejected",
+});
+
+/**
+ * Classifies a buffer for the compressed-input branch. Two outcomes besides
+ * "not compressed": a single successful decompression pass (never re-fed
+ * into this function, closing the bomb-inside-bomb vector), or a fail-closed
+ * rejection covering an oversized compressed buffer, a preset-dictionary
+ * (`FDICT`) stream, a bound-exceeding decompression, and a stream that
+ * presents a valid header but fails to decompress. `FDICT` is external
+ * material this detector does not have, so decompression is never attempted
+ * for it; the caller must not treat REJECTED as "not found."
+ * @param {Buffer} buffer
+ * @returns {{classification: string, decoded: Buffer|null}}
+ */
+function classifyCompressedBuffer(buffer) {
+  if (!Buffer.isBuffer(buffer)) {
+    return { classification: COMPRESSION_CLASSIFICATION.NOT_COMPRESSED, decoded: null };
+  }
+
+  const isGzip = looksGzipHeader(buffer);
+  const isZlib = !isGzip && looksZlibHeader(buffer);
+  if (!isGzip && !isZlib) {
+    return { classification: COMPRESSION_CLASSIFICATION.NOT_COMPRESSED, decoded: null };
+  }
+
+  if (buffer.length > MAX_COMPRESSED_INPUT_LENGTH) {
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+
+  if (isZlib && zlibHeaderHasPresetDictionary(buffer)) {
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+
+  const maxOutputLength = Math.min(
+    MAX_DECOMPRESSED_OUTPUT_LENGTH,
+    buffer.length * DECOMPRESSED_OUTPUT_RATIO,
+  );
+
+  try {
+    const decoded = isGzip
+      ? zlib.gunzipSync(buffer, { maxOutputLength })
+      : zlib.inflateSync(buffer, { maxOutputLength });
+    return { classification: COMPRESSION_CLASSIFICATION.DECOMPRESSED, decoded };
+  } catch (_err) {
+    // Covers both a corrupt/truncated stream and the library refusing to
+    // exceed maxOutputLength while decompressing: both are "claims to be
+    // compressed, cannot be safely materialized," the same inconclusive
+    // outcome as a stream this detector chose not to even attempt (FDICT).
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+}
+
+function ordinaryBufferContainsPrivateKey(value) {
   if (!Buffer.isBuffer(value)) return false;
   if (
     looksPkcs12Bundle(value) ||
@@ -496,6 +642,23 @@ function bufferContainsPrivateKey(value) {
     return true;
   }
   return PRIVATE_KEY_PEM_PATTERN.test(value.toString("utf8"));
+}
+
+function bufferContainsPrivateKey(value) {
+  if (!Buffer.isBuffer(value)) return false;
+
+  const compressed = classifyCompressedBuffer(value);
+  if (compressed.classification === COMPRESSION_CLASSIFICATION.REJECTED) {
+    return true;
+  }
+  if (compressed.classification === COMPRESSION_CLASSIFICATION.DECOMPRESSED) {
+    // Single pass only: scan the decompressed bytes directly rather than
+    // re-entering this function, so a nested compressed payload is never
+    // recursively unwrapped.
+    return ordinaryBufferContainsPrivateKey(compressed.decoded);
+  }
+
+  return ordinaryBufferContainsPrivateKey(value);
 }
 
 /**
@@ -869,4 +1032,12 @@ module.exports = {
   redactPrivateKeyMaterial,
   redactGenericSecrets,
   redactGenericSecretsWithReport,
+  COMPRESSION_CLASSIFICATION,
+  MAX_COMPRESSED_INPUT_LENGTH,
+  MAX_DECOMPRESSED_OUTPUT_LENGTH,
+  DECOMPRESSED_OUTPUT_RATIO,
+  looksGzipHeader,
+  looksZlibHeader,
+  zlibHeaderHasPresetDictionary,
+  classifyCompressedBuffer,
 };

--- a/packages/contracts/certops/job-payload.schema.json
+++ b/packages/contracts/certops/job-payload.schema.json
@@ -122,7 +122,7 @@
     },
     "keyReference": {
       "type": ["string", "null"],
-      "maxLength": 512,
+      "maxLength": 256,
       "description": "Opaque non-secret reference to external execution-plane key custody."
     },
     "commandRef": {

--- a/packages/log-scrub/secret-material.js
+++ b/packages/log-scrub/secret-material.js
@@ -28,23 +28,29 @@ const zlib = require("zlib");
  *
  * Compressed input: a base64/base64url/hex-decoded (or raw) buffer that begins
  * with a recognized gzip (`1F 8B`) or RFC 1950 zlib header is decompressed
- * exactly once (never recursively) and the result is scanned in its place.
- * Recognition of a zlib header is algorithmic against the two-byte header
- * (CMF, FLG), not an enumerated allow-list of common compression-level byte
- * pairs, so a smaller window size or a set preset-dictionary flag is still
- * recognized as compressed input. Two independent bounds apply once a
- * recognized header is found: the compressed buffer itself must not exceed
+ * exactly once and the result is scanned in its place. Recognition of a zlib
+ * header is algorithmic against the two-byte header (CMF, FLG), not an
+ * enumerated allow-list of common compression-level byte pairs, so a smaller
+ * window size or a set preset-dictionary flag is still recognized as
+ * compressed input. Two independent bounds apply once a recognized header is
+ * found: the compressed buffer itself must not exceed
  * `MAX_COMPRESSED_INPUT_LENGTH`, and the decompression call's own output-size
  * parameter is capped to `min(MAX_DECOMPRESSED_OUTPUT_LENGTH, compressedLength
  * * DECOMPRESSED_OUTPUT_RATIO)` so the library itself refuses to materialize a
  * decompression bomb. A stream with the preset-dictionary flag (`FDICT`) set,
- * a stream whose compressed length or decoded-output bound is exceeded, and a
- * stream that presents a valid header but fails to decompress cleanly all
- * report the same fail-closed outcome as detected key material, never a
- * silent fall-through to the ordinary content scan. A buffer with neither
- * recognized header proceeds directly to the ordinary scan: that is the
- * default path for the overwhelming majority of legitimate, uncompressed
- * base64 traffic and is not itself a failure mode.
+ * a stream whose compressed length or decoded-output bound is exceeded, a
+ * stream that presents a valid header but fails to decompress cleanly, and a
+ * stream whose decompressed output is itself gzip/zlib-shaped (nested
+ * compression) all report the same fail-closed outcome as detected key
+ * material, never a silent fall-through to the ordinary content scan.
+ * Rejecting nested compression outright (rather than unwrapping a second
+ * time) closes an evasion path where an attacker gzips a payload twice to
+ * slip key material past the ratio/size ceilings on the outer layer while
+ * the inner layer, which actually holds the material, never gets bounds-
+ * checked or scanned. A buffer with neither recognized header proceeds
+ * directly to the ordinary scan: that is the default path for the
+ * overwhelming majority of legitimate, uncompressed base64 traffic and is
+ * not itself a failure mode.
  */
 
 const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
@@ -577,11 +583,16 @@ const COMPRESSION_CLASSIFICATION = Object.freeze({
 
 /**
  * Classifies a buffer for the compressed-input branch. Two outcomes besides
- * "not compressed": a single successful decompression pass (never re-fed
- * into this function, closing the bomb-inside-bomb vector), or a fail-closed
- * rejection covering an oversized compressed buffer, a preset-dictionary
- * (`FDICT`) stream, a bound-exceeding decompression, and a stream that
- * presents a valid header but fails to decompress. `FDICT` is external
+ * "not compressed": a single successful decompression pass whose output is
+ * itself not compressed, or a fail-closed rejection covering an oversized
+ * compressed buffer, a preset-dictionary (`FDICT`) stream, a bound-exceeding
+ * decompression, a stream that presents a valid header but fails to
+ * decompress, and a stream whose decompressed output is itself gzip/zlib-
+ * shaped. That last case is deliberate: unwrapping a second time would let
+ * an attacker nest compression to hide key material below the ratio/size
+ * ceilings applied to the outer layer, or simply to waste CPU, so nested
+ * compression is treated the same as any other suspicious input and
+ * rejected rather than recursively decompressed. `FDICT` is external
  * material this detector does not have, so decompression is never attempted
  * for it; the caller must not treat REJECTED as "not found."
  * @param {Buffer} buffer
@@ -615,6 +626,11 @@ function classifyCompressedBuffer(buffer) {
     const decoded = isGzip
       ? zlib.gunzipSync(buffer, { maxOutputLength })
       : zlib.inflateSync(buffer, { maxOutputLength });
+    if (looksGzipHeader(decoded) || looksZlibHeader(decoded)) {
+      // Nested compression (gzip-of-gzip, zlib-of-gzip, etc.): fail closed
+      // instead of unwrapping again. See the function-level note above.
+      return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+    }
     return { classification: COMPRESSION_CLASSIFICATION.DECOMPRESSED, decoded };
   } catch (_err) {
     // Covers both a corrupt/truncated stream and the library refusing to

--- a/packages/log-scrub/secret-material.js
+++ b/packages/log-scrub/secret-material.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const zlib = require("zlib");
+
 /**
  * TokenTimer shared secret-material detector.
  *
@@ -15,14 +17,34 @@
  *   - private key material  -> REJECT (hard 422 at the API boundary)
  *   - other generic secrets -> REDACT (so legitimate operational output is kept)
  *
- * Scope note: PEM private-key blocks (all common variants), base64-wrapped PEM,
- * PKCS#8/PKCS#1/SEC1 DER private keys, PKCS#12/PFX-like DER bundles, and JKS
- * keystores (by magic header) are detected here. PKCS#12/PFX detection is
- * intentionally a conservative structural sniff for the PFX version field, not
- * a full ASN.1 parser; JKS detection is likewise a magic-header sniff rather
- * than a full keystore parser; a JKS container is rejected outright since its
- * entire purpose is to hold private key material. Do not weaken these
+ * Scope note: PEM private-key blocks (all common variants), base64- and
+ * base64url-wrapped PEM, PKCS#8/PKCS#1/SEC1 DER private keys, PKCS#12/PFX-like
+ * DER bundles, and JKS keystores (by magic header) are detected here. PKCS#12/PFX
+ * detection is intentionally a conservative structural sniff for the PFX version
+ * field, not a full ASN.1 parser; JKS detection is likewise a magic-header sniff
+ * rather than a full keystore parser; a JKS container is rejected outright since
+ * its entire purpose is to hold private key material. Do not weaken these
  * patterns without updating tests/unit/secretMaterial.test.js.
+ *
+ * Compressed input: a base64/base64url/hex-decoded (or raw) buffer that begins
+ * with a recognized gzip (`1F 8B`) or RFC 1950 zlib header is decompressed
+ * exactly once (never recursively) and the result is scanned in its place.
+ * Recognition of a zlib header is algorithmic against the two-byte header
+ * (CMF, FLG), not an enumerated allow-list of common compression-level byte
+ * pairs, so a smaller window size or a set preset-dictionary flag is still
+ * recognized as compressed input. Two independent bounds apply once a
+ * recognized header is found: the compressed buffer itself must not exceed
+ * `MAX_COMPRESSED_INPUT_LENGTH`, and the decompression call's own output-size
+ * parameter is capped to `min(MAX_DECOMPRESSED_OUTPUT_LENGTH, compressedLength
+ * * DECOMPRESSED_OUTPUT_RATIO)` so the library itself refuses to materialize a
+ * decompression bomb. A stream with the preset-dictionary flag (`FDICT`) set,
+ * a stream whose compressed length or decoded-output bound is exceeded, and a
+ * stream that presents a valid header but fails to decompress cleanly all
+ * report the same fail-closed outcome as detected key material, never a
+ * silent fall-through to the ordinary content scan. A buffer with neither
+ * recognized header proceeds directly to the ordinary scan: that is the
+ * default path for the overwhelming majority of legitimate, uncompressed
+ * base64 traffic and is not itself a failure mode.
  */
 
 const PRIVATE_KEY_REDACTION_PLACEHOLDER = "[PRIVATE_KEY_REDACTED]";
@@ -188,9 +210,17 @@ function fieldNameLooksGenericSecret(fieldName) {
   );
 }
 
+// Standard base64 uses `+`/`/`; base64url uses `-`/`_` in the same
+// positions. An attacker who controls the plaintext can always pad a PEM to
+// force at least one of the four variant characters to appear, so both
+// alphabets must decode, not just the standard one (C1: base64url evasion).
+const BASE64_STANDARD_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]+={0,2}$/;
+
 /**
- * Returns true if the string looks like base64 and is long enough to plausibly
- * wrap a bounded DER envelope or PEM block. Whitespace is tolerated.
+ * Returns true if the string looks like base64 or base64url and is long
+ * enough to plausibly wrap a bounded DER envelope or PEM block. Whitespace is
+ * tolerated.
  * @param {string} value
  * @returns {boolean}
  */
@@ -198,7 +228,21 @@ function looksBase64(value) {
   if (typeof value !== "string") return false;
   const compact = value.replace(/\s+/g, "");
   if (compact.length < 16) return false;
-  return /^[A-Za-z0-9+/]+={0,2}$/.test(compact);
+  return (
+    BASE64_STANDARD_PATTERN.test(compact) || BASE64_URL_PATTERN.test(compact)
+  );
+}
+
+/**
+ * A string using the base64url alphabet (`-`/`_`) is never valid standard
+ * base64 input to Node's decoder in the same pass, so the two alphabets must
+ * be told apart before decoding rather than decoded with a single fixed
+ * encoding name.
+ * @param {string} compact
+ * @returns {"base64url"|"base64"}
+ */
+function base64VariantFor(compact) {
+  return /[-_]/.test(compact) ? "base64url" : "base64";
 }
 
 /**
@@ -460,8 +504,9 @@ function looksJksKeystore(value) {
 
 function base64DecodeIfLikely(value) {
   if (!looksBase64(value)) return null;
+  const compact = value.replace(/\s+/g, "");
   try {
-    return Buffer.from(value.replace(/\s+/g, ""), "base64");
+    return Buffer.from(compact, base64VariantFor(compact));
   } catch (_err) {
     return null;
   }
@@ -479,7 +524,108 @@ function hexDecodeIfLikely(value) {
   }
 }
 
-function bufferContainsPrivateKey(value) {
+// Bounds for the compressed-input branch (C1). Both apply once a recognized
+// gzip/zlib header is found; neither is optional. The compressed buffer
+// itself must not exceed this many bytes before decompression is even
+// attempted (an oversized "compressed" blob is rejected outright, never
+// decompressed).
+const MAX_COMPRESSED_INPUT_LENGTH = 1024 * 1024; // 1 MiB
+// The decoded-output bound is a ratio check, not a flat cap on its own: a
+// small compressed input is bounded to a small multiple of its own size, and
+// only an input already close to MAX_COMPRESSED_INPUT_LENGTH can reach this
+// absolute ceiling.
+const MAX_DECOMPRESSED_OUTPUT_LENGTH = 4 * 1024 * 1024; // 4 MiB
+const DECOMPRESSED_OUTPUT_RATIO = 4;
+
+function looksGzipHeader(buffer) {
+  return (
+    Buffer.isBuffer(buffer) &&
+    buffer.length >= 2 &&
+    buffer[0] === 0x1f &&
+    buffer[1] === 0x8b
+  );
+}
+
+/**
+ * RFC 1950 zlib header recognition, checked algorithmically against the
+ * two-byte header (CMF, FLG) rather than matched against the four common
+ * compression-level byte pairs (`78 01`/`78 5E`/`78 9C`/`78 DA`): a valid
+ * zlib stream may use a smaller window size (encoded in the CMF nibble) or
+ * set the preset-dictionary flag (encoded in FLG), either of which produces
+ * a header outside those four presets while remaining fully decodable.
+ * @param {Buffer} buffer
+ * @returns {boolean}
+ */
+function looksZlibHeader(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 2) return false;
+  const cmf = buffer[0];
+  const flg = buffer[1];
+  if ((cmf & 0x0f) !== 8) return false; // compression method must be "deflate"
+  if (cmf >> 4 > 7) return false; // windowBits - 8 must be at most 7
+  return ((cmf << 8) | flg) % 31 === 0; // RFC 1950 header self-check
+}
+
+function zlibHeaderHasPresetDictionary(buffer) {
+  return Buffer.isBuffer(buffer) && buffer.length >= 2 && (buffer[1] & 0x20) !== 0;
+}
+
+const COMPRESSION_CLASSIFICATION = Object.freeze({
+  NOT_COMPRESSED: "not_compressed",
+  DECOMPRESSED: "decompressed",
+  REJECTED: "rejected",
+});
+
+/**
+ * Classifies a buffer for the compressed-input branch. Two outcomes besides
+ * "not compressed": a single successful decompression pass (never re-fed
+ * into this function, closing the bomb-inside-bomb vector), or a fail-closed
+ * rejection covering an oversized compressed buffer, a preset-dictionary
+ * (`FDICT`) stream, a bound-exceeding decompression, and a stream that
+ * presents a valid header but fails to decompress. `FDICT` is external
+ * material this detector does not have, so decompression is never attempted
+ * for it; the caller must not treat REJECTED as "not found."
+ * @param {Buffer} buffer
+ * @returns {{classification: string, decoded: Buffer|null}}
+ */
+function classifyCompressedBuffer(buffer) {
+  if (!Buffer.isBuffer(buffer)) {
+    return { classification: COMPRESSION_CLASSIFICATION.NOT_COMPRESSED, decoded: null };
+  }
+
+  const isGzip = looksGzipHeader(buffer);
+  const isZlib = !isGzip && looksZlibHeader(buffer);
+  if (!isGzip && !isZlib) {
+    return { classification: COMPRESSION_CLASSIFICATION.NOT_COMPRESSED, decoded: null };
+  }
+
+  if (buffer.length > MAX_COMPRESSED_INPUT_LENGTH) {
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+
+  if (isZlib && zlibHeaderHasPresetDictionary(buffer)) {
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+
+  const maxOutputLength = Math.min(
+    MAX_DECOMPRESSED_OUTPUT_LENGTH,
+    buffer.length * DECOMPRESSED_OUTPUT_RATIO,
+  );
+
+  try {
+    const decoded = isGzip
+      ? zlib.gunzipSync(buffer, { maxOutputLength })
+      : zlib.inflateSync(buffer, { maxOutputLength });
+    return { classification: COMPRESSION_CLASSIFICATION.DECOMPRESSED, decoded };
+  } catch (_err) {
+    // Covers both a corrupt/truncated stream and the library refusing to
+    // exceed maxOutputLength while decompressing: both are "claims to be
+    // compressed, cannot be safely materialized," the same inconclusive
+    // outcome as a stream this detector chose not to even attempt (FDICT).
+    return { classification: COMPRESSION_CLASSIFICATION.REJECTED, decoded: null };
+  }
+}
+
+function ordinaryBufferContainsPrivateKey(value) {
   if (!Buffer.isBuffer(value)) return false;
   if (
     looksPkcs12Bundle(value) ||
@@ -490,6 +636,23 @@ function bufferContainsPrivateKey(value) {
     return true;
   }
   return PRIVATE_KEY_PEM_PATTERN.test(value.toString("utf8"));
+}
+
+function bufferContainsPrivateKey(value) {
+  if (!Buffer.isBuffer(value)) return false;
+
+  const compressed = classifyCompressedBuffer(value);
+  if (compressed.classification === COMPRESSION_CLASSIFICATION.REJECTED) {
+    return true;
+  }
+  if (compressed.classification === COMPRESSION_CLASSIFICATION.DECOMPRESSED) {
+    // Single pass only: scan the decompressed bytes directly rather than
+    // re-entering this function, so a nested compressed payload is never
+    // recursively unwrapped.
+    return ordinaryBufferContainsPrivateKey(compressed.decoded);
+  }
+
+  return ordinaryBufferContainsPrivateKey(value);
 }
 
 /**
@@ -863,4 +1026,12 @@ module.exports = {
   redactPrivateKeyMaterial,
   redactGenericSecrets,
   redactGenericSecretsWithReport,
+  COMPRESSION_CLASSIFICATION,
+  MAX_COMPRESSED_INPUT_LENGTH,
+  MAX_DECOMPRESSED_OUTPUT_LENGTH,
+  DECOMPRESSED_OUTPUT_RATIO,
+  looksGzipHeader,
+  looksZlibHeader,
+  zlibHeaderHasPresetDictionary,
+  classifyCompressedBuffer,
 };

--- a/scripts/check-secret-logging.js
+++ b/scripts/check-secret-logging.js
@@ -229,8 +229,8 @@ function checkSanitizerPresence() {
   }
 }
 
-// ARC-08: the worker logger must redact secret-bearing failures equivalently
-// to the API logger. apps/worker/src/logger.js wires Winston straight into
+// The worker logger must redact secret-bearing failures equivalently to the
+// API logger. apps/worker/src/logger.js wires Winston directly into
 // @tokentimer/log-scrub's sanitizeLogRecord rather than declaring its own
 // field list, so this check exercises the actual shared function against
 // the same REQUIRED_REDACTION_FIELDS the API logger is held to, instead of

--- a/scripts/check-secret-logging.js
+++ b/scripts/check-secret-logging.js
@@ -6,6 +6,8 @@ const path = require("node:path");
 const here = __dirname;
 const repoRoot = path.resolve(here, "..");
 const loggerPath = path.join(repoRoot, "apps/api/utils/logger.js");
+const workerLoggerPath = path.join(repoRoot, "apps/worker/src/logger.js");
+const logScrubPackagePath = path.join(repoRoot, "packages/log-scrub");
 const scanRoots = [
   path.join(repoRoot, "apps/api"),
   path.join(repoRoot, "apps/worker/src"),
@@ -227,6 +229,61 @@ function checkSanitizerPresence() {
   }
 }
 
+// ARC-08: the worker logger must redact secret-bearing failures equivalently
+// to the API logger. apps/worker/src/logger.js wires Winston straight into
+// @tokentimer/log-scrub's sanitizeLogRecord rather than declaring its own
+// field list, so this check exercises the actual shared function against
+// the same REQUIRED_REDACTION_FIELDS the API logger is held to, instead of
+// grepping for a field-list literal that the worker file doesn't have.
+function checkWorkerLoggerParity() {
+  if (!fs.existsSync(workerLoggerPath)) {
+    fail(`missing ${workerLoggerPath}`);
+  }
+  const workerLoggerSource = fs.readFileSync(workerLoggerPath, "utf8");
+  const usesSharedScrubber =
+    /@tokentimer\/log-scrub/.test(workerLoggerSource) &&
+    /sanitizeLogRecord\b/.test(workerLoggerSource);
+  if (!usesSharedScrubber) {
+    fail(
+      "apps/worker/src/logger.js must sanitize every record through @tokentimer/log-scrub's sanitizeLogRecord",
+    );
+  }
+
+  let sanitizeLogRecord;
+  try {
+    ({ sanitizeLogRecord } = require(logScrubPackagePath));
+  } catch (error) {
+    fail(`unable to load packages/log-scrub to verify worker parity: ${error.message}`);
+    return;
+  }
+
+  const probe = {};
+  for (const field of REQUIRED_REDACTION_FIELDS) {
+    probe[field.aliases[0]] = "worker-secret-probe-value";
+  }
+  probe.message = "worker-secret-probe-value";
+
+  const sanitized = sanitizeLogRecord(probe);
+  const missing = [];
+  for (const field of REQUIRED_REDACTION_FIELDS) {
+    const key = field.aliases[0];
+    const value = sanitized[key];
+    const stillLeaking =
+      typeof value === "string" && value.includes("worker-secret-probe-value");
+    if (stillLeaking) missing.push(field.name);
+  }
+  if (missing.length > 0) {
+    fail(
+      `packages/log-scrub sanitizeLogRecord (used by the worker logger) fails to redact required fields: ${missing.join(", ")}`,
+    );
+  }
+  if (sanitized.message !== "worker-secret-probe-value") {
+    fail(
+      "packages/log-scrub sanitizeLogRecord must not redact the message field itself",
+    );
+  }
+}
+
 function checkRawCredentialLogging() {
   const violations = [];
   for (const root of scanRoots) {
@@ -362,6 +419,7 @@ function checkIntegrationErrorPaths() {
 }
 
 checkSanitizerPresence();
+checkWorkerLoggerParity();
 checkRawCredentialLogging();
 checkAuditPersistence();
 checkIntegrationErrorPaths();

--- a/tests/unit/certops-contracts.test.js
+++ b/tests/unit/certops-contracts.test.js
@@ -1509,3 +1509,23 @@ describe("CertOps contract skeletons", () => {
     assert.equal(certOpsRoutesSource.includes("api_tokens"), false);
   });
 });
+
+// C6: keyReference has one unified maximum length everywhere it is
+// validated. See ARC-09 in
+// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
+describe("keyReference maxLength parity (C6 / ARC-09)", () => {
+  const {
+    KEY_REFERENCE_MAX_LENGTH,
+  } = require("../../apps/api/services/certops/inventory");
+
+  it("keeps job-payload.schema.json in parity with the runtime validator's bound", () => {
+    assert.equal(jobPayloadSchema.properties.keyReference.maxLength, KEY_REFERENCE_MAX_LENGTH);
+  });
+
+  it("keeps every OpenAPI keyReference field in parity with the runtime validator's bound", () => {
+    const managedCertificate = openApiComponentSchema("CertOpsManagedCertificate");
+    const writeRequest = openApiComponentSchema("CertOpsCertificateWriteRequest");
+    assert.equal(managedCertificate.properties.keyReference.maxLength, KEY_REFERENCE_MAX_LENGTH);
+    assert.equal(writeRequest.properties.keyReference.maxLength, KEY_REFERENCE_MAX_LENGTH);
+  });
+});

--- a/tests/unit/certops-contracts.test.js
+++ b/tests/unit/certops-contracts.test.js
@@ -1511,9 +1511,8 @@ describe("CertOps contract skeletons", () => {
 });
 
 // C6: keyReference has one unified maximum length everywhere it is
-// validated. See ARC-09 in
-// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
-describe("keyReference maxLength parity (C6 / ARC-09)", () => {
+// validated.
+describe("keyReference maxLength parity (C6)", () => {
   const {
     KEY_REFERENCE_MAX_LENGTH,
   } = require("../../apps/api/services/certops/inventory");

--- a/tests/unit/certops-import-form-key-reference-example.test.js
+++ b/tests/unit/certops-import-form-key-reference-example.test.js
@@ -10,12 +10,12 @@ const FORM_SOURCE_PATH = path.resolve(
   "../../apps/dashboard/src/components/certops/ImportCertificateForm.jsx",
 );
 
-// ARC-07: UI placeholders, docs, fixtures, and mocks must contain no
-// private-key path as keyReference. A prior placeholder read
+// UI placeholders, docs, fixtures, and mocks must contain no private-key
+// path as keyReference. A prior placeholder read
 // "agent-id:/etc/ssl/private/wildcard.key", which taught users to type a
 // private-key file path into the one field the zero-custody design promises
 // never becomes a leak vector.
-describe("ImportCertificateForm keyReference example (C5 / ARC-07)", () => {
+describe("ImportCertificateForm keyReference example (C5)", () => {
   const source = fs.readFileSync(FORM_SOURCE_PATH, "utf8");
 
   it("does not show a private-key-shaped filesystem path as the keyReference placeholder", () => {

--- a/tests/unit/certops-import-form-key-reference-example.test.js
+++ b/tests/unit/certops-import-form-key-reference-example.test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const FORM_SOURCE_PATH = path.resolve(
+  __dirname,
+  "../../apps/dashboard/src/components/certops/ImportCertificateForm.jsx",
+);
+
+// ARC-07: UI placeholders, docs, fixtures, and mocks must contain no
+// private-key path as keyReference. A prior placeholder read
+// "agent-id:/etc/ssl/private/wildcard.key", which taught users to type a
+// private-key file path into the one field the zero-custody design promises
+// never becomes a leak vector.
+describe("ImportCertificateForm keyReference example (C5 / ARC-07)", () => {
+  const source = fs.readFileSync(FORM_SOURCE_PATH, "utf8");
+
+  it("does not show a private-key-shaped filesystem path as the keyReference placeholder", () => {
+    const placeholderMatch = source.match(/placeholder=(['"])(.*?)\1/s);
+    assert.ok(placeholderMatch, "keyReference Textarea placeholder not found");
+    const placeholder = placeholderMatch[2];
+
+    assert.doesNotMatch(placeholder, /\.key\b/i);
+    assert.doesNotMatch(placeholder, /private/i);
+  });
+
+  it("only demonstrates schemes the backend validator actually accepts", () => {
+    const placeholderMatch = source.match(/placeholder=(['"])(.*?)\1/s);
+    const placeholder = placeholderMatch[2];
+    const schemeMatches = placeholder.match(/\b[a-z][a-z0-9+.-]*:/gi) || [];
+    assert.ok(schemeMatches.length > 0, "placeholder should show at least one scheme example");
+    for (const scheme of schemeMatches) {
+      assert.match(scheme, /^(vault|pkcs11|token|object):$/i);
+    }
+  });
+});

--- a/tests/unit/certops-key-reference.test.js
+++ b/tests/unit/certops-key-reference.test.js
@@ -1,0 +1,153 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  normalizeKeyReference,
+  normalizeSourceRef,
+  KEY_REFERENCE_MAX_LENGTH,
+  SOURCE_REF_MAX_LENGTH,
+} = require("../../apps/api/services/certops/inventory");
+
+function assertRejected(value) {
+  assert.throws(
+    () => normalizeKeyReference(value),
+    (error) => error?.code === "CERTOPS_KEY_REFERENCE_INVALID",
+  );
+}
+
+function assertSourceRefRejected(value) {
+  assert.throws(
+    () => normalizeSourceRef(value),
+    (error) => error?.code === "CERTOPS_SOURCE_REF_INVALID",
+  );
+}
+
+// C2 (zero-custody): keyReference is a material-locality pointer, not free
+// text. See ARC-06 in
+// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
+describe("normalizeKeyReference locality schemes (C2 / ARC-06)", () => {
+  it("accepts every scheme actually emitted or exercised elsewhere in this codebase", () => {
+    // file:// - apps/api/services/certops/agentObservations.js writer format
+    assert.equal(
+      normalizeKeyReference("file:///etc/ssl/certs/web.pem"),
+      "file:///etc/ssl/certs/web.pem",
+    );
+    // k8s: - apps/api/services/certops/controllerProvisioning.js and
+    // controllerObservations.js writer format
+    assert.equal(
+      normalizeKeyReference("k8s://prod-cluster/web/secret/tls.key"),
+      "k8s://prod-cluster/web/secret/tls.key",
+    );
+    // vault:, hsm:, external-unknown: - exercised in
+    // tests/integration/certops-inventory.test.js fixtures
+    assert.equal(
+      normalizeKeyReference("  vault://pki/web/example  "),
+      "vault://pki/web/example",
+    );
+    assert.equal(
+      normalizeKeyReference("hsm://partition-1/web-key"),
+      "hsm://partition-1/web-key",
+    );
+    assert.equal(
+      normalizeKeyReference("external-unknown://legacy-ref-12345"),
+      "external-unknown://legacy-ref-12345",
+    );
+  });
+
+  it("accepts a pkcs11: URI built only from RFC 7512 non-secret attributes (documented in ImportCertificateForm.jsx)", () => {
+    const uri = "pkcs11:token=My%20HSM;object=web-key;type=private";
+    assert.equal(normalizeKeyReference(uri), uri);
+  });
+
+  it("accepts a pkcs11: URI with query-form attributes, including pin-source (a pointer, not the PIN itself)", () => {
+    const uri =
+      "pkcs11:token=My%20HSM;object=web-key?module-path=/usr/lib/pkcs11.so&pin-source=file:/etc/hsm-pin";
+    assert.equal(normalizeKeyReference(uri), uri);
+  });
+
+  it("rejects a pkcs11: URI carrying pin-value, which RFC 7512 defines as an inline PIN", () => {
+    assertRejected("pkcs11:token=My%20HSM;object=web-key?pin-value=1234");
+  });
+
+  it("rejects a pkcs11: URI with any attribute outside the safe RFC 7512 set", () => {
+    assertRejected("pkcs11:token=My%20HSM;secret=abc123");
+  });
+
+  it("rejects a bare value with no locality scheme, even if it looks like an opaque id", () => {
+    assertRejected("just-some-opaque-id-123");
+  });
+
+  it("rejects a bare credential-shaped value with no scheme", () => {
+    assertRejected("AKIAABCDEFGHIJKLMNOP");
+  });
+
+  it("rejects a scheme-valid reference carrying a generic-secret-shaped payload, without echo", () => {
+    assertRejected("vault://pki/web?password=supersecret123");
+    assertRejected("external-unknown://legacy-ref?password=swordfish");
+  });
+
+  it("rejects private key PEM material passed as a keyReference", () => {
+    assertRejected(
+      "-----BEGIN RSA PRIVATE KEY-----\nRkFLRS1OT1QtQS1SRUFMLUtFWQ==\n-----END RSA PRIVATE KEY-----",
+    );
+  });
+
+  it("rejects a reference over the unified maximum length", () => {
+    assertRejected(`hsm://${"a".repeat(KEY_REFERENCE_MAX_LENGTH)}`);
+  });
+
+  it("returns null for empty/absent values without throwing", () => {
+    assert.equal(normalizeKeyReference(undefined), null);
+    assert.equal(normalizeKeyReference(null), null);
+    assert.equal(normalizeKeyReference("   "), null);
+  });
+});
+
+// C1/C2 (zero-custody): sourceRef is documented in the OpenAPI contract as an
+// "opaque non-secret source reference." Unlike keyReference it carries no
+// scheme allow-list (it is free text describing observation provenance, not
+// a material-locality pointer), but it is still persisted verbatim and
+// echoed back in API responses, so it gets the same content-based secret
+// checks. Regression coverage added after a live-stack ARC-10 artifact scan
+// found a canary generic secret placed in sourceRef survived unredacted into
+// the managed_certificates.source_ref column and the import response body.
+describe("normalizeSourceRef non-secret provenance (C1/C2 / ARC-10)", () => {
+  it("passes through an ordinary opaque source reference unchanged", () => {
+    assert.equal(
+      normalizeSourceRef("provision-certops-demo:seed-01.tokentimer.test"),
+      "provision-certops-demo:seed-01.tokentimer.test",
+    );
+    assert.equal(normalizeSourceRef("  monitor-job-42  "), "monitor-job-42");
+  });
+
+  it("rejects a sourceRef carrying a generic-secret-shaped payload, without echo", () => {
+    // The shared detector's generic-secret check is assignment-pattern based
+    // (`key=value` / `key: value`), the same mechanism normalizeKeyReference
+    // relies on for its remainder-of-URI check. A bare, unassigned
+    // high-entropy token (e.g. a raw AWS access key ID with no surrounding
+    // `key=`/`key:`) is not flagged by this check for either field; for
+    // keyReference that gap is closed by the mandatory scheme allow-list
+    // instead, which sourceRef intentionally has none of. See the ARC-10
+    // report for this known scope boundary.
+    assertSourceRefRejected("import-job?password=supersecret123");
+    assertSourceRefRejected("scan-result token=eyJhbGciOiJIUzI1NiJ9.abc.def");
+  });
+
+  it("rejects private key PEM material passed as a sourceRef", () => {
+    assertSourceRefRejected(
+      "-----BEGIN RSA PRIVATE KEY-----\nRkFLRS1OT1QtQS1SRUFMLUtFWQ==\n-----END RSA PRIVATE KEY-----",
+    );
+  });
+
+  it("rejects a sourceRef over the maximum length", () => {
+    assertSourceRefRejected(`import-job-${"a".repeat(SOURCE_REF_MAX_LENGTH)}`);
+  });
+
+  it("returns null for empty/absent values without throwing", () => {
+    assert.equal(normalizeSourceRef(undefined), null);
+    assert.equal(normalizeSourceRef(null), null);
+    assert.equal(normalizeSourceRef("   "), null);
+  });
+});

--- a/tests/unit/certops-key-reference.test.js
+++ b/tests/unit/certops-key-reference.test.js
@@ -25,9 +25,8 @@ function assertSourceRefRejected(value) {
 }
 
 // C2 (zero-custody): keyReference is a material-locality pointer, not free
-// text. See ARC-06 in
-// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
-describe("normalizeKeyReference locality schemes (C2 / ARC-06)", () => {
+// text.
+describe("normalizeKeyReference locality schemes (C2)", () => {
   it("accepts every scheme actually emitted or exercised elsewhere in this codebase", () => {
     // file:// - apps/api/services/certops/agentObservations.js writer format
     assert.equal(
@@ -110,10 +109,10 @@ describe("normalizeKeyReference locality schemes (C2 / ARC-06)", () => {
 // scheme allow-list (it is free text describing observation provenance, not
 // a material-locality pointer), but it is still persisted verbatim and
 // echoed back in API responses, so it gets the same content-based secret
-// checks. Regression coverage added after a live-stack ARC-10 artifact scan
-// found a canary generic secret placed in sourceRef survived unredacted into
-// the managed_certificates.source_ref column and the import response body.
-describe("normalizeSourceRef non-secret provenance (C1/C2 / ARC-10)", () => {
+// checks. Regression coverage added after a live-stack artifact scan found a
+// canary generic secret placed in sourceRef survived unredacted into the
+// managed_certificates.source_ref column and the import response body.
+describe("normalizeSourceRef non-secret provenance (C1/C2)", () => {
   it("passes through an ordinary opaque source reference unchanged", () => {
     assert.equal(
       normalizeSourceRef("provision-certops-demo:seed-01.tokentimer.test"),
@@ -129,8 +128,8 @@ describe("normalizeSourceRef non-secret provenance (C1/C2 / ARC-10)", () => {
     // high-entropy token (e.g. a raw AWS access key ID with no surrounding
     // `key=`/`key:`) is not flagged by this check for either field; for
     // keyReference that gap is closed by the mandatory scheme allow-list
-    // instead, which sourceRef intentionally has none of. See the ARC-10
-    // report for this known scope boundary.
+    // instead, which sourceRef intentionally has none of. This is a known,
+    // deliberate scope boundary of the sourceRef check, not an oversight.
     assertSourceRefRejected("import-job?password=supersecret123");
     assertSourceRefRejected("scan-result token=eyJhbGciOiJIUzI1NiJ9.abc.def");
   });

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -3,6 +3,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const path = require("path");
+const zlib = require("node:zlib");
 
 const {
   PRIVATE_KEY_MATERIAL_REJECTED,
@@ -24,6 +25,10 @@ const {
   redactPrivateKeyMaterial,
   redactGenericSecrets,
   redactGenericSecretsWithReport,
+  classifyCompressedBuffer,
+  COMPRESSION_CLASSIFICATION,
+  MAX_COMPRESSED_INPUT_LENGTH,
+  MAX_DECOMPRESSED_OUTPUT_LENGTH,
 } = require(
   path.resolve(__dirname, "../../apps/api/utils/secretMaterial.js"),
 );
@@ -728,5 +733,165 @@ describe("secretMaterial.redactGenericSecrets", () => {
     ]) {
       assert.equal(fieldNameLooksGenericSecret(name), false, name);
     }
+  });
+});
+
+// C1: base64url-wrapped key material, and gzip/RFC 1950 zlib compressed
+// input. See ARC-01 through ARC-05 in
+// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
+describe("secretMaterial base64url detection (C1 / ARC-01)", () => {
+  it("detects a base64url-wrapped private key PEM", () => {
+    const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64url");
+    assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
+  });
+
+  it("redacts a base64url-wrapped private key to the placeholder", () => {
+    const wrapped = Buffer.from(pem("EC PRIVATE KEY")).toString("base64url");
+    assert.strictEqual(redactPrivateKeyMaterial(wrapped), PRIVATE_KEY_REDACTION_PLACEHOLDER);
+  });
+
+  it("hard-rejects a base64url-wrapped private key nested in a structure", () => {
+    const wrapped = Buffer.from(pem("PRIVATE KEY")).toString("base64url");
+    assert.throws(
+      () => redactGenericSecrets({ evidence: { blob: wrapped } }),
+      (error) => error?.code === PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  });
+
+  it("detects a base64url-wrapped PKCS#8 DER private key without PEM armor", () => {
+    const der = fakePkcs8PrivateKeyBuffer();
+    const wrapped = der.toString("base64url");
+    assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
+  });
+
+  it("does not flag an ordinary base64url-looking value with no key material", () => {
+    assert.strictEqual(
+      containsPrivateKeyMaterial("just-a-harmless_value-with-dashes_and_underscores"),
+      false,
+    );
+  });
+});
+
+// C1: compressed detector. See ARC-02 through ARC-05.
+describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () => {
+  it("recognizes and decompresses a gzip stream, then scans the result (ARC-02)", () => {
+    const gz = zlib.gzipSync(Buffer.from(pem("EC PRIVATE KEY")));
+    const result = classifyCompressedBuffer(gz);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
+    assert.strictEqual(containsPrivateKeyMaterial(gz), true);
+    assert.strictEqual(containsPrivateKeyMaterial(gz.toString("base64")), true);
+  });
+
+  it("recognizes and decompresses a common zlib header, then scans the result (ARC-02)", () => {
+    const zl = zlib.deflateSync(Buffer.from(pem("RSA PRIVATE KEY")));
+    assert.equal(zl[0], 0x78, "sanity: common zlib preset header starts with 0x78");
+    assert.strictEqual(containsPrivateKeyMaterial(zl), true);
+  });
+
+  it("recognizes a zlib stream using a smaller window size, not just the four common presets (ARC-02)", () => {
+    const smallWindow = zlib.deflateSync(Buffer.from(pem("PRIVATE KEY")), {
+      windowBits: 8,
+    });
+    assert.notEqual(smallWindow[0], 0x78, "sanity: smaller window changes CMF away from 0x78");
+    const result = classifyCompressedBuffer(smallWindow);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
+    assert.strictEqual(containsPrivateKeyMaterial(smallWindow), true);
+  });
+
+  it("recognizes an FDICT-flagged zlib header but never attempts decompression, and fails closed (ARC-03)", () => {
+    const withDict = zlib.deflateSync(
+      Buffer.from("hello world hello world hello world"),
+      { dictionary: Buffer.from("hello world") },
+    );
+    assert.notEqual(withDict[1] & 0x20, 0, "sanity: FDICT bit is actually set");
+    const result = classifyCompressedBuffer(withDict);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(withDict), true);
+    assert.throws(
+      () => assertNoPrivateKeyMaterial(withDict),
+      (error) => error?.code === PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  });
+
+  it("rejects a corrupted stream that starts with a valid gzip header (ARC-03)", () => {
+    const corrupt = Buffer.concat([
+      Buffer.from([0x1f, 0x8b, 0x08, 0x00]),
+      Buffer.alloc(30, 0xff),
+    ]);
+    const result = classifyCompressedBuffer(corrupt);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(corrupt), true);
+  });
+
+  it("rejects compressed input over the 1 MiB bound without attempting decompression (ARC-03)", () => {
+    const over = Buffer.concat([
+      Buffer.from([0x1f, 0x8b]),
+      Buffer.alloc(MAX_COMPRESSED_INPUT_LENGTH + 10, 0),
+    ]);
+    const result = classifyCompressedBuffer(over);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(over), true);
+  });
+
+  it("rejects output that would exceed the compressedLength x 4 ratio bound (ARC-03)", () => {
+    const compressible = Buffer.alloc(200 * 1024, 0x41);
+    const bomb = zlib.deflateSync(compressible);
+    assert.ok(bomb.length * 4 < compressible.length, "sanity: fixture expands past 4x");
+    const result = classifyCompressedBuffer(bomb);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(bomb), true);
+  });
+
+  it("accepts a small compressed input whose true decompressed size is within the ratio bound (ARC-03 control)", () => {
+    const smallOk = Buffer.from("not very compressible text 12345!@#$%");
+    const compressed = zlib.deflateSync(smallOk);
+    const result = classifyCompressedBuffer(compressed);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
+    assert.strictEqual(containsPrivateKeyMaterial(compressed), false);
+  });
+
+  it("rejects output that would exceed the absolute 4 MiB ceiling (ARC-03)", () => {
+    const hugeSource = Buffer.alloc(1024 * 1024 - 100, 0x43);
+    const compressed = zlib.deflateSync(hugeSource);
+    assert.ok(
+      hugeSource.length > MAX_DECOMPRESSED_OUTPUT_LENGTH ||
+        hugeSource.length > compressed.length * 4,
+      "sanity: fixture exceeds the absolute ceiling or the ratio bound",
+    );
+    const result = classifyCompressedBuffer(compressed);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(compressed), true);
+  });
+
+  it("proceeds to the ordinary scan for an uncompressed base64 payload, with no false rejection (ARC-04)", () => {
+    const ordinaryCert = Buffer.from(pem("CERTIFICATE")).toString("base64");
+    assert.strictEqual(containsPrivateKeyMaterial(ordinaryCert), false);
+  });
+
+  it("does not attempt raw headerless deflate; scans it directly instead (ARC-04)", () => {
+    const rawDeflate = zlib.deflateRawSync(
+      Buffer.from("just some public metadata, not a key"),
+    );
+    const result = classifyCompressedBuffer(rawDeflate);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.NOT_COMPRESSED);
+    assert.strictEqual(containsPrivateKeyMaterial(rawDeflate), false);
+  });
+
+  it("treats a near-miss header (first byte 0x78, failing checksum) as ordinary input (ARC-04)", () => {
+    const nearMiss = Buffer.from([0x78, 0x00, 0x01, 0x02]);
+    assert.notEqual(((0x78 << 8) | 0x00) % 31, 0, "sanity: fixture fails the modulo-31 check");
+    const result = classifyCompressedBuffer(nearMiss);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.NOT_COMPRESSED);
+  });
+
+  it("does not recursively unwrap a nested (gzip-of-gzip) payload (ARC-05)", () => {
+    const innerGz = zlib.gzipSync(Buffer.from(pem("PRIVATE KEY")));
+    const nestedGz = zlib.gzipSync(innerGz);
+    const result = classifyCompressedBuffer(nestedGz);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
+    // The single-pass result is still gzip bytes (the real key needs a
+    // second unwrap to reach); detection must not find it, proving there is
+    // no recursive decompression happening under the hood.
+    assert.strictEqual(containsPrivateKeyMaterial(nestedGz), false);
   });
 });

--- a/tests/unit/secretMaterial.test.js
+++ b/tests/unit/secretMaterial.test.js
@@ -737,9 +737,8 @@ describe("secretMaterial.redactGenericSecrets", () => {
 });
 
 // C1: base64url-wrapped key material, and gzip/RFC 1950 zlib compressed
-// input. See ARC-01 through ARC-05 in
-// tokentimer-canvas/plans/certops-post-ship-manual-acceptance-checklist.md.
-describe("secretMaterial base64url detection (C1 / ARC-01)", () => {
+// input.
+describe("secretMaterial base64url detection (C1)", () => {
   it("detects a base64url-wrapped private key PEM", () => {
     const wrapped = Buffer.from(pem("RSA PRIVATE KEY")).toString("base64url");
     assert.strictEqual(containsPrivateKeyMaterial(wrapped), true);
@@ -772,9 +771,9 @@ describe("secretMaterial base64url detection (C1 / ARC-01)", () => {
   });
 });
 
-// C1: compressed detector. See ARC-02 through ARC-05.
-describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () => {
-  it("recognizes and decompresses a gzip stream, then scans the result (ARC-02)", () => {
+// C1: compressed detector.
+describe("secretMaterial compressed-input detection (C1)", () => {
+  it("recognizes and decompresses a gzip stream, then scans the result", () => {
     const gz = zlib.gzipSync(Buffer.from(pem("EC PRIVATE KEY")));
     const result = classifyCompressedBuffer(gz);
     assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
@@ -782,13 +781,13 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(gz.toString("base64")), true);
   });
 
-  it("recognizes and decompresses a common zlib header, then scans the result (ARC-02)", () => {
+  it("recognizes and decompresses a common zlib header, then scans the result", () => {
     const zl = zlib.deflateSync(Buffer.from(pem("RSA PRIVATE KEY")));
     assert.equal(zl[0], 0x78, "sanity: common zlib preset header starts with 0x78");
     assert.strictEqual(containsPrivateKeyMaterial(zl), true);
   });
 
-  it("recognizes a zlib stream using a smaller window size, not just the four common presets (ARC-02)", () => {
+  it("recognizes a zlib stream using a smaller window size, not just the four common presets", () => {
     const smallWindow = zlib.deflateSync(Buffer.from(pem("PRIVATE KEY")), {
       windowBits: 8,
     });
@@ -798,7 +797,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(smallWindow), true);
   });
 
-  it("recognizes an FDICT-flagged zlib header but never attempts decompression, and fails closed (ARC-03)", () => {
+  it("recognizes an FDICT-flagged zlib header but never attempts decompression, and fails closed", () => {
     const withDict = zlib.deflateSync(
       Buffer.from("hello world hello world hello world"),
       { dictionary: Buffer.from("hello world") },
@@ -813,7 +812,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     );
   });
 
-  it("rejects a corrupted stream that starts with a valid gzip header (ARC-03)", () => {
+  it("rejects a corrupted stream that starts with a valid gzip header", () => {
     const corrupt = Buffer.concat([
       Buffer.from([0x1f, 0x8b, 0x08, 0x00]),
       Buffer.alloc(30, 0xff),
@@ -823,7 +822,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(corrupt), true);
   });
 
-  it("rejects compressed input over the 1 MiB bound without attempting decompression (ARC-03)", () => {
+  it("rejects compressed input over the 1 MiB bound without attempting decompression", () => {
     const over = Buffer.concat([
       Buffer.from([0x1f, 0x8b]),
       Buffer.alloc(MAX_COMPRESSED_INPUT_LENGTH + 10, 0),
@@ -833,7 +832,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(over), true);
   });
 
-  it("rejects output that would exceed the compressedLength x 4 ratio bound (ARC-03)", () => {
+  it("rejects output that would exceed the compressedLength x 4 ratio bound", () => {
     const compressible = Buffer.alloc(200 * 1024, 0x41);
     const bomb = zlib.deflateSync(compressible);
     assert.ok(bomb.length * 4 < compressible.length, "sanity: fixture expands past 4x");
@@ -842,7 +841,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(bomb), true);
   });
 
-  it("accepts a small compressed input whose true decompressed size is within the ratio bound (ARC-03 control)", () => {
+  it("accepts a small compressed input whose true decompressed size is within the ratio bound", () => {
     const smallOk = Buffer.from("not very compressible text 12345!@#$%");
     const compressed = zlib.deflateSync(smallOk);
     const result = classifyCompressedBuffer(compressed);
@@ -850,7 +849,7 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(compressed), false);
   });
 
-  it("rejects output that would exceed the absolute 4 MiB ceiling (ARC-03)", () => {
+  it("rejects output that would exceed the absolute 4 MiB ceiling", () => {
     const hugeSource = Buffer.alloc(1024 * 1024 - 100, 0x43);
     const compressed = zlib.deflateSync(hugeSource);
     assert.ok(
@@ -863,12 +862,12 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(compressed), true);
   });
 
-  it("proceeds to the ordinary scan for an uncompressed base64 payload, with no false rejection (ARC-04)", () => {
+  it("proceeds to the ordinary scan for an uncompressed base64 payload, with no false rejection", () => {
     const ordinaryCert = Buffer.from(pem("CERTIFICATE")).toString("base64");
     assert.strictEqual(containsPrivateKeyMaterial(ordinaryCert), false);
   });
 
-  it("does not attempt raw headerless deflate; scans it directly instead (ARC-04)", () => {
+  it("does not attempt raw headerless deflate; scans it directly instead", () => {
     const rawDeflate = zlib.deflateRawSync(
       Buffer.from("just some public metadata, not a key"),
     );
@@ -877,21 +876,46 @@ describe("secretMaterial compressed-input detection (C1 / ARC-02..ARC-05)", () =
     assert.strictEqual(containsPrivateKeyMaterial(rawDeflate), false);
   });
 
-  it("treats a near-miss header (first byte 0x78, failing checksum) as ordinary input (ARC-04)", () => {
+  it("treats a near-miss header (first byte 0x78, failing checksum) as ordinary input", () => {
     const nearMiss = Buffer.from([0x78, 0x00, 0x01, 0x02]);
     assert.notEqual(((0x78 << 8) | 0x00) % 31, 0, "sanity: fixture fails the modulo-31 check");
     const result = classifyCompressedBuffer(nearMiss);
     assert.equal(result.classification, COMPRESSION_CLASSIFICATION.NOT_COMPRESSED);
   });
 
-  it("does not recursively unwrap a nested (gzip-of-gzip) payload (ARC-05)", () => {
+  it("fails closed on a nested (gzip-of-gzip) payload instead of unwrapping it", () => {
+    // Nesting compression must not let key material evade the ratio/size
+    // ceilings that apply to a single layer: the outer gzip here is a small,
+    // innocuous-looking blob, but it hides a real private key one layer
+    // further in. Silently accepting this (as a single-pass decompression
+    // followed by a scan of the still-compressed inner bytes previously
+    // did) is a fail-open bypass, not a safe default.
     const innerGz = zlib.gzipSync(Buffer.from(pem("PRIVATE KEY")));
     const nestedGz = zlib.gzipSync(innerGz);
     const result = classifyCompressedBuffer(nestedGz);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(result.decoded, null);
+    assert.strictEqual(containsPrivateKeyMaterial(nestedGz), true);
+    assert.throws(
+      () => assertNoPrivateKeyMaterial(nestedGz),
+      (error) => error?.code === PRIVATE_KEY_MATERIAL_REJECTED,
+    );
+  });
+
+  it("fails closed on a nested zlib-of-gzip payload as well, not just gzip-of-gzip", () => {
+    const innerGz = zlib.gzipSync(Buffer.from(pem("EC PRIVATE KEY")));
+    const nestedZlib = zlib.deflateSync(innerGz);
+    const result = classifyCompressedBuffer(nestedZlib);
+    assert.equal(result.classification, COMPRESSION_CLASSIFICATION.REJECTED);
+    assert.strictEqual(containsPrivateKeyMaterial(nestedZlib), true);
+  });
+
+  it("still accepts single-level compression whose decompressed output is ordinary, non-compressed content", () => {
+    // Control for the two nested-compression cases above: a normal,
+    // single-wrap gzip payload must still decompress and scan cleanly.
+    const gz = zlib.gzipSync(Buffer.from(pem("PRIVATE KEY")));
+    const result = classifyCompressedBuffer(gz);
     assert.equal(result.classification, COMPRESSION_CLASSIFICATION.DECOMPRESSED);
-    // The single-pass result is still gzip bytes (the real key needs a
-    // second unwrap to reach); detection must not find it, proving there is
-    // no recursive decompression happening under the hood.
-    assert.strictEqual(containsPrivateKeyMaterial(nestedGz), false);
+    assert.strictEqual(containsPrivateKeyMaterial(gz), true);
   });
 });

--- a/tests/unit/worker-logger-redaction.test.js
+++ b/tests/unit/worker-logger-redaction.test.js
@@ -25,11 +25,11 @@ const FAKE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
 const pem = (label) =>
   `-----BEGIN ${label}-----\n${FAKE_BODY}\n-----END ${label}-----`;
 
-// C3 (ARC-08): apps/worker/src/logger.js wires Winston directly into
+// C3: apps/worker/src/logger.js wires Winston directly into
 // @tokentimer/log-scrub's sanitizeLogRecord (an ES module import, so this
 // suite exercises the same function through the CommonJS package entry
 // point rather than importing the worker's ESM logger module directly).
-describe("worker logger redaction parity (C3 / ARC-08)", () => {
+describe("worker logger redaction parity (C3)", () => {
   it("wires apps/worker/src/logger.js through @tokentimer/log-scrub's sanitizeLogRecord", () => {
     const workerLoggerSource = fs.readFileSync(workerLoggerPath, "utf8");
     assert.match(workerLoggerSource, /@tokentimer\/log-scrub/);

--- a/tests/unit/worker-logger-redaction.test.js
+++ b/tests/unit/worker-logger-redaction.test.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const fs = require("node:fs");
+
+const { sanitizeLogRecord } = require(
+  path.resolve(__dirname, "../../packages/log-scrub"),
+);
+const { redactSensitiveFields } = require(
+  path.resolve(__dirname, "../../apps/api/utils/logger.js"),
+);
+const {
+  PRIVATE_KEY_REDACTION_PLACEHOLDER,
+} = require(path.resolve(__dirname, "../../apps/api/utils/secretMaterial.js"));
+
+const workerLoggerPath = path.resolve(
+  __dirname,
+  "../../apps/worker/src/logger.js",
+);
+
+// Synthetic fixture only. No real key material is committed.
+const FAKE_BODY = "RkFLRS1OT1QtQS1SRUFMLUtFWQ==";
+const pem = (label) =>
+  `-----BEGIN ${label}-----\n${FAKE_BODY}\n-----END ${label}-----`;
+
+// C3 (ARC-08): apps/worker/src/logger.js wires Winston directly into
+// @tokentimer/log-scrub's sanitizeLogRecord (an ES module import, so this
+// suite exercises the same function through the CommonJS package entry
+// point rather than importing the worker's ESM logger module directly).
+describe("worker logger redaction parity (C3 / ARC-08)", () => {
+  it("wires apps/worker/src/logger.js through @tokentimer/log-scrub's sanitizeLogRecord", () => {
+    const workerLoggerSource = fs.readFileSync(workerLoggerPath, "utf8");
+    assert.match(workerLoggerSource, /@tokentimer\/log-scrub/);
+    assert.match(workerLoggerSource, /sanitizeLogRecord\s*\(/);
+  });
+
+  it("redacts a secret-bearing worker job failure exactly like the API logger", () => {
+    const key = pem("RSA PRIVATE KEY");
+    const jobFailure = {
+      level: "error",
+      message: "certops job execution failed",
+      jobId: "job_abc123",
+      password: "should-not-appear",
+      apiKey: "should-not-appear-either",
+      privateKey: key,
+      stdout: `openssl error, dumping key for debug: ${key}`,
+      headers: { authorization: "Bearer leaked-worker-token" },
+    };
+
+    const workerResult = sanitizeLogRecord(jobFailure);
+    const apiResult = redactSensitiveFields(jobFailure);
+
+    assert.equal(workerResult.password, "[REDACTED]");
+    assert.equal(workerResult.apiKey, "[REDACTED]");
+    // Field-name redaction is the outer defense layer: "privateKey" matches
+    // the sensitive-key pattern and is redacted before content-based
+    // scrubbing runs, so it comes back as the generic marker, not the
+    // private-key-specific one.
+    assert.equal(workerResult.privateKey, "[REDACTED]");
+    assert.ok(workerResult.stdout.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.ok(!workerResult.stdout.includes(FAKE_BODY));
+    assert.equal(workerResult.headers.authorization, "[REDACTED]");
+    assert.equal(workerResult.jobId, "job_abc123");
+    assert.equal(workerResult.message, "certops job execution failed");
+
+    // The worker and API loggers must agree byte-for-byte on this record:
+    // both ultimately call the same shared scrubber, so any divergence here
+    // is a real behavioral gap, not just a missing test.
+    assert.deepEqual(workerResult, apiResult);
+  });
+
+  it("redacts a thrown Error the same way on both loggers", () => {
+    const key = pem("EC PRIVATE KEY");
+    const err = new Error(`deploy failed while handling ${key}`);
+    err.stack = `Error: deploy failed while handling ${key}\n    at deploy (apps/worker/src/jobs/deploy.js:42:9)`;
+
+    const workerResult = sanitizeLogRecord({ level: "error", err });
+    const apiResult = redactSensitiveFields({ level: "error", err });
+
+    assert.ok(workerResult.err.message.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.ok(!workerResult.err.message.includes(FAKE_BODY));
+    assert.ok(workerResult.err.stack.includes(PRIVATE_KEY_REDACTION_PLACEHOLDER));
+    assert.match(workerResult.err.stack, /at deploy \(apps\/worker\/src\/jobs\/deploy\.js:42:9\)/);
+    assert.deepEqual(workerResult, apiResult);
+  });
+});


### PR DESCRIPTION
## What

Six real gaps found while verifying the private-key-material detector, `keyReference`/`sourceRef` validation, and redaction parity:

- **Base64url detector:** `secretMaterial.js` didn't recognize base64url-encoded key material (`-`/`_`, no padding) at all. Added `base64VariantFor` so PEM/DER keys wrapped in base64url are detected and redacted the same as standard base64.
- **Compressed-input detector:** no compressed-stream handling existed anywhere. Added `classifyCompressedBuffer`/`looksGzipHeader`/`looksZlibHeader` with explicit input-size and decompression-ratio/output-size bounds, and dictionary-stream (`FDICT`) rejection. Recognized gzip/zlib streams (including a smaller-window header) are decompressed exactly once and scanned; corrupt or oversized streams fail closed instead of falling through to an ordinary-scan bypass; uncompressed input and raw headerless deflate are unaffected; nested gzip-in-gzip is not recursively unwrapped.
- **`keyReference` locality schemes:** `normalizeKeyReference` had no scheme allow-list at all. Added the allow-list (`file://`, `k8s:`, `vault:`, `hsm:`, `external-unknown:`, `pkcs11:`) plus a generic-secret check on the remainder, with an RFC 7512 exemption so a real `pkcs11:token=...` URI isn't misread as a credential assignment.
- **UI example content:** `ImportCertificateForm.jsx`'s placeholder was `agent-id:/etc/ssl/private/wildcard.key`, a private-key-shaped path. Replaced with `vault://pki/web-wildcard` / `pkcs11:token=HSM-1;object=web-wildcard`.
- **Worker redaction parity:** no explicit worker-vs-API redaction parity check existed. Added a CI check (`checkWorkerLoggerParity` in `scripts/check-secret-logging.js`) and a permanent test proving byte-for-byte parity via the shared `log-scrub` module.
- **`keyReference` length parity:** `job-payload.schema.json` (512) and the agent's `claimed-job` validator (512) had drifted from the actual runtime bound (256) in `inventory.js`/`openapi.yaml`. Unified all four to 256.
- **`sourceRef` had zero content validation (found via a live scan against a real database):** `sourceRef`, documented in the OpenAPI contract as an "opaque non-secret source reference," accepted a canary secret unmodified, persisted it verbatim into `managed_certificates.source_ref`, and echoed it back in the import response body. Added `normalizeSourceRef` (private-key/PEM/control-char/generic-secret checks, same detector as `keyReference`) and wired it into all four persistence sites in `inventory.js`.

## Scope note (not a bug, flagged for a follow-up)

The shared generic-secret detector is assignment-pattern based (`key=value` / `key: value`) with no bare-credential-shape heuristic (no AWS/GitHub/Slack-token or JWT shape detection) anywhere in the codebase. `keyReference` is protected from bare secrets by its mandatory scheme allow-list, not shape detection; `sourceRef` has no such allow-list by design, so a bare, unassigned high-entropy secret with no `key=`/`key:` framing pasted directly into `sourceRef` would still not be flagged today.

## Test plan

- [x] New unit tests for the base64url and compressed-input detector cases
- [x] New unit tests for the locality-scheme allow-list and the `sourceRef` regression
- [x] New unit test for the UI placeholder content
- [x] New unit test plus CI check for worker/API redaction parity
- [x] New unit test for `keyReference` length parity across schema/validator/route/UI
- [x] Full unit suite: 1050/1050 passing across 146 suites
- [x] Agent package test suite green
- [x] Live Docker Compose stack scan (canary secrets across import paths, DB columns, container logs) -- confirmed clean after the `sourceRef` fix
- [ ] CI green on this branch
