### PR TITLE
fix(tests): update stale Forbidden assertion for requireWorkspaceManager

### DIFF
--- a/tests/integration/integrations-route-matrix.test.js
+++ b/tests/integration/integrations-route-matrix.test.js
@@ -159,7 +159,8 @@ describe("Integrations route matrix", function () {
         .set("Cookie", viewerSession.cookie)
         .send(route.body);
       expect(res.status).to.equal(403);
-      expect(res.body.error).to.equal("Forbidden");
+      expect(res.body.error).to.equal("Forbidden: insufficient role");
+      expect(res.body.code).to.equal("INSUFFICIENT_ROLE");
     }
   });
 


### PR DESCRIPTION
## Summary
The v0.13.1 release (#176) changed `requireWorkspaceManager`'s 403 response from a bare `Forbidden` to `Forbidden: insufficient role` (with an `INSUFFICIENT_ROLE` error code), but one integration test still asserted the old message. This broke the post-merge `main` CI run for the v0.13.1 release commit.

## Changes

### Tests
- `tests/integration/integrations-route-matrix.test.js`: updated the "rejects viewers on scan and helper routes" assertion to expect `Forbidden: insufficient role` / `INSUFFICIENT_ROLE`, matching the response shape already shipped in v0.13.1 and already covered by `tests/unit/rbac-workspace-access.test.js`.

## Test plan
- Confirmed via the failing CI run (https://github.com/tokentimerch/tokentimer-core/actions/runs/32489825053) that this was the only failing assertion in both `Build and Integration Test` and `Coverage Backend`, and that the actual API response (`Forbidden: insufficient role` / `INSUFFICIENT_ROLE`) is the intended, already-released behavior.
