### PR TITLE
fix(ci): sync check-lockfile-overrides.js js-yaml pin to 4.3.1

### DIFF
--- a/scripts/check-lockfile-overrides.js
+++ b/scripts/check-lockfile-overrides.js
@@ -22,7 +22,7 @@ const REQUIRED_PINS = {
   "brace-expansion": { "*": "5.0.9" },
   "path-to-regexp": { "*": "8.4.0" },
   yaml: { "*": "1.10.3" },
-  "js-yaml": { "*": "4.3.0" },
+  "js-yaml": { "*": "4.3.1" },
   rollup: { "*": "4.60.0" },
   flatted: { "*": "3.4.2" },
   "serialize-javascript": { "*": "7.0.5" },
@@ -34,7 +34,6 @@ const REQUIRED_PINS = {
   qs: { "*": "6.15.2" },
   "ip-address": { "*": "10.4.0" },
   "form-data": { "*": "4.0.6" },
-  "js-yaml": { "*": "4.3.0" },
   ws: { "*": "8.21.0" },
   "fast-uri": { "*": "3.1.5" },
 };


### PR DESCRIPTION
## Summary

Follow-up to #156. \scripts/check-lockfile-overrides.js\ keeps its own \REQUIRED_PINS\ copy of \pnpm-workspace.yaml\'s overrides (by design, to catch drift between the two - see its own header comment), and was left pinned at the pre-CVE js-yaml version (\4.3.0\) when #156 bumped the real override to \4.3.1\. Its own CI guard (\pnpm run check:lockfile-overrides\, wired into \ci.yml\) started failing right after the fix it exists to protect landed.

## Changes

- \scripts/check-lockfile-overrides.js\: \js-yaml\ pin \4.3.0\ -> \4.3.1\, and removed a duplicate \js-yaml\ key in the same object (both entries had identical values before this pin drifted apart, but two entries able to silently diverge is exactly the failure mode this script exists to catch).

## Test plan

- [x] \pnpm run check:lockfile-overrides\ - ok (21 resolved version(s) checked against required pins)
