### PR TITLE
fix(certops): refetch expanded job evidence timeline on Refresh

### DIFF
--- a/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
+++ b/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
@@ -239,9 +239,9 @@ function TimelineItem({ item, attemptLabel }) {
 /**
  * Full job + evidence timeline for a single CertOps job.
  *
- * @param {{ jobId: string, onClose?: function }} props
+ * @param {{ jobId: string, onClose?: function, refreshToken?: * }} props
  */
-export default function EvidenceTimeline({ jobId, onClose }) {
+export default function EvidenceTimeline({ jobId, onClose, refreshToken }) {
   const { muted, border } = useDashboardTheme();
   const failureBg = useColorModeValue('red.50', 'rgba(127, 29, 29, 0.28)');
   const failureBorder = useColorModeValue('red.200', 'red.700');
@@ -253,7 +253,7 @@ export default function EvidenceTimeline({ jobId, onClose }) {
     evidencePagination,
     loading,
     error,
-  } = useCertOpsJobTimeline(jobId);
+  } = useCertOpsJobTimeline(jobId, refreshToken);
 
   if (loading) {
     return (

--- a/apps/dashboard/src/components/certops/ExecutorJobsPanel.jsx
+++ b/apps/dashboard/src/components/certops/ExecutorJobsPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   Box,
   Button,
@@ -111,6 +111,16 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
   const [expandedId, setExpandedId] = useState(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [decisionTarget, setDecisionTarget] = useState(null);
+  // Bumped alongside the list refresh so an already-expanded row's
+  // EvidenceTimeline (a separate hook instance, not something the list's own
+  // refresh() touches) refetches too, instead of silently going stale while
+  // the top-level "Refresh" button spins.
+  const [timelineRefreshToken, setTimelineRefreshToken] = useState(0);
+
+  const refreshAll = useCallback(() => {
+    refresh();
+    setTimelineRefreshToken(tick => tick + 1);
+  }, [refresh]);
 
   const firstPage = () => setPage({ offset: 0 });
   const pageIsPastEnd = Boolean(
@@ -125,7 +135,7 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
       await decide(workspaceId, job.id, { reason });
       showSuccess(decision === 'approve' ? 'Job approved' : 'Job rejected');
       setDecisionTarget(null);
-      refresh();
+      refreshAll();
     } catch (err) {
       showError(
         decision === 'approve' ? 'Approve failed' : 'Reject failed',
@@ -136,7 +146,7 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
         'CERTOPS_APPROVAL_JOB_NOT_PENDING_APPROVAL'
       ) {
         setDecisionTarget(null);
-        refresh();
+        refreshAll();
       }
     }
   };
@@ -165,7 +175,7 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
             ) : null}
             <DashboardActionButton
               variant='outline'
-              onClick={refresh}
+              onClick={refreshAll}
               isLoading={loading}
             >
               Refresh
@@ -345,7 +355,12 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
                     bg={expandedBg}
                     borderRadius='md'
                   >
-                    {isOpen ? <EvidenceTimeline jobId={job.id} /> : null}
+                    {isOpen ? (
+                      <EvidenceTimeline
+                        jobId={job.id}
+                        refreshToken={timelineRefreshToken}
+                      />
+                    ) : null}
                   </Box>
                 </Collapse>
               </Box>
@@ -368,7 +383,7 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
       <CreateManualJobModal
         isOpen={createOpen}
         onClose={() => setCreateOpen(false)}
-        onCreated={refresh}
+        onCreated={refreshAll}
       />
       <ApprovalDecisionModal
         isOpen={Boolean(decisionTarget)}

--- a/apps/dashboard/src/components/certops/certopsApi.js
+++ b/apps/dashboard/src/components/certops/certopsApi.js
@@ -319,11 +319,34 @@ export async function updateWorkspaceCertOpsPauseState(
   return res.data;
 }
 
+/** @type {Map<string, { at: number, enabled: boolean }>} */
+const enabledProbeCache = new Map();
+const ENABLED_PROBE_TTL_MS = 60_000;
+
+/**
+ * Synchronously reads the last known `certops.enabled` result for a
+ * workspace, if it was probed within the last `ENABLED_PROBE_TTL_MS`.
+ * Lets callers seed state immediately (no "resolving" flash) instead of
+ * always starting from `null` while a fresh probe is in flight.
+ * @returns {{ enabled: boolean }|null}
+ */
+export function getCachedCertOpsEnabled(workspaceId) {
+  const cached = enabledProbeCache.get(String(workspaceId));
+  if (!cached || Date.now() - cached.at >= ENABLED_PROBE_TTL_MS) return null;
+  return { enabled: cached.enabled };
+}
+
 /**
  * Lightweight availability probe used to gate CertOps UI behind the
  * `certops.enabled` rollout flag. The backend hides the routes with a 404 when
  * the flag is off, so a successful list call means CertOps is available to this
  * workspace. Only HTTP 404 means disabled; other failures propagate.
+ *
+ * Every screen under CertOps (Jobs, Certificates, Agents, a single job's
+ * evidence timeline, ...) mounts its own copy of this probe. Without a cache,
+ * re-opening e.g. a job's evidence timeline re-probes from scratch every time
+ * and the UI briefly reports "not available" until that round-trip resolves.
+ * Callers combine this with `getCachedCertOpsEnabled` to avoid that flash.
  * @returns {Promise<{ enabled: boolean }>}
  */
 export async function probeCertOpsEnabled(workspaceId, { signal } = {}) {
@@ -333,9 +356,11 @@ export async function probeCertOpsEnabled(workspaceId, { signal } = {}) {
       signal,
       _suppressLog: true,
     });
+    enabledProbeCache.set(String(workspaceId), { at: Date.now(), enabled: true });
     return { enabled: true };
   } catch (err) {
     if (err?.response?.status === 404) {
+      enabledProbeCache.set(String(workspaceId), { at: Date.now(), enabled: false });
       return { enabled: false };
     }
     throw err;

--- a/apps/dashboard/src/components/certops/useCertOps.js
+++ b/apps/dashboard/src/components/certops/useCertOps.js
@@ -19,6 +19,10 @@ import { pickPrimaryCertificate } from './certopsFormat';
  * CertOps ships behind the `certops.enabled` rollout flag. The backend hides
  * its routes (404) while the flag is off. Only 404 means disabled; other
  * failures are surfaced as `error` so outages are not mistaken for "feature off".
+ * One nuance when a fresh cached verdict exists: a cached `enabled: true` is
+ * served through a failed background revalidation (the gated screens' own
+ * requests surface the outage), but a cached `enabled: false` is not, since
+ * a "feature off" panel makes no further requests that could reveal it.
  *
  * @returns {{ ready: boolean, enabled: boolean|null, error: string|null, retry: function }}
  */
@@ -77,7 +81,15 @@ export function useCertOpsAvailability() {
       })
       .catch(err => {
         if (cancelled) return;
-        if (cached) return; // Keep serving the cached verdict; background revalidation failed silently.
+        // A cached *enabled* verdict keeps being served through a failed
+        // background revalidation: the screens it gates are already fetching
+        // real data, and those requests surface the outage loudly on their
+        // own. A cached *disabled* verdict must not be retained the same
+        // way: it renders "feature off" panels that make no follow-up
+        // requests, so keeping it would let a revalidation outage silently
+        // masquerade as "CertOps is not enabled" (only a 404 may mean
+        // disabled).
+        if (cached?.enabled === true) return;
         const message =
           err?.response?.data?.error ||
           err?.message ||

--- a/apps/dashboard/src/components/certops/useCertOps.js
+++ b/apps/dashboard/src/components/certops/useCertOps.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
 import { workspaceAPI } from '../../utils/apiClient';
 import {
+  getCachedCertOpsEnabled,
   getCertificateInstances,
   getManagedCertificatesForToken,
   getWorkspaceCertOpsPauseState,
@@ -23,10 +24,19 @@ import { pickPrimaryCertificate } from './certopsFormat';
  */
 export function useCertOpsAvailability() {
   const { workspaceId } = useWorkspace();
-  const [state, setState] = useState({
-    ready: false,
-    enabled: null,
-    error: null,
+  // Lazy-initialized from the module-level cache (not just re-applied inside
+  // the effect below) so a cache hit is reflected in the *first* render, not
+  // one tick later. Every CertOps screen (Jobs, Certificates, Agents, a
+  // single job's evidence timeline, ...) mounts its own copy of this hook;
+  // without this, re-mounting one (e.g. re-opening a job row) always
+  // rendered `enabled: null` for at least one frame before the effect could
+  // apply the cache, which was enough for a child like the evidence timeline
+  // to render "Job not found" before flipping to the real data.
+  const [state, setState] = useState(() => {
+    const cached = workspaceId ? getCachedCertOpsEnabled(workspaceId) : null;
+    return cached
+      ? { ready: true, enabled: cached.enabled, error: null }
+      : { ready: false, enabled: null, error: null };
   });
   const [reloadTick, setReloadTick] = useState(0);
 
@@ -42,7 +52,18 @@ export function useCertOpsAvailability() {
 
     let cancelled = false;
     const controller = new AbortController();
-    setState({ ready: false, enabled: null, error: null });
+
+    // Serve the cached verdict immediately when fresh (matches the lazy
+    // initial state above; re-applied here too since `workspaceId` can
+    // change after mount), then still revalidate in the background so a
+    // real change (flag flipped, workspace switched) is picked up within
+    // the cache TTL.
+    const cached = getCachedCertOpsEnabled(workspaceId);
+    if (cached) {
+      setState({ ready: true, enabled: cached.enabled, error: null });
+    } else {
+      setState({ ready: false, enabled: null, error: null });
+    }
 
     probeCertOpsEnabled(workspaceId, { signal: controller.signal })
       .then(result => {
@@ -56,6 +77,7 @@ export function useCertOpsAvailability() {
       })
       .catch(err => {
         if (cancelled) return;
+        if (cached) return; // Keep serving the cached verdict; background revalidation failed silently.
         const message =
           err?.response?.data?.error ||
           err?.message ||

--- a/apps/dashboard/src/components/certops/useCertOpsJobs.js
+++ b/apps/dashboard/src/components/certops/useCertOpsJobs.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
 import {
   getJob,
@@ -7,7 +7,11 @@ import {
   listJobs,
 } from './certopsJobsApi';
 import { listApiTokens } from './certopsTokensApi';
-import { useCertOpsCanManage, useCertOpsEnabled } from './useCertOps.js';
+import {
+  useCertOpsAvailability,
+  useCertOpsCanManage,
+  useCertOpsEnabled,
+} from './useCertOps.js';
 
 /**
  * Loads the CertOps job list for the active workspace.
@@ -109,7 +113,10 @@ export function useCertOpsJobs(filters = {}) {
  * Loads a single job plus its log and evidence timeline in parallel.
  *
  * A 404 on getJob clears the job and leaves error empty (job gone is not an
- * outage). Other failures surface a user-readable error string.
+ * outage). Other failures surface a user-readable error string, including an
+ * availability probe that completed with a non-404 failure (which would
+ * otherwise leave the timeline loading forever); `refresh()` re-probes
+ * availability as well, so it doubles as the retry path for that case.
  *
  * `externalRefreshToken` lets a parent (e.g. a job list's own "Refresh"
  * button) force a refetch of an already-mounted timeline from the outside:
@@ -125,7 +132,17 @@ export function useCertOpsJobs(filters = {}) {
  */
 export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
   const { workspaceId } = useWorkspace();
-  const enabled = useCertOpsEnabled();
+  // The full availability state (not just the collapsed boolean of
+  // useCertOpsEnabled): `enabled` is null both while the probe is still
+  // resolving (ready: false) and after it failed (ready: true, error).
+  // The two must render differently -- a spinner versus an error -- or a
+  // failed probe leaves the timeline spinning forever with no way out.
+  const {
+    ready: availabilityReady,
+    enabled,
+    error: availabilityError,
+    retry: retryAvailability,
+  } = useCertOpsAvailability();
   const [job, setJob] = useState(null);
   const [logEntries, setLogEntries] = useState([]);
   const [logPagination, setLogPagination] = useState(null);
@@ -142,8 +159,23 @@ export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
   const [reloadTick, setReloadTick] = useState(0);
 
   const refresh = useCallback(() => {
+    // Re-probe availability too: if the previous probe failed, bumping only
+    // this hook's own tick would re-run the effect against the same failed
+    // availability state and change nothing.
+    retryAvailability();
     setReloadTick(tick => tick + 1);
-  }, []);
+  }, [retryAvailability]);
+
+  // A parent-driven refresh (externalRefreshToken change) must offer the
+  // same recovery as refresh(). Guarded by a ref so availability is only
+  // re-probed when the token actually changes, not on every effect run
+  // (retrying unconditionally would loop: retry -> state change -> rerun).
+  const lastExternalRefreshTokenRef = useRef(externalRefreshToken);
+  useEffect(() => {
+    if (lastExternalRefreshTokenRef.current === externalRefreshToken) return;
+    lastExternalRefreshTokenRef.current = externalRefreshToken;
+    retryAvailability();
+  }, [externalRefreshToken, retryAvailability]);
 
   useEffect(() => {
     if (!workspaceId || !jobId) {
@@ -157,7 +189,7 @@ export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
       return undefined;
     }
 
-    if (enabled === null) {
+    if (!availabilityReady) {
       // The availability probe (a separate hook instance per CertOps screen)
       // hasn't resolved yet for this mount. This is "still finding out",
       // not "not applicable" -- treat it as loading. Otherwise every fresh
@@ -166,6 +198,19 @@ export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
       // even though the job existed the whole time.
       setLoading(true);
       setError('');
+      return undefined;
+    }
+
+    if (availabilityError) {
+      // The probe completed but failed (network/5xx, not a 404): surface it
+      // instead of spinning forever, and leave refresh() as the retry path.
+      setJob(null);
+      setLogEntries([]);
+      setLogPagination(null);
+      setEvidence([]);
+      setEvidencePagination(null);
+      setLoading(false);
+      setError(availabilityError);
       return undefined;
     }
 
@@ -230,7 +275,15 @@ export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
       cancelled = true;
       controller.abort();
     };
-  }, [workspaceId, enabled, jobId, reloadTick, externalRefreshToken]);
+  }, [
+    workspaceId,
+    availabilityReady,
+    availabilityError,
+    enabled,
+    jobId,
+    reloadTick,
+    externalRefreshToken,
+  ]);
 
   return {
     enabled,

--- a/apps/dashboard/src/components/certops/useCertOpsJobs.js
+++ b/apps/dashboard/src/components/certops/useCertOpsJobs.js
@@ -111,10 +111,19 @@ export function useCertOpsJobs(filters = {}) {
  * A 404 on getJob clears the job and leaves error empty (job gone is not an
  * outage). Other failures surface a user-readable error string.
  *
+ * `externalRefreshToken` lets a parent (e.g. a job list's own "Refresh"
+ * button) force a refetch of an already-mounted timeline from the outside:
+ * this hook's own `refresh()` only helps a caller that holds this specific
+ * hook instance, but an expanded timeline is normally owned by a child
+ * component (EvidenceTimeline) the parent list doesn't have a handle to.
+ * Any value that changes between renders (a counter, `Date.now()`, ...)
+ * works; it is only ever compared by reference/equality, never read.
+ *
  * @param {string|null|undefined} jobId
+ * @param {*} [externalRefreshToken]
  * @returns {{ enabled: boolean|null, job: object|null, logEntries: object[], logPagination: object|null, evidence: object[], evidencePagination: object|null, loading: boolean, error: string, refresh: function }}
  */
-export function useCertOpsJobTimeline(jobId) {
+export function useCertOpsJobTimeline(jobId, externalRefreshToken) {
   const { workspaceId } = useWorkspace();
   const enabled = useCertOpsEnabled();
   const [job, setJob] = useState(null);
@@ -122,7 +131,13 @@ export function useCertOpsJobTimeline(jobId) {
   const [logPagination, setLogPagination] = useState(null);
   const [evidence, setEvidence] = useState([]);
   const [evidencePagination, setEvidencePagination] = useState(null);
-  const [loading, setLoading] = useState(false);
+  // Defaults to true (not false): the very first render happens before any
+  // effect has a chance to run, and a mounted timeline for a real jobId is
+  // always about to check availability/fetch. Defaulting to false here made
+  // that first paint show "Job not found or no longer available" instead of
+  // a spinner, however briefly (worse the more mounts happen, since every
+  // job-row expand mounts a fresh instance of this hook).
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [reloadTick, setReloadTick] = useState(0);
 
@@ -131,7 +146,30 @@ export function useCertOpsJobTimeline(jobId) {
   }, []);
 
   useEffect(() => {
-    if (!workspaceId || enabled !== true || !jobId) {
+    if (!workspaceId || !jobId) {
+      setJob(null);
+      setLogEntries([]);
+      setLogPagination(null);
+      setEvidence([]);
+      setEvidencePagination(null);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    if (enabled === null) {
+      // The availability probe (a separate hook instance per CertOps screen)
+      // hasn't resolved yet for this mount. This is "still finding out",
+      // not "not applicable" -- treat it as loading. Otherwise every fresh
+      // mount (e.g. re-opening a job's evidence timeline) briefly rendered
+      // "Job not found or no longer available" before the probe settled,
+      // even though the job existed the whole time.
+      setLoading(true);
+      setError('');
+      return undefined;
+    }
+
+    if (enabled !== true) {
       setJob(null);
       setLogEntries([]);
       setLogPagination(null);
@@ -192,7 +230,7 @@ export function useCertOpsJobTimeline(jobId) {
       cancelled = true;
       controller.abort();
     };
-  }, [workspaceId, enabled, jobId, reloadTick]);
+  }, [workspaceId, enabled, jobId, reloadTick, externalRefreshToken]);
 
   return {
     enabled,

--- a/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
@@ -15,6 +15,7 @@ import { DashboardThemeProvider } from '../../src/hooks/useDashboardTheme.js';
 const {
   useCertOpsJobsMock,
   useCertOpsCanManageMock,
+  useCertOpsJobTimelineMock,
   createJobMock,
   approveJobMock,
   rejectJobMock,
@@ -24,6 +25,13 @@ const {
 } = vi.hoisted(() => ({
   useCertOpsJobsMock: vi.fn(),
   useCertOpsCanManageMock: vi.fn(),
+  useCertOpsJobTimelineMock: vi.fn(() => ({
+    job: null,
+    logEntries: [],
+    evidence: [],
+    loading: false,
+    error: '',
+  })),
   createJobMock: vi.fn(),
   approveJobMock: vi.fn(),
   rejectJobMock: vi.fn(),
@@ -67,13 +75,7 @@ vi.mock('../../src/components/certops/certopsApi.js', async () => {
 
 vi.mock('../../src/components/certops/useCertOpsJobs.js', () => ({
   useCertOpsJobs: useCertOpsJobsMock,
-  useCertOpsJobTimeline: () => ({
-    job: null,
-    logEntries: [],
-    evidence: [],
-    loading: false,
-    error: '',
-  }),
+  useCertOpsJobTimeline: useCertOpsJobTimelineMock,
 }));
 
 vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
@@ -125,6 +127,14 @@ function job(overrides = {}) {
 beforeEach(() => {
   useCertOpsJobsMock.mockReset();
   useCertOpsCanManageMock.mockReset();
+  useCertOpsJobTimelineMock.mockClear();
+  useCertOpsJobTimelineMock.mockReturnValue({
+    job: null,
+    logEntries: [],
+    evidence: [],
+    loading: false,
+    error: '',
+  });
   createJobMock.mockReset();
   approveJobMock.mockReset();
   rejectJobMock.mockReset();
@@ -565,6 +575,31 @@ describe('ExecutorJobsPanel list states', () => {
 
     fireEvent.click(row);
     expect(row).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('refetches an expanded row\'s evidence timeline when "Refresh" is clicked', () => {
+    // Regression test: the top-level "Refresh" button used to only call the
+    // job list's own refresh(), leaving an already-expanded row's
+    // EvidenceTimeline (a separate hook instance/fetch) stale - a manager
+    // watching a mid-renewal job never saw newer log/evidence entries land
+    // without collapsing and re-expanding the row.
+    const refresh = vi.fn();
+    useCertOpsJobsMock.mockReturnValue(jobsState({ jobs: [job()], refresh }));
+
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: /Renew/i }));
+    const firstCallCount = useCertOpsJobTimelineMock.mock.calls.length;
+    const firstRefreshToken =
+      useCertOpsJobTimelineMock.mock.calls[firstCallCount - 1][1];
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    const lastCallCount = useCertOpsJobTimelineMock.mock.calls.length;
+    const lastRefreshToken =
+      useCertOpsJobTimelineMock.mock.calls[lastCallCount - 1][1];
+    expect(lastRefreshToken).not.toBe(firstRefreshToken);
   });
 
   it('renders a page control, not a caption, when more jobs exist than are shown', () => {

--- a/apps/dashboard/tests/unit/useCertOps.test.jsx
+++ b/apps/dashboard/tests/unit/useCertOps.test.jsx
@@ -47,11 +47,86 @@ vi.mock('../../src/components/certops/certopsApi', () => ({
 }));
 
 import {
+  useCertOpsAvailability,
   useWorkspaceCertOps,
   useCertOpsForToken,
   useCertOpsIsWorkspaceAdmin,
   useCertOpsWorkspaceKillSwitch,
 } from '../../src/components/certops/useCertOps.js';
+
+describe('useCertOpsAvailability cached-verdict revalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    getCachedCertOpsEnabledMock.mockReturnValue(null);
+  });
+
+  it('surfaces a probe failure as an error when there is no cached verdict', async () => {
+    probeCertOpsEnabledMock.mockRejectedValue(
+      Object.assign(new Error('network down'), {
+        response: { status: 500, data: { error: 'Internal error' } },
+      })
+    );
+
+    const { result } = renderHook(() => useCertOpsAvailability());
+
+    await waitFor(() => expect(result.current.error).toBe('Internal error'));
+    expect(result.current.ready).toBe(true);
+    expect(result.current.enabled).toBe(null);
+  });
+
+  it('keeps serving a cached enabled verdict through a failed revalidation', async () => {
+    getCachedCertOpsEnabledMock.mockReturnValue({ enabled: true });
+    probeCertOpsEnabledMock.mockRejectedValue(
+      Object.assign(new Error('network down'), {
+        response: { status: 503, data: { error: 'Service unavailable' } },
+      })
+    );
+
+    const { result } = renderHook(() => useCertOpsAvailability());
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.enabled).toBe(true);
+    await waitFor(() => expect(probeCertOpsEnabledMock).toHaveBeenCalled());
+    // The failed revalidation must not tear down the working verdict: the
+    // gated screens' own requests are what surface a real outage.
+    expect(result.current.ready).toBe(true);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('does not let a cached disabled verdict mask a revalidation outage as "feature off"', async () => {
+    getCachedCertOpsEnabledMock.mockReturnValue({ enabled: false });
+    probeCertOpsEnabledMock.mockRejectedValue(
+      Object.assign(new Error('network down'), {
+        response: { status: 503, data: { error: 'Service unavailable' } },
+      })
+    );
+
+    const { result } = renderHook(() => useCertOpsAvailability());
+
+    // Cached verdict is served first...
+    expect(result.current.enabled).toBe(false);
+    // ...but once revalidation fails, only a 404 may mean disabled, so the
+    // outage must surface as an error instead of "CertOps is not enabled".
+    await waitFor(() =>
+      expect(result.current.error).toBe('Service unavailable')
+    );
+    expect(result.current.ready).toBe(true);
+    expect(result.current.enabled).toBe(null);
+  });
+
+  it('replaces a cached disabled verdict when revalidation resolves enabled', async () => {
+    getCachedCertOpsEnabledMock.mockReturnValue({ enabled: false });
+    probeCertOpsEnabledMock.mockResolvedValue({ enabled: true });
+
+    const { result } = renderHook(() => useCertOpsAvailability());
+
+    expect(result.current.enabled).toBe(false);
+    await waitFor(() => expect(result.current.enabled).toBe(true));
+    expect(result.current.error).toBe(null);
+  });
+});
 
 describe('useWorkspaceCertOps fail-closed resolution', () => {
   beforeEach(() => {

--- a/apps/dashboard/tests/unit/useCertOps.test.jsx
+++ b/apps/dashboard/tests/unit/useCertOps.test.jsx
@@ -7,6 +7,7 @@ const {
   getManagedCertificatesForTokenMock,
   getCertificateInstancesMock,
   probeCertOpsEnabledMock,
+  getCachedCertOpsEnabledMock,
   invalidateCertOpsInventoryCacheMock,
   getWorkspaceCertOpsPauseStateMock,
   updateWorkspaceCertOpsPauseStateMock,
@@ -17,6 +18,9 @@ const {
   getManagedCertificatesForTokenMock: vi.fn(),
   getCertificateInstancesMock: vi.fn(),
   probeCertOpsEnabledMock: vi.fn(),
+  // Always "no cache entry yet" by default so existing tests keep exercising
+  // the async probe path; the caching behavior itself has its own tests.
+  getCachedCertOpsEnabledMock: vi.fn().mockReturnValue(null),
   invalidateCertOpsInventoryCacheMock: vi.fn(),
   getWorkspaceCertOpsPauseStateMock: vi.fn(),
   updateWorkspaceCertOpsPauseStateMock: vi.fn(),
@@ -36,6 +40,7 @@ vi.mock('../../src/components/certops/certopsApi', () => ({
   getManagedCertificatesForToken: getManagedCertificatesForTokenMock,
   getCertificateInstances: getCertificateInstancesMock,
   probeCertOpsEnabled: probeCertOpsEnabledMock,
+  getCachedCertOpsEnabled: getCachedCertOpsEnabledMock,
   invalidateCertOpsInventoryCache: invalidateCertOpsInventoryCacheMock,
   getWorkspaceCertOpsPauseState: getWorkspaceCertOpsPauseStateMock,
   updateWorkspaceCertOpsPauseState: updateWorkspaceCertOpsPauseStateMock,

--- a/apps/dashboard/tests/unit/useCertOpsJobTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/useCertOpsJobTimeline.test.jsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const {
+  useWorkspaceMock,
+  probeCertOpsEnabledMock,
+  getCachedCertOpsEnabledMock,
+  getJobMock,
+  listJobLogMock,
+  listJobEvidenceMock,
+} = vi.hoisted(() => ({
+  useWorkspaceMock: vi.fn(),
+  probeCertOpsEnabledMock: vi.fn(),
+  getCachedCertOpsEnabledMock: vi.fn().mockReturnValue(null),
+  getJobMock: vi.fn(),
+  listJobLogMock: vi.fn(),
+  listJobEvidenceMock: vi.fn(),
+}));
+
+vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
+  useWorkspace: useWorkspaceMock,
+}));
+
+vi.mock('../../src/utils/apiClient', () => ({
+  workspaceAPI: { get: vi.fn().mockResolvedValue({ role: 'admin' }) },
+}));
+
+vi.mock('../../src/components/certops/certopsApi', () => ({
+  probeCertOpsEnabled: probeCertOpsEnabledMock,
+  getCachedCertOpsEnabled: getCachedCertOpsEnabledMock,
+  getCertificateInstances: vi.fn(),
+  getManagedCertificatesForToken: vi.fn(),
+  getWorkspaceCertOpsPauseState: vi.fn(),
+  invalidateCertOpsInventoryCache: vi.fn(),
+  loadCertOpsInventoryIndex: vi.fn(),
+  updateWorkspaceCertOpsPauseState: vi.fn(),
+}));
+
+vi.mock('../../src/components/certops/certopsJobsApi', () => ({
+  getJob: getJobMock,
+  listJobLog: listJobLogMock,
+  listJobEvidence: listJobEvidenceMock,
+  listJobs: vi.fn(),
+}));
+
+vi.mock('../../src/components/certops/certopsTokensApi', () => ({
+  listApiTokens: vi.fn(),
+}));
+
+import { useCertOpsJobTimeline } from '../../src/components/certops/useCertOpsJobs.js';
+
+function mockTimelineData() {
+  getJobMock.mockResolvedValue({ job: { id: 'job-1', status: 'succeeded' } });
+  listJobLogMock.mockResolvedValue({ items: [], pagination: null });
+  listJobEvidenceMock.mockResolvedValue({ items: [], pagination: null });
+}
+
+describe('useCertOpsJobTimeline availability resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    getCachedCertOpsEnabledMock.mockReturnValue(null);
+  });
+
+  it('loads the timeline once availability resolves enabled', async () => {
+    probeCertOpsEnabledMock.mockResolvedValue({ enabled: true });
+    mockTimelineData();
+
+    const { result } = renderHook(() => useCertOpsJobTimeline('job-1'));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.job?.id).toBe('job-1'));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe('');
+  });
+
+  it('stays loading (not "not found") while the availability probe is unresolved', async () => {
+    let resolveProbe;
+    probeCertOpsEnabledMock.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveProbe = resolve;
+        })
+    );
+    mockTimelineData();
+
+    const { result } = renderHook(() => useCertOpsJobTimeline('job-1'));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBe('');
+    expect(getJobMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveProbe({ enabled: true });
+    });
+    await waitFor(() => expect(result.current.job?.id).toBe('job-1'));
+  });
+
+  it('surfaces a failed availability probe as an error instead of an indefinite spinner', async () => {
+    probeCertOpsEnabledMock.mockRejectedValue(
+      Object.assign(new Error('network down'), {
+        response: { status: 500, data: { error: 'Internal error' } },
+      })
+    );
+
+    const { result } = renderHook(() => useCertOpsJobTimeline('job-1'));
+
+    await waitFor(() => expect(result.current.error).toBe('Internal error'));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.job).toBe(null);
+    expect(getJobMock).not.toHaveBeenCalled();
+  });
+
+  it('refresh() re-probes availability and recovers from a failed probe', async () => {
+    probeCertOpsEnabledMock.mockRejectedValueOnce(
+      Object.assign(new Error('network down'), {
+        response: { status: 503, data: { error: 'Service unavailable' } },
+      })
+    );
+    mockTimelineData();
+
+    const { result } = renderHook(() => useCertOpsJobTimeline('job-1'));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Service unavailable')
+    );
+
+    probeCertOpsEnabledMock.mockResolvedValue({ enabled: true });
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.job?.id).toBe('job-1'));
+    expect(result.current.error).toBe('');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('an externalRefreshToken change re-probes availability like refresh()', async () => {
+    probeCertOpsEnabledMock.mockRejectedValueOnce(
+      Object.assign(new Error('network down'), {
+        response: { status: 503, data: { error: 'Service unavailable' } },
+      })
+    );
+    mockTimelineData();
+
+    const { result, rerender } = renderHook(
+      ({ token }) => useCertOpsJobTimeline('job-1', token),
+      { initialProps: { token: 0 } }
+    );
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Service unavailable')
+    );
+
+    probeCertOpsEnabledMock.mockResolvedValue({ enabled: true });
+    rerender({ token: 1 });
+
+    await waitFor(() => expect(result.current.job?.id).toBe('job-1'));
+    expect(result.current.error).toBe('');
+  });
+
+  it('clears the timeline without an error when CertOps is disabled', async () => {
+    probeCertOpsEnabledMock.mockResolvedValue({ enabled: false });
+
+    const { result } = renderHook(() => useCertOpsJobTimeline('job-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.job).toBe(null);
+    expect(result.current.error).toBe('');
+    expect(getJobMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The Jobs list's "Refresh" button only re-fetched the job list itself; an already-expanded row's evidence timeline runs its own independent data-fetching hook, so it silently went stale while a job was still in progress until the row was collapsed and re-expanded.

Also fixes a related race where useCertOpsJobTimeline briefly rendered "Job not found or no longer available" for a job that genuinely exists, because each CertOps screen re-probes certops.enabled from scratch on mount and the timeline treated "still resolving" the same as "disabled".