### PR TITLE
fix(dashboard): debounce asset search updates

### DIFF
--- a/apps/dashboard/src/App.jsx
+++ b/apps/dashboard/src/App.jsx
@@ -892,8 +892,11 @@ function App() {
   const [categoryCounts, setCategoryCounts] = useState({}); // { [category]: number }
   const [limit] = useState(500);
   const [_offset, setOffset] = useState(0);
-  const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const setCommittedSearchQuery = useCallback(
+    value => setDebouncedQuery(String(value || '').trim()),
+    []
+  );
   const [selectedCategories, setSelectedCategories] = useState([]); // array of values
   const [serverSort, setServerSort] = useState('expiration_asc');
 
@@ -1395,12 +1398,6 @@ function App() {
     },
     [selectedCategories, debouncedQuery, location.search]
   );
-
-  // Debounce global query
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
-    return () => clearTimeout(t);
-  }, [searchQuery]);
 
   // Restore pending welcome from previous navigation (robust to URL churn)
   useEffect(() => {
@@ -2995,7 +2992,7 @@ function App() {
                                   setSelectedToken={setSelectedToken}
                                   handleCloseTokenModal={handleCloseTokenModal}
                                   // Thread global filtering/search/sort state into wrapper
-                                  setSearchQuery={setSearchQuery}
+                                  setSearchQuery={setCommittedSearchQuery}
                                   showProductTour={showProductTour}
                                   setShowProductTour={setShowProductTour}
                                   tourType={tourType}

--- a/apps/dashboard/src/components/AssetFilters.jsx
+++ b/apps/dashboard/src/components/AssetFilters.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -33,6 +33,7 @@ const STATUS_COLOR_SCHEMES = {
 };
 
 const CHIP_MIN_HEIGHT = '32px';
+export const ASSET_SEARCH_DEBOUNCE_MS = 300;
 
 const STATUS_CHIP_LAYOUT = {
   variant: 'unstyled',
@@ -213,6 +214,66 @@ function ScrollableChipRow({ children, isMobileLayout }) {
   );
 }
 
+function AssetSearchInput({
+  value,
+  onCommit,
+  inputBg,
+  inputBorder,
+  placeholderColor,
+  searchIconColor,
+}) {
+  const externalValue = value || '';
+  const [draft, setDraft] = useState(externalValue);
+  const pendingRef = useRef(false);
+  const onCommitRef = useRef(onCommit);
+
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  useEffect(() => {
+    if (pendingRef.current) {
+      if (externalValue === draft) pendingRef.current = false;
+      return;
+    }
+
+    setDraft(current => (current === externalValue ? current : externalValue));
+  }, [draft, externalValue]);
+
+  useEffect(() => {
+    if (!pendingRef.current || draft === externalValue) return undefined;
+
+    const timeout = window.setTimeout(() => {
+      if (pendingRef.current) onCommitRef.current(draft);
+    }, ASSET_SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [draft, externalValue]);
+
+  return (
+    <InputGroup maxW={{ base: '100%', lg: '320px' }} size='sm'>
+      <InputLeftElement pointerEvents='none' h='32px'>
+        <Search size={16} color={searchIconColor} />
+      </InputLeftElement>
+      <Input
+        value={draft}
+        onChange={event => {
+          pendingRef.current = true;
+          setDraft(event.target.value);
+        }}
+        placeholder='Search assets, domains, owners...'
+        size='sm'
+        bg={inputBg}
+        borderColor={inputBorder}
+        borderRadius='md'
+        pl='36px'
+        minH={CHIP_MIN_HEIGHT}
+        _placeholder={{ color: placeholderColor }}
+      />
+    </InputGroup>
+  );
+}
+
 export default function AssetFilters({
   statusFilter,
   setStatusFilter,
@@ -270,33 +331,23 @@ export default function AssetFilters({
           w={{ base: '100%', lg: 'auto' }}
           flexShrink={0}
         >
-          <InputGroup maxW={{ base: '100%', lg: '320px' }} size='sm'>
-            <InputLeftElement pointerEvents='none' h='32px'>
-              <Search size={16} color={searchIconColor} />
-            </InputLeftElement>
-            <Input
-              value={panelQueries.__global || ''}
-              onChange={event => {
-                const nextValue = event.target.value;
-                setPanelQueries(prev => ({
-                  ...prev,
-                  __global: nextValue,
-                }));
-                if (typeof onGlobalSearchChange === 'function') {
-                  onGlobalSearchChange(nextValue);
-                }
-                notifyFilterReset();
-              }}
-              placeholder='Search assets, domains, owners...'
-              size='sm'
-              bg={inputBg}
-              borderColor={inputBorder}
-              borderRadius='md'
-              pl='36px'
-              minH={CHIP_MIN_HEIGHT}
-              _placeholder={{ color: placeholderColor }}
-            />
-          </InputGroup>
+          <AssetSearchInput
+            value={panelQueries.__global || ''}
+            onCommit={nextValue => {
+              setPanelQueries(prev => ({
+                ...prev,
+                __global: nextValue,
+              }));
+              if (typeof onGlobalSearchChange === 'function') {
+                onGlobalSearchChange(nextValue);
+              }
+              notifyFilterReset();
+            }}
+            inputBg={inputBg}
+            inputBorder={inputBorder}
+            placeholderColor={placeholderColor}
+            searchIconColor={searchIconColor}
+          />
           {(retiredCount > 0 || showRetired) &&
           typeof onToggleShowRetired === 'function' ? (
             <Button

--- a/apps/dashboard/tests/unit/AssetFilters.test.jsx
+++ b/apps/dashboard/tests/unit/AssetFilters.test.jsx
@@ -1,0 +1,91 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AssetFilters, {
+  ASSET_SEARCH_DEBOUNCE_MS,
+} from '../../src/components/AssetFilters.jsx';
+import { DashboardThemeProvider } from '../../src/hooks/useDashboardTheme.js';
+
+const originalMatchMedia = window.matchMedia;
+
+function renderFilters(overrides = {}) {
+  const props = {
+    statusFilter: 'all',
+    setStatusFilter: vi.fn(),
+    selectedCategories: [],
+    setSelectedCategories: vi.fn(),
+    panelQueries: { __global: '', __section: '__all__' },
+    setPanelQueries: vi.fn(),
+    onGlobalSearchChange: vi.fn(),
+    onFilterReset: vi.fn(),
+    ...overrides,
+  };
+
+  render(
+    <ChakraProvider>
+      <DashboardThemeProvider>
+        <AssetFilters {...props} />
+      </DashboardThemeProvider>
+    </ChakraProvider>
+  );
+
+  return props;
+}
+
+describe('AssetFilters search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('keeps rapid typing local and commits one search update after the pause', () => {
+    const props = renderFilters();
+    const input = screen.getByPlaceholderText(
+      'Search assets, domains, owners...'
+    );
+
+    for (const value of ['t', 'to', 'tok', 'toke', 'token']) {
+      fireEvent.change(input, { target: { value } });
+      expect(input).toHaveValue(value);
+    }
+
+    expect(props.setPanelQueries).not.toHaveBeenCalled();
+    expect(props.onGlobalSearchChange).not.toHaveBeenCalled();
+    expect(props.onFilterReset).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(ASSET_SEARCH_DEBOUNCE_MS);
+    });
+
+    expect(props.setPanelQueries).toHaveBeenCalledTimes(1);
+    const update = props.setPanelQueries.mock.calls[0][0];
+    expect(update(props.panelQueries)).toEqual({
+      __global: 'token',
+      __section: '__all__',
+    });
+    expect(props.onGlobalSearchChange).toHaveBeenCalledTimes(1);
+    expect(props.onGlobalSearchChange).toHaveBeenCalledWith('token');
+    expect(props.onFilterReset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Moves the asset search debounce out of `App.jsx` and into `AssetFilters`, so keystrokes stay local to the input and only a single, debounced value is committed upstream.

- Removes the `searchQuery` state and its `useEffect`-based 300ms debounce from `App.jsx`. `setSearchQuery` passed down to `AssetFilters` now writes directly to `debouncedQuery` (renamed prop wiring to `setCommittedSearchQuery`).
- Adds a new `AssetSearchInput` component in `AssetFilters.jsx` that owns an uncontrolled `draft` state for the text field and debounces commits (`ASSET_SEARCH_DEBOUNCE_MS = 300`) before calling `onCommit`, which updates `panelQueries`, notifies `onGlobalSearchChange`, and triggers `notifyFilterReset`.
- Previously, every keystroke updated `searchQuery` and `panelQueries` immediately, and only the derived `debouncedQuery` used for filtering was delayed. That still re-rendered the parent and reset filters on every keystroke. Now the input field re-renders locally and the parent only re-renders once per debounce window.
- Adds unit tests (`AssetFilters.test.jsx`) verifying rapid typing stays local and only commits once, after the debounce window elapses.

## Why

The asset search input was resetting filters and re-rendering the dashboard on every keystroke, making typing feel janky on large asset lists. Debouncing at the input level (instead of downstream in `App.jsx`) keeps typing responsive and only propagates a single committed value.

## Test plan

- New test: `apps/dashboard/tests/unit/AssetFilters.test.jsx` covers rapid typing staying local and a single commit firing after the debounce window.
