### PR TITLE
fix(certops): pin CERTOPS_AGENT_LATEST_KNOWN_VERSION in clock-drift test

### DIFF
--- a/tests/unit/certops-inventory-evidence-approval-cluster.test.js
+++ b/tests/unit/certops-inventory-evidence-approval-cluster.test.js
@@ -50,6 +50,11 @@ describe("agent compatibility (H8)", () => {
         CERTOPS_AGENT_MAX_PROTOCOL_VERSION: "1.0.0",
         CERTOPS_AGENT_MIN_AGENT_VERSION: "0.10.0",
         CERTOPS_AGENT_MAX_AGENT_VERSION: "0.12.0",
+        // Pinned explicitly so this clock-drift assertion doesn't drift with
+        // packages/agent/package.json's version on every release (that default
+        // is intentional for the real "outdated" heuristic, but this test is
+        // about clockDriftState, not the outdated label).
+        CERTOPS_AGENT_LATEST_KNOWN_VERSION: "0.12.0",
         CERTOPS_AGENT_CLOCK_DRIFT_WARN_MS: "5000",
         CERTOPS_AGENT_CLOCK_DRIFT_ALERT_MS: "30000",
       },

--- a/tests/unit/certops-inventory-evidence-approval-cluster.test.js
+++ b/tests/unit/certops-inventory-evidence-approval-cluster.test.js
@@ -64,6 +64,46 @@ describe("agent compatibility (H8)", () => {
     assert.equal(result.clockDriftMs, 60_000);
   });
 
+  it("flags an agent more than one minor behind CERTOPS_AGENT_LATEST_KNOWN_VERSION as outdated", () => {
+    // Both bounds pinned explicitly (not left to the packages/agent/package.json
+    // default) so this is the one deterministic, release-proof test asserting
+    // computeAgentCompatibility can actually produce "outdated" — see the
+    // clock-drift test above for why that one pins the same var away from it.
+    const result = computeAgentCompatibility(
+      {
+        protocolVersion: "1.0.0",
+        agentVersion: "0.10.0",
+        clockOffsetMs: 0,
+      },
+      {
+        CERTOPS_AGENT_MIN_PROTOCOL_VERSION: "1.0.0",
+        CERTOPS_AGENT_MAX_PROTOCOL_VERSION: "1.0.0",
+        CERTOPS_AGENT_MIN_AGENT_VERSION: "0.1.0",
+        CERTOPS_AGENT_MAX_AGENT_VERSION: "99.999.999",
+        CERTOPS_AGENT_LATEST_KNOWN_VERSION: "0.12.0",
+      },
+    );
+    assert.equal(result.compatibilityState, "outdated");
+  });
+
+  it("does not flag an agent exactly one minor behind CERTOPS_AGENT_LATEST_KNOWN_VERSION as outdated", () => {
+    const result = computeAgentCompatibility(
+      {
+        protocolVersion: "1.0.0",
+        agentVersion: "0.11.0",
+        clockOffsetMs: 0,
+      },
+      {
+        CERTOPS_AGENT_MIN_PROTOCOL_VERSION: "1.0.0",
+        CERTOPS_AGENT_MAX_PROTOCOL_VERSION: "1.0.0",
+        CERTOPS_AGENT_MIN_AGENT_VERSION: "0.1.0",
+        CERTOPS_AGENT_MAX_AGENT_VERSION: "99.999.999",
+        CERTOPS_AGENT_LATEST_KNOWN_VERSION: "0.12.0",
+      },
+    );
+    assert.equal(result.compatibilityState, "compatible");
+  });
+
   it("marks an agent live within the offline threshold", () => {
     const result = computeAgentCompatibility(
       {


### PR DESCRIPTION
## Summary
Fixes a CI break on the v0.13.0 merge to main. The main CI run for [PR #174](https://github.com/tokentimerch/tokentimer-core/pull/174) failed in three jobs (Backend Quality Checks, Coverage Backend, Build and Integration Test) with the same assertion:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ 'outdated'
- 'compatible'
```

## Root cause
`flags excessive clock drift as alert` in `tests/unit/certops-inventory-evidence-approval-cluster.test.js` hardcodes `agentVersion: "0.11.1"` and expects `compatibilityState` `"compatible"`, but never pins `CERTOPS_AGENT_LATEST_KNOWN_VERSION`. `computeAgentCompatibility` defaults that config to the live `packages/agent/package.json` version when unset. v0.13.0 bumped the agent package version, widening the gap between `0.11.1` and "latest known" past the one-minor threshold, flipping the label to `outdated` for this unrelated clock-drift assertion.

## Fix
1. Pin `CERTOPS_AGENT_LATEST_KNOWN_VERSION: "0.12.0"` explicitly in the clock-drift test's env, matching the other explicit min/max bounds already present in the same block, so it is no longer coupled to the shipped agent package version.
2. That pin alone would have left a real gap: across all of `tests/unit`, nothing ever directly asserted `compatibilityState === "outdated"` (the one test with "outdated" in its name only checks that outdated agents aren't blocked from claiming jobs, not the label itself). Added two new deterministic tests, both bounds pinned explicitly:
   - an agent two minors behind `CERTOPS_AGENT_LATEST_KNOWN_VERSION` is flagged `outdated`
   - an agent exactly one minor behind is not (the boundary case)

## Test plan
- `pnpm run test:unit` (full unit suite, via `scripts/run-unit-tests.js` which always runs all of `tests/unit`): 1630 passing, 0 failing (previously 1 failing, now +2 new tests covering the outdated branch)
- `pnpm run check:contracts && pnpm run check:contracts:integrity && CONTRACT_API_REQUIRED=0 pnpm run test:contracts`: all green
