### PR TITLE
Release TokenTimer Core v0.12.3 with Env SMTP From-Address Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-08-13
+
+### Fixed
+
+- **Env-configured SMTP sent verification and reset emails from the raw `SMTP_USER` credential instead of `FROM_EMAIL`.** With a single SMTP account, providers that enforce sender identity (e.g. Amazon SES) rejected the send whenever `SMTP_USER` was an IAM-style access key rather than a verified email address. `getFromForIndex()` in `apps/api/services/emailService.js` and `apps/worker/src/notify/email.js` now honors `FROM_EMAIL` in single-account mode; rotating multi-account SMTP setups keep using the authenticating account's address so senders still match what each account is authorized to send from. (#167)
+- **Email failure logs dropped the underlying SMTP error.** `apps/api/routes/auth.js` now logs `error`, `code`, and `providerError` as structured fields when verification or password-reset emails fail to send, instead of a bare message with no detail.
+
+### Changed
+
+- Version metadata bumped to 0.12.3 across all manifests, contracts, and Helm chart.
+
 ## [0.12.2] - 2026-08-13
 
 ### Fixed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "AGPL-3.0-or-later",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",

--- a/apps/k8s-controller/package.json
+++ b/apps/k8s-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/k8s-controller",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "main": "src/index.js",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.12.2
-appVersion: "0.12.2"
+version: 0.12.3
+appVersion: "0.12.3"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag; pin from release-manifest.json for reproducible deploys (:latest is not the source of truth)
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -158,7 +158,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.12.3"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -303,7 +303,7 @@ certops:
     image:
       registry: ""
       repository: tokentimer-core-k8s-controller
-      tag: "0.12.2"  # align with Chart.appVersion; release workflow updates this per tag
+      tag: "0.12.3"  # align with Chart.appVersion; release workflow updates this per tag
       digest: ""
       pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/agent",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "description": "TokenTimer Agent - outbound-only execution-plane process for CertOps",
   "license": "AGPL-3.0-or-later",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.12.2
+  version: 0.12.3
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",


### PR DESCRIPTION
## Summary
Patch release: env-configured SMTP now sends verification and password-reset emails from `FROM_EMAIL` instead of the raw `SMTP_USER` credential, fixing rejected sends on providers that enforce sender identity (e.g. Amazon SES) when `SMTP_USER` is an IAM-style access key. Also improves structured logging so email-send failures surface the underlying SMTP error.

## Changes

### API / Worker
- `apps/api/services/emailService.js`, `apps/worker/src/notify/email.js`: `getFromForIndex()` now honors `FROM_EMAIL` only in single-account SMTP mode; multi-account rotation keeps using the authenticating account's address so senders still match what each account is authorized to send from.
- `apps/api/routes/auth.js`: verification and password-reset email failures now log `error`, `code`, and `providerError` as structured fields instead of a bare message.

### Tests
- `tests/integration/email-service.unit.test.js`: added regression coverage for single-account `FROM_EMAIL` usage and multi-account `SMTP_USER` fallback.

### Docs / metadata
- `CHANGELOG.md`: added `0.12.3` entry.
- Version bumped to 0.12.3 across all manifests, contracts, and Helm chart.

## Test plan
- [x] Unit tests: `pnpm run test:unit` (1623 passed)
- [x] Lint: dashboard/worker/api (0 errors, pre-existing warnings only)
- [x] Contracts: `check:contracts`, `check:contracts:integrity`, `test:contracts`
- [x] Reproduced the exact issue #167 scenario against a live Docker stack (real `/auth/register` + `/auth/resend-verification` HTTP calls, IAM-style `SMTP_USER`, MailHog capture) - confirmed pre-fix leaks `SMTP_USER` into `From`, post-fix uses `FROM_EMAIL`
- [ ] CI job passes (link the run)
