### PR TITLE
fix: add endpoint-specific rate limit for CSRF token generation

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -319,6 +319,7 @@ app.use((error, req, res, next) => {
 // (extracted to middleware/rateLimit.js and config/constants.js)
 const {
   speedLimiter,
+  csrfTokenLimiter,
   applyGlobalRateLimit,
   getApiLimiter,
 } = require("./middleware/rateLimit");
@@ -579,7 +580,7 @@ const { generateToken: generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
 
 // CSRF token endpoint — always rotate (overwrite) so stale cookies after secret
 // rotation or cookie-name changes cannot 403 this route (csrf-csrf validateOnReuse).
-app.get("/api/csrf-token", (req, res) => {
+app.get("/api/csrf-token", csrfTokenLimiter, (req, res) => {
   const csrfToken = generateCsrfToken(req, res, true, false);
   res.json({ csrfToken });
 });

--- a/apps/api/middleware/rateLimit.js
+++ b/apps/api/middleware/rateLimit.js
@@ -393,15 +393,22 @@ function getApiLimiter() {
   };
 }
 
-const csrfTokenLimiter = rateLimit({
-  windowMs: intEnv("CSRF_TOKEN_RATE_LIMIT_WINDOW_MS", 15 * 60 * 1000),
-  max: intEnv("CSRF_TOKEN_RATE_LIMIT_MAX", isDevOrTest ? 1000 : 60),
-  message: "Too many CSRF token requests, please try again later.",
-  standardHeaders: true,
-  legacyHeaders: false,
-  skipSuccessfulRequests: false,
-  keyGenerator: (req) => resolveClientIp(req) || ipKeyGenerator(req),
-});
+// Defense-in-depth endpoint cap for CSRF token generation (CWE-400/770).
+// Uses in-process storage — aggregate limit scales with number of API processes.
+// Cluster-wide enforcement is provided by the application's existing infra layer.
+function createCsrfTokenLimiter({ windowMs, max } = {}) {
+  return rateLimit({
+    windowMs: windowMs ?? intEnv("CSRF_TOKEN_RATE_LIMIT_WINDOW_MS", 15 * 60 * 1000),
+    max: max ?? intEnv("CSRF_TOKEN_RATE_LIMIT_MAX", isDevOrTest ? 1000 : 60),
+    message: "Too many CSRF token requests, please try again later.",
+    standardHeaders: true,
+    legacyHeaders: false,
+    skipSuccessfulRequests: false,
+    keyGenerator: (req) => resolveClientIp(req) || ipKeyGenerator(req),
+  });
+}
+
+const csrfTokenLimiter = createCsrfTokenLimiter();
 
 const noRateLimit = (req, res, next) => next();
 
@@ -455,6 +462,7 @@ module.exports = {
   getDiagnosticBootstrapLimiter,
   getTestApiLimiter,
   csrfTokenLimiter,
+  createCsrfTokenLimiter,
   noRateLimit,
   applyGlobalRateLimit,
   normalizeEmail,

--- a/apps/api/middleware/rateLimit.js
+++ b/apps/api/middleware/rateLimit.js
@@ -393,6 +393,16 @@ function getApiLimiter() {
   };
 }
 
+const csrfTokenLimiter = rateLimit({
+  windowMs: intEnv("CSRF_TOKEN_RATE_LIMIT_WINDOW_MS", 15 * 60 * 1000),
+  max: intEnv("CSRF_TOKEN_RATE_LIMIT_MAX", isDevOrTest ? 1000 : 60),
+  message: "Too many CSRF token requests, please try again later.",
+  standardHeaders: true,
+  legacyHeaders: false,
+  skipSuccessfulRequests: false,
+  keyGenerator: (req) => resolveClientIp(req) || ipKeyGenerator(req),
+});
+
 const noRateLimit = (req, res, next) => next();
 
 /**
@@ -444,6 +454,7 @@ module.exports = {
   getDomainCheckerLookupLimiter,
   getDiagnosticBootstrapLimiter,
   getTestApiLimiter,
+  csrfTokenLimiter,
   noRateLimit,
   applyGlobalRateLimit,
   normalizeEmail,

--- a/tests/unit/csrf-token-rate-limit.test.js
+++ b/tests/unit/csrf-token-rate-limit.test.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { createCsrfTokenLimiter } = require(
+  path.resolve(__dirname, "../../apps/api/middleware/rateLimit.js"),
+);
+
+function createRequest({ ip = "203.0.113.1", forwardedFor } = {}) {
+  const headers = {};
+  if (forwardedFor) headers["x-forwarded-for"] = forwardedFor;
+  return {
+    ip,
+    headers,
+    get(name) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    getHeader(name) {
+      return this.headers[name];
+    },
+    end(payload) {
+      this.ended = true;
+      this.endPayload = payload;
+      return this;
+    },
+  };
+}
+
+async function runMiddleware(middleware, req) {
+  const res = createResponse();
+  const result = { req, res, nextCalled: false };
+
+  await middleware(req, res, (error) => {
+    result.nextCalled = !error;
+  });
+
+  return result;
+}
+
+describe("CSRF token endpoint rate limiter", () => {
+  it("allows requests under the configured limit", async () => {
+    const limiter = createCsrfTokenLimiter({ windowMs: 60_000, max: 2 });
+    const req = createRequest();
+
+    const r1 = await runMiddleware(limiter, req);
+    const r2 = await runMiddleware(limiter, req);
+
+    assert.equal(r1.nextCalled, true);
+    assert.equal(r2.nextCalled, true);
+  });
+
+  it("returns 429 after the per-IP limit is exceeded", async () => {
+    const limiter = createCsrfTokenLimiter({ windowMs: 60_000, max: 2 });
+    const req = createRequest();
+
+    await runMiddleware(limiter, req);
+    await runMiddleware(limiter, req);
+    const r3 = await runMiddleware(limiter, req);
+
+    assert.equal(r3.nextCalled, false);
+    assert.equal(r3.res.statusCode, 429);
+  });
+
+  it("different client IPs get independent buckets", async () => {
+    const limiter = createCsrfTokenLimiter({ windowMs: 60_000, max: 2 });
+    const clientA = createRequest({ ip: "1.2.3.4" });
+    const clientB = createRequest({ ip: "5.6.7.8" });
+
+    await runMiddleware(limiter, clientA);
+    await runMiddleware(limiter, clientA);
+    const r3a = await runMiddleware(limiter, clientA);
+    assert.equal(r3a.nextCalled, false, "client A should be rate limited");
+    assert.equal(r3a.res.statusCode, 429);
+
+    const r1b = await runMiddleware(limiter, clientB);
+    assert.equal(r1b.nextCalled, true, "client B should not be affected");
+  });
+
+  it("allows requests again once the rate-limit window elapses", async () => {
+    const limiter = createCsrfTokenLimiter({ windowMs: 100, max: 1 });
+    const req = createRequest();
+
+    assert.equal((await runMiddleware(limiter, req)).nextCalled, true);
+    assert.equal((await runMiddleware(limiter, req)).nextCalled, false);
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    assert.equal((await runMiddleware(limiter, req)).nextCalled, true);
+  });
+});


### PR DESCRIPTION
## Summary

`/api/csrf-token` is unauthenticated and generates cryptographic tokens. The endpoint is already covered by the application's global `speedLimiter` (which throttles after 50 requests). This change adds a tighter endpoint-specific per-IP hard limit (60 req/15 min in production, configurable via `CSRF_TOKEN_RATE_LIMIT_MAX`) as defense-in-depth against disproportionate request volume targeting this endpoint specifically.

**Classification:** CWE-400 / CWE-770 (resource exhaustion). This is an additive hardening layer, not a fix for an unprotected endpoint.

> **Note:** this limiter uses in-process storage. Deployments with multiple API processes will have an aggregate limit proportional to the number of processes. Cluster-wide enforcement is provided by the existing infrastructure/shared rate-limiting layer.

## Changes

- `apps/api/middleware/rateLimit.js` — extract `createCsrfTokenLimiter({ windowMs, max })` factory so production config and tests share the same limiter logic; production singleton `csrfTokenLimiter` is unchanged. Add comment documenting the per-process scope and CWE classification.
- `apps/api/index.js` — wire `csrfTokenLimiter` into the `/api/csrf-token` route (unchanged from original PR).
- `tests/unit/csrf-token-rate-limit.test.js` — deterministic unit tests: under-limit requests pass, (N+1)th request returns 429, different IPs have independent buckets, window reset restores access. Follows the same `node:test` + mock req/res pattern as `certops-machine-token-rate-limit.test.js`.

## Testing

```bash
node --test tests/unit/csrf-token-rate-limit.test.js
```