### PR TITLE
fix(certops): add missing skip-reason tag, regenerate skip inventory

### DIFF
--- a/docs/certops/skip-inventory.generated.md
+++ b/docs/certops/skip-inventory.generated.md
@@ -7,7 +7,7 @@ Every skip below must carry a `// skip-reason: <tag>` comment immediately above 
 - `no-host`: skipped because it needs real hardware/OS/IIS not available in CI
 - `unimplemented`: skipped because the feature does not exist yet
 
-Total skips found: 41
+Total skips found: 44
 
 | File | Line | Test/suite name | Kind | Reason |
 |---|---|---|---|---|
@@ -19,12 +19,15 @@ Total skips found: 41
 | `packages/agent/src/config/config.test.js` | 586 | sets 0600 permissions on the pin file on non-win32 platforms | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/config/config.test.js` | 683 | refuses to write the pin through a symlink | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/config/config.test.js` | 780 | sets 0600 permissions on the credential file on non-win32 platforms | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1140 | refuses a group/other-readable credentials file (POSIX) | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1150 | refuses a credentials file whose ACL grants Everyone (win32) | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1161 | accepts a credentials file restricted to the agent and SYSTEM (win32) | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1237 | refuses a group/other-readable credentials file (POSIX) | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1249 | refuses an ACL granting Everyone and never falls back to a skip (win32) | it(..., { skip }) option-object | `no-host` |
-| `packages/agent/src/config/config.test.js` | 1262 | fails closed when the ACL cannot be inspected at all (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 840 | refuses a credential file whose ACL grants Everyone (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 855 | refuses a credential file owned by an untrusted principal (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 868 | refuses a credential file owned by an untrusted principal (win32) | dynamic (this.skip() / t.skip()) | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1182 | refuses a group/other-readable credentials file (POSIX) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1192 | refuses a credentials file whose ACL grants Everyone (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1203 | accepts a credentials file restricted to the agent and SYSTEM (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1279 | refuses a group/other-readable credentials file (POSIX) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1291 | refuses an ACL granting Everyone and never falls back to a skip (win32) | it(..., { skip }) option-object | `no-host` |
+| `packages/agent/src/config/config.test.js` | 1304 | fails closed when the ACL cannot be inspected at all (win32) | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/deploy/deploy.test.js` | 526 | rejects a symlinked destination escaping the allowed root (realpath re-check) | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/deploy/deploy.test.js` | 555 | rejects a symlinked parent directory escaping the allowed root | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/discovery/discovery.test.js` | 308 | rejects symbolic-link certificate candidates | dynamic (this.skip() / t.skip()) | `no-host` |

--- a/packages/agent/src/config/config.test.js
+++ b/packages/agent/src/config/config.test.js
@@ -862,6 +862,9 @@ describe("credential file round trip", () => {
       encoding: "utf8",
     });
     if (setOwner.status !== 0) {
+      // skip-reason: no-host - this process's token cannot reassign file
+      // ownership to an unrelated SID without a real admin token (CI's
+      // windows-latest runner or a deployed service host).
       t.skip(
         "no-host: this process's token cannot reassign file ownership to an " +
           `unrelated SID (icacls: ${(setOwner.stderr || "").trim()}); needs a real ` +


### PR DESCRIPTION
## Summary

- `main`'s CI has been red since PR #147 merged (~2h ago): `verify:ci-guards`'s `skip-inventory-drift` guard failed because the win32-only dynamic skip added in that PR (`t.skip(...)` inside "refuses a credential file owned by an untrusted principal (win32)") had no `// skip-reason:` comment immediately above it, and `docs/certops/skip-inventory.generated.md` was not regenerated to include it.
- Adds the missing comment, matching the style of every other dynamic skip in this file, and regenerates the inventory.

## Verification

- `node scripts/ci-guards/run-all.cjs`: all 11 guards pass (was 1 failing: `skip-inventory-drift.cjs`).
- `node --test packages/agent/src/config/config.test.js`: 81 passing, 8 skipped (win32-only, expected on this host), 0 failing.

## Test plan

- [x] `verify:ci-guards` passes locally
- [ ] Confirm GitHub Actions `CI` goes green on `main` after merge
