### PR TITLE
fix(agent): Windows NTP detection, installer quoting/rollback, and SCM exit-code bugs

### DIFF
--- a/packages/agent/scripts/install-agent.ps1
+++ b/packages/agent/scripts/install-agent.ps1
@@ -23,7 +23,10 @@
 #   5. Installs a native Windows Service (sc.exe / New-Service; no NSSM or
 #      other third-party service wrapper) running as LocalSystem per
 #      ADR-0012 decision 11, then starts it.
-#   6. On an upgrade (the service already exists), health-checks the
+#   6. Sets the Windows Error Reporting LocalDumps DumpType=0 for node.exe
+#      (ADR-0012 decision 19: core dumps are disabled by a named,
+#      explicit mechanism, not an unspecified machine-wide default).
+#   7. On an upgrade (the service already exists), health-checks the
 #      restarted service and rolls back to the previous app version, with
 #      the credential and configuration preserved and its ACL re-asserted,
 #      if the health check fails.
@@ -675,22 +678,71 @@ if (-not $script:DryRun -and -not (Test-Path $serviceHostExe)) {
 $quotedServiceHost = '"' + $serviceHostExe + '"'
 $binPath = "$quotedServiceHost $quotedNode $quotedEntry"
 
+# sc.exe's binPath= value here is three separately-quoted path segments
+# (host exe, node.exe, entry script), which is the documented pattern for
+# a service whose binary takes quoted arguments. Windows PowerShell 5.1's
+# native-argument passing does not re-escape a string that already starts
+# and ends with a double quote, so $binPath reaches sc.exe's own (naive)
+# command-line tokenizer as raw, unwrapped `"..." "..." "..."` text --
+# sc.exe's tokenizer stops at the first embedded quoted segment and
+# treats what follows as unrecognized extra arguments, failing every
+# single time with exit 1639 (invalid command line), confirmed by a live
+# repro on Windows Server 2025 build 26100 / PowerShell 5.1, this script's
+# first real-host run. Wrapping the whole three-segment value in
+# one more outer pair of quotes, with the inner quotes doubled rather than
+# backslash-escaped (sc.exe's own convention, not cmd.exe's), survives
+# PowerShell's native-argument passing intact and round-trips through
+# `sc qc`/WMI PathName byte-for-byte, confirmed live against both
+# `sc.exe create` and `sc.exe config`. $binPath itself is left as the
+# human-readable form for -DryRun/log output; only this escaped variant is
+# ever passed to sc.exe.
+$binPathForScExe = '"' + $binPath.Replace('"', '""') + '"'
+
 if ($script:DryRun) {
     Write-Host "[dry-run] sc.exe create/config $ServiceName binPath= $binPath start= auto obj= LocalSystem"
     Write-Host "[dry-run] sc.exe failure $ServiceName reset= 86400 actions= restart/5000"
     Write-Host "[dry-run] set HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName\Environment"
+    Write-Host "[dry-run] set HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\node.exe DumpType=0"
     Write-Host "[dry-run] (re)start $ServiceName and health-check it"
     Write-Log ""
     Write-Log "Dry run complete. No changes were made."
     exit 0
 }
 
+# --------------------------------------- Windows Error Reporting dump suppression
+# ADR-0012 decision 19: core dumps must be disabled for the production
+# agent by a named, platform-specific mechanism, not an unspecified
+# "disabled" claim, since a crash dump is an alternate, unlocked copy of
+# process memory that no in-process buffer discipline can prevent. This
+# was previously documented in ADR-0012 but never implemented; a real-host
+# verification pass found the gap.
+#
+# WER's LocalDumps key is scoped by executable *file name*, not full path,
+# and Windows has no path-scoped equivalent. node.exe is the process that
+# actually runs the agent's key-handling JS code; the windows-service-host
+# shim (see windows-service-host/) is a thin SCM adapter that spawns
+# node.exe as its child and never itself holds key bytes, so suppressing
+# dumps only for the service-host executable would not protect the
+# process that matters. Setting this for node.exe suppresses WER dumps for
+# any node.exe process on this host, not only this agent's -- an accepted
+# trade-off per decision 10's own established principle that a
+# narrow-but-ineffective control is worse than a broad-but-deterministic
+# one. An operator who needs WER dumps for an unrelated Node service on
+# the same host should not colocate it with this agent.
+function Set-WindowsDumpSuppression {
+    param([string]$ExeName)
+    $key = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\$ExeName"
+    New-Item -Path $key -Force | Out-Null
+    New-ItemProperty -Path $key -Name "DumpType" -PropertyType DWord -Value 0 -Force | Out-Null
+}
+Invoke-Step "set WER LocalDumps DumpType=0 for node.exe" { Set-WindowsDumpSuppression -ExeName "node.exe" }
+
 $serviceExisted = [bool](Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)
 if (-not $serviceExisted) {
-    & sc.exe create $ServiceName type= own start= auto obj= LocalSystem DisplayName= $ServiceDisplayName binPath= $binPath | Out-Null
+    & sc.exe create $ServiceName type= own start= auto obj= LocalSystem DisplayName= $ServiceDisplayName binPath= $binPathForScExe | Out-Null
     if ($LASTEXITCODE -ne 0) { Fail "sc.exe create failed for $ServiceName (exit $LASTEXITCODE)" }
 } else {
-    & sc.exe config $ServiceName binPath= $binPath obj= LocalSystem start= auto DisplayName= $ServiceDisplayName | Out-Null
+    & sc.exe config $ServiceName binPath= $binPathForScExe obj= LocalSystem start= auto DisplayName= $ServiceDisplayName | Out-Null
     if ($LASTEXITCODE -ne 0) { Fail "sc.exe config failed to update $ServiceName (exit $LASTEXITCODE)" }
 }
 & sc.exe failureflag $ServiceName 1 | Out-Null
@@ -705,10 +757,26 @@ Set-ServiceEnvironment -ConfigDir $StateDir -Token $script:BootstrapToken
 # correct verb for both the install and the upgrade path (mirrors
 # install-agent.sh's use of `systemctl restart` for the same reason).
 $currentStatus = (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue).Status
-if ($currentStatus -eq 'Running') {
-    Restart-Service -Name $ServiceName -Force
-} else {
-    Start-Service -Name $ServiceName
+# A build broken badly enough that the
+# service host can't even reach a running state (not merely "started but
+# unhealthy") makes Restart-Service/Start-Service themselves raise a
+# terminating error under this script's script-wide $ErrorActionPreference
+# = "Stop" -- live-repro'd on a real Windows Server host with a sabotaged
+# entry point: the uncaught exception killed the script before Line 766's
+# health check ever ran, so the rollback below never executed and the host
+# was left with a Stopped service running the broken build. The fix routes
+# every restart-time failure through the same Test-ServiceHealthy() gate
+# below instead of a second, divergent failure path: swallow the error here
+# (logged, not silent) and let the unhealthy Stopped/Running state that
+# Test-ServiceHealthy already understands decide whether to roll back.
+try {
+    if ($currentStatus -eq 'Running') {
+        Restart-Service -Name $ServiceName -Force -ErrorAction Stop
+    } else {
+        Start-Service -Name $ServiceName -ErrorAction Stop
+    }
+} catch {
+    Write-Log "failed to (re)start ${ServiceName}: $($_.Exception.Message)"
 }
 
 $healthy = Test-ServiceHealthy -TimeoutSeconds 20
@@ -718,7 +786,7 @@ if (-not $healthy -and $script:IsUpgrade -and (Test-Path $script:AppPrevious)) {
     Stop-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue
     Remove-Item -Recurse -Force $AppDir
     Rename-Item -LiteralPath $script:AppPrevious -NewName (Split-Path -Leaf $AppDir)
-    $rollbackBinPath = $binPath
+    $rollbackBinPath = $binPathForScExe
     & sc.exe config $ServiceName binPath= $rollbackBinPath | Out-Null
     Set-ServiceEnvironment -ConfigDir $StateDir -Token ""
     Start-Service -Name $ServiceName -ErrorAction SilentlyContinue
@@ -738,7 +806,8 @@ if (-not $healthy) {
 }
 
 Write-Log ""
-Write-Log "Install complete. Next steps:"
+Write-Log "Install complete. Crash dumps (WER LocalDumps) are suppressed for node.exe on this host."
+Write-Log "Next steps:"
 Write-Log "  1. Check the service:      Get-Service $ServiceName"
 Write-Log "  2. Confirm registration in the dashboard (CertOps > Agent fleet):"
 Write-Log "     the agent should appear as active within about a minute."

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -832,6 +832,45 @@ describe("credential file round trip", () => {
     // The original credential must remain untouched after a rejected rotation.
     assert.equal(readCredential(dir), "ttagent_agent-01_0123456789abcdef");
   });
+
+  // skip-reason: no-host - requires a real Windows filesystem ACL.
+  // Live-repro'd on a real Windows Server 2025 host: before this fix,
+  // readCredential() read the file with no ownership/ACL check at all, the
+  // one credential-shaped path in this module that skipped it.
+  it("refuses a credential file whose ACL grants Everyone (win32)", { skip: !IS_WIN32 }, () => {
+    const dir = makeTempConfigDir();
+    writeCredential(dir, "ttagent_agent-01_0123456789abcdef");
+    const credentialPath = path.join(dir, "credential");
+    spawnSync("icacls", [credentialPath, "/grant", "*S-1-1-0:(F)"], { encoding: "utf8" });
+    assert.throws(() => readCredential(dir), /grants access to S-1-1-0/);
+  });
+
+  // skip-reason: no-host - requires a real Windows filesystem ACL
+  // and, per Windows' own rules, either SeRestorePrivilege (a real admin
+  // token, e.g. CI's windows-latest runner or a deployed service host) or
+  // ownership already vested in one of the caller's own token groups.
+  // Neither holds on an unprivileged dev workstation, so this dynamically
+  // skips there rather than failing on an environment gap unrelated to the
+  // fix under test.
+  it("refuses a credential file owned by an untrusted principal (win32)", { skip: !IS_WIN32 }, (t) => {
+    const dir = makeTempConfigDir();
+    writeCredential(dir, "ttagent_agent-01_0123456789abcdef");
+    const credentialPath = path.join(dir, "credential");
+    // BUILTIN\Guests (S-1-5-32-546) is never in the agent's trusted-owner
+    // allowlist (self/SYSTEM/Administrators).
+    const setOwner = spawnSync("icacls", [credentialPath, "/setowner", "*S-1-5-32-546"], {
+      encoding: "utf8",
+    });
+    if (setOwner.status !== 0) {
+      t.skip(
+        "no-host: this process's token cannot reassign file ownership to an " +
+          `unrelated SID (icacls: ${(setOwner.stderr || "").trim()}); needs a real ` +
+          "admin token (CI runner or deployed service host)",
+      );
+      return;
+    }
+    assert.throws(() => readCredential(dir), /not one of the trusted owners/);
+  });
 });
 
 describe("caBundlePath (loadAgentConfig)", () => {

--- a/packages/agent/src/config/index.js
+++ b/packages/agent/src/config/index.js
@@ -1139,11 +1139,29 @@ function readSigningKeyPin(configDir) {
  * Reads the credential file, returning null if it does not exist.
  * Never logs the raw value; callers must also avoid logging the return
  * value directly (use redactCredentialForLogging for any log call site).
+ *
+ * This file is agent-created and agent-written-only (writeCredential below
+ * always routes through applyRestrictivePermissions), so its owner/DACL is
+ * re-verified on every read, exactly like the DNS credentials file above --
+ * a live Windows-host check found this file was the one credential-shaped
+ * path in the module that skipped the check, silently trusting whatever
+ * bytes sat at this path regardless of who owned it. An untrusted owner
+ * here means either a
+ * hijacked install or a substituted file, never something safe to read
+ * silently: the agent authenticates to the control plane with whatever this
+ * function returns.
  * @param {string} configDir
  * @returns {string|null}
  */
 function readCredential(configDir) {
   const credentialPath = path.join(configDir, CREDENTIAL_FILE_NAME);
+  if (!fs.existsSync(credentialPath)) return null;
+
+  assertRestrictivePermissions(credentialPath, {
+    label: "credential file",
+    requireProtected: true,
+  });
+
   let raw;
   try {
     raw = fs.readFileSync(credentialPath, "utf8");

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -4340,8 +4340,10 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
       // Independent of execution mode: this reports host-level NTP sync
       // health (observe-only agents benefit from the drift signal just as
       // much as execution-enabled ones). checkNtpSynced never throws; a
-      // missing timedatectl or non-systemd host resolves to null ("unknown")
-      // rather than stalling or failing the heartbeat.
+      // missing timedatectl/w32tm binary or an unsupported/stopped time
+      // service resolves to null ("unknown") rather than stalling or
+      // failing the heartbeat. Platform detection (timedatectl vs. w32tm)
+      // is internal to checkNtpSynced.
       const ntpSynced = await checkNtpSynced();
       const response = await client.heartbeat({
         agentVersion: AGENT_VERSION,

--- a/packages/agent/src/ntp/index.js
+++ b/packages/agent/src/ntp/index.js
@@ -12,21 +12,34 @@
  * show transient header-based skew from one slow response, and vice versa,
  * a host with NTP disabled can happen to sample a near-zero offset).
  *
- * Detection strategy: `timedatectl show -p NTPSynchronized --value` is the
- * systemd-native way to ask this, and matches the agent's only supported
- * install target (Linux with systemd; see docs/certops/agent.md "Supported
- * platform / tool version matrix"). Any host where the command is missing,
- * errors, times out, or prints something unrecognized reports `null`
- * ("unknown") rather than a guessed true/false: the agent-protocol schema
- * defines `ntpSynced` as boolean|null exactly so an agent that cannot
- * determine sync state can say so honestly instead of defaulting to a
- * value that could mask real drift.
+ * Detection strategy is platform-specific, but the fail-to-null contract is
+ * shared: any host where the command is missing, errors, times out, or
+ * prints something unrecognized reports `null` ("unknown") rather than a
+ * guessed true/false. The agent-protocol schema defines `ntpSynced` as
+ * boolean|null exactly so an agent that cannot determine sync state can say
+ * so honestly instead of defaulting to a value that could mask real drift.
+ *
+ * - Linux: `timedatectl show -p NTPSynchronized --value` is the
+ *   systemd-native, locale-independent way to ask this (see
+ *   docs/certops/agent.md "Supported platform / tool version matrix").
+ * - win32: there is no timedatectl equivalent that returns a plain
+ *   boolean, and `w32tm /query /status`'s labelled fields are localized
+ *   (confirmed on a real non-Latin-1 locale host), so this uses
+ *   `w32tm /query /source` instead: on a healthy Windows Time service it
+ *   prints only the active time source name on one line, with no other
+ *   decoration to localize. `Local CMOS Clock` and `Free-running System
+ *   Clock` are w32tm's own documented tokens for "no external source is
+ *   configured" (i.e. the hardware clock, unsynced); any other source
+ *   (an NTP server, a domain hierarchy peer, or a hypervisor's time-sync
+ *   integration service such as `VM IC Time Synchronization Provider`)
+ *   counts as synced. A stopped W32Time service exits non-zero and falls
+ *   through to `null`, same as any other command failure.
  */
 
 const childProcess = require("node:child_process");
 const { buildMinimalSubprocessEnv } = require("../exec-env");
 
-/** Must never stall the heartbeat loop; timedatectl is effectively instant. */
+/** Must never stall the heartbeat loop; both commands are effectively instant. */
 const DEFAULT_TIMEOUT_MS = 5000;
 
 const NTP_SYNCHRONIZED_ARGV = Object.freeze([
@@ -37,19 +50,43 @@ const NTP_SYNCHRONIZED_ARGV = Object.freeze([
   "--value",
 ]);
 
+const WIN32_NTP_SOURCE_ARGV = Object.freeze(["w32tm", "/query", "/source"]);
+
+/** w32tm's own documented tokens for "no external time source configured". */
+const WIN32_UNSYNCED_SOURCES = Object.freeze([
+  "local cmos clock",
+  "free-running system clock",
+]);
+
+function parseLinuxNtpSynchronized(stdout) {
+  const value = String(stdout || "").trim().toLowerCase();
+  if (value === "yes") return true;
+  if (value === "no") return false;
+  return null;
+}
+
+function parseWin32NtpSource(stdout) {
+  const value = String(stdout || "").trim().toLowerCase();
+  if (!value) return null;
+  return !WIN32_UNSYNCED_SOURCES.includes(value);
+}
+
 /**
  * @param {object} [options]
  * @param {Function} [options.execFileImpl] injection point for tests;
  *   defaults to node:child_process.execFile. Must have the same
  *   (file, args, options, callback) signature.
  * @param {number} [options.timeoutMs] exec timeout in ms, default 5000.
- * @returns {Promise<boolean|null>} true/false when timedatectl reports a
- *   definite answer, null when sync state cannot be determined (missing
- *   binary, non-systemd host, timeout, nonzero exit, or unparseable output).
+ * @param {string} [options.platform] defaults to process.platform.
+ * @returns {Promise<boolean|null>} true/false on a definite answer, null
+ *   when sync state cannot be determined (missing binary, unsupported
+ *   host, stopped time service, timeout, nonzero exit, or unparseable
+ *   output).
  */
 function checkNtpSynced({
   execFileImpl = childProcess.execFile,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  platform = process.platform,
 } = {}) {
   if (typeof execFileImpl !== "function") {
     throw new Error("ntp: execFileImpl must be a function");
@@ -60,7 +97,9 @@ function checkNtpSynced({
     );
   }
 
-  const [file, ...args] = NTP_SYNCHRONIZED_ARGV;
+  const argv = platform === "win32" ? WIN32_NTP_SOURCE_ARGV : NTP_SYNCHRONIZED_ARGV;
+  const parse = platform === "win32" ? parseWin32NtpSource : parseLinuxNtpSynchronized;
+  const [file, ...args] = argv;
 
   return new Promise((resolve) => {
     try {
@@ -78,21 +117,14 @@ function checkNtpSynced({
         },
         (error, stdout) => {
           if (error) {
-            // ENOENT (no timedatectl / non-systemd host), a timeout
-            // (SIGTERM, error.killed), or a nonzero exit are all
-            // operational outcomes, not programmer errors: report
+            // ENOENT (missing binary / unsupported host), a stopped time
+            // service (nonzero exit), or a timeout (SIGTERM, error.killed)
+            // are all operational outcomes, not programmer errors: report
             // "unknown" instead of guessing.
             resolve(null);
             return;
           }
-          const value = String(stdout || "").trim().toLowerCase();
-          if (value === "yes") {
-            resolve(true);
-          } else if (value === "no") {
-            resolve(false);
-          } else {
-            resolve(null);
-          }
+          resolve(parse(stdout));
         },
       );
     } catch (_) {
@@ -107,5 +139,7 @@ function checkNtpSynced({
 module.exports = {
   DEFAULT_TIMEOUT_MS,
   NTP_SYNCHRONIZED_ARGV,
+  WIN32_NTP_SOURCE_ARGV,
+  WIN32_UNSYNCED_SOURCES,
   checkNtpSynced,
 };

--- a/packages/agent/src/ntp/ntp.test.js
+++ b/packages/agent/src/ntp/ntp.test.js
@@ -3,7 +3,12 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { DEFAULT_TIMEOUT_MS, NTP_SYNCHRONIZED_ARGV, checkNtpSynced } = require("./index.js");
+const {
+  DEFAULT_TIMEOUT_MS,
+  NTP_SYNCHRONIZED_ARGV,
+  WIN32_NTP_SOURCE_ARGV,
+  checkNtpSynced,
+} = require("./index.js");
 
 function fakeExecFile({ stdout = "", error = null } = {}) {
   return (file, args, options, callback) => {
@@ -11,9 +16,10 @@ function fakeExecFile({ stdout = "", error = null } = {}) {
   };
 }
 
-describe("checkNtpSynced", () => {
+describe("checkNtpSynced on linux", () => {
   it("resolves true when timedatectl prints yes", async () => {
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ stdout: "yes\n" }),
     });
     assert.equal(result, true);
@@ -21,6 +27,7 @@ describe("checkNtpSynced", () => {
 
   it("resolves false when timedatectl prints no", async () => {
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ stdout: "no\n" }),
     });
     assert.equal(result, false);
@@ -28,6 +35,7 @@ describe("checkNtpSynced", () => {
 
   it("is case- and whitespace-insensitive", async () => {
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ stdout: "  YES  \n" }),
     });
     assert.equal(result, true);
@@ -37,6 +45,7 @@ describe("checkNtpSynced", () => {
     const enoent = new Error("spawn timedatectl ENOENT");
     enoent.code = "ENOENT";
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ error: enoent }),
     });
     assert.equal(result, null);
@@ -47,6 +56,7 @@ describe("checkNtpSynced", () => {
     timeoutError.killed = true;
     timeoutError.signal = "SIGTERM";
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ error: timeoutError }),
     });
     assert.equal(result, null);
@@ -56,6 +66,7 @@ describe("checkNtpSynced", () => {
     const exitError = new Error("exit 1");
     exitError.code = 1;
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ error: exitError }),
     });
     assert.equal(result, null);
@@ -63,6 +74,7 @@ describe("checkNtpSynced", () => {
 
   it("resolves null on unparseable output instead of guessing", async () => {
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: fakeExecFile({ stdout: "unexpected garbage" }),
     });
     assert.equal(result, null);
@@ -70,6 +82,7 @@ describe("checkNtpSynced", () => {
 
   it("resolves null instead of rejecting when execFileImpl throws synchronously", async () => {
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: () => {
         throw new Error("boom");
       },
@@ -82,6 +95,7 @@ describe("checkNtpSynced", () => {
     let capturedArgs;
     let capturedOptions;
     const result = await checkNtpSynced({
+      platform: "linux",
       execFileImpl: (file, args, options, callback) => {
         capturedFile = file;
         capturedArgs = args;
@@ -97,6 +111,20 @@ describe("checkNtpSynced", () => {
     assert.equal(capturedOptions.shell, undefined);
   });
 
+  it("defaults to process.platform when platform is not passed explicitly", async () => {
+    // Regression guard for the option itself: an omitted platform must
+    // still resolve to *some* branch deterministically (whichever the
+    // real host is), not throw and not silently no-op.
+    let called = false;
+    await checkNtpSynced({
+      execFileImpl: (file, args, options, callback) => {
+        called = true;
+        callback(null, "", "");
+      },
+    });
+    assert.equal(called, true);
+  });
+
   it("throws on programmer error: bad execFileImpl or timeoutMs", () => {
     assert.throws(
       () => checkNtpSynced({ execFileImpl: "not-a-function" }),
@@ -110,5 +138,100 @@ describe("checkNtpSynced", () => {
       () => checkNtpSynced({ timeoutMs: 1.5 }),
       /timeoutMs/,
     );
+  });
+});
+
+describe("checkNtpSynced on win32", () => {
+  // A real-Windows-host pass found ntpSynced always resolved null on
+  // Windows: the previous implementation only ever ran timedatectl, which
+  // does not exist there. These pin the w32tm-based replacement.
+
+  it("resolves true when w32tm /query /source reports an NTP server", async () => {
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ stdout: "time.windows.com\n" }),
+    });
+    assert.equal(result, true);
+  });
+
+  it("resolves true for the Hyper-V/Azure time-sync integration source", async () => {
+    // Real output captured on a Windows Server 2025 VM.
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({
+        stdout: "VM IC Time Synchronization Provider\r\n",
+      }),
+    });
+    assert.equal(result, true);
+  });
+
+  it("resolves false for the unsynced Local CMOS Clock source", async () => {
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ stdout: "Local CMOS Clock\r\n" }),
+    });
+    assert.equal(result, false);
+  });
+
+  it("resolves false for the unsynced Free-running System Clock source", async () => {
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ stdout: "Free-running System Clock\r\n" }),
+    });
+    assert.equal(result, false);
+  });
+
+  it("is case-insensitive on the unsynced-source tokens", async () => {
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ stdout: "local cmos clock\r\n" }),
+    });
+    assert.equal(result, false);
+  });
+
+  it("resolves null when the Windows Time service is stopped (nonzero exit)", async () => {
+    // Real repro on the verification VM: `net stop w32time` then
+    // `w32tm /query /source` exits non-zero with a localized error instead
+    // of printing a source name.
+    const stoppedError = new Error("service not started");
+    stoppedError.code = 1;
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ error: stoppedError }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("resolves null on a missing w32tm binary", async () => {
+    const enoent = new Error("spawn w32tm ENOENT");
+    enoent.code = "ENOENT";
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ error: enoent }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("resolves null on empty output instead of guessing", async () => {
+    const result = await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: fakeExecFile({ stdout: "" }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("passes the fixed w32tm argv, not the Linux timedatectl argv", async () => {
+    let capturedFile;
+    let capturedArgs;
+    await checkNtpSynced({
+      platform: "win32",
+      execFileImpl: (file, args, options, callback) => {
+        capturedFile = file;
+        capturedArgs = args;
+        callback(null, "time.windows.com", "");
+      },
+    });
+    assert.equal(capturedFile, WIN32_NTP_SOURCE_ARGV[0]);
+    assert.deepEqual(capturedArgs, WIN32_NTP_SOURCE_ARGV.slice(1));
   });
 });

--- a/packages/agent/windows-service-host/service_windows.go
+++ b/packages/agent/windows-service-host/service_windows.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"errors"
+	"os/exec"
 	"time"
 
 	"golang.org/x/sys/windows/svc"
@@ -14,6 +16,32 @@ import (
 // simply never routes control requests to this process at all - the exact
 // silent failure mode this host exists to eliminate.
 const serviceName = "TokenTimerAgent"
+
+// agentRetiredExitCode must equal AGENT_RETIRED_EXIT_CODE in
+// packages/agent/src/index.js: the agent's own deliberate, clean self-exit
+// when the control plane has retired it (heartbeat HTTP 410), so it never
+// respawns into a heartbeat 410 loop. The Linux systemd unit pairs
+// `Restart=always` with `RestartPreventExitStatus=86` to name this one
+// exit code as "not a failure, don't restart" while still restarting on
+// every other (genuinely crashed) exit.
+//
+// Live-repro'd on a real Windows
+// Server 2025 SCM: `sc.exe failure ... actions= restart/5000` has no
+// per-exit-code exemption at all, unlike systemd's
+// RestartPreventExitStatus -- every non-zero Win32ExitCode this host
+// reports, retirement included, is "a failure" to the SCM. Once the
+// sibling bug above (silently reporting exit code 0 for every
+// unrequested exit, real crash or not) was fixed so a real crash
+// actually triggers the configured restart, a retire immediately became
+// a live crash-restart loop: node exits 86, SCM restarts it 5s later, it
+// heartbeats again, gets 410 again, exits 86 again -- observed
+// hammering the control plane every ~6s indefinitely in this host's own
+// log until manually stopped. This constant is this host's only
+// substitute for RestartPreventExitStatus: it maps this one specific
+// exit code to a reported Win32ExitCode of 0 (success, no failure
+// action), while every other non-zero exit still reports through
+// unchanged and still restarts.
+const agentRetiredExitCode = 86
 
 // tokenTimerAgentService implements svc.Handler. It owns no state of its
 // own beyond the already-started agentHost and stop timeout; every actual
@@ -73,18 +101,52 @@ func (s *tokenTimerAgentService) Execute(args []string, r <-chan svc.ChangeReque
 			}
 		case err := <-childExitCh:
 			// The child exited without this host asking it to: a crash,
-			// or the agent's own clean self-exit. Report Stopped with a
-			// non-zero specific error so SCM's configured failure
-			// action (sc.exe failure ... actions= restart/5000) fires
-			// exactly as it would have for a bare node.exe binPath,
-			// which is the behavior the install script's failure
-			// policy was already written to expect.
+			// or the agent's own clean self-exit (including the
+			// AGENT_RETIRED_EXIT_CODE=86 self-exit paired with
+			// RestartPreventExitStatus=86 in the Linux systemd unit).
+			// This must report Stopped with a non-zero specific error
+			// so SCM's configured failure action (sc.exe failure
+			// ... actions= restart/5000) fires exactly as it would have
+			// for a bare node.exe binPath -- which is the behavior the
+			// install script's failure policy was already written to
+			// expect, and the only thing that makes an unattended
+			// service self-heal from a real crash at all.
+			//
+			// Live-repro'd against
+			// a real Windows Server 2025 SCM: sending
+			// `changes <- svc.Status{State: svc.Stopped}` here (as this
+			// code previously did) reports the FIRST of two Stopped
+			// transitions with exit code 0 -- ec is {isSvcSpecific:
+			// true, errno: 0} in golang.org/x/sys/windows/svc's
+			// serviceMain loop until AFTER Execute returns, so that
+			// manual send always races ahead of this function's actual
+			// return value. The SCM latches onto that first report
+			// (confirmed live: `Get-CimInstance Win32_Service` and
+			// `sc.exe` both showed ExitCode=0 after a real crash, and no
+			// restart ever fired despite `actions= restart/5000` and
+			// FailureActionsOnNonCrashFailures=TRUE being verified
+			// correctly configured) and never acts on the second,
+			// correct-exit-code Stopped report serviceMain sends
+			// automatically once Execute returns -- silently defeating
+			// the install script's entire crash-recovery contract for
+			// every unrequested exit, not just retirement. The fix:
+			// never send an intermediate Stopped status from this
+			// branch at all; return directly and let serviceMain's own
+			// post-Execute updateStatus call be the one and only Stopped
+			// report, carrying the real exit code the whole way through.
 			exitCode := uint32(0)
 			if err != nil {
 				exitCode = 1
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) && exitErr.ExitCode() > 0 {
+					exitCode = uint32(exitErr.ExitCode())
+				}
 			}
-			s.log.Printf("child exited without a stop request (err=%v); stopping service so the configured failure action can react", err)
-			changes <- svc.Status{State: svc.Stopped}
+			if exitCode == agentRetiredExitCode {
+				s.log.Printf("child exited with the retirement code (%d); stopping service cleanly, not as a failure, so it does not respawn into a heartbeat-410 loop", agentRetiredExitCode)
+				return false, 0
+			}
+			s.log.Printf("child exited without a stop request (err=%v); stopping service (exit %d) so the configured failure action can react", err, exitCode)
 			return false, exitCode
 		}
 	}

--- a/packages/agent/windows-service-host/service_windows_test.go
+++ b/packages/agent/windows-service-host/service_windows_test.go
@@ -1,0 +1,173 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// drainStatus reads and discards Status updates on ch until Execute
+// returns, so Execute's unbuffered `changes <- ...` sends never block on a
+// test that isn't otherwise reading them.
+func drainStatus(t *testing.T, ch <-chan svc.Status, done <-chan struct{}) {
+	t.Helper()
+	for {
+		select {
+		case <-ch:
+		case <-done:
+			return
+		}
+	}
+}
+
+// TestExecuteReportsRealExitCodeOnUnrequestedCrash is the regression test
+// for the bug this file's sibling comment documents: a child that exits on
+// its own (a crash) must have Execute return the real non-zero exit code
+// with NO intermediate `changes <- svc.Status{State: svc.Stopped}` sent
+// first. Sending that intermediate report raced ahead of Execute's actual
+// return value and got latched by the SCM as exit code 0, silently
+// defeating `sc.exe failure ... actions= restart/5000` for every
+// unrequested exit -- live-repro'd on a real Windows Server 2025 SCM.
+func TestExecuteReportsRealExitCodeOnUnrequestedCrash(t *testing.T) {
+	log := newTestLogger(t)
+	node := nodeExe(t)
+	quickExitScript := filepath.Join(t.TempDir(), "quick-exit.js")
+	if err := os.WriteFile(quickExitScript, []byte("process.exit(3);\n"), 0o600); err != nil {
+		t.Fatalf("write quick-exit script: %v", err)
+	}
+	host := newAgentHost(node, []string{quickExitScript}, os.Environ(), log)
+	svcHandler := &tokenTimerAgentService{host: host, stopTimeout: 2 * time.Second, log: log}
+
+	reqCh := make(chan svc.ChangeRequest)
+	statusCh := make(chan svc.Status)
+	done := make(chan struct{})
+	go drainStatus(t, statusCh, done)
+
+	execDone := make(chan struct {
+		svcSpecific bool
+		exitCode    uint32
+	}, 1)
+	go func() {
+		svcSpecific, exitCode := svcHandler.Execute([]string{serviceName}, reqCh, statusCh)
+		execDone <- struct {
+			svcSpecific bool
+			exitCode    uint32
+		}{svcSpecific, exitCode}
+		close(done)
+	}()
+
+	select {
+	case result := <-execDone:
+		if result.exitCode == 0 {
+			t.Fatalf("Execute returned exit code 0 for an unrequested crash; want non-zero so the SCM's restart action fires")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return within 5s of the child's own exit")
+	}
+}
+
+// TestExecuteMapsRetiredExitCodeToCleanStop proves the fix: a child
+// that self-exits with agentRetiredExitCode (86, the control-plane-retired
+// clean exit -- see packages/agent/src/index.js's AGENT_RETIRED_EXIT_CODE)
+// must report exit code 0 (no SCM restart action), not 86 verbatim, or
+// every retired agent enters an unbounded ~5s restart loop against a real
+// SCM failure policy -- live-repro'd immediately after the crash-exit-code
+// fix above, before this mapping existed.
+func TestExecuteMapsRetiredExitCodeToCleanStop(t *testing.T) {
+	log := newTestLogger(t)
+	node := nodeExe(t)
+	retiredExitScript := filepath.Join(t.TempDir(), "retired-exit.js")
+	src := "process.exit(86);\n"
+	if err := os.WriteFile(retiredExitScript, []byte(src), 0o600); err != nil {
+		t.Fatalf("write retired-exit script: %v", err)
+	}
+	host := newAgentHost(node, []string{retiredExitScript}, os.Environ(), log)
+	svcHandler := &tokenTimerAgentService{host: host, stopTimeout: 2 * time.Second, log: log}
+
+	reqCh := make(chan svc.ChangeRequest)
+	statusCh := make(chan svc.Status)
+	done := make(chan struct{})
+	go drainStatus(t, statusCh, done)
+
+	execDone := make(chan struct {
+		svcSpecific bool
+		exitCode    uint32
+	}, 1)
+	go func() {
+		svcSpecific, exitCode := svcHandler.Execute([]string{serviceName}, reqCh, statusCh)
+		execDone <- struct {
+			svcSpecific bool
+			exitCode    uint32
+		}{svcSpecific, exitCode}
+		close(done)
+	}()
+
+	select {
+	case result := <-execDone:
+		if result.exitCode != 0 {
+			t.Fatalf("Execute returned exit code %d for the retirement exit (86); want 0 (clean stop, no SCM restart action)", result.exitCode)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return within 5s of the child's retirement exit")
+	}
+}
+
+// TestExecuteRequestedStopReturnsZero proves the ordinary Stop/Shutdown
+// path is unaffected by the crash-path changes above: it still returns 0
+// with no error, and still sends its own StopPending/Stopped transitions.
+func TestExecuteRequestedStopReturnsZero(t *testing.T) {
+	log := newTestLogger(t)
+	node := nodeExe(t)
+	entry := mockAgentPath(t)
+	host := newAgentHost(node, []string{entry}, os.Environ(), log)
+	svcHandler := &tokenTimerAgentService{host: host, stopTimeout: 2 * time.Second, log: log}
+
+	reqCh := make(chan svc.ChangeRequest)
+	statusCh := make(chan svc.Status, 8)
+
+	execDone := make(chan struct {
+		svcSpecific bool
+		exitCode    uint32
+	}, 1)
+	go func() {
+		svcSpecific, exitCode := svcHandler.Execute([]string{serviceName}, reqCh, statusCh)
+		execDone <- struct {
+			svcSpecific bool
+			exitCode    uint32
+		}{svcSpecific, exitCode}
+	}()
+
+	// Wait for the Running status before requesting a stop, otherwise the
+	// stop request could race the child's own startup.
+	waitForState(t, statusCh, svc.Running, 5*time.Second)
+	reqCh <- svc.ChangeRequest{Cmd: svc.Stop}
+
+	select {
+	case result := <-execDone:
+		if result.exitCode != 0 {
+			t.Fatalf("Execute returned exit code %d for a requested stop; want 0", result.exitCode)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return within 5s of the Stop request")
+	}
+}
+
+func waitForState(t *testing.T, ch <-chan svc.Status, want svc.State, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case s := <-ch:
+			if s.State == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("did not observe state %v within %s", want, timeout)
+		}
+	}
+}

--- a/scripts/ci-guards/core-dump-suppression.cjs
+++ b/scripts/ci-guards/core-dump-suppression.cjs
@@ -1,22 +1,25 @@
 #!/usr/bin/env node
 "use strict";
 
-// Guard: regression test for ADR-0012 decision 19's Linux core-dump
-// suppression (KEY-03 in the manual acceptance checklist). Statically
-// asserts the shipped systemd unit sets LimitCORE=0 in its [Service]
-// section.
+// Guard: regression test for ADR-0012 decision 19's core-dump suppression,
+// both platform halves: Linux and Windows. Statically asserts the shipped
+// systemd unit sets
+// LimitCORE=0, and that the Windows installer sets the WER LocalDumps
+// DumpType=0 registry value for node.exe.
 //
-// This is deliberately static, not the KEY-03 live check itself:
-// KEY-03 requires reading /proc/<pid>/limits on a real deployed service
-// to prove the limit actually governs the running process, which a unit
-// file alone cannot prove (a unit file can be present and not be the one
-// actually governing the process -- ADR-0012 says so explicitly). This
-// guard exists only to catch a future edit that silently drops the line
-// this repo already had a real, previously-unfixed gap for: the shipped
-// unit had no LimitCORE directive at all until this guard's sibling fix,
-// so `Max core file size` on a real running agent process read
-// "0 / unlimited" (soft/hard) instead of "0 / 0", the hard limit left at
-// whatever the host distribution defaulted to.
+// This is deliberately static, not the live checks
+// themselves: those require reading back real running-process/registry
+// state on a real deployed host to prove the mitigation actually governs
+// what runs, which source alone cannot prove (a unit file or installer
+// script can be present and not be the one actually governing the
+// process -- ADR-0012 says so explicitly for both halves). This guard
+// exists only to catch a future edit that silently drops either line.
+// The Linux unit had no LimitCORE directive at all until this guard's
+// sibling fix, so `Max core file size` on a real running agent process
+// read "0 / unlimited" (soft/hard) instead of "0 / 0"; the Windows
+// installer had no LocalDumps write at all until the fix this guard's
+// other half covers, despite ADR-0012 documenting it as already
+// implemented.
 
 const fs = require("node:fs");
 const path = require("node:path");
@@ -24,8 +27,10 @@ const path = require("node:path");
 const repoRoot = path.resolve(__dirname, "..", "..");
 const unitPath = path.join(repoRoot, "packages/agent/scripts/tokentimer-agent.service");
 const relUnitPath = path.relative(repoRoot, unitPath).replace(/\\/g, "/");
+const installScriptPath = path.join(repoRoot, "packages/agent/scripts/install-agent.ps1");
+const relInstallScriptPath = path.relative(repoRoot, installScriptPath).replace(/\\/g, "/");
 
-function main() {
+function checkLinux() {
   if (!fs.existsSync(unitPath)) {
     console.log(
       "core-dump-suppression: ok (vacuous pass - packages/agent/scripts/tokentimer-agent.service does not exist yet)",
@@ -48,7 +53,7 @@ function main() {
   if (!hasLimitCoreZero) {
     console.error(
       `::error file=${relUnitPath}::core-dump-suppression: [Service] section is missing "LimitCORE=0" ` +
-        "(ADR-0012 decision 19, KEY-03) -- without it, the process's RLIMIT_CORE hard limit is left at " +
+        "(ADR-0012 decision 19) -- without it, the process's RLIMIT_CORE hard limit is left at " +
         "whatever this distribution defaults to, and a soft-limit-only mitigation elsewhere would not be " +
         "authoritative since a process may raise its own soft limit back up to that hard ceiling",
     );
@@ -56,6 +61,37 @@ function main() {
   }
 
   console.log(`core-dump-suppression: ok (${relUnitPath} sets LimitCORE=0 in [Service])`);
+}
+
+function checkWindows() {
+  if (!fs.existsSync(installScriptPath)) {
+    console.log(
+      "core-dump-suppression: ok (vacuous pass - packages/agent/scripts/install-agent.ps1 does not exist yet)",
+    );
+    return;
+  }
+
+  const content = fs.readFileSync(installScriptPath, "utf8");
+  const hasLocalDumpsKey = /LocalDumps\\\$ExeName/.test(content) || /LocalDumps\\node\.exe/.test(content);
+  const hasDumpTypeZero = /Name\s+"DumpType"[\s\S]{0,80}Value\s+0/.test(content);
+  const setsForNodeExe = /Set-WindowsDumpSuppression\s+-ExeName\s+"node\.exe"/.test(content);
+
+  if (!hasLocalDumpsKey || !hasDumpTypeZero || !setsForNodeExe) {
+    console.error(
+      `::error file=${relInstallScriptPath}::core-dump-suppression: install-agent.ps1 is missing the WER ` +
+        "LocalDumps DumpType=0 write for node.exe (ADR-0012 decision 19) -- without it, the Windows " +
+        "Error Reporting default for the process that holds agent key material is left unspecified rather " +
+        "than explicitly disabled",
+    );
+    process.exit(1);
+  }
+
+  console.log(`core-dump-suppression: ok (${relInstallScriptPath} sets WER LocalDumps DumpType=0 for node.exe)`);
+}
+
+function main() {
+  checkLinux();
+  checkWindows();
 }
 
 main();


### PR DESCRIPTION
## Summary

Live testing against a real Windows Server host surfaced several bugs that a simulated/CI environment cannot catch:

- **NTP detection was Linux-only.** `ntpSynced` always resolved `null` on Windows because the check only ever ran `timedatectl`. Added a `win32` branch using `w32tm /query /source`, with unit tests covering synced/unsynced sources, case-insensitivity, a missing binary, and a stopped Windows Time service.
- **Installer `sc.exe` quoting bug.** `install-agent.ps1`'s `binPath` value failed every `sc.exe create`/`config` call with exit 1639 on a real host, because PowerShell's native-argument passing does not re-escape an already-quoted string. Fixed by wrapping the whole value in one more outer pair of quotes with doubled inner quotes (`sc.exe`'s own convention).
- **Upgrade rollback could be skipped.** `Restart-Service`/`Start-Service` failures during an upgrade could throw and kill the script under `$ErrorActionPreference = "Stop"` before the post-install health check ever ran, so the rollback path never executed. Now the error is caught and logged, and the existing health-check/rollback gate always runs.
- **`readCredential()` skipped its ACL check.** It was the one credential-shaped path in `config/index.js` that read the file with no ownership/DACL verification. Routed it through the same restrictive-permissions check as the other credential paths.
- **`windows-service-host` misreported exit codes.** Every unrequested child exit (crash or clean self-exit) was reported to the SCM as exit code 0, because an intermediate `Stopped` status send raced ahead of `Execute`'s real return value and got latched first. This silently defeated `sc.exe failure ... actions= restart/5000` for real crashes. Fixed by returning directly and letting the post-`Execute` `Stopped` report carry the real exit code. Once real crashes started restarting correctly, the agent's own clean "retired" exit code needed an explicit mapping to a successful stop, otherwise retirement loops through an unbounded restart cycle.

## Test plan

- [x] `pnpm run test:unit` — full suite passes (1446/1446)
- [x] `node scripts/ci-guards/core-dump-suppression.cjs` — passes
- [x] New/updated unit tests for both NTP platforms (`packages/agent/src/ntp/ntp.test.js`)
- [x] New Go tests for the SCM exit-code fix (`packages/agent/windows-service-host/service_windows_test.go`)
- [x] Manually reproduced and verified all five bugs live on a real Windows Server VM before fixing
