### PR TITLE
fix(deps): bump js-yaml override to 4.3.1, patch CVE-2026-59870

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   brace-expansion: 5.0.9
   path-to-regexp: 8.4.0
   yaml: 1.10.3
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   rollup: 4.60.0
   flatted: 3.4.2
   serialize-javascript: 7.0.5
@@ -197,8 +197,8 @@ importers:
         specifier: 11.18.2
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       lucide-react:
         specifier: 0.553.0
         version: 0.553.0(react@18.3.1)
@@ -3188,8 +3188,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -4742,7 +4742,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -5745,7 +5745,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5759,7 +5759,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5956,7 +5956,7 @@ snapshots:
       form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0
       openid-client: 6.8.4
@@ -7508,7 +7508,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -8219,7 +8219,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8476,7 +8476,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 10.2.5
       ms: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,9 @@ overrides:
   brace-expansion: 5.0.9
   path-to-regexp: 8.4.0
   yaml: 1.10.3
-  js-yaml: 4.3.0
+  # Quadratic CPU consumption in !!omap resolution (CVE-2026-59870 /
+  # GHSA-5p4m-2wfm-xmqj), fixed 4.3.1. Pin exact per repo policy.
+  js-yaml: 4.3.1
   rollup: 4.60.0
   flatted: 3.4.2
   serialize-javascript: 7.0.5


### PR DESCRIPTION
## Summary

\main\'s post-merge CI (\Dependency Audit\ job) is currently failing: \pnpm audit --prod --audit-level=moderate\ reports a high-severity finding for \js-yaml\ - quadratic CPU consumption in \!!omap\ resolution (CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj), vulnerable \>=4.0.0 <4.3.1\, patched \>=4.3.1\.

Root cause: \pnpm-workspace.yaml\'s own \overrides.js-yaml: 4.3.0\ pinned the exact vulnerable version, silently neutralizing Dependabot's #154 bump of \pps/dashboard/package.json\'s direct specifier to \4.3.1\ - the override forced every resolution (including \pps/api\'s \swagger-jsdoc\->\swagger-parser\ chain and \pps/k8s-controller\'s \@kubernetes/client-node\) back down to \4.3.0\.

## Changes

- \pnpm-workspace.yaml\: \js-yaml\ override \4.3.0\ -> \4.3.1\.
- \pnpm-lock.yaml\: regenerated, all \js-yaml\ resolutions now \4.3.1\.

## Test plan

- [x] \pnpm audit --prod --audit-level=moderate\ - no known vulnerabilities
- [x] \pnpm --filter @tokentimer/dashboard lint\ / \@tokentimer/worker lint\ / \@tokentimer/api lint\ - 0 errors
- [x] \pnpm run test:unit\ - 1446/1446 passing
- [x] \pnpm run check:contracts\ / \check:contracts:integrity\ / \	est:contracts\ - all ok
