### PR TITLE
Release TokenTimer Core v0.12.2 with Artifact Hub Metadata Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-08-13
+
+### Fixed
+
+- **Alpha/beta chart versions were listed and could be shown as the default version on Artifact Hub.** Added an `ignore` rule to `deploy/helm/artifacthub-repo.yml` to exclude pre-release semver suffixes (`-alpha*`, `-beta*`) from the Artifact Hub listing.
+- **Chart icon 404'd on Artifact Hub.** `deploy/helm/Chart.yaml`'s `icon` field points at `https://tokentimer.ch/icon.png`, which never existed; `tokentimer.ch` now serves an icon at that path so Artifact Hub can display the chart's logo.
+
 ### Changed
 
 - **TokenTimer Core is now fully open source.** Relicensed from Business Source License 1.1 (source-available) to the GNU Affero General Public License v3.0 (AGPLv3), an OSI-approved open-source license, effective immediately for all versions. Self-hosting, modifying, and integrating TokenTimer Core remains free; running a modified version as a network service now requires publishing the corresponding source under AGPLv3. A commercial license without that source-disclosure obligation remains available (see `COMMERCIAL_TERMS.md`).
+- Version metadata bumped to 0.12.2 across all manifests, contracts, and Helm chart.
 
 ## [0.12.1] - 2026-08-12
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "AGPL-3.0-or-later",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",

--- a/apps/k8s-controller/package.json
+++ b/apps/k8s-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/k8s-controller",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "main": "src/index.js",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.12.1
-appVersion: "0.12.1"
+version: 0.12.2
+appVersion: "0.12.2"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag; pin from release-manifest.json for reproducible deploys (:latest is not the source of truth)
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -158,7 +158,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -303,7 +303,7 @@ certops:
     image:
       registry: ""
       repository: tokentimer-core-k8s-controller
-      tag: "0.12.1"  # align with Chart.appVersion; release workflow updates this per tag
+      tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
       digest: ""
       pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/agent",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "TokenTimer Agent - outbound-only execution-plane process for CertOps",
   "license": "AGPL-3.0-or-later",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.12.1
+  version: 0.12.2
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
This release documents the AGPLv3 relicensing that already landed on `main`, and ships two Artifact Hub metadata fixes needed to get Verified Publisher status and a clean version list working correctly for the `tokentimer` Helm chart.

## Changes

### Helm / Artifact Hub
- `deploy/helm/Chart.yaml`'s `icon` field pointed at `https://tokentimer.ch/icon.png`, which never existed on the live site (404). `tokentimer-cloud` now serves an icon at that path.
- Added an `ignore` rule to `deploy/helm/artifacthub-repo.yml` to exclude alpha/beta pre-release chart versions from the Artifact Hub listing, so a pre-release build is never shown as the default/latest version.
- Updated `repositoryID` in `deploy/helm/artifacthub-repo.yml` after the Artifact Hub repository entry was removed and re-added to force reprocessing of already-indexed chart versions (icon/ignore-rule fixes don't retroactively apply to already-tracked OCI version tags).

### Docs / metadata
- CHANGELOG: documented the AGPLv3 relicensing (already on `main` via #165) under this release, plus the two Artifact Hub fixes above.
- Version bumped to 0.12.2 across all manifests, contracts, and Helm chart.

## Test plan
- [x] Agent fast gate: `pnpm audit`, lint (dashboard/worker/api), Prettier, `pnpm run test:unit` (1623 passed), contracts checks
- [x] Stale-pin audit for `0.12.1` outside CHANGELOG: clean
- [ ] CI job passes (link the run)
