### PR TITLE
fix(dashboard): revert react-router 7.18.2->8.3.0, incompatible with React 18

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -36,7 +36,7 @@
     "react-icons": "5.5.0",
     "react-joyride": "2.9.3",
     "react-query": "3.39.3",
-    "react-router": "8.3.0",
+    "react-router": "7.18.2",
     "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

main is currently broken: Dependabot's #153 body claims a 7.18.1->7.18.2 bump (matching its own lockfile diff), but its actual pps/dashboard/package.json diff jumped the specifier straight to 8.3.0, which requires eact@19.2.7+ while the dashboard pins eact@18.3.1. This is the exact same incompatibility already found and reverted twice before (#108, then #135 during the CertOps stack merge) - pnpm-workspace.yaml's own uditConfig.ignoreGhsas comment already documents this constraint explicitly.

Confirmed broken on main right now: CI failed on #152's run and #153's own run was cancelled by a queued #154 (unrelated js-yaml bump, itself a no-op since js-yaml is pinned via pnpm-workspace.yaml overrides) - pnpm install --frozen-lockfile fails with a manifest/lockfile specifier mismatch before any test ever runs.

## Changes

- pps/dashboard/package.json: eact-router 8.3.0 -> 7.18.2 (matches what pnpm-lock.yaml already has committed on main, so no lockfile change needed here).

## Test plan

- [x] \pnpm install --frozen-lockfile\ succeeds
- [x] \pnpm --filter @tokentimer/dashboard lint\ - 0 errors (41 pre-existing warnings)
- [x] \pnpm --filter @tokentimer/dashboard test\ - 40/40 files, 401/401 tests passing
- [x] \prettier --check\ clean
