### PR TITLE
fix(certops): fix cleanup race in Windows service lifecycle smoke test

### DIFF
--- a/docs/certops/skip-inventory.generated.md
+++ b/docs/certops/skip-inventory.generated.md
@@ -11,7 +11,7 @@ Total skips found: 44
 
 | File | Line | Test/suite name | Kind | Reason |
 |---|---|---|---|---|
-| `packages/agent/scripts/installer-smoke.test.js` | 317 | reaches Running and survives a Stop-Service / Start-Service cycle | dynamic (this.skip() / t.skip()) | `no-host` |
+| `packages/agent/scripts/installer-smoke.test.js` | 348 | reaches Running and survives a Stop-Service / Start-Service cycle | dynamic (this.skip() / t.skip()) | `no-host` |
 | `packages/agent/src/config/config.test.js` | 121 | sets 0700 permissions on non-win32 platforms | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/config/config.test.js` | 129 | re-asserts 0700 on every call even if the mode was loosened | it(..., { skip }) option-object | `no-host` |
 | `packages/agent/src/config/config.test.js` | 139 | applies a real restricted ACL on win32 | it(..., { skip }) option-object | `no-host` |

--- a/packages/agent/scripts/installer-smoke.test.js
+++ b/packages/agent/scripts/installer-smoke.test.js
@@ -273,6 +273,26 @@ describe("Windows service lifecycle smoke (H-blocker regression guard)", () => {
     return false;
   }
 
+  // Even after the SCM reports STOPPED, a just-exited process's file
+  // handles can take a moment longer to actually release on Windows (a
+  // known gap between "process is gone" and "handle table is drained",
+  // sometimes stretched further by an AV on-close scan) - so a bare
+  // fs.rmSync right after STOPPED can still observe a transient EPERM/
+  // EBUSY. Retry a few times with a short backoff rather than either
+  // failing the whole suite on cleanup or silently swallowing a real,
+  // permanent lock (e.g. a leaked handle bug) after the retries exhaust.
+  function removeDirWithRetry(dir, attempts = 5, delayMs = 500) {
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+        return;
+      } catch (err) {
+        if (attempt === attempts || !["EPERM", "EBUSY"].includes(err.code)) throw err;
+        spawnSync(process.execPath, ["-e", `setTimeout(()=>{}, ${delayMs})`], { timeout: delayMs + 1000 });
+      }
+    }
+  }
+
   let skipReason = null;
   let hostExe;
   let mockAgentJs;
@@ -305,10 +325,21 @@ describe("Windows service lifecycle smoke (H-blocker regression guard)", () => {
 
   after(() => {
     if (getServiceStatus() !== null) {
-      spawnSync("sc.exe", ["stop", SERVICE_NAME], { encoding: "utf8" });
+      // The test body's own final assertion leaves the service RUNNING
+      // (it stops/starts it once to prove the restart cycle, then ends).
+      // `sc.exe stop` only *requests* a stop and returns immediately - it
+      // does not wait for the SCM to actually tear the process down - so
+      // deleting serviceConfigDir right after it, with no wait, raced the
+      // mock agent's own file handles on that directory and intermittently
+      // failed cleanup with EPERM. Wait for STOPPED (bounded, same 15s
+      // ceiling the test body itself uses) before deleting the service.
+      if (getServiceStatus() !== "STOPPED") {
+        spawnSync("sc.exe", ["stop", SERVICE_NAME], { encoding: "utf8" });
+        waitForStatus("STOPPED", 15000);
+      }
       spawnSync("sc.exe", ["delete", SERVICE_NAME], { encoding: "utf8" });
     }
-    if (serviceConfigDir) fs.rmSync(serviceConfigDir, { recursive: true, force: true });
+    if (serviceConfigDir) removeDirWithRetry(serviceConfigDir);
   });
 
   it("reaches Running and survives a Stop-Service / Start-Service cycle", (t) => {


### PR DESCRIPTION
## Summary

- `Windows Agent Quality Checks` has failed on `main` twice in a row (the original push-triggered run and an explicit rerun of just that job) with `Error: EPERM, Permission denied: ...\tokentimer-agent-svc-state-*` during `after()` cleanup of the elevated "Windows service lifecycle smoke" test.
- Root cause: the test body ends with the service left `RUNNING` (it stops/starts it once to prove the restart cycle, then ends). `after()` called `sc.exe stop` and immediately `fs.rmSync(serviceConfigDir, ...)` with no wait between the two - `sc.exe stop` only *requests* a stop and returns immediately, it does not wait for the SCM to actually tear the process down, so the mock agent's own open file handles on that directory could still be live when the `rmSync` ran.
- Fix: wait for `STOPPED` (bounded, same 15s ceiling the test body itself uses) before deleting the service, and wrap the final `rmSync` in a bounded retry (5 attempts, 500ms backoff) for `EPERM`/`EBUSY` specifically - absorbing the residual gap between "process exited" and "handle table fully drained" (e.g. an AV on-close scan) without masking a genuinely stuck lock once the retries exhaust.

## Verification

- `node scripts/ci-guards/run-all.cjs`: 11/11 pass (regenerated `docs/certops/skip-inventory.generated.md` for the line-number shift from this edit).
- `node --test packages/agent/scripts/installer-smoke.test.js`: passes; the elevated suite still skips cleanly on this unelevated workstation, as expected.
- Could not reproduce/verify the elevated Stop/Start cycle itself locally (this workstation is not running as Administrator); the next `windows-latest` CI run on this branch is the real verification.

## Test plan

- [x] `verify:ci-guards` passes locally
- [ ] Confirm `Windows Agent Quality Checks` goes green on this branch's CI run, twice if possible, given the intermittent nature of the original failure
