### PR TITLE
chore(helm): ignore alpha/beta chart versions on Artifact Hub

### DIFF
--- a/deploy/helm/artifacthub-repo.yml
+++ b/deploy/helm/artifacthub-repo.yml
@@ -6,3 +6,11 @@
 # special "artifacthub.io" tag by the publish-helm-chart job in .github/workflows/release.yml
 # on every release. See https://artifacthub.io/docs/topics/repositories/#verified-publisher.
 repositoryID: f3bc26ba-0d50-473e-88ff-45ab49ca2098
+
+# Hide pre-release chart versions (alpha/beta) from the Artifact Hub listing so a
+# pre-release never gets presented to users as the default/latest version. The `v`
+# prefix is omitted below because Artifact Hub strips it before matching.
+# See https://github.com/artifacthub/hub/issues/1359
+ignore:
+  - name: tokentimer
+    version: '^\d+\.\d+\.\d+-(alpha|beta)\.?\d+$'


### PR DESCRIPTION
## Summary

- Adds an `ignore` rule to `deploy/helm/artifacthub-repo.yml` so Artifact Hub excludes alpha/beta pre-release chart versions (e.g. `0.12.1-beta.1`, `0.1.0-alpha2`) from the package's version list.
- Without this, pre-release builds show up as selectable versions on Artifact Hub and can even be presented as the default/latest version, which is misleading for users looking for a stable release.
- Regex verified against every currently published version tag (stable and pre-release) to confirm it matches only the intended pre-release suffixes.
- Already manually pushed to the `artifacthub.io` OCI tag via `oras` so Artifact Hub picks this up without waiting for the next chart release; this PR lands the same content as the source of truth in git for future releases.

## Test plan

- [x] Verified regex `^\d+\.\d+\.\d+-(alpha|beta)\.?\d+$` matches `0.1.0-alpha2`, `0.11.1-beta.1`, `0.12.0-beta.1`, `0.12.1-beta.1` and does not match any stable version
- [x] Manually pushed updated metadata to `oci://ghcr.io/tokentimerch/charts/tokentimer:artifacthub.io`
- [ ] Confirm Artifact Hub reprocesses the repo and hides pre-release versions from the version dropdown
