### PR TITLE
feat(integrations): Vault scan scoping by secrets engine, asset kind, and filter rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.13.2] - 2026-08-25
 
+### Added
+
+- **Vault scans can now be narrowed by secrets engine, asset kind, and include/exclude rules.** The Vault import form gained a secrets-engine picker (load the engine list and tick which KV/PKI mounts to scan), asset-kind checkboxes (certificates, secrets & keys; all selected by default), and the same ordered include/exclude filter-rules editor already available for GitHub and GitLab imports. Rules can match the Vault location (`vault:mount/path`), so a whole engine, a folder, or a single secret can be included or excluded. The scan endpoint accepts a matching optional `categories` parameter, now documented in the OpenAPI contract along with the previously undocumented `pathPrefix`, `maxItemsPerMount`, and `filterRules` request fields.
+
 ### Fixed
 
 - **The webhook Test button could not reach Microsoft Teams destinations set up through Power Automate or Logic Apps.** The webhook destination allowlist only recognized the legacy `*.webhook.office.com` Teams connector hosts, not the `*.logic.azure.com` / `*.environment.api.powerplatform.com` hosts that Power Automate and Logic Apps flows actually use, nor the bare `office.com` / `office365.com` apex domains. All four are now in the built-in provider list.
@@ -20,6 +24,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`tests/integration/webhook-test-endpoint.test.js` intermittently reported the wrong status code post-merge.** The Power Automate/Teams and `WEBHOOK_EXTRA_PROVIDER_HOSTS` cases both reach the real network-fetch stage and arm the test-webhook endpoint's 5-second per-user cooldown; sharing one authenticated user across the whole suite let that cooldown leak into the unrelated IPv6-loopback and connection-error cases below, which then received `429` instead of their actual expected response. Each cooldown-arming case now uses its own authenticated user, and the `WEBHOOK_EXTRA_PROVIDER_HOSTS` case is exercised via `docker-compose.test.yml`'s API environment instead of mutating the test runner's own `process.env` (which never reached the separate Dockerized API and made that assertion pass for the wrong reason). All webhook-test-endpoint cases now also explicitly assert the response is never `429`.
 - **HashiCorp Vault KV scans only reported one certificate per secret.** When a KV v2 secret stored several certificates under different keys (a common layout for CA bundles), the scanner inspected every key but stopped at the first certificate it found and reported the secret as a single inventory item, silently dropping the rest. Every certificate key in a secret is now returned as its own item; secrets with a single certificate keep their existing identity so previously imported tokens are updated in place rather than duplicated.
 - **The Vault KV "Path Prefix" field returned no results when pointed at an exact secret instead of a folder.** The prefix was only ever resolved as a folder to `LIST`, so entering the full path to a specific secret (rather than its parent folder) returned an empty scan with no indication of why. The prefix now also resolves as an exact secret path when the folder listing comes up empty.
+- **A Vault KV "Path Prefix" that included the secrets engine's own name returned an empty scan.** Prefixes are relative to each scanned engine, but a path copied from the Vault CLI or UI usually includes the mount name itself (e.g. `staging/team/app` for a secret at `team/app` inside the `staging/` engine). A leading prefix segment matching the scanned engine's name is now stripped instead of silently matching nothing.
 
 ### Changed
 

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -99,6 +99,7 @@ router.post(
         maxItemsPerMount,
         pathPrefix,
         filterRules,
+        categories,
       } = req.body || {};
       // Prevent caching of sensitive responses
       res.set("Cache-Control", "no-store");
@@ -110,6 +111,19 @@ router.post(
       const filterRulesError = validateFilterRules(filterRules);
       if (filterRulesError)
         return res.status(400).json(withQuota({ error: filterRulesError }));
+      const VAULT_ASSET_CATEGORIES = ["cert", "key_secret"];
+      if (
+        categories !== undefined &&
+        categories !== null &&
+        (!Array.isArray(categories) ||
+          categories.some((c) => !VAULT_ASSET_CATEGORIES.includes(c)))
+      ) {
+        return res.status(400).json(
+          withQuota({
+            error: `categories must be an array containing only: ${VAULT_ASSET_CATEGORIES.join(", ")}`,
+          }),
+        );
+      }
       // Basic allowlist for schemes
       try {
         const u = new URL(address);
@@ -153,6 +167,7 @@ router.post(
           typeof pathPrefix === "string"
             ? pathPrefix.trim().replace(/^\/+|\/+$/g, "")
             : "",
+        categories: Array.isArray(categories) ? categories : null,
       });
       applyScanFilterRulesToResult(filterRules, result);
 

--- a/apps/api/services/vaultIntegration.js
+++ b/apps/api/services/vaultIntegration.js
@@ -477,10 +477,23 @@ async function scanKvV2({
   pathPrefix = "",
 }) {
   const mountPath = mount.path; // already ends with '/'
-  const trimmedPrefix =
+  let trimmedPrefix =
     typeof pathPrefix === "string"
       ? pathPrefix.replace(/^\/+|\/+$/g, "")
       : "";
+  // A prefix copied from the Vault CLI/UI often includes the mount name
+  // itself (e.g. "staging/test/test" when scanning the "staging/" engine).
+  // The prefix is only meant to filter paths *inside* a mount, so strip a
+  // leading segment that matches this mount's own name; otherwise it would
+  // never match anything and silently return an empty scan.
+  const mountName = mountPath.replace(/\/$/, "");
+  if (mountName) {
+    if (trimmedPrefix === mountName) {
+      trimmedPrefix = "";
+    } else if (trimmedPrefix.startsWith(`${mountName}/`)) {
+      trimmedPrefix = trimmedPrefix.slice(mountName.length + 1);
+    }
+  }
   const normalizedPrefix = trimmedPrefix.length > 0 ? `${trimmedPrefix}/` : "";
   const keys = await listKvV2KeysRecursive({
     address,
@@ -644,6 +657,7 @@ async function scanVault({
   mounts: mountFilters = null,
   maxItemsPerMount = 250,
   pathPrefix = "",
+  categories = null,
 }) {
   if (!address || !token) {
     logger.error("Vault scan missing required parameters", {
@@ -664,12 +678,22 @@ async function scanVault({
     throw new Error(`Invalid Vault address: ${e.message}`);
   }
 
+  // Allowlist of asset categories to keep (e.g. only "cert"). Empty/absent
+  // means no filtering, matching the "all kinds" default in the UI.
+  const categorySet =
+    Array.isArray(categories) && categories.length > 0
+      ? new Set(categories.map((c) => String(c)))
+      : null;
+  const keepByCategory = (item) =>
+    !categorySet || categorySet.has(String(item.category));
+
   logger.info("Starting Vault scan", {
     address: address.replace(/\/\/[^@]+@/, "//***@"),
     includeKV: include.kv,
     includePKI: include.pki,
     pathPrefix: pathPrefix || "none",
     mountFilters: mountFilters?.length || "none",
+    categories: categorySet ? [...categorySet] : "all",
   });
 
   let mounts;
@@ -722,13 +746,14 @@ async function scanVault({
     if (m.type === "kv") {
       try {
         logger.debug("Scanning Vault KV mount", { mount: m.path });
-        const { items, truncated } = await scanKvV2({
+        const { items: rawItems, truncated } = await scanKvV2({
           address,
           token,
           mount: m,
           maxItems: maxItemsPerMount,
           pathPrefix,
         });
+        const items = rawItems.filter(keepByCategory);
         results.push(...items);
         summary.push({
           mount: m.path,
@@ -752,12 +777,13 @@ async function scanVault({
     } else if (m.type === "pki") {
       try {
         logger.debug("Scanning Vault PKI mount", { mount: m.path });
-        const { items, truncated } = await scanPki({
+        const { items: rawItems, truncated } = await scanPki({
           address,
           token,
           mount: m,
           maxItems: maxItemsPerMount,
         });
+        const items = rawItems.filter(keepByCategory);
         results.push(...items);
         summary.push({
           mount: m.path,

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -6,6 +6,7 @@ import {
   Text,
   Input,
   Switch,
+  Checkbox,
   Button,
   Badge,
   Accordion,
@@ -18,12 +19,19 @@ import {
   IconButton,
   Tooltip,
   Link as ChakraLink,
+  Spinner,
 } from '@chakra-ui/react';
-import { FiEye, FiEyeOff, FiHelpCircle } from 'react-icons/fi';
+import { FiEye, FiEyeOff, FiHelpCircle, FiRefreshCw } from 'react-icons/fi';
 import { vaultAPI, integrationAPI } from '../../utils/apiClient';
 import { logger } from '../../utils/logger';
 import IntegrationImportTable from '../IntegrationImportTable';
 import BulkIntegrationAssignment from '../BulkIntegrationAssignment';
+import FilterRulesEditor, { sanitizeFilterRules } from '../FilterRulesEditor';
+
+const VAULT_CATEGORY_OPTIONS = [
+  { value: 'cert', label: 'Certificates' },
+  { value: 'key_secret', label: 'Secrets & keys' },
+];
 
 function getVaultItemDetails(item) {
   const details = [];
@@ -128,6 +136,23 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
       return '';
     }
   });
+
+  // Secrets-engine (mount) picker. Empty `availableMounts` means the picker
+  // hasn't been engaged yet, so scans keep scanning every mount (unchanged
+  // default behavior) until the user explicitly loads and narrows the list.
+  const [availableMounts, setAvailableMounts] = React.useState([]);
+  const [selectedMountPaths, setSelectedMountPaths] = React.useState(new Set());
+  const [isLoadingMounts, setIsLoadingMounts] = React.useState(false);
+  const [mountsError, setMountsError] = React.useState(null);
+
+  // Asset-kind filter: all kinds Vault can produce are included by default.
+  const [selectedCategories, setSelectedCategories] = React.useState(
+    new Set(VAULT_CATEGORY_OPTIONS.map(c => c.value))
+  );
+
+  const [filterRules, setFilterRules] = React.useState([]);
+  const [filterSummary, setFilterSummary] = React.useState(null);
+
   const [isScanning, setIsScanning] = React.useState(false);
   const [vaultItems, setVaultItems] = React.useState([]);
   const [summary, setSummary] = React.useState([]);
@@ -147,6 +172,60 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
     onSelectionChange && onSelectionChange(selectedRowsVault.size);
   }, [selectedRowsVault.size, onSelectionChange]);
 
+  const loadMounts = async () => {
+    if (!vaultAddress || !vaultAddress.trim()) {
+      setMountsError('Vault address is required');
+      return;
+    }
+    if (!vaultToken || !vaultToken.trim()) {
+      setMountsError('Vault token is required');
+      return;
+    }
+    setIsLoadingMounts(true);
+    setMountsError(null);
+    try {
+      const mounts = await vaultAPI.listMounts({
+        workspaceId,
+        address: vaultAddress,
+        token: vaultToken,
+      });
+      const scannable = mounts.filter(m => m.type === 'kv' || m.type === 'pki');
+      setAvailableMounts(scannable);
+      setSelectedMountPaths(new Set(scannable.map(m => m.path)));
+    } catch (e) {
+      setAvailableMounts([]);
+      setMountsError(e?.message || 'Failed to load secrets engines');
+    } finally {
+      setIsLoadingMounts(false);
+    }
+  };
+
+  const toggleMount = path => {
+    setSelectedMountPaths(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const toggleCategory = value => {
+    setSelectedCategories(prev => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+  };
+
+  // Only send an explicit mount list when the picker was used and the user
+  // narrowed it down; otherwise every mount is scanned (unchanged default).
+  const mountsFilterForScan = () => {
+    if (availableMounts.length === 0) return null;
+    if (selectedMountPaths.size >= availableMounts.length) return null;
+    return Array.from(selectedMountPaths);
+  };
+
   const doVaultScan = async () => {
     if (!workspaceId) {
       onError && onError('Please select a workspace first.');
@@ -161,24 +240,36 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
       onError && onError('Vault token is required');
       return;
     }
+    if (availableMounts.length > 0 && selectedMountPaths.size === 0) {
+      onError && onError('Select at least one secrets engine to scan.');
+      return;
+    }
+    if (selectedCategories.size === 0) {
+      onError && onError('Select at least one asset kind to scan.');
+      return;
+    }
 
     onError && onError(null);
     setIsScanning(true);
     setVaultItems([]);
     setSummary([]);
+    setFilterSummary(null);
     try {
       const res = await vaultAPI.scan({
         workspaceId,
         address: vaultAddress,
         token: vaultToken,
         include: { kv: includeKV, pki: includePKI },
-        mounts: null,
+        mounts: mountsFilterForScan(),
         maxItemsPerMount,
         pathPrefix,
+        categories: Array.from(selectedCategories),
+        filterRules: sanitizeFilterRules(filterRules),
       });
       const items = Array.isArray(res?.items) ? res.items : [];
       setVaultItems(items);
       setSummary(Array.isArray(res?.summary) ? res.summary : []);
+      setFilterSummary(res?.filterSummary || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('vault');
       }
@@ -256,6 +347,9 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
         include: { kv: includeKV, pki: includePKI },
         pathPrefix: pathPrefix || '',
         maxItemsPerMount,
+        mounts: mountsFilterForScan(),
+        categories: Array.from(selectedCategories),
+        filterRules: sanitizeFilterRules(filterRules),
       },
     }),
   }));
@@ -393,44 +487,161 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
           </Button>
         </HStack>
 
+        <Box>
+          <Text fontSize='sm' mb={1}>
+            Asset kinds to scan
+          </Text>
+          <HStack spacing={4} flexWrap='wrap'>
+            {VAULT_CATEGORY_OPTIONS.map(opt => (
+              <Checkbox
+                key={opt.value}
+                size='sm'
+                isChecked={selectedCategories.has(opt.value)}
+                onChange={() => toggleCategory(opt.value)}
+              >
+                {opt.label}
+              </Checkbox>
+            ))}
+          </HStack>
+          <Text fontSize='xs' color={helpTextColor} mt={1}>
+            All kinds are scanned by default. Uncheck a kind to skip it, e.g.
+            uncheck Secrets &amp; keys to only import certificates.
+          </Text>
+        </Box>
+
         {/* Advanced options - collapsible */}
         <Accordion allowToggle>
           <AccordionItem border='none'>
             <AccordionButton px={0}>
               <Box flex='1' textAlign='left'>
                 <Text fontSize='sm' color={helpTextColor}>
-                  Advanced: Path filtering
+                  Advanced: Secrets engines and path filtering
                 </Text>
               </Box>
               <AccordionIcon />
             </AccordionButton>
             <AccordionPanel pb={4} px={0}>
-              <Box>
-                <Text fontSize='sm' mb={1}>
-                  Path prefix (KV only)
-                </Text>
-                <Input
-                  placeholder='e.g., prod/api (optional)'
-                  value={pathPrefix}
-                  onChange={e => {
-                    setPathPrefix(e.target.value);
-                    try {
-                      localStorage.setItem(
-                        'tt_vault_path_prefix',
-                        e.target.value
-                      );
-                    } catch (_) {}
-                  }}
-                  size='sm'
-                />
-                <Text fontSize='xs' color={helpTextColor} mt={1}>
-                  Folder inside each KV engine (e.g., prod/api) or an exact
-                  secret path. Leave empty to scan all.
-                </Text>
-              </Box>
+              <VStack align='stretch' spacing={4}>
+                <Box>
+                  <HStack justify='space-between' mb={1}>
+                    <Text fontSize='sm'>Secrets engines (mounts)</Text>
+                    <Button
+                      size='xs'
+                      variant='outline'
+                      leftIcon={
+                        isLoadingMounts ? (
+                          <Spinner size='xs' />
+                        ) : (
+                          <FiRefreshCw />
+                        )
+                      }
+                      onClick={loadMounts}
+                      isDisabled={
+                        isLoadingMounts || !vaultAddress || !vaultToken
+                      }
+                    >
+                      {availableMounts.length > 0 ? 'Refresh' : 'Load engines'}
+                    </Button>
+                  </HStack>
+                  {mountsError ? (
+                    <Text fontSize='xs' color='red.400' mb={1}>
+                      {mountsError}
+                    </Text>
+                  ) : null}
+                  {availableMounts.length > 0 ? (
+                    <Box
+                      border='1px solid'
+                      borderColor={borderColor}
+                      borderRadius='md'
+                      p={2}
+                      maxH='180px'
+                      overflowY='auto'
+                    >
+                      <VStack align='stretch' spacing={1}>
+                        {availableMounts.map(m => {
+                          const kvVersion =
+                            m.type === 'kv'
+                              ? String(m.options?.version || '1')
+                              : null;
+                          const unsupported = kvVersion === '1';
+                          return (
+                            <Checkbox
+                              key={m.path}
+                              size='sm'
+                              isChecked={selectedMountPaths.has(m.path)}
+                              onChange={() => toggleMount(m.path)}
+                            >
+                              {m.path} ({m.type}
+                              {kvVersion ? ` v${kvVersion}` : ''})
+                              {unsupported ? (
+                                <Text
+                                  as='span'
+                                  fontSize='2xs'
+                                  color='orange.400'
+                                  ml={1}
+                                >
+                                  KV v1 not supported
+                                </Text>
+                              ) : null}
+                            </Checkbox>
+                          );
+                        })}
+                      </VStack>
+                    </Box>
+                  ) : (
+                    <Text fontSize='xs' color={helpTextColor}>
+                      All secrets engines are scanned by default. Load the list
+                      to include or exclude specific ones (e.g. only the
+                      &quot;staging&quot; KV engine).
+                    </Text>
+                  )}
+                </Box>
+                <Box>
+                  <Text fontSize='sm' mb={1}>
+                    Path prefix (KV only)
+                  </Text>
+                  <Input
+                    placeholder='e.g., prod/api (optional)'
+                    value={pathPrefix}
+                    onChange={e => {
+                      setPathPrefix(e.target.value);
+                      try {
+                        localStorage.setItem(
+                          'tt_vault_path_prefix',
+                          e.target.value
+                        );
+                      } catch (_) {}
+                    }}
+                    size='sm'
+                  />
+                  <Text fontSize='xs' color={helpTextColor} mt={1}>
+                    Folder inside each KV engine (e.g., prod/api) or an exact
+                    secret path. Leave empty to scan all. Do not include the
+                    engine name itself, use the secrets engines picker above for
+                    that.
+                  </Text>
+                </Box>
+              </VStack>
             </AccordionPanel>
           </AccordionItem>
         </Accordion>
+
+        <FilterRulesEditor
+          rules={filterRules}
+          onChange={setFilterRules}
+          borderColor={borderColor}
+          helpTextColor={helpTextColor}
+        />
+        {filterSummary ? (
+          <HStack spacing={2}>
+            <Badge colorScheme='green'>
+              {filterSummary.matchedCount} matched
+            </Badge>
+            <Badge colorScheme='red'>
+              {filterSummary.excludedCount} excluded by rules
+            </Badge>
+          </HStack>
+        ) : null}
       </VStack>
 
       {summary.length > 0 ? (

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -1150,6 +1150,8 @@ export const vaultAPI = {
     mounts = [],
     maxItemsPerMount = 250,
     pathPrefix,
+    categories = undefined,
+    filterRules = undefined,
   }) => {
     if (!workspaceId) {
       throw new Error('workspaceId is required for integration scans');
@@ -1162,6 +1164,12 @@ export const vaultAPI = {
         mounts: Array.isArray(mounts) ? mounts : [],
         maxItemsPerMount,
         pathPrefix,
+        ...(Array.isArray(categories) && categories.length > 0
+          ? { categories }
+          : {}),
+        ...(Array.isArray(filterRules) && filterRules.length > 0
+          ? { filterRules }
+          : {}),
       };
       const res = await apiClient.post(
         API_ENDPOINTS.VAULT_SCAN(workspaceId),

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -9063,6 +9063,45 @@ components:
           type: array
           items:
             type: string
+        maxItemsPerMount:
+          type: integer
+          minimum: 1
+          maximum: 2000
+        pathPrefix:
+          type: string
+          description: >-
+            Folder inside each KV engine, or an exact secret path. A leading
+            segment matching the mount's own name is ignored.
+        categories:
+          type: array
+          description: >-
+            Asset categories to keep in the scan result. Omit to keep all.
+          items:
+            type: string
+            enum: [cert, key_secret]
+        filterRules:
+          type: array
+          maxItems: 50
+          description: >-
+            Ordered include/exclude rules applied to scan results before
+            import. Exclude rules always win; when include rules exist, only
+            matching items are kept.
+          items:
+            type: object
+            required: [action, matchType, field, value]
+            properties:
+              action:
+                type: string
+                enum: [include, exclude]
+              matchType:
+                type: string
+                enum: [regex, exact]
+              field:
+                type: string
+                enum: [name, description, location]
+              value:
+                type: string
+                maxLength: 500
     VaultMountsRequest:
       type: object
       required: [address, token]

--- a/tests/integration/vault-scan-multicert.unit.test.js
+++ b/tests/integration/vault-scan-multicert.unit.test.js
@@ -262,5 +262,99 @@ describe("Vault KV scan behavior", () => {
       const res = await scan("does/not/exist");
       expect(res.items).to.have.length(0);
     });
+
+    it("strips a leading mount-name segment copied into the prefix", async () => {
+      // Customers often copy the full Vault path including the mount name
+      // (e.g. from `vault kv get secret/common/ca`); that leading "secret/"
+      // must not be treated as part of the in-mount path.
+      const res = await scan("secret/common/ca");
+      expect(res.items).to.have.length(2);
+      for (const item of res.items) {
+        expect(item.category).to.equal("cert");
+        expect(item.path).to.equal("common/ca");
+      }
+    });
+
+    it("treats a prefix equal to just the mount name as no prefix", async () => {
+      const res = await scan("secret");
+      expect(res.items).to.have.length(3);
+    });
+  });
+
+  describe("scanVault category filtering", () => {
+    const routes = {
+      "GET /v1/sys/mounts": {
+        status: 200,
+        body: {
+          data: { "secret/": { type: "kv", options: { version: "2" } } },
+        },
+      },
+      "LIST /v1/secret/metadata/": {
+        status: 200,
+        body: { data: { keys: ["ca", "creds"] } },
+      },
+      "GET /v1/secret/data/ca": {
+        status: 200,
+        body: {
+          data: {
+            data: { certificate: TEST_PEM },
+            metadata: { created_time: "2026-01-01T00:00:00Z" },
+          },
+        },
+      },
+      "GET /v1/secret/data/creds": {
+        status: 200,
+        body: {
+          data: {
+            data: { password: "hunter2" },
+            metadata: { created_time: "2026-01-01T00:00:00Z" },
+          },
+        },
+      },
+    };
+
+    let vault;
+
+    before(async () => {
+      vault = await startFakeVault(routes);
+    });
+
+    after(async () => {
+      if (vault) await vault.close();
+    });
+
+    it("returns every category when no filter is given", async () => {
+      const res = await mod.scanVault({
+        address: vault.address,
+        token: "test-token",
+        include: { kv: true, pki: false },
+      });
+      expect(res.items).to.have.length(2);
+    });
+
+    it("keeps only cert items when categories is ['cert']", async () => {
+      const res = await mod.scanVault({
+        address: vault.address,
+        token: "test-token",
+        include: { kv: true, pki: false },
+        categories: ["cert"],
+      });
+      expect(res.items).to.have.length(1);
+      expect(res.items[0].category).to.equal("cert");
+      expect(res.summary).to.deep.equal([
+        { mount: "secret/", type: "kv", found: 1, truncated: false },
+      ]);
+    });
+
+    it("keeps only key_secret items when categories is ['key_secret']", async () => {
+      const res = await mod.scanVault({
+        address: vault.address,
+        token: "test-token",
+        include: { kv: true, pki: false },
+        categories: ["key_secret"],
+      });
+      expect(res.items).to.have.length(1);
+      expect(res.items[0].category).to.equal("key_secret");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a secrets-engine (mount) picker to the Vault import form: load the engine list, tick which KV/PKI mounts to scan (all selected by default); a narrowed selection is sent via the existing `mounts` scan parameter.
- Adds asset-kind checkboxes (Certificates, Secrets & keys) backed by a new optional `categories` scan parameter, validated in the route and applied per mount in `scanVault`.
- Wires the existing `FilterRulesEditor` (already used by GitHub/GitLab imports) into the Vault form, so include/exclude rules can match the Vault location (`vault:mount/path`) to include or exclude a whole engine, a folder, or a single secret.
- Fixes a path-prefix trap: a prefix copied from the Vault CLI/UI usually includes the engine name itself (e.g. `staging/team/app` for a secret at `team/app` inside the `staging/` engine) and previously matched nothing; a leading segment matching the scanned mount's own name is now stripped.
- Documents `pathPrefix`, `maxItemsPerMount`, `filterRules`, and the new `categories` field in the `VaultScanRequest` OpenAPI schema.
- Changelog entries folded into the 0.13.2 section.

## Test plan
- [x] `tests/integration/vault-scan-multicert.unit.test.js` extended with mount-name stripping and category-filter cases (18 tests passing)
- [x] `pnpm run test:unit`
- [x] `CONTRACT_API_REQUIRED=0 pnpm run test:contracts` (validates the OpenAPI edit)
- [x] `pnpm run check:contracts` / `check:contracts:integrity` / `check:lockfile-overrides` / `check:secret-logging`
- [x] Dashboard lint, prettier check, type-check, and production build
- [x] API lint
- [x] Internal-reference leak scan on all changed files
