### PR TITLE
fix(agent): retry post-reload verify probe on transient fingerprint mismatch (VERIFY-RACE-01)

### DIFF
--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -386,6 +386,26 @@ const LEASE_TRANSIENT_BACKOFF_MS = 200;
 const LEASE_HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
 /**
+ * VERIFY-RACE-01: max retries for a live verify probe that connects fine
+ * but reports the *previous* certificate's fingerprint. `maybeReloadForJob`
+ * returns as soon as `systemctl reload`/equivalent exits, which only
+ * guarantees the reload was requested, not that every worker/connection has
+ * cut over to the new certificate. On some services (multi-worker nginx
+ * with long-lived keepalive connections, blue/green LBs, etc.) a probe run
+ * immediately after reload can land on a worker that has not yet rotated,
+ * observed empirically at ~9ms post-reload while ~1500ms post-reload was
+ * reliably safe. Retrying only this specific outcome absorbs that gap
+ * without masking a genuinely wrong deploy.
+ */
+const MAX_VERIFY_TRANSIENT_RETRIES = 4;
+/**
+ * Fixed backoff schedule between transient verify-mismatch retries (ms).
+ * Cumulative worst case is 2500ms, comfortably past the ~1500ms
+ * empirically-safe mark with margin for slower reload paths.
+ */
+const VERIFY_TRANSIENT_RETRY_DELAYS_MS = [250, 500, 750, 1000];
+
+/**
  * Mutable lease session shared across accept + execute for one job attempt.
  * @returns {{ lastConfirmedExpiresAtMs: number|null, consecutiveTransientFailures: number, abort: object|null }}
  */
@@ -401,6 +421,61 @@ function sleepMs(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+/**
+ * VERIFY-RACE-01 mitigation: retries `probeImpl` (defaults to the real
+ * `verifyDeployedCertificate`) when, and only when, the probe connected
+ * successfully and got back an actual certificate whose fingerprint simply
+ * does not match yet. That specific shape (`actualFingerprintSha256` is a
+ * non-null string different from the expected one) is the signature of the
+ * reload-cutover race: the endpoint is reachable and serving *some*
+ * certificate, it just has not rotated to the new one on every path yet.
+ *
+ * Every other failure shape -- connect failures, handshake timeouts, no
+ * certificate presented at all (`actualFingerprintSha256 === null`) -- is
+ * NOT retried. Those are not known to self-heal on a short timer and
+ * retrying them would only extend a genuinely broken deploy's failure
+ * latency by several seconds for no benefit.
+ *
+ * Authorization/policy rejections never reach this function at all: the
+ * `checkVerifyHost` gate at the call site runs first and returns its own
+ * fail-fast outcome before `probeImpl` is ever invoked.
+ *
+ * @param {object} probeOptions forwarded verbatim to `probeImpl`.
+ * @param {object} [opts]
+ * @param {Function} [opts.probeImpl] injection point for tests; defaults to
+ *   `verifyDeployedCertificate`.
+ * @param {number} [opts.maxRetries] defaults to MAX_VERIFY_TRANSIENT_RETRIES.
+ * @param {number[]} [opts.retryDelaysMs] defaults to
+ *   VERIFY_TRANSIENT_RETRY_DELAYS_MS.
+ * @param {Function} [opts.sleep] injection point for tests; defaults to
+ *   sleepMs.
+ * @returns {Promise<ReturnType<typeof verifyDeployedCertificate>>}
+ */
+async function verifyDeployedCertificateWithRetry(
+  probeOptions,
+  {
+    probeImpl = verifyDeployedCertificate,
+    maxRetries = MAX_VERIFY_TRANSIENT_RETRIES,
+    retryDelaysMs = VERIFY_TRANSIENT_RETRY_DELAYS_MS,
+    sleep = sleepMs,
+  } = {},
+) {
+  let result;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    result = await probeImpl(probeOptions);
+    if (result.verified === true) return result;
+
+    const isTransientMismatch =
+      typeof result.actualFingerprintSha256 === "string" &&
+      result.actualFingerprintSha256.length > 0;
+    if (!isTransientMismatch || attempt === maxRetries) return result;
+
+    const delay = retryDelaysMs[attempt] ?? retryDelaysMs[retryDelaysMs.length - 1];
+    await sleep(delay);
+  }
+  return result;
 }
 
 function extractLeaseExpiresAtMs(response, nowMs) {
@@ -3558,7 +3633,7 @@ async function runDeployReloadVerify({
       return { ...withRollbackNote(failedOutcome, rollback), deployResult };
     }
 
-    const probe = await verifyDeployedCertificate({
+    const probe = await verifyDeployedCertificateWithRetry({
       host: job.verifyHost,
       port: typeof job.verifyPort === "number" ? job.verifyPort : undefined,
       expectedFingerprintSha256: fingerprint,
@@ -4427,6 +4502,9 @@ module.exports = {
   DEFAULT_JOB_LEASE_MS,
   MAX_LEASE_TRANSIENT_RETRIES,
   LEASE_HEARTBEAT_INTERVAL_MS,
+  verifyDeployedCertificateWithRetry,
+  MAX_VERIFY_TRANSIENT_RETRIES,
+  VERIFY_TRANSIENT_RETRY_DELAYS_MS,
   AGENT_CANDIDATE_CAPABILITIES,
   AGENT_DECLARED_CAPABILITIES,
   resolveDeclaredCapabilities,

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -41,6 +41,9 @@ const {
   mapJobKeyAlgorithm,
   resolveJobDeployTargets,
   resolveDeclaredCapabilities,
+  verifyDeployedCertificateWithRetry,
+  MAX_VERIFY_TRANSIENT_RETRIES,
+  VERIFY_TRANSIENT_RETRY_DELAYS_MS,
 } = require("./index.js");
 const {
   markSideEffectReached,
@@ -3526,3 +3529,131 @@ describe("renew chain deployment", () => {
     assert.match(outcome.errorMessage, /Skipping renew, Next renewal time is/);
   });
 });
+
+describe("verifyDeployedCertificateWithRetry (VERIFY-RACE-01)", () => {
+  function fakeSleep(delays) {
+    return async (ms) => {
+      delays.push(ms);
+    };
+  }
+
+  it("returns immediately on a first-attempt verified probe (no retry, no sleep)", async () => {
+    const delays = [];
+    let calls = 0;
+    const probeImpl = async () => {
+      calls++;
+      return { verified: true, actualFingerprintSha256: "abc123" };
+    };
+
+    const result = await verifyDeployedCertificateWithRetry(
+      { host: "example.com", expectedFingerprintSha256: "abc123" },
+      { probeImpl, sleep: fakeSleep(delays) },
+    );
+
+    assert.equal(result.verified, true);
+    assert.equal(calls, 1);
+    assert.deepEqual(delays, []);
+  });
+
+  it("retries on a fingerprint mismatch with an actual certificate, then succeeds once the endpoint cuts over", async () => {
+    const delays = [];
+    let calls = 0;
+    const probeImpl = async () => {
+      calls++;
+      if (calls < 3) {
+        return {
+          verified: false,
+          actualFingerprintSha256: "stale-fingerprint",
+          detail: "Fingerprint mismatch",
+        };
+      }
+      return { verified: true, actualFingerprintSha256: "new-fingerprint" };
+    };
+
+    const result = await verifyDeployedCertificateWithRetry(
+      { host: "example.com", expectedFingerprintSha256: "new-fingerprint" },
+      { probeImpl, sleep: fakeSleep(delays) },
+    );
+
+    assert.equal(result.verified, true);
+    assert.equal(calls, 3);
+    // Two retries happened before the third (successful) attempt, using the
+    // configured backoff schedule's first two delays.
+    assert.deepEqual(delays, VERIFY_TRANSIENT_RETRY_DELAYS_MS.slice(0, 2));
+  });
+
+  it("exhausts retries and returns the last mismatch outcome if the endpoint never cuts over", async () => {
+    const delays = [];
+    let calls = 0;
+    const probeImpl = async () => {
+      calls++;
+      return {
+        verified: false,
+        actualFingerprintSha256: "still-stale",
+        detail: "Fingerprint mismatch",
+      };
+    };
+
+    const result = await verifyDeployedCertificateWithRetry(
+      { host: "example.com", expectedFingerprintSha256: "expected" },
+      { probeImpl, sleep: fakeSleep(delays) },
+    );
+
+    assert.equal(result.verified, false);
+    assert.equal(result.actualFingerprintSha256, "still-stale");
+    // maxRetries retries after the first attempt = maxRetries + 1 calls.
+    assert.equal(calls, MAX_VERIFY_TRANSIENT_RETRIES + 1);
+    assert.equal(delays.length, MAX_VERIFY_TRANSIENT_RETRIES);
+  });
+
+  it("does not retry a connect/handshake failure (no certificate presented at all)", async () => {
+    const delays = [];
+    let calls = 0;
+    const probeImpl = async () => {
+      calls++;
+      return {
+        verified: false,
+        actualFingerprintSha256: null,
+        detail: "Connection refused",
+      };
+    };
+
+    const result = await verifyDeployedCertificateWithRetry(
+      { host: "example.com", expectedFingerprintSha256: "expected" },
+      { probeImpl, sleep: fakeSleep(delays) },
+    );
+
+    assert.equal(result.verified, false);
+    assert.equal(result.actualFingerprintSha256, null);
+    assert.equal(calls, 1);
+    assert.deepEqual(delays, []);
+  });
+
+  it("respects a custom maxRetries/retryDelaysMs override", async () => {
+    const delays = [];
+    let calls = 0;
+    const probeImpl = async () => {
+      calls++;
+      return {
+        verified: false,
+        actualFingerprintSha256: "stale",
+        detail: "Fingerprint mismatch",
+      };
+    };
+
+    const result = await verifyDeployedCertificateWithRetry(
+      { host: "example.com", expectedFingerprintSha256: "expected" },
+      {
+        probeImpl,
+        sleep: fakeSleep(delays),
+        maxRetries: 1,
+        retryDelaysMs: [42],
+      },
+    );
+
+    assert.equal(result.verified, false);
+    assert.equal(calls, 2);
+    assert.deepEqual(delays, [42]);
+  });
+});
+


### PR DESCRIPTION
## Summary

The agent's verify step probes the live endpoint immediately after a service reload returns success. On multi-worker services (nginx with long-lived keepalive connections, blue/green load balancers) the reload command can return before every worker has actually cut over to the new certificate, so the probe connects fine but observes the previous certificate's fingerprint and the agent fails a perfectly good deploy.

Reproduced empirically against a live nginx reload: a probe run immediately after reload (about 9ms later) reliably saw the old fingerprint, while a probe run about 1500ms after reload reliably saw the new one.

This adds `verifyDeployedCertificateWithRetry`, a bounded retry-with-backoff wrapper around the existing `verifyDeployedCertificate`:

- Retries only when the probe connected successfully and observed a real, non-null certificate fingerprint that simply does not match yet, the exact signature of the reload-cutover race.
- Connect failures, timeouts, and "no certificate presented at all" are never retried.
- Authorization and policy rejections never reach this function since `checkVerifyHost` runs first and fails fast before the probe is invoked.
- Retry budget is 4 attempts with backoff of 250/500/750/1000ms (cumulative worst case 2500ms), comfortably past the observed 1500ms-safe mark with margin.

## Changes

- `packages/agent/src/index.js`: adds `verifyDeployedCertificateWithRetry`, `MAX_VERIFY_TRANSIENT_RETRIES`, `VERIFY_TRANSIENT_RETRY_DELAYS_MS`; `runDeployReloadVerify`'s call site now calls the retry wrapper instead of `verifyDeployedCertificate` directly; both new symbols are exported.
- `packages/agent/src/index.test.js`: deterministic regression test using an injected fake sleep and a stubbed probe implementation (no real timing dependency), covering:
  - immediate success on the first attempt (no retry, no sleep)
  - a transient mismatch that recovers within the retry budget
  - a mismatch that never recovers, exhausting the retry budget and returning the final failed result
  - a non-transient failure (no certificate presented) returning on the first attempt with zero retries
  - a custom `maxRetries`/`retryDelaysMs` override

## Test plan

- [x] `node --test src/index.test.js` in `packages/agent`: 110/110 passing, including the 5 new VERIFY-RACE-01 cases.
- [x] Full agent suite (`npm test` in `packages/agent`): 942 passing, 0 failing, 16 pre-existing skips, no regressions.
- [x] Live re-repro in a throwaway WSL2 Ubuntu + nginx setup: a probe without the retry wrapper failed 5/5 times when run immediately (about 0ms) after `nginx -s reload` following a certificate rotation, always observing the previous fingerprint. The same reload followed by the retry wrapper succeeded 5/5 times, each time recovering on the second attempt (one 250ms backoff). This matches the 9ms-fail / 1500ms-pass pattern originally observed. The throwaway nginx instance and repro files were removed afterward.
