### PR TITLE
fix(security): bump Go builder image and golang.org/x/sys to patched versions

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,6 @@
 # Build context must be the repo root.
 # Prefer deploy/compose/Dockerfile.api for production Compose/CI images.
-FROM golang:1.26.5-alpine3.23 AS subfinder-builder
+FROM golang:1.26.6-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -12,7 +12,8 @@ RUN go get \
       golang.org/x/crypto@v0.52.0 \
       golang.org/x/net@v0.55.0 \
       golang.org/x/sys@v0.45.0 \
-      github.com/cloudflare/circl@v1.6.3 && \
+      github.com/cloudflare/circl@v1.6.3 \
+      github.com/klauspost/compress@v1.18.7 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Build context must be the repo root (see docker-compose.*.yml).
-FROM golang:1.26.5-alpine3.23 AS subfinder-builder
+FROM golang:1.26.6-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -11,7 +11,8 @@ RUN go get \
       golang.org/x/crypto@v0.52.0 \
       golang.org/x/net@v0.55.0 \
       golang.org/x/sys@v0.45.0 \
-      github.com/cloudflare/circl@v1.6.3 && \
+      github.com/cloudflare/circl@v1.6.3 \
+      github.com/klauspost/compress@v1.18.7 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -1,5 +1,5 @@
 # TokenTimer API Dockerfile
-FROM golang:1.26.5-alpine3.23 AS subfinder-builder
+FROM golang:1.26.6-alpine3.23 AS subfinder-builder
 
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates git
@@ -13,7 +13,8 @@ RUN go get \
       golang.org/x/sys@v0.46.0 \
       golang.org/x/text@v0.39.0 \
       github.com/yuin/goldmark@v1.7.17 \
-      github.com/cloudflare/circl@v1.6.3 && \
+      github.com/cloudflare/circl@v1.6.3 \
+      github.com/klauspost/compress@v1.18.7 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /go/bin/subfinder .
 

--- a/packages/agent/windows-service-host/go.mod
+++ b/packages/agent/windows-service-host/go.mod
@@ -1,5 +1,5 @@
 module github.com/tokentimerch/tokentimer-core/packages/agent/windows-service-host
 
-go 1.21
+go 1.25.0
 
-require golang.org/x/sys v0.20.0
+require golang.org/x/sys v0.47.0

--- a/packages/agent/windows-service-host/go.sum
+++ b/packages/agent/windows-service-host/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary
- The post-merge `main` CI run for the 0.12.4 release PR failed the Docker Build & Security Scan Grype gate: `golang:1.26.5-alpine3.23` (used only as the `subfinder` builder stage in the API image) carried multiple Go stdlib CVEs, plus a `klauspost/compress` transitive OOB read (GHSA-259r-337f-4rfw / GO-2026-5841).
- Bump the builder image to `golang:1.26.6-alpine3.23` in all three API Dockerfiles and pin `klauspost/compress` to `v1.18.7` in the same `go get` step.
- Bump `golang.org/x/sys` to `v0.47.0` in `packages/agent/windows-service-host` (fixes GO-2026-5024); the shipped agent host binaries are rebuilt fresh by `pack-release.js` for every release, so this is picked up automatically.

## Test plan
- `docker build -f deploy/compose/Dockerfile.api .` succeeds locally with the bumped builder image.
- Grype scan (`--fail-on high --only-fixed`) against the rebuilt local image reports no vulnerabilities.
- `go build` for both `windows/amd64` and `windows/arm64` succeeds against the bumped `golang.org/x/sys`.
