### PR TITLE
Release TokenTimer Core v0.12.1 with Artifact Hub Publishing and Renewal-Setup Fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,11 @@ jobs:
       packages: write
       contents: read
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: deploy/helm/artifacthub-repo.yml
+          sparse-checkout-cone-mode: false
+
       - name: Extract version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -240,6 +245,20 @@ jobs:
 
       - name: Push chart to OCI registry
         run: helm push .helm-pkg/tokentimer-${{ steps.get_version.outputs.VERSION }}.tgz oci://${{ env.HELM_OCI_REPO }}
+
+      - name: Install oras
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+      - name: Log in to OCI registry (oras)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ${{ env.HELM_OCI_REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Publish Artifact Hub repository metadata
+        # Enables Artifact Hub's verified publisher check. Pushed to the same OCI ref as
+        # the chart itself, under the reserved "artifacthub.io" tag Artifact Hub looks for.
+        run: |
+          oras push ${{ env.HELM_OCI_REPO }}/tokentimer:artifacthub.io \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            deploy/helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
   # Stage 3b: create the public GitHub Release with the agent tarball attached.
   # Skipped for pre-release tags so a beta dry-run never gets a public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-12
+
+### Fixed
+
+- **Renewal-setup jobs for non-Windows deployments failed with `renew job has no target.reference to use as the certificate CN`.** `renewalSetupJobCreator` never populated `payload.target` for filesystem-discovered certificates, even though the agent's `executeRenewJob` requires `target.reference` to build the renewal CSR's CN for every renew job, not just `windows-iis`. Now derives it from the certificate's `common_name` or first subject alternative name, stripping the typed SAN prefix (`DNS:`, `IP Address:`, etc.) that discovery records verbatim. Certificates with no usable name now fail fast with a clear `422 CERTOPS_RENEWAL_SETUP_NO_COMMON_NAME` instead of creating a job that can only fail downstream once an agent claims it. (#161)
+
+### Added
+
+- **Artifact Hub repository metadata for the Helm chart.** `deploy/helm/artifacthub-repo.yml` is now pushed to the chart's OCI repository (`oci://ghcr.io/tokentimerch/charts/tokentimer`) under the reserved `artifacthub.io` tag on every release, enabling Artifact Hub's verified-publisher check for the `tokentimer` chart.
+
+### Changed
+
+- Version metadata bumped to 0.12.1 across all manifests, contracts, and Helm chart.
+
 ## [0.12.0] - 2026-08-10
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "BUSL-1.1",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/apps/k8s-controller/package.json
+++ b/apps/k8s-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/k8s-controller",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "BUSL-1.1",
   "main": "src/index.js",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "BUSL-1.1",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.12.0
-appVersion: "0.12.0"
+version: 0.12.1
+appVersion: "0.12.1"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/artifacthub-repo.yml
+++ b/deploy/helm/artifacthub-repo.yml
@@ -1,0 +1,8 @@
+# Artifact Hub repository metadata for the tokentimer Helm chart.
+#
+# This chart is published as an OCI artifact (oci://ghcr.io/tokentimerch/charts/tokentimer),
+# not a classic index.yaml Helm repo, so Artifact Hub cannot read this file directly from
+# GitHub. It is kept here as the source of truth and pushed to the OCI registry under the
+# special "artifacthub.io" tag by the publish-helm-chart job in .github/workflows/release.yml
+# on every release. See https://artifacthub.io/docs/topics/repositories/#verified-publisher.
+repositoryID: f3bc26ba-0d50-473e-88ff-45ab49ca2098

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.12.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag; pin from release-manifest.json for reproducible deploys (:latest is not the source of truth)
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.12.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -158,7 +158,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.12.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -303,7 +303,7 @@ certops:
     image:
       registry: ""
       repository: tokentimer-core-k8s-controller
-      tag: "0.12.0"  # align with Chart.appVersion; release workflow updates this per tag
+      tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
       digest: ""
       pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/agent",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "description": "TokenTimer Agent - outbound-only execution-plane process for CertOps",
   "license": "BUSL-1.1",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.12.0
+  version: 0.12.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "BUSL-1.1",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
This patch release adds Artifact Hub distribution for the Helm chart and ships the certops renewal-setup fix merged since v0.12.0 (#161). No breaking changes.

## Changes

### CertOps (already merged to main via #161, included in this release)
- `renewalSetupJobCreator` now populates `payload.target` for non-Windows (filesystem-discovered) certificates, deriving `target.reference` from the certificate's `common_name` or first subject alternative name and stripping typed SAN prefixes (`DNS:`, `IP Address:`, etc.). Previously every "Renew and set up" click on a non-Windows deployment failed once claimed with `renew job has no target.reference to use as the certificate CN`.
- Certificates with no usable name now fail fast with a clear `422 CERTOPS_RENEWAL_SETUP_NO_COMMON_NAME` instead of creating a job that only fails once an agent claims it.

### Helm / distribution
- Added `deploy/helm/artifacthub-repo.yml` with the repository's Artifact Hub `repositoryID`.
- `release.yml`'s `publish-helm-chart` job now pushes that file to the chart's OCI repository (`oci://ghcr.io/tokentimerch/charts/tokentimer`) under the reserved `artifacthub.io` tag via `oras`, right after `helm push`, enabling Artifact Hub's verified-publisher check on every future release.

### Docs / metadata
- `CHANGELOG.md`: added the `[0.12.1]` section.
- Version bumped to 0.12.1 across all manifests, contracts, and the Helm chart (`Chart.yaml` `version`/`appVersion`, four `values.yaml` image tags).

## Test plan
- [x] Agent fast gate: `pnpm audit --prod --audit-level=moderate` clean, dashboard/worker/api lint clean (0 errors), dashboard Prettier unchanged, `pnpm run test:unit` 1623/1623 passing, `check:contracts` + `check:contracts:integrity` + `test:contracts` all green.
- [x] Stale-pin audit: no leftover `0.12.0` references outside `CHANGELOG.md`.
- [ ] CI job passes (link the run)
- [ ] Beta dry-run (`v0.12.1-beta.1`) exercises the new `oras` publish step end to end before the real tag
