### PR TITLE
fix(certops): preserve agent-host in IIS target migration

### DIFF
--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -2978,7 +2978,7 @@ const migrations = [
           target_type IN (
             'endpoint', 'domain', 'host', 'kubernetes-secret',
             'load-balancer', 'cdn', 'appliance', 'hsm', 'vault', 'other',
-            'windows-iis'
+            'agent-host', 'windows-iis'
           )
         );
     `,

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -1197,9 +1197,20 @@ describe("CertOps inventory migration", () => {
 });
 
 describe("migration 42 Windows IIS target descriptors", () => {
+  const agentHostMigration = migrations.find(
+    (entry) => entry.name === "certificate_targets_target_type_agent_host",
+  );
   const migration = migrations.find(
     (entry) => entry.name === "certops_windows_iis_target_descriptors",
   );
+
+  function getCertificateTargetTypes(entry) {
+    const constraint = entry.sql.match(
+      /ADD CONSTRAINT certificate_targets_target_type_check CHECK \(\s*target_type IN \(([\s\S]*?)\)\s*\)/,
+    );
+    assert.ok(constraint, "certificate target-type CHECK constraint expected");
+    return [...constraint[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+  }
 
   it("exists at version 42 and widens certificate_targets", () => {
     assert.ok(migration, "certops_windows_iis_target_descriptors migration expected");
@@ -1215,22 +1226,13 @@ describe("migration 42 Windows IIS target descriptors", () => {
   });
 
   it("widens certificate_targets_target_type_check to accept windows-iis while keeping every earlier type", () => {
-    assert.match(migration.sql, /certificate_targets_target_type_check/);
-    for (const value of [
-      "endpoint",
-      "domain",
-      "host",
-      "kubernetes-secret",
-      "load-balancer",
-      "cdn",
-      "appliance",
-      "hsm",
-      "vault",
-      "other",
+    assert.ok(agentHostMigration, "migration 32 agent-host vocabulary expected");
+    const earlierTypes = getCertificateTargetTypes(agentHostMigration);
+    assert.ok(earlierTypes.includes("agent-host"));
+    assert.deepEqual(getCertificateTargetTypes(migration), [
+      ...earlierTypes,
       "windows-iis",
-    ]) {
-      assert.match(migration.sql, new RegExp(`'${value}'`));
-    }
+    ]);
   });
 
   it("constrains windows_port to the valid TCP port range and never uses CREATE TYPE", () => {


### PR DESCRIPTION
## Summary

Migration 42 (`certops_windows_iis_target_descriptors`) widened `certificate_targets_target_type_check` to add `windows-iis`, but the literal list it rebuilt the constraint from omitted `agent-host`, a target type migration 32 (`certificate_targets_target_type_agent_host`) had already added for agent filesystem-discovery evidence. Since a `CHECK` rebuild replaces the whole clause rather than appending to it, any workspace applying migrations in order would silently lose `agent-host` as a valid `target_type` the moment migration 42 ran.

- `apps/api/migrations/migrate.js`: migration 42's `CHECK` now carries the complete target-type union (`endpoint`, `domain`, `host`, `kubernetes-secret`, `load-balancer`, `cdn`, `appliance`, `hsm`, `vault`, `other`, `agent-host`, `windows-iis`) instead of dropping `agent-host`.
- `tests/unit/certops-migration.test.js`: the "widens ... while keeping every earlier type" case no longer hardcodes the expected type list, which is exactly how the missing type went unnoticed in the first place. It now reads migration 32's own constraint SQL as the source of truth for "every earlier type," asserts `agent-host` is in it, and asserts migration 42's constraint equals that list plus `windows-iis`. A future migration that drops a previously supported target type now fails this test immediately instead of only being caught by manual inspection.

## Why

Found by re-deriving migration 42's full `CHECK` constraint against every earlier migration that touches `certificate_targets_target_type_check`, rather than trusting the hardcoded list the original test asserted against.

## Test plan

- [x] `node --test tests/unit/certops-migration.test.js`: 57/57 passing, including the strengthened migration-42 assertion and the "runs migrations 1-44 in order" live-schema case.
- [x] `pnpm run test:unit`: 1446/1446 passing, no regressions.
- [x] `node scripts/ci-guards/run-all.cjs`: `migration-ddl-guard` passes (44 migrations, gapless). The 3 other failures (`minimal-command-allowlist`, `two-decode-gate` needing real `bash`/`jq`/`curl` binaries, and a pre-existing `skip-inventory-drift` staleness) are environment/tooling gaps unrelated to this change and reproduce the same way on `main`.
