### PR TITLE
fix(certops): bump reference-client encoded-payload bound to match ADR-0012's ninth amendment

### DIFF
--- a/packages/agent/reference/tokentimer-protocol.ps1
+++ b/packages/agent/reference/tokentimer-protocol.ps1
@@ -141,7 +141,13 @@ $script:ProtocolVersion = "1.0.0"
 $script:SchemaVersion = 1
 
 $script:MaxClaimResponseBytes = 1048576
-$script:MaxEncodedPayloadChars = 65536
+# ADR-0012's ninth amendment (2026-08-04): 65536 was the tightest value that
+# still decodes to exactly the 49152-byte decoded bound, which made the
+# decoded-byte check below mathematically unreachable. 98304 gives real
+# headroom (floor(98304/4)*3 = 73728 decoded bytes) so a payload between the
+# two bounds is actually rejected by the decoded-byte check that enforces the
+# real content-size policy, matching packages/agent/src/signing/index.js.
+$script:MaxEncodedPayloadChars = 98304
 $script:MaxDecodedPayloadBytes = 49152
 $script:DefaultClockSkewToleranceSeconds = 300
 

--- a/packages/agent/reference/tokentimer-protocol.sh
+++ b/packages/agent/reference/tokentimer-protocol.sh
@@ -146,7 +146,13 @@ readonly TOKENTIMER_CLAIM_PATH="/api/v1/certops/agent/jobs/claim"
 readonly TOKENTIMER_RESULTS_PATH="/api/v1/certops/agent/jobs/results"
 
 readonly TOKENTIMER_MAX_CLAIM_RESPONSE_BYTES=1048576
-readonly TOKENTIMER_MAX_ENCODED_PAYLOAD_CHARS=65536
+# ADR-0012's ninth amendment (2026-08-04): 65536 was the tightest value that
+# still decodes to exactly the 49152-byte decoded bound, which made the
+# decoded-byte check below mathematically unreachable. 98304 gives real
+# headroom (floor(98304/4)*3 = 73728 decoded bytes) so a payload between the
+# two bounds is actually rejected by the decoded-byte check that enforces the
+# real content-size policy, matching packages/agent/src/signing/index.js.
+readonly TOKENTIMER_MAX_ENCODED_PAYLOAD_CHARS=98304
 readonly TOKENTIMER_MAX_DECODED_PAYLOAD_BYTES=49152
 readonly TOKENTIMER_SIGNATURE_DECODED_BYTES=64
 readonly TOKENTIMER_DEFAULT_CLOCK_SKEW_TOLERANCE_S=300


### PR DESCRIPTION
## Summary
- The Bash and PowerShell reference clients (`packages/agent/reference/tokentimer-protocol.sh`, `tokentimer-protocol.ps1`) were missed when ADR-0012's ninth amendment fixed the same bug in the Node agent's `packages/agent/src/signing/index.js`.
- 65536 was the tightest encoded-payload-char bound that still decodes to exactly the 49152-byte decoded bound, which made the decoded-byte check mathematically unreachable in both reference-client implementations (no base64 string within a byte-for-byte-equal encoded ceiling can ever decode to more bytes than that same ceiling already permits).
- Bumped both constants to 98304 to match the JS implementation and the ADR exactly, restoring real headroom (`floor(98304/4)*3 = 73728` decoded bytes) so payloads in the 49153-73728 decoded-byte range are actually caught by the decoded-byte check, with its own more specific rejection reason, instead of never reaching it.

## Why now
Found during a post-merge documentation/implementation consistency audit of ADR-0012 against all three implementations (Node agent, Bash reference client, PowerShell reference client).

## Test plan
- [x] `bash -n` syntax check on the modified shell script.
- [x] PowerShell AST parser confirms zero syntax errors on the modified script.
- [x] `ascii-only-signed-scripts` and `leak-scan` CI guards both pass on the changed files.
- [x] No behavior change for any payload actually seen in production; only affects payloads in the narrow 49153-73728 decoded-byte gap between the two bounds, which previously could not exist without also failing the encoded check first.