### PR TITLE
fix(email): use FROM_EMAIL as the From address for env-configured SMTP

### DIFF
--- a/apps/api/routes/auth.js
+++ b/apps/api/routes/auth.js
@@ -957,11 +957,12 @@ router.post(
       );
 
       if (!emailResult.success) {
-        logger.error(
-          "Failed to send verification email to:",
+        logger.error("Failed to send verification email", {
           email,
-          emailResult.error,
-        );
+          error: emailResult.error,
+          code: emailResult.code,
+          providerError: emailResult.providerError,
+        });
         // Do not block user flow with 500; respond with emailSent=false
         return res.status(200).json({
           message: "Email service unavailable. Please try again later.",
@@ -1050,7 +1051,7 @@ router.post(
         );
       }
 
-      logger.info("Attempting to send password reset email:", {
+      logger.info("Attempting to send password reset email", {
         email,
         tokenLength: resetToken.length,
         displayName: user.display_name,
@@ -1062,14 +1063,15 @@ router.post(
         user.display_name,
       );
 
-      logger.info("Password reset email result:", emailResult);
+      logger.info("Password reset email result", { email, ...emailResult });
 
       if (!emailResult.success) {
-        logger.error(
-          "Failed to send password reset email to:",
+        logger.error("Failed to send password reset email", {
           email,
-          emailResult.error,
-        );
+          error: emailResult.error,
+          code: emailResult.code,
+          providerError: emailResult.providerError,
+        });
         return res.status(500).json({
           error: "Failed to send password reset email",
           details: emailResult.error,

--- a/apps/api/services/emailService.js
+++ b/apps/api/services/emailService.js
@@ -435,7 +435,13 @@ function getFromForIndex(index) {
   const addr = SMTP_USERS[index] || process.env.SMTP_USER;
   if (!addr) return null;
   const displayName = process.env.FROM_EMAIL_NAME || "TokenTimer";
-  return `"${displayName}" <${addr}>`;
+  // Only honor FROM_EMAIL in single-account mode; with rotating SMTP_USER
+  // accounts, From must match whichever account authenticated the send.
+  const fromAddr =
+    SMTP_USERS.length <= 1 && process.env.FROM_EMAIL
+      ? process.env.FROM_EMAIL
+      : addr;
+  return `"${displayName}" <${fromAddr}>`;
 }
 
 /**

--- a/apps/worker/src/notify/email.js
+++ b/apps/worker/src/notify/email.js
@@ -447,8 +447,13 @@ function getFromForIndex(index) {
   const addr = SMTP_USERS[index] || process.env.SMTP_USER;
   if (!addr) return null;
   const displayName = process.env.FROM_EMAIL_NAME || "TokenTimer";
+  // FROM_EMAIL only applies in single-account mode; see sendEmailNotification().
+  const fromAddr =
+    SMTP_USERS.length <= 1 && process.env.FROM_EMAIL
+      ? process.env.FROM_EMAIL
+      : addr;
   // Format as display name + address so recipient sees the brand name
-  return `${JSON.stringify(displayName)} <${addr}>`;
+  return `${JSON.stringify(displayName)} <${fromAddr}>`;
 }
 
 // Cached DB-based transporter
@@ -532,7 +537,10 @@ export async function sendEmailNotification({
       });
     }
   }
-  const fromEnv = process.env.FROM_EMAIL; // optional explicit from
+  // FROM_EMAIL is only safe to force onto the From header in single-account
+  // mode; with rotating SMTP_USER accounts it can cause sender-mismatch
+  // rejections (e.g. Amazon SES) if it doesn't match the authenticating account.
+  const fromEnv = SMTP_USERS.length <= 1 ? process.env.FROM_EMAIL : null; // optional explicit from
   try {
     // Check if HTML already contains the full template (with footer)
     // appendFooter handles checking both HTML and Text versions independently

--- a/tests/integration/email-service.unit.test.js
+++ b/tests/integration/email-service.unit.test.js
@@ -68,6 +68,7 @@ function makeNodemailerStub({
   sendAccepted = ["ok@example.com"],
 } = {}) {
   const calls = [];
+  const sendMailCalls = [];
   return {
     createTransport(options = {}) {
       calls.push(options);
@@ -76,13 +77,17 @@ function makeNodemailerStub({
           if (!verifyOk) throw new Error("verify failed");
           return true;
         },
-        async sendMail() {
+        async sendMail(mailOptions) {
+          sendMailCalls.push(mailOptions);
           return { accepted: sendAccepted, response: "250 OK" };
         },
       };
     },
     __getCalls() {
       return calls;
+    },
+    __getSendMailCalls() {
+      return sendMailCalls;
     },
   };
 }
@@ -123,6 +128,7 @@ describe("Email service unit coverage", () => {
     delete process.env.SMTP_SECURE;
     delete process.env.SMTP_REQUIRE_TLS;
     delete process.env.FROM_EMAIL;
+    delete process.env.FROM_EMAIL_NAME;
   });
 
   after(() => {
@@ -271,5 +277,48 @@ describe("Email service unit coverage", () => {
     expect(String(result.error || result.providerError || "")).to.match(
       /(Failed to send email|SMTP|support@example.com|contact)/i,
     );
+  });
+
+  it("uses FROM_EMAIL as the From address in single-account mode (issue #167)", async () => {
+    process.env.SMTP_HOST = "smtp.local";
+    process.env.SMTP_USER = "AKIAEXAMPLE";
+    process.env.SMTP_PASS = "secret";
+    process.env.SMTP_PORT = "587";
+    process.env.FROM_EMAIL = "verified-sender@example.com";
+    process.env.FROM_EMAIL_NAME = "TokenTimer";
+    const nodemailerStub = makeNodemailerStub();
+    const email = requireEmailServiceWithStubs({ nodemailer: nodemailerStub });
+    const result = await email.sendEmail({
+      to: "x@example.com",
+      subject: "Test",
+      text: "Body",
+      html: "<p>Body</p>",
+    });
+    expect(result.success).to.equal(true);
+    const sent = nodemailerStub.__getSendMailCalls();
+    expect(sent).to.have.length(1);
+    expect(sent[0].from).to.include("verified-sender@example.com");
+    expect(sent[0].from).to.not.include("AKIAEXAMPLE");
+  });
+
+  it("keeps From on the authenticating SMTP_USER in multi-account mode", async () => {
+    process.env.SMTP_HOST = "smtp.local";
+    process.env.SMTP_USER = "user1@example.com,user2@example.com";
+    process.env.SMTP_PASS = "p1,p2";
+    process.env.SMTP_PORT = "2525";
+    process.env.FROM_EMAIL = "verified-sender@example.com";
+    const nodemailerStub = makeNodemailerStub();
+    const email = requireEmailServiceWithStubs({ nodemailer: nodemailerStub });
+    const result = await email.sendEmail({
+      to: "x@example.com",
+      subject: "Test",
+      text: "Body",
+      html: "<p>Body</p>",
+    });
+    expect(result.success).to.equal(true);
+    const sent = nodemailerStub.__getSendMailCalls();
+    expect(sent).to.have.length(1);
+    expect(sent[0].from).to.include("user1@example.com");
+    expect(sent[0].from).to.not.include("verified-sender@example.com");
   });
 });


### PR DESCRIPTION
## Summary

- Env-configured SMTP always sent with `From: SMTP_USER`, never referencing `FROM_EMAIL`. This breaks providers like Amazon SES where `SMTP_USER` is an IAM-style credential and the sender must be a separately verified email identity: SMTP auth succeeds but the send is rejected.
- `getFromForIndex()` in both `apps/api/services/emailService.js` and `apps/worker/src/notify/email.js` now uses `FROM_EMAIL` as the From address when a single SMTP account is configured.
- With multiple rotating `SMTP_USER` accounts, From still tracks whichever account actually authenticated the send. Forcing one fixed `FROM_EMAIL` there would cause sender-mismatch rejections from providers that verify sender identity.
- Fixed two `logger.error`/`logger.info` calls in the resend-verification and password-reset routes that passed the error as an extra positional argument instead of structured metadata, so the real provider error was dropped from logs instead of surfacing.
- Added regression tests pinning both the single-account (`FROM_EMAIL` used) and multi-account (per-account address kept) behavior.

Fixes #167

## Test plan

- [x] `pnpm run test:unit` — 1623/1623 passing
- [x] `pnpm run check:contracts`, `check:contracts:integrity`, `check:lockfile-overrides`, `check:secret-logging` — all ok
- [x] `pnpm --filter @tokentimer/api lint`, `pnpm --filter @tokentimer/worker lint` — no new errors
- [x] `pnpm audit --prod --audit-level=moderate` — no known vulnerabilities
- [x] Targeted `email-service.unit.test.js` (mocha) — 10/10 passing, including 2 new regression tests for this fix
- [x] Built and ran the full Docker test stack (postgres + api + MailHog); contract tests (8/8) and auth integration suite (11/11) passing
- [x] Live end-to-end verification via MailHog: confirmed captured `From` header uses `FROM_EMAIL` in single-account mode, and the authenticating `SMTP_USER` in multi-account mode
