### PR TITLE
fix(docker): bump libcrypto3/libssl3 pin to 3.5.8-r0, unblocking Alpine builds

### DIFF
--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -32,9 +32,12 @@ FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r4 (patched Alpine 3.23 revision).
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead,
+# the currently selectable Alpine 3.23 revision (apk upgrade already installs it, forcing the
+# old pin back down conflicts with nginx/libcurl/ca-certificates which require the newer one).
 # Drop unused nginx-module-* packages first; their r1 revisions block apk upgrades.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
     && apk del --no-cache \
         nginx \
         nginx-module-acme \
@@ -43,7 +46,7 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-njs \
         nginx-module-xslt \
     && apk add --no-cache 'nginx~1.28.3' \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0" \
     && nginx_version="$(apk info -v nginx | sed 's/^nginx-//')" \
     && test "$(apk version -t "$nginx_version" "1.28.3-r4")" != "<" \
     && mkdir -p /run/nginx

--- a/apps/dashboard/Dockerfile.dev
+++ b/apps/dashboard/Dockerfile.dev
@@ -2,9 +2,10 @@
 FROM node:22.23.2-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# 3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 WORKDIR /app
 

--- a/apps/k8s-controller/Dockerfile
+++ b/apps/k8s-controller/Dockerfile
@@ -1,9 +1,10 @@
 FROM node:22.23.2-alpine3.23
 
 # Keep the controller base aligned with the worker image's patched Alpine base.
+# 3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead
+# (the explicit pin exists to avoid stale GHA cache layers reporting pre-fix revisions).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile.dev
+++ b/apps/worker/Dockerfile.dev
@@ -1,9 +1,10 @@
 FROM node:22.23.2-alpine3.23
 
 # Explicit pin avoids stale cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# 3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 WORKDIR /app
 

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -21,10 +21,11 @@ RUN go get \
 FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead
+# (the explicit pin exists to avoid stale GHA cache layers reporting pre-fix revisions).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 RUN apk add --no-cache ca-certificates
 

--- a/deploy/compose/Dockerfile.dashboard
+++ b/deploy/compose/Dockerfile.dashboard
@@ -2,10 +2,11 @@
 FROM node:22.23.2-alpine3.23 AS builder
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead
+# (the explicit pin exists to avoid stale GHA cache layers reporting pre-fix revisions).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
@@ -44,10 +45,13 @@ FROM nginx:1.28.3-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
 # CVE-2026-9256 / CVE-2026-49975: pin nginx=1.28.3-r4 (patched Alpine 3.23 revision).
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead,
+# the currently selectable Alpine 3.23 revision (apk upgrade already installs it, forcing the
+# old pin back down conflicts with nginx/libcurl/ca-certificates which require the newer one).
 # Drop unused nginx-module-* packages first; their r1
 # revisions block apk from replacing nginx while those modules stay installed.
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
     && apk del --no-cache \
         nginx \
         nginx-module-acme \
@@ -56,7 +60,7 @@ RUN apk update && apk upgrade --no-cache \
         nginx-module-njs \
         nginx-module-xslt \
     && apk add --no-cache 'nginx~1.28.3' \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0" \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0" \
     && nginx_version="$(apk info -v nginx | sed 's/^nginx-//')" \
     && test "$(apk version -t "$nginx_version" "1.28.3-r4")" != "<" \
     && mkdir -p /run/nginx

--- a/deploy/compose/Dockerfile.worker
+++ b/deploy/compose/Dockerfile.worker
@@ -2,10 +2,11 @@
 FROM node:22.23.2-alpine3.23
 
 # Refresh indexes and upgrade base packages (openssl/musl) so scans see current Alpine 3.23 fixes.
-# Explicit pin avoids stale GHA cache layers reporting pre-fix libcrypto3/libssl3 revisions.
+# libcrypto3/libssl3=3.5.7-r0 was superseded upstream by 3.5.8-r0; pin to 3.5.8-r0 instead
+# (the explicit pin exists to avoid stale GHA cache layers reporting pre-fix revisions).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache libcrypto3=3.5.7-r0 libssl3=3.5.7-r0 \
-    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.7-r0"
+    && apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
+    && test "$(apk list -I libcrypto3 | cut -d- -f2- | cut -d' ' -f1)" = "3.5.8-r0"
 
 # Install curl for optional probes / tooling
 RUN apk add --no-cache curl


### PR DESCRIPTION
## Summary

Alpine's package index advanced `libcrypto3`/`libssl3` to `3.5.8-r0`, superseding the `3.5.7-r0` pin in the API/worker/dashboard/k8s-controller Dockerfiles. `apk upgrade` already installs the newer package, so the explicit downgrade to `3.5.7-r0` now conflicts with everything that depends on the newer one (`nginx`, `libcurl`, `ca-certificates`, `apk-tools` itself):

```
ERROR: unable to select packages:
  libcrypto3-3.5.8-r0:
    breaks: world[libcrypto3=3.5.7-r0]
```

Every image build using this pin fails outright, blocking cloud's CI, and would have blocked core/enterprise's own builds on their next run too (their CI is push-only, so it hadn't fired there yet).

## Fix

Bumps the pin to `3.5.8-r0` (the currently selectable Alpine 3.23 revision) across all eight affected files, mirroring how the `nginx=1.28.3-rN` pin in these same files has been bumped several times before (r3→r4→r5→r6→r7) as Alpine's index moved forward:

- `apps/dashboard/Dockerfile`
- `apps/dashboard/Dockerfile.dev`
- `apps/k8s-controller/Dockerfile`
- `apps/worker/Dockerfile`
- `apps/worker/Dockerfile.dev`
- `deploy/compose/Dockerfile.api`
- `deploy/compose/Dockerfile.dashboard`
- `deploy/compose/Dockerfile.worker`

## Test plan

- [x] `docker build -f apps/dashboard/Dockerfile.dev` succeeds
- [x] `docker build -f apps/dashboard/Dockerfile` succeeds (both build and nginx stages, including the `apk del`/`apk add nginx` step)
- [x] `git grep 3.5.7-r0` only matches explanatory comment text, no remaining `apk add`/`test` pins
