### PR TITLE
chore(helm): update Artifact Hub repositoryID after repository re-add

### DIFF
--- a/deploy/helm/artifacthub-repo.yml
+++ b/deploy/helm/artifacthub-repo.yml
@@ -5,7 +5,7 @@
 # GitHub. It is kept here as the source of truth and pushed to the OCI registry under the
 # special "artifacthub.io" tag by the publish-helm-chart job in .github/workflows/release.yml
 # on every release. See https://artifacthub.io/docs/topics/repositories/#verified-publisher.
-repositoryID: f3bc26ba-0d50-473e-88ff-45ab49ca2098
+repositoryID: b9f10773-25d3-4bb2-a740-db5a09adb46d
 
 # Hide pre-release chart versions (alpha/beta) from the Artifact Hub listing so a
 # pre-release never gets presented to users as the default/latest version. The `v`


### PR DESCRIPTION
The tokentimer-core Helm chart repository on Artifact Hub was removed and re-added to force reprocessing of already-indexed versions (the icon fix and pre-release ignore rule did not apply retroactively to old versions). Re-adding assigned a new repository ID. This updates repositoryID in artifacthub-repo.yml to match, so Verified Publisher status can be re-established. Already manually pushed to the live oci://ghcr.io/tokentimerch/charts/tokentimer:artifacthub.io tag.