### PR TITLE
fix(agent): set LimitCORE=0 in Linux systemd unit

### DIFF
--- a/packages/agent/scripts/tokentimer-agent.service
+++ b/packages/agent/scripts/tokentimer-agent.service
@@ -48,6 +48,20 @@ RestartSec=5
 RestartPreventExitStatus=86
 SuccessExitStatus=86
 
+# Core dumps disabled (ADR-0012 decision 19): both the soft AND hard
+# RLIMIT_CORE must be 0 before the Node process starts handling key
+# material, authoritatively, regardless of this distribution's
+# core_pattern/ulimit -c default. Setting only the soft limit (e.g. via a
+# ulimit call in a wrapper script) is not equivalent: a process may raise
+# its own soft limit back up to the hard ceiling at any time, so an
+# ambient or wrapper-set soft-only 0 with hard left at its distribution
+# default (commonly "unlimited") is not the guarantee this decision
+# requires. LimitCORE=0 sets systemd's own default of "soft=hard" to 0,
+# closing that gap before exec. Verified by reading the running process's
+# /proc/<pid>/limits "Max core file size" row, not by inspecting this unit
+# file alone -- see KEY-03 in the manual acceptance checklist.
+LimitCORE=0
+
 # Hardening. ProtectSystem=strict makes the whole filesystem read-only for
 # the service except ReadWritePaths. The base unit only opens the state dir
 # (which also covers ACME tool state under state/acme/); install-agent.sh

--- a/scripts/ci-guards/core-dump-suppression.cjs
+++ b/scripts/ci-guards/core-dump-suppression.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+"use strict";
+
+// Guard: regression test for ADR-0012 decision 19's Linux core-dump
+// suppression (KEY-03 in the manual acceptance checklist). Statically
+// asserts the shipped systemd unit sets LimitCORE=0 in its [Service]
+// section.
+//
+// This is deliberately static, not the KEY-03 live check itself:
+// KEY-03 requires reading /proc/<pid>/limits on a real deployed service
+// to prove the limit actually governs the running process, which a unit
+// file alone cannot prove (a unit file can be present and not be the one
+// actually governing the process -- ADR-0012 says so explicitly). This
+// guard exists only to catch a future edit that silently drops the line
+// this repo already had a real, previously-unfixed gap for: the shipped
+// unit had no LimitCORE directive at all until this guard's sibling fix,
+// so `Max core file size` on a real running agent process read
+// "0 / unlimited" (soft/hard) instead of "0 / 0", the hard limit left at
+// whatever the host distribution defaulted to.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const unitPath = path.join(repoRoot, "packages/agent/scripts/tokentimer-agent.service");
+const relUnitPath = path.relative(repoRoot, unitPath).replace(/\\/g, "/");
+
+function main() {
+  if (!fs.existsSync(unitPath)) {
+    console.log(
+      "core-dump-suppression: ok (vacuous pass - packages/agent/scripts/tokentimer-agent.service does not exist yet)",
+    );
+    return;
+  }
+
+  const content = fs.readFileSync(unitPath, "utf8");
+  const serviceSectionMatch = content.match(/\[Service\]([\s\S]*?)(\n\[|$)/);
+  if (!serviceSectionMatch) {
+    console.error(
+      `::error file=${relUnitPath}::core-dump-suppression: could not find a [Service] section in the unit file`,
+    );
+    process.exit(1);
+  }
+
+  const serviceSection = serviceSectionMatch[1];
+  const hasLimitCoreZero = /^\s*LimitCORE\s*=\s*0\s*$/m.test(serviceSection);
+
+  if (!hasLimitCoreZero) {
+    console.error(
+      `::error file=${relUnitPath}::core-dump-suppression: [Service] section is missing "LimitCORE=0" ` +
+        "(ADR-0012 decision 19, KEY-03) -- without it, the process's RLIMIT_CORE hard limit is left at " +
+        "whatever this distribution defaults to, and a soft-limit-only mitigation elsewhere would not be " +
+        "authoritative since a process may raise its own soft limit back up to that hard ceiling",
+    );
+    process.exit(1);
+  }
+
+  console.log(`core-dump-suppression: ok (${relUnitPath} sets LimitCORE=0 in [Service])`);
+}
+
+main();


### PR DESCRIPTION
The shipped tokentimer-agent.service had no LimitCORE directive, so the process's RLIMIT_CORE hard limit was left at whatever the host distribution defaulted to.

Setting only the soft limit is not sufficient: a process can raise its own soft limit back up to the hard ceiling at any time. LimitCORE=0 sets systemd's soft=hard default to 0, closing that gap before the process starts handling key material.

Verified on a real systemd-managed agent process on Ubuntu 22.04: /proc/<pid>/limits read '0 / unlimited' (soft/hard) before this fix, and '0 / 0' after.

Adds a static CI guard (core-dump-suppression.cjs) so a future edit to the unit file cannot silently drop LimitCORE=0 again. This guard is deliberately static; it cannot prove the limit governs the running process by itself, only that the directive is present in the shipped unit file.