### PR TITLE
fix(deps): bump Node base images 22.23.0 -> 22.23.2

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,7 +16,7 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.23.0-slim
+FROM node:22.23.2-slim
 
 WORKDIR /app
 

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.23.0-slim
+FROM node:22.23.2-slim
 
 WORKDIR /app
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,6 +1,6 @@
 # Build context must be the repo root.
 # Prefer deploy/compose/Dockerfile.dashboard for production Compose/CI images.
-FROM node:22.23.0-slim AS build
+FROM node:22.23.2-slim AS build
 
 ARG VITE_API_URL=
 ARG API_URL=

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Build context must be the repo root (see docker-compose.*.yml).
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
 RUN apk update && apk upgrade --no-cache \

--- a/apps/k8s-controller/Dockerfile
+++ b/apps/k8s-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Keep the controller base aligned with the worker image's patched Alpine base.
 RUN apk update && apk upgrade --no-cache \

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
 RUN apk update && apk upgrade --no-cache \

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -17,7 +17,7 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -1,5 +1,5 @@
 # TokenTimer Dashboard Dockerfile
-FROM node:22.23.0-alpine3.23 AS builder
+FROM node:22.23.2-alpine3.23 AS builder
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -1,5 +1,5 @@
 # TokenTimer Worker Dockerfile
-FROM node:22.23.0-alpine3.23
+FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.

--- a/tests/integration/certops-k8s-controller-wiring.test.js
+++ b/tests/integration/certops-k8s-controller-wiring.test.js
@@ -28,7 +28,7 @@ describe("CertOps Kubernetes controller wiring", () => {
     const dockerfile = read("apps/k8s-controller/Dockerfile");
     const logScrubber = read("packages/log-scrub/index.js");
     const apiDetectorShim = read("apps/api/utils/secretMaterial.js");
-    expect(dockerfile).to.include("FROM node:22.23.0-alpine3.23");
+    expect(dockerfile).to.include("FROM node:22.23.2-alpine3.23");
     expect(dockerfile).to.include("pnpm install --prod --frozen-lockfile");
     expect(dockerfile).to.include("corepack disable");
     expect(dockerfile).to.include("/usr/local/lib/node_modules/corepack");


### PR DESCRIPTION
## Summary

Bumps every pinned Node Docker base image from \22.23.0\ to \22.23.2\ to clear the Grype High findings against the \	okentimer/api\ image binary:

- CVE-2026-56846 (High)
- CVE-2026-56848 (High)
- CVE-2026-58043 (High)
- plus related Medium/Low Node CVEs all fixed in 22.23.2

## Changes

- All \
ode:22.23.0-alpine3.23\ / \
ode:22.23.0-slim\ Dockerfiles (api, dashboard, worker, k8s-controller, compose)
- \	ests/integration/certops-k8s-controller-wiring.test.js\ expectation kept in sync

Floating \
ode:22-*\ tags in \docker-compose.dev.yml\ are unchanged (not pinned).

## Test plan

- [ ] Grype re-scan of rebuilt api/dashboard/worker images (user-owned)
