### PR TITLE
fix(dashboard): reformat Audit.jsx capabilities-diff line to satisfy Prettier

### DIFF
--- a/apps/dashboard/src/pages/Audit.jsx
+++ b/apps/dashboard/src/pages/Audit.jsx
@@ -896,7 +896,9 @@ export default function Audit({ session, onLogout, onAccountClick }) {
       if (added.length > 0) parts.push(`Added: ${formatArrayValue(added)}`);
       if (removed.length > 0)
         parts.push(`Removed: ${formatArrayValue(removed)}`);
-      parts.push(`Capabilities: ${current.length > 0 ? formatArrayValue(current) : '(none)'}`);
+      parts.push(
+        `Capabilities: ${current.length > 0 ? formatArrayValue(current) : '(none)'}`
+      );
       return parts.length > 0 ? parts.join(' | ') : '';
     } catch (_) {
       return '';


### PR DESCRIPTION
PR #118's manual conflict resolution during the 2026-08-04 stack merge left one line in \enderCapabilitiesDiff\'s \parts.push(...)\ call over Prettier's 80-column limit, which \rontend_quality\'s \prettier --check\ job would fail on the next PR that touches this file. Found while re-running the full \rontend_quality\ job set against the merged \main\ as part of a post-merge integrity check (not caught earlier because CI wasn't re-run against the final merge state until now). Pure formatting change, no behavior difference. Verified: \prettier --check\ clean, lint 0 errors, type-check clean, dashboard build succeeds.