### PR TITLE
feat(integrations): port obsolete-item cleanup to Vault, AWS, Azure, Azure AD, GCP imports

### DIFF
--- a/apps/api/db/models/Token.js
+++ b/apps/api/db/models/Token.js
@@ -131,6 +131,14 @@ const create = async (tokenData) => {
     last_used = null,
     created_at = null,
     certops_api_token_id = null,
+    source_provider = null,
+    source_instance = null,
+    source_owner_key = null,
+    source_owner_display = null,
+    source_kind = null,
+    source_dimensions = null,
+    source_object_id = null,
+    source_observed_at = null,
   } = tokenData;
 
   const query = `
@@ -138,9 +146,10 @@ const create = async (tokenData) => {
       user_id, workspace_id, created_by, name, expiration, type, category, domains, location, used_by, section, contact_group_id,
       issuer, serial_number, subject, key_size, algorithm, license_type, vendor, cost,
       renewal_url, renewal_date, contacts, description, notes, privileges, imported_at, last_used, created_at, updated_at,
-      certops_api_token_id
+      certops_api_token_id, source_provider, source_instance, source_owner_key, source_owner_display,
+      source_kind, source_dimensions, source_object_id, source_observed_at
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, NOW(), $30)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, NOW(), $30, $31, $32, $33, $34, $35, $36, $37, $38)
     RETURNING *
   `;
 
@@ -175,6 +184,14 @@ const create = async (tokenData) => {
     last_used,
     created_at || null,
     certops_api_token_id,
+    source_provider,
+    source_instance,
+    source_owner_key,
+    source_owner_display,
+    source_kind,
+    source_dimensions,
+    source_object_id,
+    source_observed_at,
   ];
 
   try {
@@ -227,6 +244,14 @@ const update = async (id, tokenData) => {
     last_used,
     created_at,
     imported_at,
+    source_provider,
+    source_instance,
+    source_owner_key,
+    source_owner_display,
+    source_kind,
+    source_dimensions,
+    source_object_id,
+    source_observed_at,
   } = tokenData;
 
   // Build dynamic query to only update provided fields
@@ -337,6 +362,44 @@ const update = async (id, tokenData) => {
   if (imported_at !== undefined) {
     updateFields.push(`imported_at = $${paramIndex++}`);
     values.push(imported_at);
+  }
+  if (source_provider !== undefined) {
+    updateFields.push(`source_provider = $${paramIndex++}`);
+    values.push(source_provider);
+  }
+  if (source_instance !== undefined) {
+    updateFields.push(`source_instance = $${paramIndex++}`);
+    values.push(source_instance);
+  }
+  if (source_owner_key !== undefined) {
+    updateFields.push(`source_owner_key = $${paramIndex++}`);
+    values.push(source_owner_key);
+  }
+  if (source_owner_display !== undefined) {
+    updateFields.push(`source_owner_display = $${paramIndex++}`);
+    values.push(source_owner_display);
+  }
+  if (source_kind !== undefined) {
+    updateFields.push(`source_kind = $${paramIndex++}`);
+    values.push(source_kind);
+  }
+  if (source_dimensions !== undefined) {
+    updateFields.push(`source_dimensions = $${paramIndex++}`);
+    values.push(source_dimensions);
+  }
+  if (source_object_id !== undefined) {
+    updateFields.push(`source_object_id = $${paramIndex++}`);
+    values.push(source_object_id);
+  }
+  if (source_observed_at !== undefined) {
+    // Monotonic: never let an older/slower scan's observed_at move the
+    // fence backwards past a newer one already recorded by a concurrent
+    // scan (see importCleanup.js's observation fence).
+    updateFields.push(
+      `source_observed_at = GREATEST(COALESCE(source_observed_at, $${paramIndex}), $${paramIndex})`,
+    );
+    values.push(source_observed_at);
+    paramIndex++;
   }
 
   // If no fields to update, return the existing token
@@ -472,6 +535,41 @@ const findByNameLocationAndWorkspace = async (name, location, workspaceId) => {
   return token ? convertNumericFields(token) : null;
 };
 
+// Find token by its provenance-aware upsert identity (see migration 48's
+// uq_tokens_source_identity). Used by provenance-aware imports instead of
+// findByNameLocationAndWorkspace so re-importing the same upstream object
+// updates the same row even if its display name or location string changed.
+const findBySourceIdentity = async ({
+  workspaceId,
+  sourceProvider,
+  sourceInstance,
+  sourceOwnerKey,
+  sourceKind,
+  sourceObjectId,
+}) => {
+  if (!sourceObjectId) return null;
+  const query = `
+    SELECT * FROM tokens
+    WHERE workspace_id = $1
+      AND source_provider = $2
+      AND source_instance = $3
+      AND source_owner_key = $4
+      AND source_kind = $5
+      AND source_object_id = $6
+    LIMIT 1
+  `;
+  const result = await pool.query(query, [
+    workspaceId,
+    sourceProvider,
+    sourceInstance,
+    sourceOwnerKey,
+    sourceKind,
+    sourceObjectId,
+  ]);
+  const token = result.rows[0];
+  return token ? convertNumericFields(token) : null;
+};
+
 module.exports = {
   convertNumericFields,
   findByUserId,
@@ -485,4 +583,5 @@ module.exports = {
   findExpiringSoon,
   findByDomain,
   findByNameLocationAndWorkspace,
+  findBySourceIdentity,
 };

--- a/apps/api/db/models/Token.js
+++ b/apps/api/db/models/Token.js
@@ -133,7 +133,10 @@ const create = async (tokenData) => {
     certops_api_token_id = null,
     source_provider = null,
     source_instance = null,
-    source_owner_key = null,
+    // source_owner_key is NOT NULL DEFAULT '' in the schema (the sentinel
+    // lets legacy/no-provenance rows participate in the uniqueness index
+    // without colliding on NULL), so default here must match, not null.
+    source_owner_key = "",
     source_owner_display = null,
     source_kind = null,
     source_dimensions = null,

--- a/apps/api/migrations/migrate.js
+++ b/apps/api/migrations/migrate.js
@@ -3553,6 +3553,97 @@ const migrations = [
         ON certops_trust_reference_release_idempotency(workspace_id, trust_anchor_id, agent_id, store, owner);
     `,
   },
+  {
+    version: 50,
+    name: "import_cleanup_scan_provenance",
+    sql: `
+      -- Per-instance/owner provenance for imported tokens. NULL on every
+      -- pre-existing row (legacy tokens cannot be safely backfilled from the
+      -- old free-text "location" column alone) and populated going forward
+      -- by the source identity resolver on every import/auto-sync path.
+      -- source_owner_key is an immutable principal id (e.g. a numeric
+      -- GitHub/GitLab user or repo id, an AWS/GCP/Azure account or project
+      -- id) -- never a mutable display name -- so cleanup matching never
+      -- depends on something a user can rename. source_owner_display is
+      -- kept separately for UI only.
+      --
+      -- source_owner_key is NOT NULL DEFAULT '' rather than nullable:
+      -- Postgres treats NULL as distinct in unique indexes, which would
+      -- silently defeat uq_tokens_source_identity below for every provider
+      -- using the '' ownership sentinel (Vault/AWS/Azure/Azure AD/GCP).
+      ALTER TABLE tokens
+        ADD COLUMN IF NOT EXISTS source_provider TEXT NULL,
+        ADD COLUMN IF NOT EXISTS source_instance TEXT NULL,
+        ADD COLUMN IF NOT EXISTS source_owner_key TEXT NOT NULL DEFAULT '',
+        ADD COLUMN IF NOT EXISTS source_owner_display TEXT NULL,
+        ADD COLUMN IF NOT EXISTS source_kind TEXT NULL,
+        ADD COLUMN IF NOT EXISTS source_dimensions JSONB NULL,
+        ADD COLUMN IF NOT EXISTS source_object_id TEXT NULL,
+        ADD COLUMN IF NOT EXISTS source_observed_at TIMESTAMPTZ NULL;
+
+      -- Upsert identity for provenance-aware imports: one row per distinct
+      -- upstream object per workspace/provider/instance/owner/kind. Legacy
+      -- rows (source_object_id IS NULL) are intentionally excluded rather
+      -- than backfilled -- see integration_scans below.
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_tokens_source_identity
+        ON tokens (workspace_id, source_provider, source_instance, source_owner_key, source_kind, source_object_id)
+        WHERE source_object_id IS NOT NULL;
+
+      -- Cleanup candidate-selection scope (provider+instance+owner+kind),
+      -- used by the anti-join in importCleanup.js.
+      CREATE INDEX IF NOT EXISTS idx_tokens_source_scope
+        ON tokens (workspace_id, source_provider, source_instance, source_owner_key, source_kind);
+
+      -- One row per completed (or attempted) scan. cleanup_scope records,
+      -- per source kind/dimension actually scanned, whether that sub-scope
+      -- was fully enumerated ("complete") or degraded (truncated/errored) --
+      -- the authoritative contract cleanup checks before deleting anything.
+      -- cleanup_consumed_at is the single-use claim: a scan can drive at
+      -- most one destructive cleanup.
+      CREATE TABLE IF NOT EXISTS integration_scans (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        provider TEXT NOT NULL,
+        source_instance TEXT NOT NULL,
+        source_owner_key TEXT NOT NULL,
+        started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        completed_at TIMESTAMPTZ NULL,
+        cleanup_scope JSONB NOT NULL DEFAULT '{}'::jsonb,
+        cleanup_consumed_at TIMESTAMPTZ NULL,
+        created_by INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_integration_scans_scope
+        ON integration_scans(workspace_id, provider, source_instance, source_owner_key);
+
+      -- Metadata-only record of every item a scan actually rediscovered
+      -- (never secret material). Import binds client-submitted items to a
+      -- real row here by (scan_id, source_kind, source_object_id) instead of
+      -- trusting whatever provenance the client claims, and cleanup's
+      -- anti-join uses this table to find tokens NOT rediscovered.
+      CREATE TABLE IF NOT EXISTS integration_scan_items (
+        id BIGSERIAL PRIMARY KEY,
+        scan_id UUID NOT NULL REFERENCES integration_scans(id) ON DELETE CASCADE,
+        source_kind TEXT NOT NULL,
+        source_object_id TEXT NOT NULL,
+        source_dimensions JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_integration_scan_items_identity
+        ON integration_scan_items(scan_id, source_kind, source_object_id);
+      CREATE INDEX IF NOT EXISTS idx_integration_scan_items_scan
+        ON integration_scan_items(scan_id);
+
+      -- connection_key lets a future multi-config-per-provider workspace
+      -- distinguish auto-sync configs pointing at different instances of
+      -- the same provider. cleanup_obsolete makes scheduled-sync cleanup an
+      -- explicit per-config opt-in, matching manual import's opt-in cleanup
+      -- checkbox rather than being implied by scan_params.
+      ALTER TABLE auto_sync_configs
+        ADD COLUMN IF NOT EXISTS connection_key TEXT NULL,
+        ADD COLUMN IF NOT EXISTS cleanup_obsolete BOOLEAN NOT NULL DEFAULT FALSE;
+    `,
+  },
 ];
 
 async function runMigrations() {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-acm": "3.1045.0",
+    "@aws-sdk/client-ec2": "3.1045.0",
     "@aws-sdk/client-iam": "3.1045.0",
     "@aws-sdk/client-secrets-manager": "3.1045.0",
     "@aws-sdk/client-sts": "3.1045.0",

--- a/apps/api/routes/admin.js
+++ b/apps/api/routes/admin.js
@@ -221,7 +221,8 @@ router.get(
       const result = await pool.query(
         `SELECT id, provider, scan_params, frequency, schedule_time, schedule_tz,
                 enabled, last_sync_at, last_sync_status, last_sync_error,
-                last_sync_items_count, next_sync_at, created_at, updated_at
+                last_sync_items_count, next_sync_at, created_at, updated_at,
+                cleanup_obsolete, connection_key
          FROM auto_sync_configs WHERE workspace_id = $1 ORDER BY provider`,
         [req.workspace.id],
       );
@@ -250,6 +251,7 @@ router.post(
         frequency,
         schedule_time,
         schedule_tz,
+        cleanup_obsolete,
       } = req.body || {};
       if (!provider || !credentials) {
         return res
@@ -286,9 +288,9 @@ router.post(
 
       const result = await pool.query(
         `INSERT INTO auto_sync_configs
-          (workspace_id, provider, credentials_encrypted, scan_params, frequency, schedule_time, schedule_tz, next_sync_at, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-         RETURNING id, provider, scan_params, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_at`,
+          (workspace_id, provider, credentials_encrypted, scan_params, frequency, schedule_time, schedule_tz, next_sync_at, created_by, cleanup_obsolete)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         RETURNING id, provider, scan_params, frequency, schedule_time, schedule_tz, enabled, next_sync_at, created_at, cleanup_obsolete`,
         [
           req.workspace.id,
           provider,
@@ -299,6 +301,7 @@ router.post(
           effTz,
           nextSync,
           req.user.id,
+          cleanup_obsolete === true,
         ],
       );
       try {
@@ -361,6 +364,7 @@ router.put(
         schedule_time,
         schedule_tz,
         enabled,
+        cleanup_obsolete,
       } = req.body || {};
       const updates = [];
       const values = [];
@@ -404,6 +408,10 @@ router.put(
         updates.push(`enabled = $${idx++}`);
         values.push(enabled);
       }
+      if (cleanup_obsolete !== undefined) {
+        updates.push(`cleanup_obsolete = $${idx++}`);
+        values.push(cleanup_obsolete === true);
+      }
       updates.push(`updated_at = NOW()`);
 
       if (updates.length <= 1) {
@@ -414,7 +422,7 @@ router.put(
       const result = await pool.query(
         `UPDATE auto_sync_configs SET ${updates.join(", ")}
          WHERE id = $${idx++} AND workspace_id = $${idx}
-         RETURNING id, provider, scan_params, frequency, schedule_time, schedule_tz, enabled, next_sync_at, updated_at`,
+         RETURNING id, provider, scan_params, frequency, schedule_time, schedule_tz, enabled, next_sync_at, updated_at, cleanup_obsolete`,
         values,
       );
       if (result.rows.length === 0) {

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -1512,6 +1512,38 @@ router.post(
       });
       applyScanFilterRulesToResult(filterRules, result);
 
+      // Persist this scan as the backend-authoritative record (per source
+      // kind completeness: secrets/certificates/keys tracked independently
+      // so a failure or truncation in one kind never marks another kind
+      // complete), so import's cleanup request can be driven by scan_id.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "azure",
+            identityContext: { vaultUrl },
+            createdBy: req.user?.id || null,
+            items: (result.items || []).map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {},
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: {},
+              complete: s.complete === true,
+              reason: s.error ? "error" : s.truncated ? "truncated" : s.failedCount > 0 ? "describe_failures" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("Azure Key Vault scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
+
       res.json(withQuota(result));
       try {
         if (req && req.user) {
@@ -1774,6 +1806,39 @@ router.post(
         maxItems: maxItems || 500,
       });
       applyScanFilterRulesToResult(filterRules, result);
+
+      // Persist this scan as the backend-authoritative record (Applications
+      // and Service Principals tracked as independent completeness
+      // dimensions, so a global item cap or partial failure in one never
+      // silently marks the other "scanned"), so import's cleanup request
+      // can be driven by scan_id.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId && result.tenantId) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "azure-ad",
+            identityContext: { tenantId: result.tenantId },
+            createdBy: req.user?.id || null,
+            items: (result.items || []).map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {},
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: {},
+              complete: s.complete === true,
+              reason: s.error ? "error" : s.truncated ? "truncated" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("Azure AD scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
 
       res.json(withQuota(result));
       try {

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -1309,6 +1309,37 @@ router.post(
       });
       applyScanFilterRulesToResult(filterRules, result);
 
+      // Persist this scan as the backend-authoritative record of what was
+      // covered (per region+service completeness), so import's cleanup
+      // request can be driven by scan_id.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId && result.accountId) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "aws",
+            identityContext: { accountId: result.accountId },
+            createdBy: req.user?.id || null,
+            items: result.items.map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: { region: region || "us-east-1", service: item.sourceKind },
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: s.region ? { region: s.region, service: s.service } : { service: s.service },
+              complete: s.complete === true,
+              reason: s.error ? "error" : s.failedCount > 0 ? "describe_failures" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("AWS scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
+
       res.json(withQuota(result));
       try {
         if (req && req.user) {
@@ -1904,6 +1935,7 @@ router.post(
         contact_group_id,
         filterRules,
         cleanup,
+        scan_id: scanId,
       } = req.body || {};
       if (!Array.isArray(items) || items.length === 0) {
         return res.status(400).json({ error: "items array required" });
@@ -1912,14 +1944,72 @@ router.post(
       if (filterRulesError) {
         return res.status(400).json({ error: filterRulesError });
       }
-      const cleanupError = validateCleanupRequest(cleanup);
+      const cleanupError = validateCleanupRequest(
+        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
+          ? { ...cleanup, scanId }
+          : cleanup,
+      );
       if (cleanupError) {
         return res.status(400).json({ error: cleanupError });
       }
+      const effectiveCleanup =
+        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
+          ? { ...cleanup, scanId }
+          : cleanup;
       // Issue #69: apply include/exclude rules at import time too, so
       // auto-sync (which posts scan items here) honors the same rules.
       const { items: itemsToImport, excludedCount: filteredOutCount } =
         applyFilterRules(filterRules, items);
+
+      // Derive which of the 7 known providers each item's `source` belongs
+      // to (azure-ad must be checked before the plainer "azure" prefix),
+      // then bind each item to the scan that actually discovered it -- see
+      // scanBinding.js. Grouped per-provider since a single import batch is
+      // expected to come from one provider's scan, but nothing here assumes
+      // that beyond grouping the lookup calls.
+      const deriveProvider = (source) => {
+        const s = String(source || "");
+        if (s.startsWith("gitlab")) return "gitlab";
+        if (s.startsWith("github")) return "github";
+        if (s.startsWith("aws")) return "aws";
+        if (s.startsWith("azure-ad")) return "azure-ad";
+        if (s.startsWith("azure")) return "azure";
+        if (s.startsWith("gcp")) return "gcp";
+        return null;
+      };
+      const itemProviders = itemsToImport.map((it) => deriveProvider(it?.source));
+      const resolvers = new Array(itemsToImport.length).fill(null);
+      const providersPresent = [...new Set(itemProviders.filter(Boolean))];
+      for (const provider of providersPresent) {
+        const indices = [];
+        const pairs = [];
+        itemsToImport.forEach((it, idx) => {
+          if (itemProviders[idx] !== provider) return;
+          indices.push(idx);
+          pairs.push({
+            sourceKind: it?.sourceKind || it?.source || provider,
+            sourceObjectId:
+              it?.sourceObjectId || String(it?.location || "").trim(),
+          });
+        });
+        try {
+          const { resolveForItem } = await bindImportItemsToScan({
+            scanId: scanId || null,
+            workspaceId,
+            provider,
+            pairs,
+          });
+          indices.forEach((originalIdx, i) => {
+            resolvers[originalIdx] = resolveForItem(i);
+          });
+        } catch (bindErr) {
+          logger.warn("Scan binding failed for provider group", {
+            provider,
+            error: bindErr.message,
+          });
+        }
+      }
+
       const ALLOWED_TYPES = [
         "ssl_cert",
         "tls_cert",
@@ -1942,7 +2032,8 @@ router.post(
       const updated = [];
       const errors = [];
       const NEVER_EXPIRES_DATE = "2099-12-31"; // Default for tokens without expiration
-      for (const it of itemsToImport) {
+      for (let itemIndex = 0; itemIndex < itemsToImport.length; itemIndex++) {
+        const it = itemsToImport[itemIndex];
         try {
           // Sanitize and validate name (HTML escape for XSS protection)
           let name = String(it?.name || "").trim();
@@ -2286,15 +2377,29 @@ router.post(
             last_used: parseIntegrationDate(it?.last_used_at || it?.last_used),
             created_at: parseIntegrationDate(it?.created_at),
             imported_at: new Date(),
+            ...(resolvers[itemIndex] || {}),
           };
 
-          // Check if token with same name and location already exists in this workspace
+          // Provenance-aware imports upsert by source identity (immune to
+          // name/location drift); items that didn't bind to a scan fall
+          // back to the pre-existing name+location match. See
+          // importCleanup.js for why ambiguous legacy rows are never
+          // retrofitted with guessed provenance.
           let tok;
-          const existingToken = await Token.findByNameLocationAndWorkspace(
-            tokenPayload.name,
-            tokenPayload.location,
-            workspaceId,
-          );
+          const existingToken = tokenPayload.source_object_id
+            ? await Token.findBySourceIdentity({
+                workspaceId,
+                sourceProvider: tokenPayload.source_provider,
+                sourceInstance: tokenPayload.source_instance,
+                sourceOwnerKey: tokenPayload.source_owner_key,
+                sourceKind: tokenPayload.source_kind,
+                sourceObjectId: tokenPayload.source_object_id,
+              })
+            : await Token.findByNameLocationAndWorkspace(
+                tokenPayload.name,
+                tokenPayload.location,
+                workspaceId,
+              );
 
           if (existingToken) {
             // Update existing token with new characteristics
@@ -2368,17 +2473,18 @@ router.post(
           });
         }
       }
-      // Item 4 (0.10.0): remove previously imported tokens that are no longer
-      // present at the source. Opt-in via the `cleanup` payload; scoped to the
-      // provider prefix and the source kinds included in this scan.
+      // Remove previously imported tokens that are no longer present at the
+      // source. Opt-in via the `cleanup` payload, driven by a backend-
+      // persisted scan_id (see importCleanup.js for the full safety
+      // contract) rather than a client-reconstructed scope.
       let cleanupDeleted = [];
-      if (cleanup && cleanup.enabled === true) {
+      if (effectiveCleanup && effectiveCleanup.enabled === true) {
         try {
           const cleanupResult = await cleanupObsoleteTokens({
             workspaceId,
             actorUserId: req.user.id,
-            cleanup,
-            reason: cleanup.reason === "auto_sync_cleanup"
+            cleanup: effectiveCleanup,
+            reason: effectiveCleanup.reason === "auto_sync_cleanup"
               ? "auto_sync_cleanup"
               : "import_cleanup",
           });

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -479,12 +479,13 @@ router.post(
           it?.sourceObjectId ||
           String(it?.location || "").replace(/^vault:/, ""),
       }));
-      // The client sends the scan id nested as `cleanup.scanId` (the shape
-      // `effectiveCleanup` normalizes into), not as a bare top-level
-      // `scan_id`/`scanId` -- so binding must use the resolved value, or
-      // every import silently fails to bind and every token stays
-      // unattributed (permanently cleanup-ineligible) regardless of the
-      // cleanup checkbox.
+      // Provenance binding must not depend on the cleanup checkbox: the
+      // dashboard sends a bare top-level `scan_id` on every scan-backed
+      // import, and additionally nests `cleanup.scanId` when cleanup is
+      // enabled. Prefer the cleanup-nested id (covers older/other callers
+      // that only set it there) and fall back to the top-level id, so an
+      // import with cleanup off still gets attributed instead of staying
+      // permanently ambiguous once cleanup is turned on later.
       const { resolveForItem } = await bindImportItemsToScan({
         scanId: effectiveCleanup?.scanId || scanId || null,
         workspaceId,
@@ -910,7 +911,7 @@ router.post(
               sourceKind: s.sourceKind,
               dimensions: {},
               complete: s.complete === true,
-              reason: s.error ? "error" : null,
+              reason: s.error ? "error" : s.truncated ? "truncated" : null,
             })),
           });
           result.scan_id = scan.scanId;
@@ -1127,7 +1128,7 @@ router.post(
               sourceKind: s.sourceKind,
               dimensions: {},
               complete: s.complete === true,
-              reason: s.error ? "error" : null,
+              reason: s.error ? "error" : s.truncated ? "truncated" : null,
             })),
           });
           result.scan_id = scan.scanId;
@@ -1411,13 +1412,22 @@ router.post(
             items: result.items.map((item) => ({
               sourceKind: item.sourceKind,
               sourceObjectId: item.sourceObjectId,
-              dimensions: { region: region || "us-east-1", service: item.sourceKind },
+              // `service` intentionally omitted: sourceKind already
+              // distinguishes aws-secrets-manager / aws-acm / aws-iam-key,
+              // and the summary's `service` field below uses different
+              // string values (e.g. "secrets_manager") than sourceKind
+              // (e.g. "aws-secrets-manager") -- keeping both would make
+              // cleanup's exact-match dimension filter never match.
+              dimensions:
+                item.sourceKind === "aws-iam-key"
+                  ? {}
+                  : { region: region || "us-east-1" },
             })),
             subScopes: (result.summary || []).map((s) => ({
               sourceKind: s.sourceKind,
-              dimensions: s.region ? { region: s.region, service: s.service } : { service: s.service },
+              dimensions: s.region ? { region: s.region } : {},
               complete: s.complete === true,
-              reason: s.error ? "error" : s.failedCount > 0 ? "describe_failures" : null,
+              reason: s.error ? "error" : s.truncated ? "truncated" : s.failedCount > 0 ? "describe_failures" : null,
             })),
           });
           result.scan_id = scan.scanId;
@@ -2174,9 +2184,12 @@ router.post(
           });
         });
         try {
-          // See the vault/import route above: the client sends the scan id
-          // nested as `cleanup.scanId`, so binding must use the resolved
-          // `effectiveCleanup.scanId`, not the always-empty top-level field.
+          // Provenance binding must not depend on the cleanup checkbox: the
+          // dashboard sends a bare top-level `scan_id` on every scan-backed
+          // import, and additionally nests `cleanup.scanId` when cleanup is
+          // enabled. Prefer the cleanup-nested id and fall back to the
+          // top-level id (see the vault/import route above for the same
+          // pattern).
           const { resolveForItem } = await bindImportItemsToScan({
             scanId: effectiveCleanup?.scanId || scanId || null,
             workspaceId,

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -1668,6 +1668,36 @@ router.post(
       });
       applyScanFilterRulesToResult(filterRules, result);
 
+      // Persist this scan as the backend-authoritative record, so import's
+      // cleanup request can be driven by scan_id.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "gcp",
+            identityContext: { projectId },
+            createdBy: req.user?.id || null,
+            items: (result.items || []).map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {},
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: {},
+              complete: s.complete === true,
+              reason: s.error ? "error" : s.truncated ? "truncated" : s.failedCount > 0 ? "describe_failures" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("GCP scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
+
       res.json(withQuota(result));
       try {
         if (req && req.user) {

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -30,6 +30,10 @@ const {
   validateCleanupRequest,
   cleanupObsoleteTokens,
 } = require("../services/importCleanup");
+const {
+  persistScan,
+} = require("../services/integrationScans");
+const { bindImportItemsToScan } = require("../services/scanBinding");
 
 const router = require("express").Router();
 
@@ -170,6 +174,43 @@ router.post(
         categories: Array.isArray(categories) ? categories : null,
       });
       applyScanFilterRulesToResult(filterRules, result);
+
+      // Persist this scan as the backend-authoritative record of what was
+      // covered, so a later import's cleanup request can be driven by
+      // scan_id instead of trusting reconstructed client-side scan state.
+      // Best-effort: a persistence failure must not block returning scan
+      // results to the user, it only means cleanup won't be offered.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "vault",
+            identityContext: { address },
+            createdBy: req.user?.id || null,
+            items: result.items.map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {
+                mount: item.mount,
+                path: item.path,
+                category: item.category,
+              },
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: s.dimensions || { mount: s.mount },
+              complete: s.complete === true,
+              reason: s.error ? "error" : s.truncated ? "truncated" : s.hasErrors ? "read_errors" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("Vault scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
 
       res.json(withQuota(result));
       try {
@@ -389,14 +430,43 @@ router.post(
         default_type,
         contact_group_id,
         cleanup,
+        scan_id: scanId,
       } = req.body || {};
       if (!Array.isArray(items) || items.length === 0) {
         return res.status(400).json({ error: "items array required" });
       }
-      const cleanupError = validateCleanupRequest(cleanup);
+      const cleanupError = validateCleanupRequest(
+        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
+          ? { ...cleanup, scanId }
+          : cleanup,
+      );
       if (cleanupError) {
         return res.status(400).json({ error: cleanupError });
       }
+      const effectiveCleanup =
+        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
+          ? { ...cleanup, scanId }
+          : cleanup;
+
+      // Bind each submitted item to the scan that actually discovered it
+      // (metadata-only integration_scan_items rows), so provenance comes
+      // from what the backend recorded, never from client-echoed fields.
+      // Items that don't bind (no scan_id, stale scan_id, or the item
+      // wasn't part of that scan) import unattributed, same as before this
+      // feature existed -- never a cleanup candidate.
+      const bindingPairs = items.map((it) => ({
+        sourceKind: it?.sourceKind || it?.source || "vault-kv",
+        sourceObjectId:
+          it?.sourceObjectId ||
+          String(it?.location || "").replace(/^vault:/, ""),
+      }));
+      const { resolveForItem } = await bindImportItemsToScan({
+        scanId: scanId || null,
+        workspaceId,
+        provider: "vault",
+        pairs: bindingPairs,
+      });
+
       // Reuse core validation constraints for type/category; allow past expiration for imports
       const ALLOWED_TYPES = [
         "ssl_cert",
@@ -424,7 +494,8 @@ router.post(
       const updated = [];
       const errors = [];
       const NEVER_EXPIRES_DATE = "2099-12-31"; // Default for tokens without expiration
-      for (const it of items) {
+      for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+        const it = items[itemIndex];
         try {
           const name = String(it?.name || "").trim();
           let expiration = it?.expiration || it?.expiresAt || null;
@@ -534,15 +605,30 @@ router.post(
             last_used: it?.last_used_at || it?.last_used || null,
             created_at: it?.created_at || null,
             imported_at: new Date(),
+            ...(resolveForItem(itemIndex) || {}),
           };
 
-          // Check if token with same name and location already exists in this workspace
+          // Provenance-aware imports upsert by source identity so
+          // re-scanning updates the same row even if name/location changed.
+          // Items that didn't bind to a scan (legacy behavior) fall back to
+          // the old name+location match -- see the "ambiguous legacy rows"
+          // policy in importCleanup.js: we never try to retrofit provenance
+          // onto a pre-existing ambiguous row by guessing.
           let tok;
-          const existingToken = await Token.findByNameLocationAndWorkspace(
-            tokenPayload.name,
-            tokenPayload.location,
-            workspaceId,
-          );
+          const existingToken = tokenPayload.source_object_id
+            ? await Token.findBySourceIdentity({
+                workspaceId,
+                sourceProvider: tokenPayload.source_provider,
+                sourceInstance: tokenPayload.source_instance,
+                sourceOwnerKey: tokenPayload.source_owner_key,
+                sourceKind: tokenPayload.source_kind,
+                sourceObjectId: tokenPayload.source_object_id,
+              })
+            : await Token.findByNameLocationAndWorkspace(
+                tokenPayload.name,
+                tokenPayload.location,
+                workspaceId,
+              );
 
           if (existingToken) {
             // Update existing token with new characteristics
@@ -612,19 +698,18 @@ router.post(
         }
       }
       // Remove previously imported tokens that are no longer present at the
-      // source. Opt-in via the `cleanup` payload; scoped to the provider
-      // prefix and the source kinds included in this scan. Only attempted
-      // when the scan returned at least one item, so an empty/broken scan
-      // can never mass-delete a workspace.
+      // source. Opt-in via the `cleanup` payload, driven by a backend-
+      // persisted scan_id (see importCleanup.js for the full safety
+      // contract) rather than a client-reconstructed scope.
       let cleanupDeleted = [];
-      if (cleanup && cleanup.enabled === true) {
+      if (effectiveCleanup && effectiveCleanup.enabled === true) {
         try {
           const cleanupResult = await cleanupObsoleteTokens({
             workspaceId,
             actorUserId: req.user.id,
-            cleanup,
+            cleanup: { ...effectiveCleanup, provider: "vault" },
             reason:
-              cleanup.reason === "auto_sync_cleanup"
+              effectiveCleanup.reason === "auto_sync_cleanup"
                 ? "auto_sync_cleanup"
                 : "import_cleanup",
           });

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -73,6 +73,27 @@ function summarizeImportErrors(errors) {
   }));
 }
 
+// importCleanup.validateCleanupRequest requires `cleanup.scanId` (camelCase).
+// Callers have echoed the scan id under other names -- a top-level
+// `scan_id` on the request body, or a `scan_id` nested inside the `cleanup`
+// object itself -- so this normalizes every accepted shape into
+// `cleanup.scanId` in exactly one place, shared by both import routes,
+// rather than trusting each call site to get the casing right.
+function resolveEffectiveCleanup(cleanup, topLevelScanId) {
+  if (!cleanup || cleanup.enabled !== true) return cleanup;
+  if (typeof cleanup.scanId === "string" && cleanup.scanId.trim() !== "") {
+    return cleanup;
+  }
+  const nestedScanId =
+    typeof cleanup.scan_id === "string" && cleanup.scan_id.trim() !== ""
+      ? cleanup.scan_id
+      : null;
+  const scanId = nestedScanId || topLevelScanId;
+  if (!scanId) return cleanup;
+  const { scan_id: _unused, ...rest } = cleanup;
+  return { ...rest, scanId };
+}
+
 // --- Vault integration: scan mounts for inventory/expirations ---
 router.post(
   "/api/v1/integrations/vault/scan",
@@ -432,21 +453,19 @@ router.post(
         cleanup,
         scan_id: scanId,
       } = req.body || {};
-      if (!Array.isArray(items) || items.length === 0) {
-        return res.status(400).json({ error: "items array required" });
-      }
-      const cleanupError = validateCleanupRequest(
-        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
-          ? { ...cleanup, scanId }
-          : cleanup,
-      );
+      const effectiveCleanup = resolveEffectiveCleanup(cleanup, scanId);
+      const cleanupError = validateCleanupRequest(effectiveCleanup);
       if (cleanupError) {
         return res.status(400).json({ error: cleanupError });
       }
-      const effectiveCleanup =
-        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
-          ? { ...cleanup, scanId }
-          : cleanup;
+      // A complete scan that legitimately finds zero items is still a real
+      // cleanup-driving result (see importCleanup.js), so an empty items
+      // array is only rejected when cleanup isn't the reason for the call.
+      const cleanupWillRun =
+        effectiveCleanup && effectiveCleanup.enabled === true;
+      if (!Array.isArray(items) || (items.length === 0 && !cleanupWillRun)) {
+        return res.status(400).json({ error: "items array required" });
+      }
 
       // Bind each submitted item to the scan that actually discovered it
       // (metadata-only integration_scan_items rows), so provenance comes
@@ -2095,25 +2114,23 @@ router.post(
         cleanup,
         scan_id: scanId,
       } = req.body || {};
-      if (!Array.isArray(items) || items.length === 0) {
-        return res.status(400).json({ error: "items array required" });
+      const effectiveCleanup = resolveEffectiveCleanup(cleanup, scanId);
+      const cleanupError = validateCleanupRequest(effectiveCleanup);
+      if (cleanupError) {
+        return res.status(400).json({ error: cleanupError });
       }
       const filterRulesError = validateFilterRules(filterRules);
       if (filterRulesError) {
         return res.status(400).json({ error: filterRulesError });
       }
-      const cleanupError = validateCleanupRequest(
-        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
-          ? { ...cleanup, scanId }
-          : cleanup,
-      );
-      if (cleanupError) {
-        return res.status(400).json({ error: cleanupError });
+      // A complete scan that legitimately finds zero items is still a real
+      // cleanup-driving result (see importCleanup.js), so an empty items
+      // array is only rejected when cleanup isn't the reason for the call.
+      const cleanupWillRun =
+        effectiveCleanup && effectiveCleanup.enabled === true;
+      if (!Array.isArray(items) || (items.length === 0 && !cleanupWillRun)) {
+        return res.status(400).json({ error: "items array required" });
       }
-      const effectiveCleanup =
-        cleanup && cleanup.enabled === true && !cleanup.scanId && scanId
-          ? { ...cleanup, scanId }
-          : cleanup;
       // Issue #69: apply include/exclude rules at import time too, so
       // auto-sync (which posts scan items here) honors the same rules.
       const { items: itemsToImport, excludedCount: filteredOutCount } =

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -864,6 +864,38 @@ router.post(
       });
       applyScanFilterRulesToResult(filterRules, result);
 
+      // Persist this scan as the backend-authoritative record. Host
+      // anchors the instance so two self-hosted GitLab servers with
+      // colliding numeric user/project/group ids never share a cleanup
+      // scope.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId && result.host && result.ownerKey) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "gitlab",
+            identityContext: { host: result.host, ownerKey: result.ownerKey },
+            createdBy: req.user?.id || null,
+            items: (result.items || []).map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {},
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: {},
+              complete: s.complete === true,
+              reason: s.error ? "error" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("GitLab scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
+
       res.json(withQuota(result));
       try {
         if (req && req.user) {
@@ -1049,6 +1081,37 @@ router.post(
         maxItems: maxItems || 500,
       });
       applyScanFilterRulesToResult(filterRules, result);
+
+      // Persist this scan as the backend-authoritative record. Host
+      // anchors the instance so two GitHub Enterprise servers with
+      // colliding numeric user/repo ids never share a cleanup scope.
+      try {
+        const workspaceId = req.workspace?.id || req.integrationQuota?.workspaceId;
+        if (workspaceId && result.host && result.ownerKey) {
+          const scan = await persistScan({
+            workspaceId,
+            provider: "github",
+            identityContext: { host: result.host, ownerKey: result.ownerKey },
+            createdBy: req.user?.id || null,
+            items: (result.items || []).map((item) => ({
+              sourceKind: item.sourceKind,
+              sourceObjectId: item.sourceObjectId,
+              dimensions: {},
+            })),
+            subScopes: (result.summary || []).map((s) => ({
+              sourceKind: s.sourceKind,
+              dimensions: {},
+              complete: s.complete === true,
+              reason: s.error ? "error" : null,
+            })),
+          });
+          result.scan_id = scan.scanId;
+        }
+      } catch (scanPersistErr) {
+        logger.warn("GitHub scan persistence failed (cleanup will be unavailable for this scan)", {
+          error: scanPersistErr.message,
+        });
+      }
 
       res.json(withQuota(result));
       try {

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -383,10 +383,19 @@ router.post(
         return res.status(403).json({ error: "Forbidden" });
       }
       const workspaceId = req.workspace.id;
-      const { items, default_category, default_type, contact_group_id } =
-        req.body || {};
+      const {
+        items,
+        default_category,
+        default_type,
+        contact_group_id,
+        cleanup,
+      } = req.body || {};
       if (!Array.isArray(items) || items.length === 0) {
         return res.status(400).json({ error: "items array required" });
+      }
+      const cleanupError = validateCleanupRequest(cleanup);
+      if (cleanupError) {
+        return res.status(400).json({ error: cleanupError });
       }
       // Reuse core validation constraints for type/category; allow past expiration for imports
       const ALLOWED_TYPES = [
@@ -602,6 +611,32 @@ router.post(
           });
         }
       }
+      // Remove previously imported tokens that are no longer present at the
+      // source. Opt-in via the `cleanup` payload; scoped to the provider
+      // prefix and the source kinds included in this scan. Only attempted
+      // when the scan returned at least one item, so an empty/broken scan
+      // can never mass-delete a workspace.
+      let cleanupDeleted = [];
+      if (cleanup && cleanup.enabled === true) {
+        try {
+          const cleanupResult = await cleanupObsoleteTokens({
+            workspaceId,
+            actorUserId: req.user.id,
+            cleanup,
+            reason:
+              cleanup.reason === "auto_sync_cleanup"
+                ? "auto_sync_cleanup"
+                : "import_cleanup",
+          });
+          cleanupDeleted = cleanupResult.deleted;
+        } catch (cleanupErr) {
+          logger.error("Obsolete token cleanup failed", {
+            error: cleanupErr.message,
+            workspaceId,
+          });
+        }
+      }
+
       // Batch audit summary (best-effort)
       try {
         await writeAudit({
@@ -619,6 +654,7 @@ router.post(
             ...(errors.length > 0
               ? { errors: summarizeImportErrors(errors) }
               : {}),
+            deleted_count: cleanupDeleted.length,
             source: "vault",
           },
         });
@@ -629,6 +665,8 @@ router.post(
         created_count: created.length,
         updated_count: updated.length,
         error_count: errors.length,
+        deleted_count: cleanupDeleted.length,
+        deleted: cleanupDeleted,
         created,
         updated,
         errors,

--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -479,8 +479,14 @@ router.post(
           it?.sourceObjectId ||
           String(it?.location || "").replace(/^vault:/, ""),
       }));
+      // The client sends the scan id nested as `cleanup.scanId` (the shape
+      // `effectiveCleanup` normalizes into), not as a bare top-level
+      // `scan_id`/`scanId` -- so binding must use the resolved value, or
+      // every import silently fails to bind and every token stays
+      // unattributed (permanently cleanup-ineligible) regardless of the
+      // cleanup checkbox.
       const { resolveForItem } = await bindImportItemsToScan({
-        scanId: scanId || null,
+        scanId: effectiveCleanup?.scanId || scanId || null,
         workspaceId,
         provider: "vault",
         pairs: bindingPairs,
@@ -2168,8 +2174,11 @@ router.post(
           });
         });
         try {
+          // See the vault/import route above: the client sends the scan id
+          // nested as `cleanup.scanId`, so binding must use the resolved
+          // `effectiveCleanup.scanId`, not the always-empty top-level field.
           const { resolveForItem } = await bindImportItemsToScan({
-            scanId: scanId || null,
+            scanId: effectiveCleanup?.scanId || scanId || null,
             workspaceId,
             provider,
             pairs,

--- a/apps/api/services/awsIntegration.js
+++ b/apps/api/services/awsIntegration.js
@@ -277,10 +277,15 @@ async function scanAWSSingleRegion({
         secrets.push(...(listResponse.SecretList || []));
         secretsNextToken = listResponse.NextToken;
       } while (secretsNextToken && secrets.length < maxItems);
+      // If a NextToken is still present when we stop, the account has more
+      // secrets than maxItems allowed us to enumerate -- this sub-scope did
+      // not see the whole region and must not be reported complete.
+      const secretsListTruncated = Boolean(secretsNextToken);
       logger.info("AWS Secrets Manager list response", {
         region,
         totalSecretsFound: secrets.length,
         maxItems,
+        truncated: secretsListTruncated,
       });
 
       let describedCount = 0;
@@ -336,6 +341,11 @@ async function scanAWSSingleRegion({
       const secretsCount = items.filter(
         (item) => item.source === "aws-secrets-manager",
       ).length;
+      // Truncated if: (a) NextToken remained (more secrets exist upstream
+      // than we listed), or (b) we found more secrets than maxItems allowed
+      // us to describe/import.
+      const secretsTruncated =
+        secretsListTruncated || secrets.length > maxItems;
       // A DescribeSecret failure means that secret's continued existence is
       // unconfirmed, not confirmed-deleted -- this region+service sub-scope
       // must be reported incomplete so cleanup never treats a describe
@@ -347,7 +357,8 @@ async function scanAWSSingleRegion({
         service: "secrets_manager",
         found: secretsCount,
         failedCount,
-        complete: failedCount === 0,
+        truncated: secretsTruncated,
+        complete: failedCount === 0 && !secretsTruncated,
       });
       logger.info("AWS Secrets Manager scan completed", {
         found: secretsCount,
@@ -414,9 +425,14 @@ async function scanAWSSingleRegion({
         certificates.push(...(listResponse.CertificateSummaryList || []));
         acmNextToken = listResponse.NextToken;
       } while (acmNextToken && certificates.length < acmMaxItems);
+      // If a NextToken remains, the account has more certificates than
+      // acmMaxItems allowed us to enumerate -- this sub-scope did not see
+      // the whole region.
+      const certsListTruncated = Boolean(acmNextToken);
       logger.info("AWS ACM list response", {
         region,
         totalCertificatesFound: certificates.length,
+        truncated: certsListTruncated,
       });
 
       let describedCount = 0;
@@ -495,6 +511,8 @@ async function scanAWSSingleRegion({
       const certsCount = items.filter(
         (item) => item.source === "aws-acm",
       ).length;
+      const certsTruncated =
+        certsListTruncated || certificates.length > maxItems;
       summary.push({
         type: "acm_certificates",
         sourceKind: "aws-acm",
@@ -502,7 +520,8 @@ async function scanAWSSingleRegion({
         service: "acm_certificates",
         found: certsCount,
         failedCount,
-        complete: failedCount === 0,
+        truncated: certsTruncated,
+        complete: failedCount === 0 && !certsTruncated,
       });
       logger.info("AWS ACM scan completed", {
         found: certsCount,
@@ -556,14 +575,21 @@ async function scanAWSSingleRegion({
           ? usersResponse.Marker
           : undefined;
       } while (usersMarker && users.length < maxItems);
+      // If a Marker remains, IAM has more users than maxItems allowed us to
+      // enumerate -- some users' keys were never even attempted.
+      const usersListTruncated = Boolean(usersMarker);
       let iamKeysCount = 0;
       let iamListFailedCount = 0;
+      let usersSkippedByCap = 0;
       const BATCH_SIZE = 10;
 
       // Scan IAM keys independently of items from other services
       // Apply maxItems limit per-service to ensure each service gets fair representation
       for (let i = 0; i < users.length; i += BATCH_SIZE) {
-        if (iamKeysCount >= maxItems) break;
+        if (iamKeysCount >= maxItems) {
+          usersSkippedByCap += users.length - i;
+          break;
+        }
         const batch = users.slice(i, i + BATCH_SIZE);
 
         await Promise.all(
@@ -633,13 +659,16 @@ async function scanAWSSingleRegion({
       // IAM keys are global, not per-region, so this sub-scope's dimensions
       // omit `region` entirely -- a token here is never partitioned by
       // which region happened to be selected for the rest of the scan.
+      const iamTruncated =
+        usersListTruncated || usersSkippedByCap > 0 || iamKeysCount >= maxItems;
       summary.push({
         type: "iam_keys",
         sourceKind: "aws-iam-key",
         service: "iam_keys",
         found: iamKeysCount,
         failedCount: iamListFailedCount,
-        complete: iamListFailedCount === 0,
+        truncated: iamTruncated,
+        complete: iamListFailedCount === 0 && !iamTruncated,
       });
       logger.info("AWS IAM scan completed", { found: iamKeysCount });
     } catch (e) {

--- a/apps/api/services/awsIntegration.js
+++ b/apps/api/services/awsIntegration.js
@@ -97,8 +97,17 @@ async function scanAWS({
     throw new Error("maxItems must be between 1 and 2000");
   }
 
+  // STS account id is the immutable identity cleanup scopes against (see
+  // sourceIdentity.js) -- resolved once up front so a single scan/import
+  // round-trip never has to guess it from unrelated API responses.
+  const accountId = await getAccountId({
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+  });
+
   // Single region scan only
-  return await scanAWSSingleRegion({
+  const result = await scanAWSSingleRegion({
     accessKeyId,
     secretAccessKey,
     sessionToken,
@@ -106,6 +115,70 @@ async function scanAWS({
     include,
     maxItems,
   });
+  return { ...result, accountId };
+}
+
+async function getAccountId({ accessKeyId, secretAccessKey, sessionToken }) {
+  try {
+    const { STSClient, GetCallerIdentityCommand } = require("@aws-sdk/client-sts");
+    const client = new STSClient({
+      region: "us-east-1",
+      credentials: { accessKeyId, secretAccessKey, sessionToken },
+      requestHandler: createDetectRequestHandler(),
+    });
+    const identity = await client.send(new GetCallerIdentityCommand({}));
+    if (!identity.Account) {
+      throw new Error("STS GetCallerIdentity returned no Account");
+    }
+    return identity.Account;
+  } catch (e) {
+    // The account id anchors every AWS token's provenance; without it there
+    // is no safe instance/ownerKey to attribute this scan's tokens to, so a
+    // scan that can't resolve it must fail outright rather than silently
+    // produce unattributed (and therefore cleanup-ineligible) results.
+    const err = new Error(`Failed to resolve AWS account id via STS: ${e.message}`);
+    err.status = e.status || 401;
+    throw err;
+  }
+}
+
+// Enumerates regions actually enabled for this account via EC2
+// DescribeRegions instead of a hardcoded list, so newly-launched AWS
+// regions and accounts that opted out of "all regions" both scan exactly
+// their real footprint. Falls back to the hardcoded list (with an explicit
+// `usedFallbackList: true` flag) only if EC2 access itself fails, so a scan
+// missing an intended region is always visible in scan output rather than
+// silently narrowed.
+async function listEnabledAWSRegions({
+  accessKeyId,
+  secretAccessKey,
+  sessionToken,
+}) {
+  try {
+    const { EC2Client, DescribeRegionsCommand } = require("@aws-sdk/client-ec2");
+    const client = new EC2Client({
+      region: "us-east-1",
+      credentials: { accessKeyId, secretAccessKey, sessionToken },
+      requestHandler: createDetectRequestHandler(),
+    });
+    const res = await client.send(
+      new DescribeRegionsCommand({ AllRegions: false }),
+    );
+    const regions = (res.Regions || [])
+      .map((r) => r.RegionName)
+      .filter(Boolean)
+      .sort();
+    if (regions.length === 0) {
+      throw new Error("DescribeRegions returned no regions");
+    }
+    return { regions, usedFallbackList: false };
+  } catch (e) {
+    logger.warn(
+      "EC2 DescribeRegions failed; falling back to hardcoded region list",
+      { error: e.message },
+    );
+    return { regions: [...ALL_AWS_REGIONS], usedFallbackList: true };
+  }
 }
 
 // Internal function to scan a single AWS region
@@ -242,6 +315,8 @@ async function scanAWSSingleRegion({
                 last_used_at: desc.LastAccessedDate
                   ? new Date(desc.LastAccessedDate).toISOString()
                   : null,
+                sourceKind: "aws-secrets-manager",
+                sourceObjectId: secret.ARN,
               });
               describedCount++;
             } catch (e) {
@@ -261,7 +336,19 @@ async function scanAWSSingleRegion({
       const secretsCount = items.filter(
         (item) => item.source === "aws-secrets-manager",
       ).length;
-      summary.push({ type: "secrets_manager", found: secretsCount });
+      // A DescribeSecret failure means that secret's continued existence is
+      // unconfirmed, not confirmed-deleted -- this region+service sub-scope
+      // must be reported incomplete so cleanup never treats a describe
+      // failure as "not rediscovered, therefore obsolete".
+      summary.push({
+        type: "secrets_manager",
+        sourceKind: "aws-secrets-manager",
+        region,
+        service: "secrets_manager",
+        found: secretsCount,
+        failedCount,
+        complete: failedCount === 0,
+      });
       logger.info("AWS Secrets Manager scan completed", {
         found: secretsCount,
         described: describedCount,
@@ -275,7 +362,14 @@ async function scanAWSSingleRegion({
         errorName: e.name,
         region,
       });
-      summary.push({ type: "secrets_manager", error: e.message });
+      summary.push({
+        type: "secrets_manager",
+        sourceKind: "aws-secrets-manager",
+        region,
+        service: "secrets_manager",
+        error: e.message,
+        complete: false,
+      });
     }
   }
 
@@ -381,6 +475,8 @@ async function scanAWSSingleRegion({
                   : null,
                 // Store status and in_use in notes/description since they're not standard fields
                 description: `Status: ${certificate.Status || "Unknown"}. In use: ${certificate.InUseBy && certificate.InUseBy.length > 0 ? "Yes" : "No"}`,
+                sourceKind: "aws-acm",
+                sourceObjectId: cert.CertificateArn,
               });
               describedCount++;
             } catch (e) {
@@ -399,7 +495,15 @@ async function scanAWSSingleRegion({
       const certsCount = items.filter(
         (item) => item.source === "aws-acm",
       ).length;
-      summary.push({ type: "acm_certificates", found: certsCount });
+      summary.push({
+        type: "acm_certificates",
+        sourceKind: "aws-acm",
+        region,
+        service: "acm_certificates",
+        found: certsCount,
+        failedCount,
+        complete: failedCount === 0,
+      });
       logger.info("AWS ACM scan completed", {
         found: certsCount,
         described: describedCount,
@@ -413,7 +517,14 @@ async function scanAWSSingleRegion({
         errorName: e.name,
         region,
       });
-      summary.push({ type: "acm_certificates", error: e.message });
+      summary.push({
+        type: "acm_certificates",
+        sourceKind: "aws-acm",
+        region,
+        service: "acm_certificates",
+        error: e.message,
+        complete: false,
+      });
     }
   }
 
@@ -446,6 +557,7 @@ async function scanAWSSingleRegion({
           : undefined;
       } while (usersMarker && users.length < maxItems);
       let iamKeysCount = 0;
+      let iamListFailedCount = 0;
       const BATCH_SIZE = 10;
 
       // Scan IAM keys independently of items from other services
@@ -502,10 +614,13 @@ async function scanAWSSingleRegion({
                     ? new Date(key.CreateDate).toISOString()
                     : null,
                   last_used_at: lastUsedAt,
+                  sourceKind: "aws-iam-key",
+                  sourceObjectId: key.AccessKeyId,
                 });
                 iamKeysCount++;
               }
             } catch (e) {
+              iamListFailedCount++;
               logger.warn("Failed to list IAM keys for user", {
                 userName: user.UserName,
                 error: e.message,
@@ -515,11 +630,27 @@ async function scanAWSSingleRegion({
           }),
         );
       }
-      summary.push({ type: "iam_keys", found: iamKeysCount });
+      // IAM keys are global, not per-region, so this sub-scope's dimensions
+      // omit `region` entirely -- a token here is never partitioned by
+      // which region happened to be selected for the rest of the scan.
+      summary.push({
+        type: "iam_keys",
+        sourceKind: "aws-iam-key",
+        service: "iam_keys",
+        found: iamKeysCount,
+        failedCount: iamListFailedCount,
+        complete: iamListFailedCount === 0,
+      });
       logger.info("AWS IAM scan completed", { found: iamKeysCount });
     } catch (e) {
       logger.error("AWS IAM scan failed", { error: e.message, region });
-      summary.push({ type: "iam_keys", error: e.message });
+      summary.push({
+        type: "iam_keys",
+        sourceKind: "aws-iam-key",
+        service: "iam_keys",
+        error: e.message,
+        complete: false,
+      });
     }
   }
 
@@ -551,9 +682,7 @@ async function detectAWSRegions({
     throw new Error("Invalid sessionToken format");
   }
 
-  logger.info("Starting AWS region detection", {
-    totalRegions: ALL_AWS_REGIONS.length,
-  });
+  logger.info("Starting AWS region detection");
 
   // Try to load AWS SDK
   let SecretsManagerClient, ListSecretsCommand;
@@ -601,6 +730,7 @@ async function detectAWSRegions({
   const results = [];
   let iamKeysCount = 0;
   let iamUsersCount = 0;
+  let accountId = null;
 
   // First, validate credentials using STS GetCallerIdentity
   // This is the standard AWS way to validate credentials - works with any valid credentials
@@ -613,6 +743,7 @@ async function detectAWSRegions({
         requestHandler: createDetectRequestHandler(),
       });
       const identity = await stsClient.send(new GetCallerIdentityCommand({}));
+      accountId = identity.Account || null;
       logger.info("AWS credentials validated", {
         account: identity.Account,
         arn: identity.Arn,
@@ -757,9 +888,16 @@ async function detectAWSRegions({
     }
   };
 
+  // Enumerate regions actually enabled for this account (EC2
+  // DescribeRegions) instead of iterating a static hardcoded list, so a
+  // newly-launched AWS region or an account that opted out of "all
+  // regions" both scan exactly their real footprint.
+  const { regions: regionsToCheck, usedFallbackList } =
+    await listEnabledAWSRegions({ accessKeyId, secretAccessKey, sessionToken });
+
   // Process regions in batches to avoid overwhelming the API
-  for (let i = 0; i < ALL_AWS_REGIONS.length; i += DETECT_REGION_BATCH_SIZE) {
-    const batch = ALL_AWS_REGIONS.slice(i, i + DETECT_REGION_BATCH_SIZE);
+  for (let i = 0; i < regionsToCheck.length; i += DETECT_REGION_BATCH_SIZE) {
+    const batch = regionsToCheck.slice(i, i + DETECT_REGION_BATCH_SIZE);
     await Promise.all(
       batch.map((region) =>
         withWallClockTimeout(
@@ -826,7 +964,8 @@ async function detectAWSRegions({
   }
 
   logger.info("AWS region detection completed", {
-    totalRegions: ALL_AWS_REGIONS.length,
+    totalRegionsChecked: regionsToCheck.length,
+    usedFallbackList,
     regionsWithSecrets: regionsWithSecrets.length,
     regionsWithCertificates: regionsWithCertificates.length,
     iamUsers: iamUsersCount,
@@ -839,8 +978,11 @@ async function detectAWSRegions({
   );
 
   return {
+    accountId,
     regionsWithSecrets: regionsWithSecrets.sort(),
     regionsWithCertificates: regionsWithCertificates.sort(),
+    regionsChecked: regionsToCheck.sort(),
+    usedFallbackRegionList: usedFallbackList,
     allResults: relevantResults, // Only regions with resources or errors
     iam: {
       usersCount: iamUsersCount,
@@ -856,11 +998,15 @@ async function detectAWSRegions({
 module.exports = {
   scanAWS,
   detectAWSRegions,
+  listEnabledAWSRegions,
+  getAccountId,
 };
 
 // Test-only exports for unit coverage (when AWS SDK is available)
 if (process.env.NODE_ENV === "test") {
   module.exports._test = {
-    // AWS SDK-dependent functions would be exported here if needed for testing
+    listEnabledAWSRegions,
+    getAccountId,
+    ALL_AWS_REGIONS,
   };
 }

--- a/apps/api/services/azureADIntegration.js
+++ b/apps/api/services/azureADIntegration.js
@@ -275,9 +275,17 @@ async function scanAzureAD({
           await listApplications({ token: cleanToken, maxItems });
         let secretsCount = 0;
         let certsCount = 0;
+        let appsBudgetExhausted = false;
 
         for (const app of apps) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            // The shared cross-type item budget ran out before every listed
+            // application's credentials were inspected -- some apps here
+            // were never even attempted, so this cannot be "complete" even
+            // though listApplications() itself paginated fine.
+            appsBudgetExhausted = true;
+            break;
+          }
 
           logger.debug("Azure AD app credentials", {
             appId: app.appId,
@@ -353,8 +361,8 @@ async function scanAzureAD({
           found: apps.length,
           secrets: secretsCount,
           certificates: certsCount,
-          truncated: appsTruncated,
-          complete: !appsTruncated,
+          truncated: appsTruncated || appsBudgetExhausted,
+          complete: !appsTruncated && !appsBudgetExhausted,
         });
         summary.push({
           type: "applications",
@@ -362,8 +370,8 @@ async function scanAzureAD({
           found: apps.length,
           secrets: secretsCount,
           certificates: certsCount,
-          truncated: appsTruncated,
-          complete: !appsTruncated,
+          truncated: appsTruncated || appsBudgetExhausted,
+          complete: !appsTruncated && !appsBudgetExhausted,
         });
         logger.info("Azure AD applications scan completed", {
           apps: apps.length,
@@ -398,9 +406,13 @@ async function scanAzureAD({
           });
         let secretsCount = 0;
         let certsCount = 0;
+        let spsBudgetExhausted = false;
 
         for (const sp of sps) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            spsBudgetExhausted = true;
+            break;
+          }
 
           // Process passwordCredentials (client secrets)
           for (const cred of sp.passwordCredentials || []) {
@@ -469,8 +481,8 @@ async function scanAzureAD({
           found: sps.length,
           secrets: secretsCount,
           certificates: certsCount,
-          truncated: spsTruncated,
-          complete: !spsTruncated,
+          truncated: spsTruncated || spsBudgetExhausted,
+          complete: !spsTruncated && !spsBudgetExhausted,
         });
         summary.push({
           type: "service_principals",
@@ -478,8 +490,8 @@ async function scanAzureAD({
           found: sps.length,
           secrets: secretsCount,
           certificates: certsCount,
-          truncated: spsTruncated,
-          complete: !spsTruncated,
+          truncated: spsTruncated || spsBudgetExhausted,
+          complete: !spsTruncated && !spsBudgetExhausted,
         });
         logger.info("Azure AD service principals scan completed", {
           sps: sps.length,

--- a/apps/api/services/azureADIntegration.js
+++ b/apps/api/services/azureADIntegration.js
@@ -100,6 +100,7 @@ async function listApplications({ token, maxItems = 500 }) {
   let nextLink = null;
   let pageCount = 0;
   const maxPages = 50;
+  let truncated = false;
 
   do {
     try {
@@ -129,14 +130,17 @@ async function listApplications({ token, maxItems = 500 }) {
       nextLink = data["@odata.nextLink"] || null;
       pageCount++;
 
-      if (apps.length >= maxItems || pageCount >= maxPages) break;
+      if (apps.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextLink) || apps.length > maxItems;
+        break;
+      }
     } catch (e) {
       if (e.status === 404 || e.status === 403) break;
       throw e;
     }
   } while (nextLink && apps.length < maxItems);
 
-  return apps.slice(0, maxItems);
+  return { items: apps.slice(0, maxItems), truncated };
 }
 
 async function listServicePrincipals({ token, maxItems = 500 }) {
@@ -144,6 +148,7 @@ async function listServicePrincipals({ token, maxItems = 500 }) {
   let nextLink = null;
   let pageCount = 0;
   const maxPages = 50;
+  let truncated = false;
 
   do {
     try {
@@ -171,14 +176,17 @@ async function listServicePrincipals({ token, maxItems = 500 }) {
       nextLink = data["@odata.nextLink"] || null;
       pageCount++;
 
-      if (sps.length >= maxItems || pageCount >= maxPages) break;
+      if (sps.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextLink) || sps.length > maxItems;
+        break;
+      }
     } catch (e) {
       if (e.status === 404 || e.status === 403) break;
       throw e;
     }
   } while (nextLink && sps.length < maxItems);
 
-  return sps.slice(0, maxItems);
+  return { items: sps.slice(0, maxItems), truncated };
 }
 
 async function scanAzureAD({
@@ -233,6 +241,19 @@ async function scanAzureAD({
     logger.warn("Failed to decode token claims", { error: e.message });
   }
 
+  // The tenant id anchors every Azure AD token's provenance (see
+  // sourceIdentity.js); it comes from the token's own `tid` claim rather
+  // than a caller-supplied value, since a caller cannot be trusted to
+  // correctly attribute which tenant a given app registration belongs to.
+  const tenantId = tokenClaims?.tid || null;
+  if (!tenantId) {
+    const err = new Error(
+      "Azure AD token is missing a tenant id (tid claim); cannot safely attribute scan results",
+    );
+    err.status = 401;
+    throw err;
+  }
+
   logger.info("Starting Azure AD scan", {
     maxItems,
     includeApps: include.applications,
@@ -250,7 +271,8 @@ async function scanAzureAD({
     // Scan Applications
     if (include.applications) {
       try {
-        const apps = await listApplications({ token: cleanToken, maxItems });
+        const { items: apps, truncated: appsTruncated } =
+          await listApplications({ token: cleanToken, maxItems });
         let secretsCount = 0;
         let certsCount = 0;
 
@@ -277,6 +299,8 @@ async function scanAzureAD({
 
             items.push({
               source: "azure-ad-client-secret",
+              sourceKind: "azure-ad-client-secret",
+              sourceObjectId: `${app.appId}:${cred.keyId}`,
               name: `${app.displayName || app.appId}/${cred.displayName || cred.hint || "Secret"}`,
               category: "key_secret",
               type: "api_key",
@@ -304,6 +328,8 @@ async function scanAzureAD({
 
             items.push({
               source: "azure-ad-certificate",
+              sourceKind: "azure-ad-certificate",
+              sourceObjectId: `${app.appId}:${cert.keyId}`,
               name: `${app.displayName || app.appId}/${cert.displayName || "Certificate"}`,
               category: "cert",
               type: "ssl_cert",
@@ -323,9 +349,21 @@ async function scanAzureAD({
 
         summary.push({
           type: "applications",
+          sourceKind: "azure-ad-client-secret",
           found: apps.length,
           secrets: secretsCount,
           certificates: certsCount,
+          truncated: appsTruncated,
+          complete: !appsTruncated,
+        });
+        summary.push({
+          type: "applications",
+          sourceKind: "azure-ad-certificate",
+          found: apps.length,
+          secrets: secretsCount,
+          certificates: certsCount,
+          truncated: appsTruncated,
+          complete: !appsTruncated,
         });
         logger.info("Azure AD applications scan completed", {
           apps: apps.length,
@@ -335,17 +373,29 @@ async function scanAzureAD({
         });
       } catch (e) {
         logger.error("Azure AD applications scan failed", { error: e.message });
-        summary.push({ type: "applications", error: e.message });
+        summary.push({
+          type: "applications",
+          sourceKind: "azure-ad-client-secret",
+          error: e.message,
+          complete: false,
+        });
+        summary.push({
+          type: "applications",
+          sourceKind: "azure-ad-certificate",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
     // Scan Service Principals
     if (include.servicePrincipals) {
       try {
-        const sps = await listServicePrincipals({
-          token: cleanToken,
-          maxItems,
-        });
+        const { items: sps, truncated: spsTruncated } =
+          await listServicePrincipals({
+            token: cleanToken,
+            maxItems,
+          });
         let secretsCount = 0;
         let certsCount = 0;
 
@@ -365,6 +415,8 @@ async function scanAzureAD({
 
             items.push({
               source: "azure-ad-sp-secret",
+              sourceKind: "azure-ad-sp-secret",
+              sourceObjectId: `${sp.appId}:${cred.keyId}`,
               name: `${sp.displayName || sp.appId}/SP/${cred.displayName || cred.hint || "Secret"}`,
               category: "key_secret",
               type: "api_key",
@@ -392,6 +444,8 @@ async function scanAzureAD({
 
             items.push({
               source: "azure-ad-sp-certificate",
+              sourceKind: "azure-ad-sp-certificate",
+              sourceObjectId: `${sp.appId}:${cert.keyId}`,
               name: `${sp.displayName || sp.appId}/SP/${cert.displayName || "Certificate"}`,
               category: "cert",
               type: "ssl_cert",
@@ -411,9 +465,21 @@ async function scanAzureAD({
 
         summary.push({
           type: "service_principals",
+          sourceKind: "azure-ad-sp-secret",
           found: sps.length,
           secrets: secretsCount,
           certificates: certsCount,
+          truncated: spsTruncated,
+          complete: !spsTruncated,
+        });
+        summary.push({
+          type: "service_principals",
+          sourceKind: "azure-ad-sp-certificate",
+          found: sps.length,
+          secrets: secretsCount,
+          certificates: certsCount,
+          truncated: spsTruncated,
+          complete: !spsTruncated,
         });
         logger.info("Azure AD service principals scan completed", {
           sps: sps.length,
@@ -424,12 +490,23 @@ async function scanAzureAD({
         logger.error("Azure AD service principals scan failed", {
           error: e.message,
         });
-        summary.push({ type: "service_principals", error: e.message });
+        summary.push({
+          type: "service_principals",
+          sourceKind: "azure-ad-sp-secret",
+          error: e.message,
+          complete: false,
+        });
+        summary.push({
+          type: "service_principals",
+          sourceKind: "azure-ad-sp-certificate",
+          error: e.message,
+          complete: false,
+        });
       }
     }
   } catch (e) {
     logger.error("Azure AD scan failed", { error: e.message });
-    summary.push({ type: "scan", error: e.message });
+    summary.push({ type: "scan", error: e.message, complete: false });
   }
 
   // If all scan types failed with authentication errors, throw instead of returning partial results
@@ -454,7 +531,7 @@ async function scanAzureAD({
     summaryCount: summary.length,
     items: items.map((i) => ({ name: i.name, type: i.type, source: i.source })),
   });
-  return { items, summary };
+  return { items, summary, tenantId };
 }
 
 module.exports = {

--- a/apps/api/services/azureIntegration.js
+++ b/apps/api/services/azureIntegration.js
@@ -299,9 +299,18 @@ async function scanAzure({
         const seenSecrets = new Set();
         const BATCH_SIZE = 10;
         let describeFailedCount = 0;
+        let secretsBudgetExhausted = false;
 
         for (let i = 0; i < secretList.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            // The shared cross-type item budget ran out before this
+            // sub-scope finished processing its own listed secrets --
+            // report incomplete even though listSecrets() itself paginated
+            // fine, since some listed secrets here were never even
+            // attempted.
+            secretsBudgetExhausted = true;
+            break;
+          }
           const batch = secretList.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -403,8 +412,11 @@ async function scanAzure({
           sourceKind: "azure-key-vault-secret",
           found: secretsFound,
           failedCount: describeFailedCount,
-          truncated: secretsTruncated,
-          complete: describeFailedCount === 0 && !secretsTruncated,
+          truncated: secretsTruncated || secretsBudgetExhausted,
+          complete:
+            describeFailedCount === 0 &&
+            !secretsTruncated &&
+            !secretsBudgetExhausted,
         });
         logger.info("Azure secrets scan completed", {
           found: secretsFound,
@@ -437,9 +449,13 @@ async function scanAzure({
         const seenCertificates = new Set();
         const BATCH_SIZE = 10;
         let describeFailedCount = 0;
+        let certsBudgetExhausted = false;
 
         for (let i = 0; i < certificateList.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            certsBudgetExhausted = true;
+            break;
+          }
           const batch = certificateList.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -560,8 +576,11 @@ async function scanAzure({
           sourceKind: "azure-key-vault-certificate",
           found: certsFound,
           failedCount: describeFailedCount,
-          truncated: certsTruncated,
-          complete: describeFailedCount === 0 && !certsTruncated,
+          truncated: certsTruncated || certsBudgetExhausted,
+          complete:
+            describeFailedCount === 0 &&
+            !certsTruncated &&
+            !certsBudgetExhausted,
         });
         logger.info("Azure certificates scan completed", {
           found: certsFound,
@@ -589,9 +608,13 @@ async function scanAzure({
 
         // Deduplicate - keep only latest version of each key
         const seenKeys = new Set();
+        let keysBudgetExhausted = false;
 
         for (const key of keyList) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            keysBudgetExhausted = true;
+            break;
+          }
 
           // Extract key name from identifier URL (remove version if present)
           // The keys list API returns the identifier in `kid` (not `id`):
@@ -655,8 +678,8 @@ async function scanAzure({
           type: "keys",
           sourceKind: "azure-key-vault-key",
           found: keysFound,
-          truncated: keysTruncated,
-          complete: !keysTruncated,
+          truncated: keysTruncated || keysBudgetExhausted,
+          complete: !keysTruncated && !keysBudgetExhausted,
         });
         logger.info("Azure keys scan completed", {
           found: keysFound,

--- a/apps/api/services/azureIntegration.js
+++ b/apps/api/services/azureIntegration.js
@@ -86,6 +86,11 @@ async function listSecrets({ vaultUrl, token, maxItems = 500 }) {
   let nextLink = null;
   let pageCount = 0;
   const maxPages = 50;
+  // truncated tracks "there was more to see than we looked at" -- distinct
+  // from a 404/403 on the collection itself, which means "nothing here",
+  // not "couldn't finish". A truncated listing must never gate cleanup as
+  // if this source kind were fully enumerated.
+  let truncated = false;
 
   do {
     try {
@@ -104,14 +109,17 @@ async function listSecrets({ vaultUrl, token, maxItems = 500 }) {
       nextLink = data.nextLink || null;
       pageCount++;
 
-      if (secrets.length >= maxItems || pageCount >= maxPages) break;
+      if (secrets.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextLink) || secrets.length > maxItems;
+        break;
+      }
     } catch (e) {
       if (e.status === 404 || e.status === 403) break;
       throw e;
     }
   } while (nextLink && secrets.length < maxItems);
 
-  return secrets.slice(0, maxItems);
+  return { items: secrets.slice(0, maxItems), truncated };
 }
 
 async function _getSecretVersions({ vaultUrl, token, secretName }) {
@@ -152,6 +160,7 @@ async function listCertificates({ vaultUrl, token, maxItems = 500 }) {
   let nextLink = null;
   let pageCount = 0;
   const maxPages = 50;
+  let truncated = false;
 
   do {
     try {
@@ -170,14 +179,17 @@ async function listCertificates({ vaultUrl, token, maxItems = 500 }) {
       nextLink = data.nextLink || null;
       pageCount++;
 
-      if (certificates.length >= maxItems || pageCount >= maxPages) break;
+      if (certificates.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextLink) || certificates.length > maxItems;
+        break;
+      }
     } catch (e) {
       if (e.status === 404 || e.status === 403) break;
       throw e;
     }
   } while (nextLink && certificates.length < maxItems);
 
-  return certificates.slice(0, maxItems);
+  return { items: certificates.slice(0, maxItems), truncated };
 }
 
 async function getCertificate({
@@ -208,6 +220,7 @@ async function listKeys({ vaultUrl, token, maxItems = 500 }) {
   let nextLink = null;
   let pageCount = 0;
   const maxPages = 50;
+  let truncated = false;
 
   do {
     try {
@@ -226,14 +239,17 @@ async function listKeys({ vaultUrl, token, maxItems = 500 }) {
       nextLink = data.nextLink || null;
       pageCount++;
 
-      if (keys.length >= maxItems || pageCount >= maxPages) break;
+      if (keys.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextLink) || keys.length > maxItems;
+        break;
+      }
     } catch (e) {
       if (e.status === 404 || e.status === 403) break;
       throw e;
     }
   } while (nextLink && keys.length < maxItems);
 
-  return keys.slice(0, maxItems);
+  return { items: keys.slice(0, maxItems), truncated };
 }
 
 async function scanAzure({
@@ -269,11 +285,12 @@ async function scanAzure({
     // Scan Secrets
     if (include.secrets) {
       try {
-        const secretList = await listSecrets({
-          vaultUrl: normalizedUrl,
-          token,
-          maxItems,
-        });
+        const { items: secretList, truncated: secretsTruncated } =
+          await listSecrets({
+            vaultUrl: normalizedUrl,
+            token,
+            maxItems,
+          });
         logger.info("Azure secrets list retrieved", {
           count: secretList.length,
         });
@@ -281,6 +298,7 @@ async function scanAzure({
         // Deduplicate - Azure API may return multiple versions, keep only latest
         const seenSecrets = new Set();
         const BATCH_SIZE = 10;
+        let describeFailedCount = 0;
 
         for (let i = 0; i < secretList.length; i += BATCH_SIZE) {
           if (items.length >= maxItems) break;
@@ -322,11 +340,25 @@ async function scanAzure({
               seenSecrets.add(secretName);
 
               // Get full secret details (latest version) to ensure we have expiration
-              const secretDetails = await getSecret({
-                vaultUrl: normalizedUrl,
-                token,
-                secretName,
-              });
+              let secretDetails;
+              try {
+                secretDetails = await getSecret({
+                  vaultUrl: normalizedUrl,
+                  token,
+                  secretName,
+                });
+              } catch (e) {
+                // A failed detail fetch means this secret's continued
+                // existence/expiration is unconfirmed -- count it so the
+                // "secrets" sub-scope is reported incomplete rather than
+                // silently treating the fetch failure as "not present".
+                describeFailedCount++;
+                logger.warn("Failed to get Azure secret details", {
+                  secretName,
+                  error: e.message,
+                });
+                return;
+              }
 
               // Skip disabled secrets
               if (secretDetails?.attributes?.enabled === false) {
@@ -342,6 +374,8 @@ async function scanAzure({
 
               items.push({
                 source: "azure-key-vault-secret",
+                sourceKind: "azure-key-vault-secret",
+                sourceObjectId: secretName,
                 name: secretName,
                 category: "key_secret",
                 type: "secret",
@@ -361,29 +395,40 @@ async function scanAzure({
             }),
           );
         }
+        const secretsFound = items.filter(
+          (i) => i.source === "azure-key-vault-secret",
+        ).length;
         summary.push({
           type: "secrets",
-          found: items.filter((i) => i.source === "azure-key-vault-secret")
-            .length,
+          sourceKind: "azure-key-vault-secret",
+          found: secretsFound,
+          failedCount: describeFailedCount,
+          truncated: secretsTruncated,
+          complete: describeFailedCount === 0 && !secretsTruncated,
         });
         logger.info("Azure secrets scan completed", {
-          found: items.filter((i) => i.source === "azure-key-vault-secret")
-            .length,
+          found: secretsFound,
         });
       } catch (e) {
         logger.error("Azure secrets scan failed", { error: e.message });
-        summary.push({ type: "secrets", error: e.message });
+        summary.push({
+          type: "secrets",
+          sourceKind: "azure-key-vault-secret",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
     // Scan Certificates
     if (include.certificates) {
       try {
-        const certificateList = await listCertificates({
-          vaultUrl: normalizedUrl,
-          token,
-          maxItems,
-        });
+        const { items: certificateList, truncated: certsTruncated } =
+          await listCertificates({
+            vaultUrl: normalizedUrl,
+            token,
+            maxItems,
+          });
         logger.info("Azure certificates list retrieved", {
           count: certificateList.length,
         });
@@ -391,6 +436,7 @@ async function scanAzure({
         // Deduplicate - keep only latest version of each certificate
         const seenCertificates = new Set();
         const BATCH_SIZE = 10;
+        let describeFailedCount = 0;
 
         for (let i = 0; i < certificateList.length; i += BATCH_SIZE) {
           if (items.length >= maxItems) break;
@@ -429,11 +475,21 @@ async function scanAzure({
               seenCertificates.add(certName);
 
               // Get full certificate details (latest version)
-              const certDetails = await getCertificate({
-                vaultUrl: normalizedUrl,
-                token,
-                certificateName: certName,
-              });
+              let certDetails;
+              try {
+                certDetails = await getCertificate({
+                  vaultUrl: normalizedUrl,
+                  token,
+                  certificateName: certName,
+                });
+              } catch (e) {
+                describeFailedCount++;
+                logger.warn("Failed to get Azure certificate details", {
+                  certName,
+                  error: e.message,
+                });
+                return;
+              }
 
               // Skip disabled certificates
               if (certDetails?.attributes?.enabled === false) {
@@ -473,6 +529,8 @@ async function scanAzure({
 
               items.push({
                 source: "azure-key-vault-certificate",
+                sourceKind: "azure-key-vault-certificate",
+                sourceObjectId: certName,
                 name: certName,
                 category: "cert",
                 type: "ssl_cert",
@@ -494,25 +552,35 @@ async function scanAzure({
             }),
           );
         }
+        const certsFound = items.filter(
+          (i) => i.source === "azure-key-vault-certificate",
+        ).length;
         summary.push({
           type: "certificates",
-          found: items.filter((i) => i.source === "azure-key-vault-certificate")
-            .length,
+          sourceKind: "azure-key-vault-certificate",
+          found: certsFound,
+          failedCount: describeFailedCount,
+          truncated: certsTruncated,
+          complete: describeFailedCount === 0 && !certsTruncated,
         });
         logger.info("Azure certificates scan completed", {
-          found: items.filter((i) => i.source === "azure-key-vault-certificate")
-            .length,
+          found: certsFound,
         });
       } catch (e) {
         logger.error("Azure certificates scan failed", { error: e.message });
-        summary.push({ type: "certificates", error: e.message });
+        summary.push({
+          type: "certificates",
+          sourceKind: "azure-key-vault-certificate",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
     // Scan Keys
     if (include.keys) {
       try {
-        const keyList = await listKeys({
+        const { items: keyList, truncated: keysTruncated } = await listKeys({
           vaultUrl: normalizedUrl,
           token,
           maxItems,
@@ -562,6 +630,8 @@ async function scanAzure({
 
           items.push({
             source: "azure-key-vault-key",
+            sourceKind: "azure-key-vault-key",
+            sourceObjectId: keyName,
             name: keyName,
             category: "key_secret",
             type: "encryption_key",
@@ -578,16 +648,27 @@ async function scanAzure({
               : null,
           });
         }
+        const keysFound = items.filter(
+          (i) => i.source === "azure-key-vault-key",
+        ).length;
         summary.push({
           type: "keys",
-          found: items.filter((i) => i.source === "azure-key-vault-key").length,
+          sourceKind: "azure-key-vault-key",
+          found: keysFound,
+          truncated: keysTruncated,
+          complete: !keysTruncated,
         });
         logger.info("Azure keys scan completed", {
-          found: items.filter((i) => i.source === "azure-key-vault-key").length,
+          found: keysFound,
         });
       } catch (e) {
         logger.error("Azure keys scan failed", { error: e.message });
-        summary.push({ type: "keys", error: e.message });
+        summary.push({
+          type: "keys",
+          sourceKind: "azure-key-vault-key",
+          error: e.message,
+          complete: false,
+        });
       }
     }
   } catch (e) {

--- a/apps/api/services/gcpIntegration.js
+++ b/apps/api/services/gcpIntegration.js
@@ -60,6 +60,7 @@ async function listSecrets({ projectId, accessToken, maxItems = 500 }) {
   let nextPageToken = null;
   let pageCount = 0;
   const maxPages = 50;
+  let truncated = false;
 
   do {
     try {
@@ -91,7 +92,10 @@ async function listSecrets({ projectId, accessToken, maxItems = 500 }) {
       nextPageToken = data.nextPageToken || null;
       pageCount++;
 
-      if (secrets.length >= maxItems || pageCount >= maxPages) break;
+      if (secrets.length >= maxItems || pageCount >= maxPages) {
+        truncated = Boolean(nextPageToken) || secrets.length > maxItems;
+        break;
+      }
     } catch (e) {
       // Axios errors have response.status, not status directly
       const status = e.response?.status || e.status;
@@ -105,7 +109,7 @@ async function listSecrets({ projectId, accessToken, maxItems = 500 }) {
     }
   } while (nextPageToken && secrets.length < maxItems);
 
-  return secrets.slice(0, maxItems);
+  return { items: secrets.slice(0, maxItems), truncated };
 }
 
 async function getSecretVersions({ projectId, accessToken, secretId }) {
@@ -210,7 +214,8 @@ async function scanGCP({
     // Scan Secrets
     if (include.secrets) {
       try {
-        const secrets = await listSecrets({ projectId, accessToken, maxItems });
+        const { items: secrets, truncated: secretsTruncated } =
+          await listSecrets({ projectId, accessToken, maxItems });
         logger.info("GCP secrets listed", {
           count: secrets.length,
           firstSecretSample:
@@ -225,6 +230,7 @@ async function scanGCP({
               : null,
         });
 
+        let describeFailedCount = 0;
         const BATCH_SIZE = 10;
         for (let i = 0; i < secrets.length; i += BATCH_SIZE) {
           if (items.length >= maxItems) break;
@@ -233,13 +239,14 @@ async function scanGCP({
           await Promise.all(
             batch.map(async (secret) => {
               if (items.length >= maxItems) return;
+              const secretName = secret.name.split("/").pop();
 
               // Get enabled versions to check expiration
               try {
                 const versions = await getSecretVersions({
                   projectId,
                   accessToken,
-                  secretId: secret.name.split("/").pop(),
+                  secretId: secretName,
                 });
 
                 // Filter for enabled versions and get the latest by version number
@@ -275,7 +282,7 @@ async function scanGCP({
                 }
 
                 logger.debug("GCP secret expiration check", {
-                  secretName: secret.name.split("/").pop(),
+                  secretName,
                   hasSecretExpireTime: !!secret.expireTime,
                   secretExpireTime: secret.expireTime,
                   hasNestedExpiration: !!secret.expiration?.expireTime,
@@ -289,17 +296,26 @@ async function scanGCP({
 
                 items.push({
                   source: "gcp-secret-manager",
-                  name: secret.name.split("/").pop() || secret.name,
+                  sourceKind: "gcp-secret-manager",
+                  sourceObjectId: secretName,
+                  name: secretName || secret.name,
                   category: "key_secret",
                   type: "secret",
                   expiration: expiresAt ? formatDateYmd(expiresAt) : null,
-                  location: `gcp:${projectId}/secrets/${secret.name.split("/").pop()}`,
+                  location: `gcp:${projectId}/secrets/${secretName}`,
                   created_at: secret.createTime || null,
                   updated_at: secret.updateTime || null,
                   version_count: versions.length || 0,
                   enabled_versions: enabledVersions.length || 0,
                 });
               } catch (e) {
+                // A failed version lookup means this secret's expiration
+                // (and, by extension, whether it's genuinely still active)
+                // is unconfirmed -- still record the secret itself (it
+                // demonstrably exists) but count the failure so this scan's
+                // "secrets" sub-scope is reported incomplete rather than
+                // silently treating the lookup failure as fully resolved.
+                describeFailedCount++;
                 logger.warn("Failed to get GCP secret versions", {
                   secretName: secret.name,
                   error: e.message,
@@ -307,11 +323,13 @@ async function scanGCP({
                 // Add secret without expiration if we can't access versions
                 items.push({
                   source: "gcp-secret-manager",
-                  name: secret.name.split("/").pop() || secret.name,
+                  sourceKind: "gcp-secret-manager",
+                  sourceObjectId: secretName,
+                  name: secretName || secret.name,
                   category: "key_secret",
                   type: "secret",
                   expiration: null,
-                  location: `gcp:${projectId}/secrets/${secret.name.split("/").pop()}`,
+                  location: `gcp:${projectId}/secrets/${secretName}`,
                   created_at: secret.createTime || null,
                   updated_at: secret.updateTime || null,
                 });
@@ -319,7 +337,14 @@ async function scanGCP({
             }),
           );
         }
-        summary.push({ type: "secrets", found: secrets.length });
+        summary.push({
+          type: "secrets",
+          sourceKind: "gcp-secret-manager",
+          found: secrets.length,
+          failedCount: describeFailedCount,
+          truncated: secretsTruncated,
+          complete: describeFailedCount === 0 && !secretsTruncated,
+        });
         logger.info("GCP secrets scan completed", {
           secretsFound: secrets.length,
           itemsExtracted: items.length,
@@ -332,14 +357,16 @@ async function scanGCP({
         });
         summary.push({
           type: "secrets",
+          sourceKind: "gcp-secret-manager",
           error: e.message,
           status: e.status || e.response?.status,
+          complete: false,
         });
       }
     }
   } catch (e) {
     logger.error("GCP scan failed", { error: e.message, projectId });
-    summary.push({ type: "scan", error: e.message });
+    summary.push({ type: "scan", error: e.message, complete: false });
   }
 
   // If all scan types failed with authentication errors, throw instead of returning partial results

--- a/apps/api/services/githubIntegration.js
+++ b/apps/api/services/githubIntegration.js
@@ -127,10 +127,18 @@ async function githubRequest({
   }
 }
 
-async function listRepositories({ baseUrl, token, maxItems = 100 }) {
+// Returns `{ repos, truncated }`. `truncated` is true whenever the caller
+// cannot trust that every repository the token can see was actually listed
+// -- either the `maxItems` cap was hit while more pages likely remained, or
+// a page fetch failed partway through pagination. A truncated repo list
+// means every downstream per-repo scan (secrets, deploy keys) is scanning
+// less than the real scope, so those sub-scopes must never be reported
+// complete in that case (see scanGitHub below).
+async function listRepositories({ baseUrl, token, maxItems = 2000 }) {
   const repos = [];
   let page = 1;
   const perPage = Math.min(100, maxItems);
+  let truncated = false;
 
   while (repos.length < maxItems) {
     try {
@@ -146,15 +154,26 @@ async function listRepositories({ baseUrl, token, maxItems = 100 }) {
       if (data.length === 0) break;
 
       repos.push(...data);
+      if (repos.length >= maxItems && data.length === perPage) {
+        // Hit the cap on a full page -- there may be more repos we never
+        // even requested.
+        truncated = true;
+        break;
+      }
       if (data.length < perPage) break;
       page++;
     } catch (e) {
-      if (e.status === 404 || e.status === 403) break;
+      if (e.status === 404 || e.status === 403) {
+        // A 403/404 mid-pagination (rate limit, permission change) means
+        // the repo list itself is incomplete, not merely "no more pages".
+        truncated = true;
+        break;
+      }
       throw e;
     }
   }
 
-  return repos.slice(0, maxItems);
+  return { repos: repos.slice(0, maxItems), truncated };
 }
 
 async function listRepoSecrets({ baseUrl, token, owner, repo }) {
@@ -306,8 +325,12 @@ async function scanGitHub({
       try {
         const sshKeys = await listSSHKeys({ baseUrl: apiBase, token });
         logger.info("GitHub SSH keys retrieved", { count: sshKeys.length });
+        let sshKeysSkippedByCap = 0;
         for (const key of sshKeys) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            sshKeysSkippedByCap++;
+            continue;
+          }
           // GitHub SSH keys don't have expiration dates in the API
           items.push({
             source: "github-ssh-key",
@@ -326,7 +349,8 @@ async function scanGitHub({
           type: "ssh_keys",
           sourceKind: "github-ssh-key",
           found: sshKeys.length,
-          complete: true,
+          truncated: sshKeysSkippedByCap > 0,
+          complete: sshKeysSkippedByCap === 0,
         });
       } catch (e) {
         logger.error("GitHub SSH keys scan failed", {
@@ -363,17 +387,21 @@ async function scanGitHub({
     // Scan Repository Secrets (Actions secrets)
     if (include.secrets) {
       try {
-        const repos = await listRepositories({
-          baseUrl: apiBase,
-          token,
-          maxItems: 100,
-        });
+        const { repos, truncated: reposListTruncated } =
+          await listRepositories({
+            baseUrl: apiBase,
+            token,
+          });
         let secretsCount = 0;
         let reposFailed = 0;
+        let reposSkippedByCap = 0;
         const BATCH_SIZE = 10;
 
         for (let i = 0; i < repos.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            reposSkippedByCap += repos.length - i;
+            break;
+          }
           const batch = repos.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -414,12 +442,19 @@ async function scanGitHub({
             }),
           );
         }
+        // "Complete" requires: the repo list itself was exhaustive, every
+        // repo we did visit succeeded, and the shared item cap never cut
+        // the scan short before every repo was visited.
+        const truncated =
+          reposListTruncated || reposSkippedByCap > 0 || items.length >= maxItems;
         summary.push({
           type: "repository_secrets",
           sourceKind: "github-secret",
           found: secretsCount,
           reposFailed,
-          complete: reposFailed === 0,
+          reposSkippedByCap,
+          truncated,
+          complete: reposFailed === 0 && !truncated,
         });
       } catch (e) {
         if (e.status === 403) {
@@ -443,17 +478,21 @@ async function scanGitHub({
     // Scan Deploy Keys (repository-scoped keys)
     if (include.deployKeys) {
       try {
-        const repos = await listRepositories({
-          baseUrl: apiBase,
-          token,
-          maxItems: 100,
-        });
+        const { repos, truncated: reposListTruncated } =
+          await listRepositories({
+            baseUrl: apiBase,
+            token,
+          });
         let deployKeysCount = 0;
         let reposFailed = 0;
+        let reposSkippedByCap = 0;
         const BATCH_SIZE = 10;
 
         for (let i = 0; i < repos.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            reposSkippedByCap += repos.length - i;
+            break;
+          }
           const batch = repos.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -489,12 +528,16 @@ async function scanGitHub({
             }),
           );
         }
+        const truncated =
+          reposListTruncated || reposSkippedByCap > 0 || items.length >= maxItems;
         summary.push({
           type: "deploy_keys",
           sourceKind: "github-deploy-key",
           found: deployKeysCount,
           reposFailed,
-          complete: reposFailed === 0,
+          reposSkippedByCap,
+          truncated,
+          complete: reposFailed === 0 && !truncated,
         });
       } catch (e) {
         summary.push({

--- a/apps/api/services/githubIntegration.js
+++ b/apps/api/services/githubIntegration.js
@@ -220,6 +220,8 @@ async function scanGitHub({
 
   const items = [];
   const summary = [];
+  let host = null;
+  let ghUser = null;
 
   try {
     // Normalize baseUrl (default to github.com if not provided)
@@ -233,10 +235,15 @@ async function scanGitHub({
         ? "https://api.github.com"
         : normalizedUrl;
 
+    // The host anchors every GitHub token's provenance (see
+    // sourceIdentity.js) so that two GitHub Enterprise instances with
+    // colliding user/repo ids can never cross-delete each other's tokens.
+    host = new URL(apiBase).host;
+
     // Get current user info
     // Use short timeout (15s) for initial connection check - fail fast if unreachable
     try {
-      await githubRequest({
+      ghUser = await githubRequest({
         baseUrl: apiBase,
         token,
         method: "GET",
@@ -304,6 +311,8 @@ async function scanGitHub({
           // GitHub SSH keys don't have expiration dates in the API
           items.push({
             source: "github-ssh-key",
+            sourceKind: "github-ssh-key",
+            sourceObjectId: String(key.id),
             name: key.title || `SSH Key (${key.id})`,
             category: "key_secret",
             type: "ssh_key",
@@ -313,7 +322,12 @@ async function scanGitHub({
             last_used_at: key.last_used_at || null,
           });
         }
-        summary.push({ type: "ssh_keys", found: sshKeys.length });
+        summary.push({
+          type: "ssh_keys",
+          sourceKind: "github-ssh-key",
+          found: sshKeys.length,
+          complete: true,
+        });
       } catch (e) {
         logger.error("GitHub SSH keys scan failed", {
           error: e.message,
@@ -330,13 +344,17 @@ async function scanGitHub({
         if (e.status === 403) {
           summary.push({
             type: "ssh_keys",
+            sourceKind: "github-ssh-key",
             error:
               "Your PAT needs 'read:public_key' or 'admin:public_key' scope",
+            complete: false,
           });
         } else {
           summary.push({
             type: "ssh_keys",
+            sourceKind: "github-ssh-key",
             error: e.message || "Unknown error",
+            complete: false,
           });
         }
       }
@@ -351,6 +369,7 @@ async function scanGitHub({
           maxItems: 100,
         });
         let secretsCount = 0;
+        let reposFailed = 0;
         const BATCH_SIZE = 10;
 
         for (let i = 0; i < repos.length; i += BATCH_SIZE) {
@@ -372,6 +391,8 @@ async function scanGitHub({
                   // GitHub secrets don't expose expiration dates in the API
                   items.push({
                     source: "github-secret",
+                    sourceKind: "github-secret",
+                    sourceObjectId: `${repo.id}:${secret.name}`,
                     name: secret.name || `Secret (${secret.name})`,
                     category: "key_secret",
                     type: "secret",
@@ -385,20 +406,36 @@ async function scanGitHub({
                   secretsCount++;
                 }
               } catch (_e) {
-                // Skip repos we can't access
+                // Skip repos we can't access, but count them so a scan
+                // that couldn't see every repo's secrets is never reported
+                // complete for this sub-scope.
+                reposFailed++;
               }
             }),
           );
         }
-        summary.push({ type: "repository_secrets", found: secretsCount });
+        summary.push({
+          type: "repository_secrets",
+          sourceKind: "github-secret",
+          found: secretsCount,
+          reposFailed,
+          complete: reposFailed === 0,
+        });
       } catch (e) {
         if (e.status === 403) {
           summary.push({
             type: "repository_secrets",
+            sourceKind: "github-secret",
             error: "Your PAT needs 'repo' scope",
+            complete: false,
           });
         } else {
-          summary.push({ type: "repository_secrets", error: e.message });
+          summary.push({
+            type: "repository_secrets",
+            sourceKind: "github-secret",
+            error: e.message,
+            complete: false,
+          });
         }
       }
     }
@@ -412,6 +449,7 @@ async function scanGitHub({
           maxItems: 100,
         });
         let deployKeysCount = 0;
+        let reposFailed = 0;
         const BATCH_SIZE = 10;
 
         for (let i = 0; i < repos.length; i += BATCH_SIZE) {
@@ -432,6 +470,8 @@ async function scanGitHub({
                   if (items.length >= maxItems) break;
                   items.push({
                     source: "github-deploy-key",
+                    sourceKind: "github-deploy-key",
+                    sourceObjectId: `${repo.id}:${key.id}`,
                     name: key.title || `Deploy Key (${key.id})`,
                     category: "key_secret",
                     type: "ssh_key",
@@ -444,14 +484,25 @@ async function scanGitHub({
                   deployKeysCount++;
                 }
               } catch (_e) {
-                // Skip repos we can't access
+                reposFailed++;
               }
             }),
           );
         }
-        summary.push({ type: "deploy_keys", found: deployKeysCount });
+        summary.push({
+          type: "deploy_keys",
+          sourceKind: "github-deploy-key",
+          found: deployKeysCount,
+          reposFailed,
+          complete: reposFailed === 0,
+        });
       } catch (e) {
-        summary.push({ type: "deploy_keys", error: e.message });
+        summary.push({
+          type: "deploy_keys",
+          sourceKind: "github-deploy-key",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
@@ -567,7 +618,7 @@ async function scanGitHub({
   }
 
   logger.info("GitHub scan completed", { itemsFound: items.length });
-  return { items, summary };
+  return { items, summary, host, ownerKey: ghUser?.id ? String(ghUser.id) : null };
 }
 
 module.exports = {

--- a/apps/api/services/gitlabIntegration.js
+++ b/apps/api/services/gitlabIntegration.js
@@ -170,10 +170,14 @@ function isServiceAccount(username) {
   return serviceKeywords.some((keyword) => lowerUsername.includes(keyword));
 }
 
+// Returns `{ projects, truncated }` -- see listRepositories in
+// githubIntegration.js for why enumeration truncation must be reported
+// explicitly rather than silently swallowed.
 async function listProjects({ baseUrl, token, maxItems = 2000 }) {
   const projects = [];
   let page = 1;
   const perPage = Math.min(100, maxItems);
+  let truncated = false;
 
   while (projects.length < maxItems) {
     try {
@@ -204,21 +208,30 @@ async function listProjects({ baseUrl, token, maxItems = 2000 }) {
       if (data.length === 0) break;
 
       projects.push(...data);
+      if (projects.length >= maxItems && data.length === perPage) {
+        truncated = true;
+        break;
+      }
       if (data.length < perPage) break;
       page++;
     } catch (e) {
-      if (e.status === 404 || e.status === 403) break;
+      if (e.status === 404 || e.status === 403) {
+        truncated = true;
+        break;
+      }
       throw e;
     }
   }
 
-  return projects.slice(0, maxItems);
+  return { projects: projects.slice(0, maxItems), truncated };
 }
 
+// Returns `{ groups, truncated }` -- see listProjects above.
 async function listGroups({ baseUrl, token, maxItems = 2000 }) {
   const groups = [];
   let page = 1;
   const perPage = Math.min(100, maxItems);
+  let truncated = false;
 
   while (groups.length < maxItems) {
     try {
@@ -238,15 +251,22 @@ async function listGroups({ baseUrl, token, maxItems = 2000 }) {
       if (data.length === 0) break;
 
       groups.push(...data);
+      if (groups.length >= maxItems && data.length === perPage) {
+        truncated = true;
+        break;
+      }
       if (data.length < perPage) break;
       page++;
     } catch (e) {
-      if (e.status === 404 || e.status === 403) break;
+      if (e.status === 404 || e.status === 403) {
+        truncated = true;
+        break;
+      }
       throw e;
     }
   }
 
-  return groups.slice(0, maxItems);
+  return { groups: groups.slice(0, maxItems), truncated };
 }
 
 async function listPersonalAccessTokens({
@@ -533,14 +553,17 @@ async function scanGitLab({
     // We only scan projects where user has min_access_level=40 (Maintainer) to reduce 401/403 errors
     if (include.tokens && filters.includeProjectTokens) {
       try {
-        const projects = await listProjects({
-          baseUrl: normalizedUrl,
-          token,
-          maxItems: 1000,
-        });
+        const { projects, truncated: projectsListTruncated } =
+          await listProjects({
+            baseUrl: normalizedUrl,
+            token,
+            maxItems: 1000,
+          });
         let projectTokensCount = 0;
         let projectsScanned = 0;
         let projectsWithTokens = 0;
+        let projectsFailed = 0;
+        let projectsSkippedByCap = 0;
         let skippedRevoked = 0;
         let skippedExpired = 0;
 
@@ -549,7 +572,10 @@ async function scanGitLab({
         });
 
         for (let i = 0; i < projects.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            projectsSkippedByCap += projects.length - i;
+            break;
+          }
           const batch = projects.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -615,8 +641,11 @@ async function scanGitLab({
                   projectTokensCount++;
                 }
               } catch (_e) {
-                // Expected: user may see project but can't access its tokens (401/403/404)
-                // This is normal and we silently skip these projects
+                // A project we could see but couldn't read tokens for
+                // (401/403/404) means this sub-scope did not actually see
+                // every project's tokens -- count it so "complete" reflects
+                // that, instead of silently treating it as "no tokens".
+                projectsFailed++;
               }
             }),
           );
@@ -624,17 +653,24 @@ async function scanGitLab({
         logger.info("GitLab project tokens scan completed", {
           projectsScanned,
           projectsWithTokens,
+          projectsFailed,
           tokensFound: projectTokensCount,
           skippedRevoked,
           skippedExpired,
         });
+        const truncated =
+          projectsListTruncated ||
+          projectsSkippedByCap > 0 ||
+          items.length >= maxItems;
         summary.push({
           type: "project_access_tokens",
           sourceKind: "gitlab-project-token",
           found: projectTokensCount,
           skippedRevoked,
           skippedExpired,
-          complete: true,
+          projectsFailed,
+          truncated,
+          complete: projectsFailed === 0 && !truncated,
         });
       } catch (e) {
         // Feature may not be available on older self-hosted instances
@@ -662,7 +698,7 @@ async function scanGitLab({
     // Cloud: Always available | Self-hosted: May not be available on older versions or free tier
     if (include.tokens && filters.includeGroupTokens) {
       try {
-        const groups = await listGroups({
+        const { groups, truncated: groupsListTruncated } = await listGroups({
           baseUrl: normalizedUrl,
           token,
           maxItems: 1000,
@@ -670,6 +706,8 @@ async function scanGitLab({
         let groupTokensCount = 0;
         let groupsScanned = 0;
         let groupsWithTokens = 0;
+        let groupsFailed = 0;
+        let groupsSkippedByCap = 0;
         let skippedRevoked = 0;
         let skippedExpired = 0;
 
@@ -678,7 +716,10 @@ async function scanGitLab({
         });
 
         for (let i = 0; i < groups.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            groupsSkippedByCap += groups.length - i;
+            break;
+          }
           const batch = groups.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -743,8 +784,11 @@ async function scanGitLab({
                   groupTokensCount++;
                 }
               } catch (_e) {
-                // Expected: user may see group but can't access its tokens (401/403/404)
-                // This is normal and we silently skip these groups
+                // A group we could see but couldn't read tokens for
+                // (401/403/404) means this sub-scope did not actually see
+                // every group's tokens -- count it so "complete" reflects
+                // that, instead of silently treating it as "no tokens".
+                groupsFailed++;
               }
             }),
           );
@@ -752,17 +796,24 @@ async function scanGitLab({
         logger.info("GitLab group tokens scan completed", {
           groupsScanned,
           groupsWithTokens,
+          groupsFailed,
           tokensFound: groupTokensCount,
           skippedRevoked,
           skippedExpired,
         });
+        const truncated =
+          groupsListTruncated ||
+          groupsSkippedByCap > 0 ||
+          items.length >= maxItems;
         summary.push({
           type: "group_access_tokens",
           sourceKind: "gitlab-group-token",
           found: groupTokensCount,
           skippedRevoked,
           skippedExpired,
-          complete: true,
+          groupsFailed,
+          truncated,
+          complete: groupsFailed === 0 && !truncated,
         });
       } catch (e) {
         // Feature may not be available on older self-hosted instances
@@ -799,6 +850,8 @@ async function scanGitLab({
         let skippedExpired = 0; // Track expired tokens that are skipped
         let skippedUserPATs = 0; // Track user PATs excluded when excludeUserPATs is enabled
         let skippedBotUserPATs = 0; // Track bot user PATs that are duplicates of group/project tokens
+        let adminScanFailed = false; // Admin PAT pagination raised mid-scan (not just 404/403 at start)
+        let patsTruncated = false; // maxItems cap hit before pagination was exhausted
 
         // Build a set of bot user IDs from group and project tokens to avoid duplicates
         // Group/project access tokens create bot users whose PATs would be counted separately
@@ -960,15 +1013,33 @@ async function scanGitLab({
                 patsFound++;
               }
 
+              if (items.length >= maxItems) {
+                // Stopped early with more PATs potentially unseen on this
+                // page or later pages -- this sub-scope did not see the
+                // whole instance.
+                patsTruncated = true;
+              }
+
               if (pats.length < perPage) {
                 hasMore = false;
               }
               page++;
             }
+            if (hasMore && patsFound >= maxItems) {
+              // Loop exited because we hit the maxItems cap, not because
+              // pagination was exhausted.
+              patsTruncated = true;
+            }
           } catch (e) {
             logger.warn("Admin PAT scanning failed", {
               error: e.message,
             });
+            // A raised error here means the admin PAT listing did not
+            // finish -- some PATs on the instance were never seen. Treat
+            // this the same as a truncated/incomplete scan rather than
+            // silently reporting complete: true with whatever partial
+            // results we gathered before the failure.
+            adminScanFailed = true;
           }
         } else {
           // Regular user mode: Only scan own PATs
@@ -1054,7 +1125,8 @@ async function scanGitLab({
             ? skippedUserPATs
             : undefined,
           skippedBotUserPATs,
-          complete: true,
+          truncated: isAdmin ? adminScanFailed || patsTruncated : false,
+          complete: isAdmin ? !adminScanFailed && !patsTruncated : true,
         });
       } catch (e) {
         // On self-hosted instances with older versions, this endpoint may not exist
@@ -1088,21 +1160,27 @@ async function scanGitLab({
     // We only scan projects where user has min_access_level=40 to reduce permission errors
     if (include.tokens && filters.includeDeployTokens) {
       try {
-        const projects = await listProjects({
-          baseUrl: normalizedUrl,
-          token,
-          maxItems: 1000,
-        });
+        const { projects, truncated: projectsListTruncated } =
+          await listProjects({
+            baseUrl: normalizedUrl,
+            token,
+            maxItems: 1000,
+          });
         let deployTokensCount = 0;
         let projectsScanned = 0;
         let projectsWithTokens = 0;
+        let projectsFailed = 0;
+        let projectsSkippedByCap = 0;
 
         logger.info("Scanning GitLab deploy tokens", {
           totalProjects: projects.length,
         });
 
         for (let i = 0; i < projects.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            projectsSkippedByCap += projects.length - i;
+            break;
+          }
           const batch = projects.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -1161,8 +1239,11 @@ async function scanGitLab({
                   deployTokensCount++;
                 }
               } catch (_e) {
-                // Expected: user may see project but can't access its tokens (401/403/404)
-                // This is normal and we silently skip these projects
+                // A project we could see but couldn't read tokens for
+                // (401/403/404) means this sub-scope did not actually see
+                // every project's tokens -- count it so "complete" reflects
+                // that, instead of silently treating it as "no tokens".
+                projectsFailed++;
               }
             }),
           );
@@ -1170,13 +1251,20 @@ async function scanGitLab({
         logger.info("GitLab deploy tokens scan completed", {
           projectsScanned,
           projectsWithTokens,
+          projectsFailed,
           tokensFound: deployTokensCount,
         });
+        const truncated =
+          projectsListTruncated ||
+          projectsSkippedByCap > 0 ||
+          items.length >= maxItems;
         summary.push({
           type: "deploy_tokens",
           sourceKind: "gitlab-deploy-token",
           found: deployTokensCount,
-          complete: true,
+          projectsFailed,
+          truncated,
+          complete: projectsFailed === 0 && !truncated,
         });
       } catch (e) {
         logger.warn("Deploy tokens scan failed", {
@@ -1198,22 +1286,27 @@ async function scanGitLab({
     // never expire.
     if (include.tokens && filters.includeTriggerTokens) {
       try {
-        const projects = await listProjects({
-          baseUrl: normalizedUrl,
-          token,
-          maxItems: 1000,
-        });
+        const { projects, truncated: projectsListTruncated } =
+          await listProjects({
+            baseUrl: normalizedUrl,
+            token,
+            maxItems: 1000,
+          });
         let triggerTokensCount = 0;
         let projectsScanned = 0;
         let projectsWithTriggers = 0;
         let projectsSkipped = 0; // Permission-denied (401/403/404) or not-found projects
+        let projectsSkippedByCap = 0;
 
         logger.info("Scanning GitLab pipeline trigger tokens", {
           totalProjects: projects.length,
         });
 
         for (let i = 0; i < projects.length; i += BATCH_SIZE) {
-          if (items.length >= maxItems) break;
+          if (items.length >= maxItems) {
+            projectsSkippedByCap += projects.length - i;
+            break;
+          }
           const batch = projects.slice(i, i + BATCH_SIZE);
 
           await Promise.all(
@@ -1287,7 +1380,16 @@ async function scanGitLab({
           found: triggerTokensCount,
           projectsScanned,
           projectsSkipped,
-          complete: projectsSkipped === 0,
+          projectsSkippedByCap,
+          truncated:
+            projectsListTruncated ||
+            projectsSkippedByCap > 0 ||
+            items.length >= maxItems,
+          complete:
+            projectsSkipped === 0 &&
+            !projectsListTruncated &&
+            projectsSkippedByCap === 0 &&
+            items.length < maxItems,
         });
       } catch (e) {
         logger.warn("Pipeline trigger tokens scan failed", {

--- a/apps/api/services/gitlabIntegration.js
+++ b/apps/api/services/gitlabIntegration.js
@@ -445,6 +445,12 @@ async function scanGitLab({
   const normalizedUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   const isGitLabCloud = normalizedUrl.toLowerCase().includes("gitlab.com");
 
+  // The host anchors every GitLab token's provenance (see
+  // sourceIdentity.js) so that two self-hosted GitLab instances with
+  // colliding numeric user/project/group ids can never cross-delete each
+  // other's tokens.
+  const host = new URL(normalizedUrl).host;
+
   logger.info("Starting GitLab scan", {
     baseUrl: baseUrl.replace(/\/\/[^@]+@/, "//***@"),
     maxItems,
@@ -454,11 +460,11 @@ async function scanGitLab({
   const items = [];
   const summary = [];
   const BATCH_SIZE = 10; // Concurrency limit for parallel API calls
+  let currentUser = null;
 
   try {
     // Get current user info (works on both cloud and self-hosted)
     // Use short timeout (15s) for initial connection check - fail fast if unreachable
-    let currentUser = null;
     try {
       currentUser = await gitlabRequest({
         baseUrl: normalizedUrl,
@@ -588,6 +594,8 @@ async function scanGitLab({
 
                   items.push({
                     source: "gitlab-project-token",
+                    sourceKind: "gitlab-project-token",
+                    sourceObjectId: `${project.id}:${pt.id}`,
                     name: pt.name || `Project Access Token (${pt.id})`,
                     category: "key_secret",
                     type: "api_key",
@@ -622,9 +630,11 @@ async function scanGitLab({
         });
         summary.push({
           type: "project_access_tokens",
+          sourceKind: "gitlab-project-token",
           found: projectTokensCount,
           skippedRevoked,
           skippedExpired,
+          complete: true,
         });
       } catch (e) {
         // Feature may not be available on older self-hosted instances
@@ -713,6 +723,8 @@ async function scanGitLab({
 
                   items.push({
                     source: "gitlab-group-token",
+                    sourceKind: "gitlab-group-token",
+                    sourceObjectId: `${group.id}:${gt.id}`,
                     name: gt.name || `Group Access Token (${gt.id})`,
                     category: "key_secret",
                     type: "api_key",
@@ -746,9 +758,11 @@ async function scanGitLab({
         });
         summary.push({
           type: "group_access_tokens",
+          sourceKind: "gitlab-group-token",
           found: groupTokensCount,
           skippedRevoked,
           skippedExpired,
+          complete: true,
         });
       } catch (e) {
         // Feature may not be available on older self-hosted instances
@@ -923,6 +937,8 @@ async function scanGitLab({
 
                 items.push({
                   source: "gitlab-pat",
+                  sourceKind: "gitlab-pat",
+                  sourceObjectId: String(pat.id),
                   name: pat.name || `Personal Access Token (${pat.id})`,
                   category: "key_secret",
                   type: "api_key",
@@ -997,6 +1013,8 @@ async function scanGitLab({
 
               items.push({
                 source: "gitlab-pat",
+                sourceKind: "gitlab-pat",
+                sourceObjectId: String(pat.id),
                 name: pat.name || `Personal Access Token (${pat.id})`,
                 category: "key_secret",
                 type: "api_key",
@@ -1029,12 +1047,14 @@ async function scanGitLab({
         });
         summary.push({
           type: "personal_access_tokens",
+          sourceKind: "gitlab-pat",
           found: patsFound,
           skippedExpired,
           skippedUserPATs: filters.excludeUserPATs
             ? skippedUserPATs
             : undefined,
           skippedBotUserPATs,
+          complete: true,
         });
       } catch (e) {
         // On self-hosted instances with older versions, this endpoint may not exist
@@ -1044,14 +1064,21 @@ async function scanGitLab({
           );
           summary.push({
             type: "personal_access_tokens",
+            sourceKind: "gitlab-pat",
             note: "Not available (GitLab 13.3+ required)",
+            complete: false,
           });
         } else {
           logger.warn("Personal access tokens scan failed", {
             error: e.message,
             status: e.status,
           });
-          summary.push({ type: "personal_access_tokens", error: e.message });
+          summary.push({
+            type: "personal_access_tokens",
+            sourceKind: "gitlab-pat",
+            error: e.message,
+            complete: false,
+          });
         }
       }
     }
@@ -1118,6 +1145,8 @@ async function scanGitLab({
 
                   items.push({
                     source: "gitlab-deploy-token",
+                    sourceKind: "gitlab-deploy-token",
+                    sourceObjectId: `${project.id}:${dt.id}`,
                     name: dt.name || `Deploy Token (${dt.id})`,
                     category: "key_secret",
                     type: "api_key",
@@ -1143,13 +1172,23 @@ async function scanGitLab({
           projectsWithTokens,
           tokensFound: deployTokensCount,
         });
-        summary.push({ type: "deploy_tokens", found: deployTokensCount });
+        summary.push({
+          type: "deploy_tokens",
+          sourceKind: "gitlab-deploy-token",
+          found: deployTokensCount,
+          complete: true,
+        });
       } catch (e) {
         logger.warn("Deploy tokens scan failed", {
           error: e.message,
           status: e.status,
         });
-        summary.push({ type: "deploy_tokens", error: e.message });
+        summary.push({
+          type: "deploy_tokens",
+          sourceKind: "gitlab-deploy-token",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
@@ -1195,6 +1234,8 @@ async function scanGitLab({
 
                   items.push({
                     source: "gitlab-trigger-token",
+                    sourceKind: "gitlab-trigger-token",
+                    sourceObjectId: `${project.id}:${trigger.id}`,
                     name:
                       trigger.description ||
                       `Pipeline Trigger Token (${trigger.id})`,
@@ -1242,16 +1283,23 @@ async function scanGitLab({
         });
         summary.push({
           type: "pipeline_trigger_tokens",
+          sourceKind: "gitlab-trigger-token",
           found: triggerTokensCount,
           projectsScanned,
           projectsSkipped,
+          complete: projectsSkipped === 0,
         });
       } catch (e) {
         logger.warn("Pipeline trigger tokens scan failed", {
           error: e.message,
           status: e.status,
         });
-        summary.push({ type: "pipeline_trigger_tokens", error: e.message });
+        summary.push({
+          type: "pipeline_trigger_tokens",
+          sourceKind: "gitlab-trigger-token",
+          error: e.message,
+          complete: false,
+        });
       }
     }
 
@@ -1277,6 +1325,8 @@ async function scanGitLab({
 
           items.push({
             source: "gitlab-ssh-key",
+            sourceKind: "gitlab-ssh-key",
+            sourceObjectId: String(key.id),
             name: key.title || `SSH Key (${key.id})`,
             category: "key_secret",
             type: "ssh_key",
@@ -1286,9 +1336,19 @@ async function scanGitLab({
             last_used_at: key.last_used_at || null,
           });
         }
-        summary.push({ type: "ssh_keys", found: sshKeys.length });
+        summary.push({
+          type: "ssh_keys",
+          sourceKind: "gitlab-ssh-key",
+          found: sshKeys.length,
+          complete: true,
+        });
       } catch (e) {
-        summary.push({ type: "ssh_keys", error: e.message });
+        summary.push({
+          type: "ssh_keys",
+          sourceKind: "gitlab-ssh-key",
+          error: e.message,
+          complete: false,
+        });
       }
     }
   } catch (e) {
@@ -1420,7 +1480,7 @@ async function scanGitLab({
     ...resultsByType,
   });
 
-  return { items, summary };
+  return { items, summary, host, ownerKey: currentUser?.id ? String(currentUser.id) : null };
 }
 
 module.exports = {

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -1,77 +1,69 @@
 /**
  * Obsolete-token cleanup for integration imports and auto-sync.
  *
- * When a scan completes and cleanup is requested, previously imported tokens
- * that belong to the scanned provider AND fall inside the scanned scope
- * (source kinds actually included in this scan) but were NOT rediscovered
- * are hard-deleted with a TOKEN_DELETED audit event.
+ * Cleanup runs against a backend-persisted `integration_scans` row (see
+ * integrationScans.js), never against frontend-reconstructed
+ * `scannedSources`/`scannedLocations`. The scan record is the single
+ * authoritative statement of what was actually, completely scanned.
  *
- * Safety rules:
- *   - Only tokens in the same workspace.
- *   - Only tokens whose location starts with the provider prefix (e.g. "gitlab:").
- *   - Only tokens matching a location pattern of a source kind that was part
- *     of this scan (a PAT-less scan never deletes PAT entries).
- *   - Only tokens that were previously imported (imported_at IS NOT NULL).
+ * Safety rules (all enforced inside one DB transaction):
+ *   - The scan must exist, belong to this workspace/provider, be completed,
+ *     and not already have been consumed by an earlier cleanup. The claim
+ *     (`UPDATE ... WHERE cleanup_consumed_at IS NULL RETURNING`) is atomic,
+ *     so a scan_id can drive at most one destructive cleanup even under
+ *     concurrent requests.
+ *   - Cleanup is refused unless the scan reports at least one *complete*
+ *     sub-scope. "Complete" means fully enumerated, not "found something":
+ *     a scan that legitimately finds zero items in a fully-scanned scope
+ *     still cleans up everything in that scope, because that is a true
+ *     obsolete-everything result. A sub-scope reported truncated/errored is
+ *     never used as a deletion basis.
+ *   - Candidate tokens are scoped by provider + instance + owner key (never
+ *     just a provider prefix), so a second AWS account / Key Vault / GitHub
+ *     Enterprise host / etc. in the same workspace is never touched by a
+ *     scan of a different instance.
+ *   - Candidate selection uses a NOT EXISTS anti-join against
+ *     integration_scan_items for this scan_id (no giant IN-lists), so it
+ *     scales with "how many tokens exist", not "how many locations were
+ *     scanned".
+ *   - Observation fence: a token is never deleted if its
+ *     `source_observed_at` is newer than the cleanup-driving scan's
+ *     `started_at`. This stops a stale/slow scan's cleanup from deleting
+ *     something a newer, faster, concurrent scan just (re)discovered.
+ *   - Legacy tokens (imported before per-instance provenance existed) have
+ *     `source_provider IS NULL` and can never match any scope filter here,
+ *     so they are structurally excluded from this cleanup path forever --
+ *     not a "best effort", a hard exclusion by construction.
  *
- * Known limitation: candidates are scoped by provider prefix only, not by
- * the specific account/vault/project/instance that was scanned. A workspace
- * that has imported from two instances of the same provider (two AWS
- * accounts, two Key Vaults, two self-hosted GitLab servers, etc.) will have
- * cleanup delete tokens from instance B when scanning instance A, since B's
- * locations never appear in A's scan results. Tracked in GitHub issue #71
- * ("Support multiple auto-sync configurations per provider in a workspace"),
- * whose acceptance criteria already call for per-instance token attribution.
+ * Known, deliberate limitation: legacy tokens are never adopted into a new
+ * scan's provenance by guessing. If a legacy token's underlying object is
+ * rediscovered by a provenance-aware scan, the import path inserts a new,
+ * fully-attributed row for it; the old ambiguous row is left alone and is
+ * only ever removable by the user manually.
  */
 
 const { pool } = require("../db/database");
 const { writeAudit } = require("./audit");
 const { logger } = require("../utils/logger");
+const { claimScanForCleanup } = require("./integrationScans");
 
-const PROVIDER_PREFIXES = {
-  gitlab: "gitlab:",
-  github: "github:",
-  vault: "vault:",
-  aws: "aws:",
-  azure: "azure:",
-  "azure-ad": "azure-ad:",
-  gcp: "gcp:",
-};
-
-// Location shape per scan source kind. A stored token is only eligible for
-// cleanup when its location matches the pattern of a source kind that was
-// included in the current scan.
-const SOURCE_LOCATION_PATTERNS = {
-  "gitlab-pat": /^gitlab:(users\/[^/]+\/)?personal_access_tokens\//,
-  "gitlab-project-token": /^gitlab:projects\/[^/]+\/access_tokens\//,
-  "gitlab-group-token": /^gitlab:groups\/[^/]+\/access_tokens\//,
-  "gitlab-deploy-token": /^gitlab:projects\/[^/]+\/deploy_tokens\//,
-  "gitlab-trigger-token": /^gitlab:projects\/[^/]+\/triggers\//,
-  "gitlab-ssh-key": /^gitlab:user\/keys\//,
-  "github-ssh-key": /^github:user\/keys\//,
-  "github-secret": /^github:repos\/.+\/actions\/secrets\//,
-  "github-deploy-key": /^github:repos\/.+\/keys\//,
-  // PKI certs always live at "<mount>/cert/<serial>"; KV entries are
-  // everything else under the vault: prefix. Distinguishing the two here
-  // (instead of both matching every vault: location) means a KV-only scan
-  // with cleanup enabled never touches PKI certs, and vice versa.
-  "vault-kv": /^vault:(?!.+\/cert\/[^/]+$).+/,
-  "vault-pki": /^vault:.+\/cert\/[^/]+$/,
-  "aws-secrets-manager": /^aws:secretsmanager:/,
-  "aws-acm": /^aws:acm:/,
-  "aws-iam-key": /^aws:iam:/,
-  "azure-key-vault-secret": /^azure:.+\/secrets\//,
-  "azure-key-vault-certificate": /^azure:.+\/certificates\//,
-  "azure-key-vault-key": /^azure:.+\/keys\//,
-  "azure-ad-client-secret": /^azure-ad:applications\/.+\/secrets\//,
-  "azure-ad-certificate": /^azure-ad:applications\/.+\/certificates\//,
-  "azure-ad-sp-secret": /^azure-ad:servicePrincipals\/.+\/secrets\//,
-  "azure-ad-sp-certificate": /^azure-ad:servicePrincipals\/.+\/certificates\//,
-  "gcp-secret-manager": /^gcp:.+\/secrets\//,
-};
+const KNOWN_PROVIDERS = [
+  "github",
+  "gitlab",
+  "vault",
+  "aws",
+  "azure",
+  "azure-ad",
+  "gcp",
+];
 
 /**
- * Validates a cleanup payload. Returns null when valid, otherwise an error
- * string suitable for a 400 response.
+ * Validates a cleanup request payload. Returns null when valid, otherwise
+ * an error string suitable for a 400 response.
+ *
+ * Contract: `{ enabled: true, provider, scanId, reason? }`. The scan itself
+ * (not this payload) carries the scope/completeness data; this object only
+ * says "yes, run cleanup, driven by this scan".
  */
 function validateCleanupRequest(cleanup) {
   if (cleanup === undefined || cleanup === null) return null;
@@ -79,29 +71,47 @@ function validateCleanupRequest(cleanup) {
     return "cleanup must be an object";
   }
   if (cleanup.enabled !== true) return null;
-  if (!PROVIDER_PREFIXES[cleanup.provider]) {
-    return `cleanup.provider must be one of: ${Object.keys(PROVIDER_PREFIXES).join(", ")}`;
+  if (!KNOWN_PROVIDERS.includes(cleanup.provider)) {
+    return `cleanup.provider must be one of: ${KNOWN_PROVIDERS.join(", ")}`;
   }
-  if (!Array.isArray(cleanup.scannedSources) || cleanup.scannedSources.length === 0) {
-    return "cleanup.scannedSources must be a non-empty array of source kinds";
-  }
-  for (const s of cleanup.scannedSources) {
-    if (!SOURCE_LOCATION_PATTERNS[s]) {
-      return `cleanup.scannedSources contains unknown source kind: ${s}`;
-    }
-  }
-  if (!Array.isArray(cleanup.scannedLocations)) {
-    return "cleanup.scannedLocations must be an array of location strings";
-  }
-  if (cleanup.scannedLocations.length > 50000) {
-    return "cleanup.scannedLocations is too large";
+  if (typeof cleanup.scanId !== "string" || cleanup.scanId.trim() === "") {
+    return "cleanup.scanId is required (cleanup must be driven by a completed backend scan)";
   }
   return null;
 }
 
+// A sub-scope's dimension filter narrows which candidate tokens fall inside
+// it. Only keys the scan actually recorded are compared; a key absent from
+// the sub-scope's dimensions means "not narrowed on this axis" for that
+// provider (e.g. an AWS sub-scope with no `service` means "this region,
+// every service checked in it"). `pathPrefix` (Vault) is a prefix match
+// against the token's own recorded `path` dimension; everything else is
+// exact-match.
+function buildDimensionFilterSql(dimensions, paramOffset) {
+  const clauses = [];
+  const params = [];
+  let p = paramOffset;
+  const dims = dimensions && typeof dimensions === "object" ? dimensions : {};
+  for (const [key, value] of Object.entries(dims)) {
+    if (value === null || value === undefined || value === "") continue;
+    if (key === "pathPrefix") {
+      clauses.push(`(t.source_dimensions->>'path') LIKE $${p}`);
+      params.push(`${String(value)}%`);
+      p++;
+    } else {
+      clauses.push(`(t.source_dimensions->>'${key.replace(/[^a-zA-Z0-9_]/g, "")}') = $${p}`);
+      params.push(String(value));
+      p++;
+    }
+  }
+  return { sql: clauses.length ? ` AND ${clauses.join(" AND ")}` : "", params };
+}
+
 /**
- * Deletes workspace tokens that were previously imported from the given
- * provider, fall inside the scanned scope, and were not rediscovered.
+ * Deletes workspace tokens that belong to the scan's provider/instance/
+ * owner, fall inside a sub-scope the scan reported complete, and were not
+ * rediscovered by that scan -- all inside one transaction with the scan
+ * claim, the delete, and the audit write.
  *
  * @returns {Promise<{deleted: Array<{id:number,name:string,location:string}>}>}
  */
@@ -113,78 +123,145 @@ async function cleanupObsoleteTokens({
 }) {
   const deleted = [];
   if (!cleanup || cleanup.enabled !== true) return { deleted };
-
-  const prefix = PROVIDER_PREFIXES[cleanup.provider];
-  if (!prefix) return { deleted };
-
-  const patterns = (cleanup.scannedSources || [])
-    .map((s) => SOURCE_LOCATION_PATTERNS[s])
-    .filter(Boolean);
-  if (patterns.length === 0) return { deleted };
-
-  const rediscovered = new Set(
-    (cleanup.scannedLocations || [])
-      .map((l) => String(l || "").trim())
-      .filter(Boolean),
-  );
-
-  // Candidates: previously imported tokens from this provider in this workspace.
-  const candidatesRes = await pool.query(
-    `SELECT id, name, location FROM tokens
-     WHERE workspace_id = $1
-       AND imported_at IS NOT NULL
-       AND location LIKE $2`,
-    [workspaceId, `${prefix}%`],
-  );
-
-  for (const row of candidatesRes.rows) {
-    const location = String(row.location || "");
-    // Only delete inside the scanned scope.
-    if (!patterns.some((p) => p.test(location))) continue;
-    if (rediscovered.has(location)) continue;
-
-    try {
-      // Reuse the manual delete semantics: clear queue entries and linked
-      // endpoint monitors so they don't become orphaned.
-      await pool.query("DELETE FROM alert_queue WHERE token_id = $1", [row.id]);
-      await pool.query("DELETE FROM domain_monitors WHERE token_id = $1", [
-        row.id,
-      ]);
-      await pool.query("DELETE FROM tokens WHERE id = $1", [row.id]);
-      deleted.push({ id: row.id, name: row.name, location });
-      try {
-        await writeAudit({
-          actorUserId: actorUserId || null,
-          subjectUserId: actorUserId || null,
-          action: "TOKEN_DELETED",
-          targetType: "token",
-          targetId: row.id,
-          channel: null,
-          workspaceId,
-          metadata: {
-            name: row.name,
-            location,
-            reason,
-            provider: cleanup.provider,
-          },
-        });
-      } catch (auditErr) {
-        logger.warn("Cleanup audit write failed", { error: auditErr.message });
-      }
-    } catch (delErr) {
-      logger.warn("Obsolete token cleanup failed for token", {
-        tokenId: row.id,
-        error: delErr.message,
-      });
-    }
+  const validationError = validateCleanupRequest(cleanup);
+  if (validationError) {
+    throw new Error(`Invalid cleanup request: ${validationError}`);
   }
 
-  return { deleted };
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const scan = await claimScanForCleanup({
+      scanId: cleanup.scanId,
+      workspaceId,
+      provider: cleanup.provider,
+      client,
+    });
+    if (!scan) {
+      await client.query("ROLLBACK");
+      logger.warn("Cleanup refused: scan not found, incomplete, or already consumed", {
+        workspaceId,
+        provider: cleanup.provider,
+        scanId: cleanup.scanId,
+      });
+      return { deleted: [] };
+    }
+
+    const subScopes = Array.isArray(scan.cleanup_scope?.subScopes)
+      ? scan.cleanup_scope.subScopes
+      : [];
+    const completeSubScopes = subScopes.filter((s) => s && s.complete === true);
+    if (completeSubScopes.length === 0) {
+      // The scan was claimed (consumed) even though it drove no deletions,
+      // by design: a scan that produced nothing usable for cleanup should
+      // not be replayable either, since replay-ability is exactly the
+      // property claiming exists to remove.
+      await client.query("COMMIT");
+      logger.info("Cleanup ran but no sub-scope was complete; nothing deleted", {
+        workspaceId,
+        provider: cleanup.provider,
+        scanId: cleanup.scanId,
+      });
+      return { deleted: [] };
+    }
+
+    for (const subScope of completeSubScopes) {
+      const { sql: dimensionSql, params: dimensionParams } =
+        buildDimensionFilterSql(subScope.dimensions, 6);
+      const params = [
+        workspaceId,
+        cleanup.provider,
+        scan.source_instance,
+        scan.source_owner_key,
+        String(subScope.sourceKind),
+        scan.id,
+        scan.started_at,
+        ...dimensionParams,
+      ];
+      // Anti-join: candidates are previously-imported tokens in this exact
+      // provider/instance/owner/kind scope that have no matching row in
+      // integration_scan_items for *this* scan -- i.e. not rediscovered.
+      // The observation fence (source_observed_at <= scan.started_at)
+      // excludes anything a newer, still-running concurrent scan already
+      // touched, even if this (older, slower) scan is the one committing
+      // first.
+      const res = await client.query(
+        `SELECT t.id, t.name, t.location
+         FROM tokens t
+         WHERE t.workspace_id = $1
+           AND t.imported_at IS NOT NULL
+           AND t.source_provider = $2
+           AND t.source_instance = $3
+           AND t.source_owner_key = $4
+           AND t.source_kind = $5
+           AND (t.source_observed_at IS NULL OR t.source_observed_at <= $7)
+           ${dimensionSql}
+           AND NOT EXISTS (
+             SELECT 1 FROM integration_scan_items si
+             WHERE si.scan_id = $6
+               AND si.source_kind = t.source_kind
+               AND si.source_object_id = t.source_object_id
+           )
+         FOR UPDATE`,
+        params,
+      );
+
+      for (const row of res.rows) {
+        try {
+          await client.query("DELETE FROM alert_queue WHERE token_id = $1", [row.id]);
+          await client.query("DELETE FROM domain_monitors WHERE token_id = $1", [row.id]);
+          await client.query("DELETE FROM tokens WHERE id = $1", [row.id]);
+          deleted.push({ id: row.id, name: row.name, location: row.location });
+          await writeAudit({
+            client,
+            actorUserId: actorUserId || null,
+            subjectUserId: actorUserId || null,
+            action: "TOKEN_DELETED",
+            targetType: "token",
+            targetId: row.id,
+            channel: null,
+            workspaceId,
+            metadata: {
+              name: row.name,
+              location: row.location,
+              reason,
+              provider: cleanup.provider,
+              scanId: scan.id,
+              sourceKind: subScope.sourceKind,
+            },
+          });
+        } catch (delErr) {
+          // A per-token failure must not silently roll back deletions that
+          // already succeeded in this loop, but it also must not be
+          // swallowed: surface it so the caller's audit summary reflects a
+          // partial cleanup rather than a clean one.
+          logger.error("Obsolete token cleanup failed for token; aborting transaction", {
+            tokenId: row.id,
+            error: delErr.message,
+          });
+          throw delErr;
+        }
+      }
+    }
+
+    await client.query("COMMIT");
+    return { deleted };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_rollbackErr) {
+      logger.warn("Cleanup rollback failed", { error: _rollbackErr.message });
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 module.exports = {
-  PROVIDER_PREFIXES,
-  SOURCE_LOCATION_PATTERNS,
+  KNOWN_PROVIDERS,
   validateCleanupRequest,
   cleanupObsoleteTokens,
+  buildDimensionFilterSql,
 };

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -41,8 +41,12 @@ const SOURCE_LOCATION_PATTERNS = {
   "github-ssh-key": /^github:user\/keys\//,
   "github-secret": /^github:repos\/.+\/actions\/secrets\//,
   "github-deploy-key": /^github:repos\/.+\/keys\//,
-  "vault-kv": /^vault:/,
-  "vault-pki": /^vault:/,
+  // PKI certs always live at "<mount>/cert/<serial>"; KV entries are
+  // everything else under the vault: prefix. Distinguishing the two here
+  // (instead of both matching every vault: location) means a KV-only scan
+  // with cleanup enabled never touches PKI certs, and vice versa.
+  "vault-kv": /^vault:(?!.+\/cert\/[^/]+$).+/,
+  "vault-pki": /^vault:.+\/cert\/[^/]+$/,
   "aws-secrets-manager": /^aws:secretsmanager:/,
   "aws-acm": /^aws:acm:/,
   "aws-iam-key": /^aws:iam:/,

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -12,6 +12,15 @@
  *   - Only tokens matching a location pattern of a source kind that was part
  *     of this scan (a PAT-less scan never deletes PAT entries).
  *   - Only tokens that were previously imported (imported_at IS NOT NULL).
+ *
+ * Known limitation: candidates are scoped by provider prefix only, not by
+ * the specific account/vault/project/instance that was scanned. A workspace
+ * that has imported from two instances of the same provider (two AWS
+ * accounts, two Key Vaults, two self-hosted GitLab servers, etc.) will have
+ * cleanup delete tokens from instance B when scanning instance A, since B's
+ * locations never appear in A's scan results. Tracked in GitHub issue #71
+ * ("Support multiple auto-sync configurations per provider in a workspace"),
+ * whose acceptance criteria already call for per-instance token attribution.
  */
 
 const { pool } = require("../db/database");

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -83,10 +83,12 @@ function validateCleanupRequest(cleanup) {
 // A sub-scope's dimension filter narrows which candidate tokens fall inside
 // it. Only keys the scan actually recorded are compared; a key absent from
 // the sub-scope's dimensions means "not narrowed on this axis" for that
-// provider (e.g. an AWS sub-scope with no `service` means "this region,
-// every service checked in it"). `pathPrefix` (Vault) is a prefix match
-// against the token's own recorded `path` dimension; everything else is
-// exact-match.
+// provider (e.g. an AWS sub-scope with no `region` means "global, every
+// region-independent resource"). `pathPrefix` (Vault) is a prefix match
+// against the token's own recorded `path` dimension. `categories` (Vault)
+// is a membership check against the token's own recorded `category`
+// dimension, since a scan can narrow to more than one category at once.
+// Everything else is exact-match.
 function buildDimensionFilterSql(dimensions, paramOffset) {
   const clauses = [];
   const params = [];
@@ -97,6 +99,12 @@ function buildDimensionFilterSql(dimensions, paramOffset) {
     if (key === "pathPrefix") {
       clauses.push(`(t.source_dimensions->>'path') LIKE $${p}`);
       params.push(`${String(value)}%`);
+      p++;
+    } else if (key === "categories") {
+      const list = Array.isArray(value) ? value : [value];
+      if (list.length === 0) continue;
+      clauses.push(`(t.source_dimensions->>'category') = ANY($${p}::text[])`);
+      params.push(list.map((v) => String(v)));
       p++;
     } else {
       clauses.push(`(t.source_dimensions->>'${key.replace(/[^a-zA-Z0-9_]/g, "")}') = $${p}`);

--- a/apps/api/services/importCleanup.js
+++ b/apps/api/services/importCleanup.js
@@ -167,8 +167,10 @@ async function cleanupObsoleteTokens({
     }
 
     for (const subScope of completeSubScopes) {
+      // Dimension placeholders start after the 7 fixed params below ($1-$7),
+      // so the offset here must stay in sync with that fixed param count.
       const { sql: dimensionSql, params: dimensionParams } =
-        buildDimensionFilterSql(subScope.dimensions, 6);
+        buildDimensionFilterSql(subScope.dimensions, 8);
       const params = [
         workspaceId,
         cleanup.provider,

--- a/apps/api/services/integrationScans.js
+++ b/apps/api/services/integrationScans.js
@@ -18,6 +18,7 @@
  */
 
 const { pool } = require("../db/database");
+const { resolveSourceIdentity } = require("./sourceIdentity");
 
 async function createScan({
   workspaceId,
@@ -136,10 +137,70 @@ async function claimScanForCleanup({ scanId, workspaceId, provider, client }) {
   return res.rows[0] || null;
 }
 
+/**
+ * Non-destructive lookup used by import to validate a client-submitted
+ * `scan_id` belongs to this workspace/provider and to read back its
+ * authoritative started_at (for the observation fence) -- distinct from
+ * claimScanForCleanup, which is the one-time destructive claim.
+ */
+async function getScan({ scanId, workspaceId, provider, client = null }) {
+  const db = client || pool;
+  if (!scanId) return null;
+  const res = await db.query(
+    `SELECT id, source_instance, source_owner_key, started_at, completed_at, cleanup_scope, cleanup_consumed_at
+     FROM integration_scans
+     WHERE id = $1 AND workspace_id = $2 AND provider = $3`,
+    [scanId, workspaceId, provider],
+  );
+  return res.rows[0] || null;
+}
+
+/**
+ * End-to-end helper for the common case: resolve this provider's identity
+ * from the raw scan context, create the scan row, persist every discovered
+ * item (metadata only), and finalize with the caller-computed sub-scopes --
+ * one call from a scan route instead of every route re-deriving identity
+ * and re-sequencing create/record/finalize by hand.
+ *
+ * @param {string} provider
+ * @param {Object} identityContext - Passed to resolveSourceIdentity(provider, ...).
+ * @param {Array<{sourceKind, sourceObjectId, dimensions}>} items - Metadata-only discovered items.
+ * @param {Array<{sourceKind, dimensions, complete, reason}>} subScopes - Per-kind/dimension completeness.
+ * @returns {Promise<{scanId: string, startedAt: Date, instance: string, ownerKey: string, ownerDisplay: string|null}>}
+ */
+async function persistScan({
+  workspaceId,
+  provider,
+  identityContext,
+  items,
+  subScopes,
+  createdBy = null,
+}) {
+  const identity = resolveSourceIdentity(provider, identityContext);
+  const scan = await createScan({
+    workspaceId,
+    provider,
+    instance: identity.instance,
+    ownerKey: identity.ownerKey,
+    createdBy,
+  });
+  await recordScanItems(scan.id, items);
+  await finalizeScan(scan.id, subScopes);
+  return {
+    scanId: scan.id,
+    startedAt: scan.startedAt,
+    instance: identity.instance,
+    ownerKey: identity.ownerKey,
+    ownerDisplay: identity.ownerDisplay,
+  };
+}
+
 module.exports = {
   createScan,
   recordScanItems,
   finalizeScan,
   lookupScanItems,
   claimScanForCleanup,
+  getScan,
+  persistScan,
 };

--- a/apps/api/services/integrationScans.js
+++ b/apps/api/services/integrationScans.js
@@ -10,7 +10,12 @@
  *   2. recordScanItems() as items are discovered (metadata only, never
  *      secret material) -- gives import something to bind client-submitted
  *      items against instead of trusting arbitrary client-supplied
- *      provenance.
+ *      provenance. Also bumps source_observed_at on any already-imported
+ *      token this scan just rediscovered, so the rediscovery is visible to
+ *      the cleanup observation fence immediately, not only after a later
+ *      import step runs. Without this, an older/slower concurrent scan's
+ *      cleanup could still delete a token that a newer scan just saw but
+ *      had not yet re-imported (see importCleanup.js's observation fence).
  *   3. finalizeScan() once the scan is done, with the authoritative
  *      cleanup_scope (per source-kind/dimension completeness).
  *   4. claimScanForCleanup() at cleanup time: a single-use, transactional
@@ -43,8 +48,21 @@ async function createScan({
  * client-submitted items to a real row here by (scanId, sourceKind,
  * sourceObjectId), rather than trusting whatever provenance the client
  * claims for an arbitrary item object.
+ *
+ * Also immediately bumps `source_observed_at` on any already-imported token
+ * matching this scan's (workspace, provider, instance, owner) scope and one
+ * of the discovered (sourceKind, sourceObjectId) pairs. This closes the
+ * concurrency gap where rediscovery would otherwise only become visible to
+ * the cleanup observation fence once a later, separate import step ran --
+ * by then an older/slower concurrent scan's cleanup could already have
+ * deleted the token. GREATEST(...) keeps the timestamp monotonic even if
+ * an older scan's items are recorded after a newer one's.
  */
-async function recordScanItems(scanId, items, { client = null } = {}) {
+async function recordScanItems(
+  scanId,
+  items,
+  { client = null, workspaceId = null, provider = null, instance = null, ownerKey = null, observedAt = null } = {},
+) {
   if (!Array.isArray(items) || items.length === 0) return;
   const db = client || pool;
   const CHUNK = 500;
@@ -68,6 +86,23 @@ async function recordScanItems(scanId, items, { client = null } = {}) {
        ON CONFLICT (scan_id, source_kind, source_object_id) DO NOTHING`,
       params,
     );
+
+    if (workspaceId && provider && instance && ownerKey && observedAt) {
+      const kinds = chunk.map((item) => String(item.sourceKind));
+      const objectIds = chunk.map((item) => String(item.sourceObjectId));
+      await db.query(
+        `UPDATE tokens t
+         SET source_observed_at = GREATEST(COALESCE(t.source_observed_at, $7), $7)
+         FROM UNNEST($4::text[], $5::text[]) AS pair(kind, object_id)
+         WHERE t.workspace_id = $1
+           AND t.source_provider = $2
+           AND t.source_instance = $3
+           AND t.source_owner_key = $6
+           AND t.source_kind = pair.kind
+           AND t.source_object_id = pair.object_id`,
+        [workspaceId, provider, instance, kinds, objectIds, ownerKey, observedAt],
+      );
+    }
   }
 }
 
@@ -184,7 +219,13 @@ async function persistScan({
     ownerKey: identity.ownerKey,
     createdBy,
   });
-  await recordScanItems(scan.id, items);
+  await recordScanItems(scan.id, items, {
+    workspaceId,
+    provider,
+    instance: identity.instance,
+    ownerKey: identity.ownerKey,
+    observedAt: scan.startedAt,
+  });
   await finalizeScan(scan.id, subScopes);
   return {
     scanId: scan.id,

--- a/apps/api/services/integrationScans.js
+++ b/apps/api/services/integrationScans.js
@@ -1,0 +1,145 @@
+"use strict";
+
+/**
+ * Scan persistence: the backend-authoritative record of what an integration
+ * scan actually covered, used as the single source of truth for cleanup
+ * scope instead of frontend-reconstructed `scannedSources`/`scannedLocations`.
+ *
+ * Lifecycle:
+ *   1. createScan() at the start of a provider scan -> { id, startedAt }.
+ *   2. recordScanItems() as items are discovered (metadata only, never
+ *      secret material) -- gives import something to bind client-submitted
+ *      items against instead of trusting arbitrary client-supplied
+ *      provenance.
+ *   3. finalizeScan() once the scan is done, with the authoritative
+ *      cleanup_scope (per source-kind/dimension completeness).
+ *   4. claimScanForCleanup() at cleanup time: a single-use, transactional
+ *      claim so a scan can never drive more than one destructive cleanup.
+ */
+
+const { pool } = require("../db/database");
+
+async function createScan({
+  workspaceId,
+  provider,
+  instance,
+  ownerKey,
+  createdBy = null,
+  client = null,
+}) {
+  const db = client || pool;
+  const res = await db.query(
+    `INSERT INTO integration_scans (workspace_id, provider, source_instance, source_owner_key, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, started_at`,
+    [workspaceId, provider, instance, ownerKey, createdBy],
+  );
+  return { id: res.rows[0].id, startedAt: res.rows[0].started_at };
+}
+
+/**
+ * Bulk-persist discovered items (metadata only) so import can later bind
+ * client-submitted items to a real row here by (scanId, sourceKind,
+ * sourceObjectId), rather than trusting whatever provenance the client
+ * claims for an arbitrary item object.
+ */
+async function recordScanItems(scanId, items, { client = null } = {}) {
+  if (!Array.isArray(items) || items.length === 0) return;
+  const db = client || pool;
+  const CHUNK = 500;
+  for (let i = 0; i < items.length; i += CHUNK) {
+    const chunk = items.slice(i, i + CHUNK);
+    const values = [];
+    const params = [];
+    let p = 1;
+    for (const item of chunk) {
+      values.push(`($${p++}, $${p++}, $${p++}, $${p++})`);
+      params.push(
+        scanId,
+        String(item.sourceKind),
+        String(item.sourceObjectId),
+        item.dimensions || {},
+      );
+    }
+    await db.query(
+      `INSERT INTO integration_scan_items (scan_id, source_kind, source_object_id, source_dimensions)
+       VALUES ${values.join(", ")}
+       ON CONFLICT (scan_id, source_kind, source_object_id) DO NOTHING`,
+      params,
+    );
+  }
+}
+
+/**
+ * @param {Array<{sourceKind, dimensions, complete, reason}>} subScopes - Per
+ *   source-kind/dimension completeness, e.g. one entry per Vault mount, per
+ *   AWS region+service, per Azure Key Vault source kind, etc. A subScope
+ *   with complete:true and zero discovered items is a legitimate
+ *   "obsolete-everything-in-this-scope" result, not a signal to skip it.
+ */
+async function finalizeScan(scanId, subScopes, { client = null } = {}) {
+  const db = client || pool;
+  await db.query(
+    `UPDATE integration_scans
+     SET completed_at = NOW(), cleanup_scope = $2
+     WHERE id = $1`,
+    [scanId, JSON.stringify({ subScopes: subScopes || [] })],
+  );
+}
+
+/**
+ * Looks up recorded scan items matching the given (sourceKind, objectId)
+ * pairs, so import can trust only the dimensions the scan actually
+ * observed rather than whatever the client echoes back.
+ */
+async function lookupScanItems(scanId, pairs, { client = null } = {}) {
+  const db = client || pool;
+  if (!scanId || !Array.isArray(pairs) || pairs.length === 0) return new Map();
+  const kinds = pairs.map((p) => String(p.sourceKind));
+  const objectIds = pairs.map((p) => String(p.sourceObjectId));
+  const res = await db.query(
+    `SELECT source_kind, source_object_id, source_dimensions
+     FROM integration_scan_items
+     WHERE scan_id = $1
+       AND (source_kind, source_object_id) IN (
+         SELECT * FROM UNNEST($2::text[], $3::text[])
+       )`,
+    [scanId, kinds, objectIds],
+  );
+  const map = new Map();
+  for (const row of res.rows) {
+    map.set(`${row.source_kind}::${row.source_object_id}`, row.source_dimensions);
+  }
+  return map;
+}
+
+/**
+ * Atomically claims a scan for a destructive cleanup run. Returns null if
+ * the scan does not exist, does not belong to this workspace/provider
+ * scope, or has already been consumed by a previous cleanup -- the single
+ * UPDATE ... WHERE cleanup_consumed_at IS NULL RETURNING makes replay of
+ * the same scan_id for a second cleanup impossible even under concurrency.
+ */
+async function claimScanForCleanup({ scanId, workspaceId, provider, client }) {
+  const db = client || pool;
+  const res = await db.query(
+    `UPDATE integration_scans
+     SET cleanup_consumed_at = NOW()
+     WHERE id = $1
+       AND workspace_id = $2
+       AND provider = $3
+       AND completed_at IS NOT NULL
+       AND cleanup_consumed_at IS NULL
+     RETURNING id, source_instance, source_owner_key, started_at, cleanup_scope`,
+    [scanId, workspaceId, provider],
+  );
+  return res.rows[0] || null;
+}
+
+module.exports = {
+  createScan,
+  recordScanItems,
+  finalizeScan,
+  lookupScanItems,
+  claimScanForCleanup,
+};

--- a/apps/api/services/scanBinding.js
+++ b/apps/api/services/scanBinding.js
@@ -1,0 +1,62 @@
+"use strict";
+
+/**
+ * Shared import-time helper: binds client-submitted import items to the
+ * scan that actually discovered them, so a token's provenance always comes
+ * from what the backend recorded during the scan (see integrationScans.js)
+ * rather than from fields the client echoes back on the import request.
+ *
+ * Every provider's import route follows the same shape: build a
+ * `{sourceKind, sourceObjectId}` pair per raw item, look those pairs up
+ * against `integration_scan_items` for the submitted `scan_id`, and only
+ * attribute source_* fields on the ones that match a real recorded row.
+ * An item that doesn't match (no scan_id supplied, wrong scan_id, or the
+ * item simply wasn't part of that scan) is imported the same way imports
+ * always worked before this feature -- unattributed, and therefore never a
+ * cleanup candidate. This is the deliberate "don't guess" behavior for
+ * ambiguous/legacy-shaped imports.
+ */
+
+const { getScan, lookupScanItems } = require("./integrationScans");
+
+/**
+ * @param {Object} params
+ * @param {string|null} params.scanId - Client-submitted scan_id, if any.
+ * @param {string} params.workspaceId
+ * @param {string} params.provider
+ * @param {Array<{sourceKind: string, sourceObjectId: string}>} params.pairs - One entry per raw import item, in the same order.
+ * @returns {Promise<{scan: Object|null, resolveForItem: (index: number) => (Object|null)}>}
+ *   `resolveForItem(i)` returns the source_* fields to spread onto that
+ *   item's token payload, or null if the item could not be bound.
+ */
+async function bindImportItemsToScan({ scanId, workspaceId, provider, pairs }) {
+  if (!scanId || typeof scanId !== "string") {
+    return { scan: null, resolveForItem: () => null };
+  }
+  const scan = await getScan({ scanId, workspaceId, provider });
+  if (!scan) {
+    return { scan: null, resolveForItem: () => null };
+  }
+  const recordedByKey = await lookupScanItems(scanId, pairs);
+  return {
+    scan,
+    resolveForItem(index) {
+      const pair = pairs[index];
+      if (!pair) return null;
+      const key = `${pair.sourceKind}::${pair.sourceObjectId}`;
+      const recordedDimensions = recordedByKey.get(key);
+      if (recordedDimensions === undefined) return null;
+      return {
+        source_provider: provider,
+        source_instance: scan.source_instance,
+        source_owner_key: scan.source_owner_key,
+        source_kind: pair.sourceKind,
+        source_dimensions: recordedDimensions,
+        source_object_id: pair.sourceObjectId,
+        source_observed_at: scan.started_at,
+      };
+    },
+  };
+}
+
+module.exports = { bindImportItemsToScan };

--- a/apps/api/services/sourceIdentity.js
+++ b/apps/api/services/sourceIdentity.js
@@ -17,7 +17,7 @@
  * @property {string} instance - Host/account/project/vault/tenant identifying this connection.
  * @property {string} ownerKey - Immutable principal id scoping ownership within the instance.
  * @property {string|null} ownerDisplay - Mutable human-readable label (UI only).
- * @property {Object} dimensions - Provider-specific narrowing (mount, region, source kind, ...).
+ * @property {Object} dimensions - Provider-specific per-token narrowing (mount+path for Vault, region+service for AWS, source kind for Azure/Azure AD, ...). Distinct from a scan's coarser sub-scope filter (e.g. a requested path *prefix*), which callers build separately when finalizing a scan.
  */
 
 function requireString(value, field, provider) {
@@ -58,9 +58,13 @@ function resolveSourceIdentity(provider, context = {}) {
     case "vault": {
       // Vault has no separate per-object ownership concept beyond "which
       // server (and, for Enterprise namespaces, which namespace)": ownerKey
-      // mirrors instance. dimensions carry the actual narrowing applied by
-      // the scan (mount/path/category/KV-vs-PKI) so cleanup can be scoped
-      // to exactly what was scanned, not "the whole Vault server".
+      // mirrors instance. dimensions describe *this token's own* narrowing
+      // (which mount, which exact path, which category) -- kvOrPki is
+      // deliberately omitted here since that distinction is already carried
+      // by the token's source_kind field, not duplicated into dimensions.
+      // Scan-level sub-scope filters (e.g. a requested path *prefix*) are a
+      // separate, coarser concept built by the caller when finalizing the
+      // scan, not by this per-token resolver.
       const address = requireString(context.address, "address", provider);
       const instance = context.namespace
         ? `${address}::${String(context.namespace)}`
@@ -71,9 +75,8 @@ function resolveSourceIdentity(provider, context = {}) {
         ownerDisplay: instance,
         dimensions: {
           mount: context.mount ?? null,
-          pathPrefix: context.pathPrefix ?? null,
+          path: context.path ?? null,
           category: context.category ?? null,
-          kvOrPki: context.kvOrPki ?? null,
         },
       };
     }

--- a/apps/api/services/sourceIdentity.js
+++ b/apps/api/services/sourceIdentity.js
@@ -1,0 +1,142 @@
+"use strict";
+
+/**
+ * Single source of truth for "which credential/account/vault/project did
+ * this token come from" across every provider. Both the manual-import
+ * routes and the auto-sync worker call this resolver so a token's
+ * provenance is computed identically regardless of which code path
+ * triggered the scan -- no route-specific or worker-specific divergence.
+ *
+ * `ownerKey` is always an immutable principal id (a numeric user/org/repo
+ * id, an account id, a project id, a tenant id, a vault URL) -- never a
+ * mutable display name -- because obsolete-token cleanup matches on it.
+ * `ownerDisplay` carries a human-readable label for the UI only and must
+ * never be used in a matching predicate.
+ *
+ * @typedef {Object} SourceIdentity
+ * @property {string} instance - Host/account/project/vault/tenant identifying this connection.
+ * @property {string} ownerKey - Immutable principal id scoping ownership within the instance.
+ * @property {string|null} ownerDisplay - Mutable human-readable label (UI only).
+ * @property {Object} dimensions - Provider-specific narrowing (mount, region, source kind, ...).
+ */
+
+function requireString(value, field, provider) {
+  if (value === null || value === undefined || String(value).trim() === "") {
+    throw new Error(
+      `resolveSourceIdentity(${provider}): missing required "${field}"`,
+    );
+  }
+  return String(value);
+}
+
+/**
+ * @param {string} provider - One of: github, gitlab, vault, aws, azure, azure-ad, gcp.
+ * @param {Object} context - Provider-specific identity inputs (see cases below).
+ * @returns {SourceIdentity}
+ */
+function resolveSourceIdentity(provider, context = {}) {
+  switch (provider) {
+    case "github":
+    case "gitlab": {
+      // instance = host/baseUrl so two self-hosted (or GHE) instances with
+      // colliding numeric owner/repo ids never share a cleanup scope.
+      // ownerKey is whichever numeric id actually owns/scopes this token's
+      // object: the authenticated user for user-owned objects (PATs, SSH
+      // keys), or the repo/project/group's own numeric id for repo- or
+      // group-scoped objects (deploy keys, repo secrets, project/group
+      // access tokens) -- callers pass the correct one per item.
+      const instance = requireString(context.host, "host", provider);
+      const ownerKey = requireString(context.ownerKey, "ownerKey", provider);
+      return {
+        instance,
+        ownerKey,
+        ownerDisplay: context.ownerDisplay ? String(context.ownerDisplay) : null,
+        dimensions: {},
+      };
+    }
+
+    case "vault": {
+      // Vault has no separate per-object ownership concept beyond "which
+      // server (and, for Enterprise namespaces, which namespace)": ownerKey
+      // mirrors instance. dimensions carry the actual narrowing applied by
+      // the scan (mount/path/category/KV-vs-PKI) so cleanup can be scoped
+      // to exactly what was scanned, not "the whole Vault server".
+      const address = requireString(context.address, "address", provider);
+      const instance = context.namespace
+        ? `${address}::${String(context.namespace)}`
+        : address;
+      return {
+        instance,
+        ownerKey: instance,
+        ownerDisplay: instance,
+        dimensions: {
+          mount: context.mount ?? null,
+          pathPrefix: context.pathPrefix ?? null,
+          category: context.category ?? null,
+          kvOrPki: context.kvOrPki ?? null,
+        },
+      };
+    }
+
+    case "aws": {
+      // instance/ownerKey = STS account id (the only thing that reliably
+      // identifies "which AWS account" regardless of which IAM principal
+      // within it made the call).
+      const accountId = requireString(context.accountId, "accountId", provider);
+      return {
+        instance: accountId,
+        ownerKey: accountId,
+        ownerDisplay: accountId,
+        dimensions: {
+          region: context.region ?? null,
+          service: context.service ?? null,
+        },
+      };
+    }
+
+    case "azure": {
+      // Azure Key Vault: the vault itself is both the instance and the
+      // owner -- there is no further per-object ownership within a vault.
+      const vaultUrl = requireString(context.vaultUrl, "vaultUrl", provider);
+      return {
+        instance: vaultUrl,
+        ownerKey: vaultUrl,
+        ownerDisplay: vaultUrl,
+        dimensions: {
+          sourceKind: context.sourceKind ?? null,
+        },
+      };
+    }
+
+    case "azure-ad": {
+      // Azure AD (Microsoft Graph): tenant id scopes both instance and
+      // ownership. Applications/ServicePrincipals are tracked as an
+      // independent completeness dimension (see azureADIntegration.js).
+      const tenantId = requireString(context.tenantId, "tenantId", provider);
+      return {
+        instance: tenantId,
+        ownerKey: tenantId,
+        ownerDisplay: tenantId,
+        dimensions: {
+          sourceKind: context.sourceKind ?? null,
+        },
+      };
+    }
+
+    case "gcp": {
+      // GCP Secret Manager is already project-scoped; no further narrowing.
+      const projectId = requireString(context.projectId, "projectId", provider);
+      return {
+        instance: projectId,
+        ownerKey: projectId,
+        ownerDisplay: projectId,
+        dimensions: {},
+      };
+    }
+
+    default:
+      throw new Error(`resolveSourceIdentity: unknown provider "${provider}"`);
+  }
+}
+
+module.exports = { resolveSourceIdentity };

--- a/apps/api/services/vaultIntegration.js
+++ b/apps/api/services/vaultIntegration.js
@@ -838,10 +838,15 @@ async function scanVault({
           truncated,
           hasErrors,
           complete: !truncated && !hasErrors,
+          // Sub-scope dimensions use different key semantics than a token's
+          // own recorded dimensions: `pathPrefix` triggers a LIKE-prefix
+          // match against the token's exact `path`, and `categories` is a
+          // membership check against the token's single `category` --
+          // neither can be exact-matched against, unlike `mount`.
           dimensions: {
             mount: m.path,
-            path: pathPrefix || null,
-            category: categorySet ? [...categorySet].sort().join(",") : null,
+            pathPrefix: pathPrefix || null,
+            categories: categorySet ? [...categorySet].sort() : null,
           },
         });
         logger.info("Vault KV mount scan completed", {
@@ -889,7 +894,7 @@ async function scanVault({
           complete: !truncated && !hasErrors,
           dimensions: {
             mount: m.path,
-            category: categorySet ? [...categorySet].sort().join(",") : null,
+            categories: categorySet ? [...categorySet].sort() : null,
           },
         });
         logger.info("Vault PKI mount scan completed", {

--- a/apps/api/services/vaultIntegration.js
+++ b/apps/api/services/vaultIntegration.js
@@ -441,6 +441,11 @@ function buildKvSecretItems({ mountPath, key, secret }) {
         issuer: null,
         subject: null,
         location: `vault:${mountPath}${key}`,
+        // Explicit KV source kind, never inferred from a path-shape regex --
+        // a KV secret can legally live at a path shaped like a PKI cert path
+        // (e.g. ".../cert/my-secret") without being one.
+        sourceKind: "vault-kv",
+        sourceObjectId: `${mountPath}${key}`,
       },
     ];
   }
@@ -466,6 +471,9 @@ function buildKvSecretItems({ mountPath, key, secret }) {
       field,
     });
 
+    const location = multipleCerts
+      ? `vault:${mountPath}${key}#${field}`
+      : `vault:${mountPath}${key}`;
     return {
       ...base,
       secret_key: field,
@@ -478,9 +486,14 @@ function buildKvSecretItems({ mountPath, key, secret }) {
       // Single-cert secrets keep the legacy location so tokens imported
       // before per-key scanning still dedupe on (name, location);
       // multi-cert secrets need one location per KV field.
-      location: multipleCerts
-        ? `vault:${mountPath}${key}#${field}`
-        : `vault:${mountPath}${key}`,
+      location,
+      // Still vault-kv: a certificate stored as a KV value is a KV object,
+      // not a PKI-engine-issued certificate (vault-pki is reserved for
+      // /pki mount-issued certs enumerated via scanPki below).
+      sourceKind: "vault-kv",
+      sourceObjectId: multipleCerts
+        ? `${mountPath}${key}#${field}`
+        : `${mountPath}${key}`,
     };
   });
 }
@@ -536,6 +549,7 @@ async function scanKvV2({
   }
   const items = [];
   let truncated = false;
+  let hasReadErrors = false;
   const BATCH_SIZE = 10;
 
   for (let i = 0; i < keys.length; i += BATCH_SIZE) {
@@ -557,7 +571,11 @@ async function scanKvV2({
             secretPath: key,
           });
         } catch (_e) {
-          // Skip secrets we cannot read
+          // A secret we know exists (it was LIST-ed) but cannot read means
+          // its continued existence is unconfirmed, not confirmed-absent --
+          // the mount's KV sub-scope must be reported incomplete so cleanup
+          // never treats "we skipped it" as "it's gone".
+          hasReadErrors = true;
           return null;
         }
         return buildKvSecretItems({ mountPath, key, secret });
@@ -576,7 +594,7 @@ async function scanKvV2({
       }
     }
   }
-  return { items, truncated };
+  return { items, truncated, hasErrors: hasReadErrors };
 }
 
 async function tryListPkiCertSerials({ address, token, mountPath }) {
@@ -613,6 +631,7 @@ async function scanPki({ address, token, mount, maxItems = 500 }) {
   const mountPath = mount.path; // ends with '/'
   const serials = await tryListPkiCertSerials({ address, token, mountPath });
   const items = [];
+  let hasReadErrors = false;
   const BATCH_SIZE = 10;
 
   for (let i = 0; i < serials.length; i += BATCH_SIZE) {
@@ -631,6 +650,11 @@ async function scanPki({ address, token, mount, maxItems = 500 }) {
             serial,
           });
         } catch (_) {
+          // A per-serial read failure means this cert's continued existence
+          // is unconfirmed, not confirmed-absent -- the mount's PKI
+          // sub-scope must be reported incomplete so cleanup never treats
+          // an unreadable cert as "not rediscovered, therefore obsolete".
+          hasReadErrors = true;
           return null;
         }
         if (!pem) return null;
@@ -651,9 +675,12 @@ async function scanPki({ address, token, mount, maxItems = 500 }) {
           issuer,
           subject,
           location: `vault:${mountPath}cert/${serial}`,
+          sourceKind: "vault-pki",
+          sourceObjectId: `${mountPath}cert/${serial}`,
         };
       }),
     );
+
 
     // Add non-null results to items
     for (const item of batchResults) {
@@ -662,7 +689,8 @@ async function scanPki({ address, token, mount, maxItems = 500 }) {
       }
     }
   }
-  return { items, truncated: serials.length > items.length };
+  const truncated = serials.length > items.length && !hasReadErrors;
+  return { items, truncated, hasErrors: hasReadErrors };
 }
 
 async function scanVault({
@@ -761,7 +789,11 @@ async function scanVault({
     if (m.type === "kv") {
       try {
         logger.debug("Scanning Vault KV mount", { mount: m.path });
-        const { items: rawItems, truncated } = await scanKvV2({
+        const {
+          items: rawItems,
+          truncated,
+          hasErrors,
+        } = await scanKvV2({
           address,
           token,
           mount: m,
@@ -770,16 +802,29 @@ async function scanVault({
         });
         const items = rawItems.filter(keepByCategory);
         results.push(...items);
+        // A mount sub-scope is only "complete" (usable as a cleanup basis)
+        // when nothing was truncated by the item cap and no per-secret read
+        // failed -- either would make "not rediscovered" ambiguous between
+        // "actually gone" and "we just didn't get to check".
         summary.push({
           mount: m.path,
           type: m.type,
+          sourceKind: "vault-kv",
           found: items.length,
           truncated,
+          hasErrors,
+          complete: !truncated && !hasErrors,
+          dimensions: {
+            mount: m.path,
+            path: pathPrefix || null,
+            category: categorySet ? [...categorySet].sort().join(",") : null,
+          },
         });
         logger.info("Vault KV mount scan completed", {
           mount: m.path,
           itemsFound: items.length,
           truncated,
+          hasErrors,
         });
       } catch (e) {
         logger.warn("Vault KV mount scan failed", {
@@ -787,12 +832,22 @@ async function scanVault({
           error: e.message,
           status: e.status,
         });
-        summary.push({ mount: m.path, type: m.type, error: e.message });
+        summary.push({
+          mount: m.path,
+          type: m.type,
+          sourceKind: "vault-kv",
+          error: e.message,
+          complete: false,
+        });
       }
     } else if (m.type === "pki") {
       try {
         logger.debug("Scanning Vault PKI mount", { mount: m.path });
-        const { items: rawItems, truncated } = await scanPki({
+        const {
+          items: rawItems,
+          truncated,
+          hasErrors,
+        } = await scanPki({
           address,
           token,
           mount: m,
@@ -803,13 +858,21 @@ async function scanVault({
         summary.push({
           mount: m.path,
           type: m.type,
+          sourceKind: "vault-pki",
           found: items.length,
           truncated,
+          hasErrors,
+          complete: !truncated && !hasErrors,
+          dimensions: {
+            mount: m.path,
+            category: categorySet ? [...categorySet].sort().join(",") : null,
+          },
         });
         logger.info("Vault PKI mount scan completed", {
           mount: m.path,
           itemsFound: items.length,
           truncated,
+          hasErrors,
         });
       } catch (e) {
         logger.warn("Vault PKI mount scan failed", {
@@ -817,7 +880,13 @@ async function scanVault({
           error: e.message,
           status: e.status,
         });
-        summary.push({ mount: m.path, type: m.type, error: e.message });
+        summary.push({
+          mount: m.path,
+          type: m.type,
+          sourceKind: "vault-pki",
+          error: e.message,
+          complete: false,
+        });
       }
     }
   }

--- a/apps/api/services/vaultIntegration.js
+++ b/apps/api/services/vaultIntegration.js
@@ -301,9 +301,27 @@ async function listKvV2KeysRecursive({
   prefix = "",
   limit = 1000,
 }) {
-  // LIST metadata to enumerate keys; recurse into folders
+  // LIST metadata to enumerate keys; recurse into folders.
+  //
+  // `limit` here caps *key enumeration*, a separate and earlier truncation
+  // point than the later per-secret read loop in scanKvV2. If a mount has
+  // more keys than `limit`, this walk stops early and returns fewer keys
+  // than actually exist -- silently, from the caller's point of view, since
+  // a short-but-real key list and a short-because-truncated key list look
+  // identical unless this function also reports which one happened. Without
+  // `truncated` here, scanKvV2's own truncation check (which only fires when
+  // the *read* loop hits `maxItems`) never fires either, because it never
+  // sees more keys than the enumeration cap already trimmed away -- so a
+  // mount with more secrets than maxItemsPerMount was scanned as `complete:
+  // true`, and cleanup could (and in manual testing, did) delete secrets
+  // that were never actually looked at.
   const results = [];
+  let truncated = false;
   async function walk(pathPrefix) {
+    if (results.length >= limit) {
+      truncated = true;
+      return;
+    }
     const listPath = `/v1/${mountPath}metadata/${pathPrefix}`;
     let data;
     try {
@@ -321,7 +339,10 @@ async function listKvV2KeysRecursive({
     const keys =
       data && data.data && Array.isArray(data.data.keys) ? data.data.keys : [];
     for (const key of keys) {
-      if (results.length >= limit) return;
+      if (results.length >= limit) {
+        truncated = true;
+        return;
+      }
       if (key.endsWith("/")) {
         await walk(`${pathPrefix}${key}`);
       } else {
@@ -330,7 +351,7 @@ async function listKvV2KeysRecursive({
     }
   }
   await walk(prefix);
-  return results;
+  return { keys: results, truncated };
 }
 
 async function readKvV2Secret({ address, token, mountPath, secretPath }) {
@@ -524,7 +545,7 @@ async function scanKvV2({
     }
   }
   const normalizedPrefix = trimmedPrefix.length > 0 ? `${trimmedPrefix}/` : "";
-  const keys = await listKvV2KeysRecursive({
+  const { keys, truncated: keyListTruncated } = await listKvV2KeysRecursive({
     address,
     token,
     mountPath,
@@ -548,7 +569,10 @@ async function scanKvV2({
     }
   }
   const items = [];
-  let truncated = false;
+  // Key enumeration can itself be truncated (see listKvV2KeysRecursive)
+  // before the read loop below ever runs; that must carry through even if
+  // every enumerated key happens to be readable and under maxItems.
+  let truncated = keyListTruncated;
   let hasReadErrors = false;
   const BATCH_SIZE = 10;
 

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -999,6 +999,12 @@ export default function ImportTokensModal({
   const [selectedRowsAzureAD, setSelectedRowsAzureAD] = React.useState(
     new Set()
   );
+  const [azureADCleanupObsolete, setAzureADCleanupObsolete] =
+    React.useState(false);
+  // Source kinds included in the last scan; cleanup only touches these.
+  const [azureADLastScanSources, setAzureADLastScanSources] = React.useState(
+    []
+  );
 
   // Show/hide toggle for secret fields
   const [showSecrets, setShowSecrets] = React.useState({});
@@ -1925,6 +1931,14 @@ export default function ImportTokensModal({
       const items = Array.isArray(res?.items) ? res.items : [];
       setAzureADItems(items);
       setAzureADSummary(Array.isArray(res?.summary) ? res.summary : []);
+      const scannedSources = [];
+      if (azureADIncludeApps) {
+        scannedSources.push('azure-ad-client-secret', 'azure-ad-certificate');
+      }
+      if (azureADIncludeSPs) {
+        scannedSources.push('azure-ad-sp-secret', 'azure-ad-sp-certificate');
+      }
+      setAzureADLastScanSources(scannedSources);
       if (items.length > 0)
         setScanSucceededFor(prev => new Set(prev).add('azure-ad'));
 
@@ -1977,6 +1991,20 @@ export default function ImportTokensModal({
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup:
+          azureADCleanupObsolete && azureADLastScanSources.length > 0
+            ? {
+                enabled: true,
+                provider: 'azure-ad',
+                scannedSources: azureADLastScanSources,
+                // All rediscovered locations (whole scan, not just
+                // selection) so unselected-but-still-present items are
+                // never deleted.
+                scannedLocations: azureADItems
+                  .map(it => it.location)
+                  .filter(Boolean),
+              }
+            : undefined,
       });
       onImported && onImported(selected);
     } catch (e) {
@@ -2909,6 +2937,32 @@ export default function ImportTokensModal({
                       Scan
                     </Button>
                   </HStack>
+                  <Box border='1px solid' borderColor={border} borderRadius='md' p={3}>
+                    <VStack align='stretch' spacing={2}>
+                      <Checkbox
+                        isChecked={azureADCleanupObsolete}
+                        onChange={e =>
+                          setAzureADCleanupObsolete(e.target.checked)
+                        }
+                        size='sm'
+                        colorScheme='red'
+                      >
+                        Remove previously imported items no longer found at
+                        the source
+                      </Checkbox>
+                      {azureADCleanupObsolete ? (
+                        <Text fontSize='xs' color='red.400' pl={6}>
+                          Deletes previously imported secrets and
+                          certificates of the item types scanned above (App
+                          Registrations, Service Principals, or both) that no
+                          longer appear anywhere in this scan's results,
+                          regardless of which items you select for import
+                          below. Item types you did not scan for are never
+                          affected. This cannot be undone.
+                        </Text>
+                      ) : null}
+                    </VStack>
+                  </Box>
                   {azureADSummary.length > 0 && !error && (
                     <Box
                       border='1px solid'

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -1983,6 +1983,10 @@ export default function ImportTokensModal({
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: azureADLastScanId || undefined,
         cleanup:
           azureADCleanupObsolete && azureADLastScanId
             ? {

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -1001,10 +1001,8 @@ export default function ImportTokensModal({
   );
   const [azureADCleanupObsolete, setAzureADCleanupObsolete] =
     React.useState(false);
-  // Source kinds included in the last scan; cleanup only touches these.
-  const [azureADLastScanSources, setAzureADLastScanSources] = React.useState(
-    []
-  );
+  // The backend-authoritative scan record cleanup is driven from.
+  const [azureADLastScanId, setAzureADLastScanId] = React.useState(null);
 
   // Show/hide toggle for secret fields
   const [showSecrets, setShowSecrets] = React.useState({});
@@ -1931,14 +1929,7 @@ export default function ImportTokensModal({
       const items = Array.isArray(res?.items) ? res.items : [];
       setAzureADItems(items);
       setAzureADSummary(Array.isArray(res?.summary) ? res.summary : []);
-      const scannedSources = [];
-      if (azureADIncludeApps) {
-        scannedSources.push('azure-ad-client-secret', 'azure-ad-certificate');
-      }
-      if (azureADIncludeSPs) {
-        scannedSources.push('azure-ad-sp-secret', 'azure-ad-sp-certificate');
-      }
-      setAzureADLastScanSources(scannedSources);
+      setAzureADLastScanId(res?.scan_id || null);
       if (items.length > 0)
         setScanSucceededFor(prev => new Set(prev).add('azure-ad'));
 
@@ -1954,6 +1945,7 @@ export default function ImportTokensModal({
       // Clear summary on error to prevent showing partial/error data
       setAzureADItems([]);
       setAzureADSummary([]);
+      setAzureADLastScanId(null);
       // Handle quota exceeded error
       if (isQuotaExceededError(e)) {
         setError(formatQuotaError(e));
@@ -1992,17 +1984,11 @@ export default function ImportTokensModal({
         items: selected,
         defaults: {},
         cleanup:
-          azureADCleanupObsolete && azureADLastScanSources.length > 0
+          azureADCleanupObsolete && azureADLastScanId
             ? {
                 enabled: true,
                 provider: 'azure-ad',
-                scannedSources: azureADLastScanSources,
-                // All rediscovered locations (whole scan, not just
-                // selection) so unselected-but-still-present items are
-                // never deleted.
-                scannedLocations: azureADItems
-                  .map(it => it.location)
-                  .filter(Boolean),
+                scanId: azureADLastScanId,
               }
             : undefined,
       });
@@ -2951,19 +2937,34 @@ export default function ImportTokensModal({
                         }
                         size='sm'
                         colorScheme='red'
+                        isDisabled={!azureADLastScanId}
                       >
                         Remove previously imported items no longer found at the
                         source
                       </Checkbox>
+                      {!azureADLastScanId ? (
+                        <Text fontSize='xs' color={muted} pl={6}>
+                          Run a scan first; cleanup is driven by the backend's
+                          record of what that scan covered.
+                        </Text>
+                      ) : azureADSummary.some(s => s.complete === false) ? (
+                        <Text fontSize='xs' color='orange.400' pl={6}>
+                          The last scan didn't fully complete for every item
+                          type above (see the errors below). The backend will
+                          only clean up App Registrations or Service Principals
+                          it confirmed were fully scanned; nothing incomplete or
+                          errored is ever touched.
+                        </Text>
+                      ) : null}
                       {azureADCleanupObsolete ? (
                         <Text fontSize='xs' color='red.400' pl={6}>
                           Deletes previously imported secrets and certificates
                           of the item types scanned above (App Registrations,
                           Service Principals, or both) that no longer appear
                           anywhere in this scan's results, regardless of which
-                          items you select for import below. Item types you did
-                          not scan for are never affected. This cannot be
-                          undone.
+                          items you select for import below. Item types this
+                          scan couldn't fully complete are never affected. This
+                          cannot be undone.
                         </Text>
                       ) : null}
                     </VStack>

--- a/apps/dashboard/src/components/ImportTokensModal.jsx
+++ b/apps/dashboard/src/components/ImportTokensModal.jsx
@@ -2937,7 +2937,12 @@ export default function ImportTokensModal({
                       Scan
                     </Button>
                   </HStack>
-                  <Box border='1px solid' borderColor={border} borderRadius='md' p={3}>
+                  <Box
+                    border='1px solid'
+                    borderColor={border}
+                    borderRadius='md'
+                    p={3}
+                  >
                     <VStack align='stretch' spacing={2}>
                       <Checkbox
                         isChecked={azureADCleanupObsolete}
@@ -2947,18 +2952,18 @@ export default function ImportTokensModal({
                         size='sm'
                         colorScheme='red'
                       >
-                        Remove previously imported items no longer found at
-                        the source
+                        Remove previously imported items no longer found at the
+                        source
                       </Checkbox>
                       {azureADCleanupObsolete ? (
                         <Text fontSize='xs' color='red.400' pl={6}>
-                          Deletes previously imported secrets and
-                          certificates of the item types scanned above (App
-                          Registrations, Service Principals, or both) that no
-                          longer appear anywhere in this scan's results,
-                          regardless of which items you select for import
-                          below. Item types you did not scan for are never
-                          affected. This cannot be undone.
+                          Deletes previously imported secrets and certificates
+                          of the item types scanned above (App Registrations,
+                          Service Principals, or both) that no longer appear
+                          anywhere in this scan's results, regardless of which
+                          items you select for import below. Item types you did
+                          not scan for are never affected. This cannot be
+                          undone.
                         </Text>
                       ) : null}
                     </VStack>

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -511,19 +511,18 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
             Remove previously imported items no longer found at the source
           </Checkbox>
           <Text fontSize='xs' color={helpTextColor} pl={6}>
-            Only available for &quot;All Regions + Global&quot; or
-            &quot;Global (IAM only)&quot; scans. AWS secrets and certificates
-            can exist in any region, so a single-region scan never sees
-            enough of the account to safely judge what is obsolete.
+            Only available for &quot;All Regions + Global&quot; or &quot;Global
+            (IAM only)&quot; scans. AWS secrets and certificates can exist in
+            any region, so a single-region scan never sees enough of the account
+            to safely judge what is obsolete.
           </Text>
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
-              Deletes previously imported items of the item types scanned
-              above (secrets, certificates, and/or IAM keys, depending on the
-              scan you run) that no longer appear anywhere in this scan's
-              results, regardless of which items you select for import
-              below. Item types you did not scan for are never affected.
-              This cannot be undone.
+              Deletes previously imported items of the item types scanned above
+              (secrets, certificates, and/or IAM keys, depending on the scan you
+              run) that no longer appear anywhere in this scan's results,
+              regardless of which items you select for import below. Item types
+              you did not scan for are never affected. This cannot be undone.
             </Text>
           ) : null}
         </VStack>

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -405,6 +405,10 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -7,6 +7,7 @@ import {
   Input,
   Button,
   Badge,
+  Checkbox,
   InputGroup,
   InputRightElement,
   IconButton,
@@ -148,6 +149,9 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   const [showSecret, setShowSecret] = React.useState(false);
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // Source kinds included in the last scan; cleanup only touches these.
+  const [lastScanSources, setLastScanSources] = React.useState([]);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsAws.size);
@@ -305,6 +309,9 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         const aggregatedSummary = Object.values(summaryByType);
         setAwsItems(allItems);
         setAwsSummary(aggregatedSummary);
+        // All-regions scan always includes IAM (global) plus secrets and
+        // certificates for every detected region.
+        setLastScanSources(['aws-iam-key', 'aws-secrets-manager', 'aws-acm']);
         if (allItems.length > 0) {
           onScanSuccess && onScanSuccess('aws');
         }
@@ -332,6 +339,13 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         const items = Array.isArray(res?.items) ? res.items : [];
         setAwsItems(items);
         setAwsSummary(Array.isArray(res?.summary) ? res.summary : []);
+        // IAM keys are account-wide (not region-scoped), so a global-only
+        // scan sees the whole population and can safely support cleanup.
+        // A single specific-region scan only sees one region's secrets and
+        // certificates out of the whole account, so it must never enable
+        // cleanup for those kinds (the location patterns aren't region-
+        // scoped) - leave lastScanSources empty in that case.
+        setLastScanSources(isGlobalScan ? ['aws-iam-key'] : []);
         if (items.length > 0) {
           onScanSuccess && onScanSuccess('aws');
         }
@@ -385,6 +399,19 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup:
+          cleanupObsolete && lastScanSources.length > 0
+            ? {
+                enabled: true,
+                provider: 'aws',
+                scannedSources: lastScanSources,
+                // All rediscovered locations (whole scan, not just selection)
+                // so unselected-but-still-present items are never deleted.
+                scannedLocations: awsItems
+                  .map(it => it.location)
+                  .filter(Boolean),
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -472,6 +499,35 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
           Detect Regions
         </Button>
       </HStack>
+      <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+        <VStack align='stretch' spacing={2}>
+          <Checkbox
+            isChecked={cleanupObsolete}
+            onChange={e => setCleanupObsolete(e.target.checked)}
+            isDisabled={awsRegion !== 'all-regions' && awsRegion !== 'global'}
+            size='sm'
+            colorScheme='red'
+          >
+            Remove previously imported items no longer found at the source
+          </Checkbox>
+          <Text fontSize='xs' color={helpTextColor} pl={6}>
+            Only available for &quot;All Regions + Global&quot; or
+            &quot;Global (IAM only)&quot; scans. AWS secrets and certificates
+            can exist in any region, so a single-region scan never sees
+            enough of the account to safely judge what is obsolete.
+          </Text>
+          {cleanupObsolete ? (
+            <Text fontSize='xs' color='red.400' pl={6}>
+              Deletes previously imported items of the item types scanned
+              above (secrets, certificates, and/or IAM keys, depending on the
+              scan you run) that no longer appear anywhere in this scan's
+              results, regardless of which items you select for import
+              below. Item types you did not scan for are never affected.
+              This cannot be undone.
+            </Text>
+          ) : null}
+        </VStack>
+      </Box>
       {(awsDetectedRegions.length > 0 ||
         (awsIamInfo && awsIamInfo.keysCount > 0)) && (
         <VStack align='stretch' spacing={3}>

--- a/apps/dashboard/src/components/imports/ImportAWSForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAWSForm.jsx
@@ -150,8 +150,14 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
-  // Source kinds included in the last scan; cleanup only touches these.
-  const [lastScanSources, setLastScanSources] = React.useState([]);
+  // The backend-authoritative scan record cleanup is driven from. Only set
+  // when a single backend scan call covers this scan (global or one
+  // specific region); "all regions" makes multiple backend calls (one per
+  // region, since AWS has no single "list every region" secrets API), so
+  // there's no single scan_id that covers the whole sweep yet -- cleanup
+  // stays unavailable for that mode until scan persistence supports
+  // combining multiple scan calls into one record.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsAws.size);
@@ -309,9 +315,10 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         const aggregatedSummary = Object.values(summaryByType);
         setAwsItems(allItems);
         setAwsSummary(aggregatedSummary);
-        // All-regions scan always includes IAM (global) plus secrets and
-        // certificates for every detected region.
-        setLastScanSources(['aws-iam-key', 'aws-secrets-manager', 'aws-acm']);
+        // Each region (and the IAM call) is a separate backend scan record,
+        // so there is no single scan_id covering the whole sweep -- cleanup
+        // stays unavailable for this mode.
+        setLastScanId(null);
         if (allItems.length > 0) {
           onScanSuccess && onScanSuccess('aws');
         }
@@ -339,13 +346,11 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         const items = Array.isArray(res?.items) ? res.items : [];
         setAwsItems(items);
         setAwsSummary(Array.isArray(res?.summary) ? res.summary : []);
-        // IAM keys are account-wide (not region-scoped), so a global-only
-        // scan sees the whole population and can safely support cleanup.
-        // A single specific-region scan only sees one region's secrets and
-        // certificates out of the whole account, so it must never enable
-        // cleanup for those kinds (the location patterns aren't region-
-        // scoped) - leave lastScanSources empty in that case.
-        setLastScanSources(isGlobalScan ? ['aws-iam-key'] : []);
+        // A single backend call (global IAM sweep, or one specific region)
+        // maps to exactly one persisted scan record, so its scan_id can
+        // drive cleanup scoped to whatever the backend confirms it fully
+        // covered (account-wide IAM, or that one region's secrets/certs).
+        setLastScanId(res?.scan_id || null);
         if (items.length > 0) {
           onScanSuccess && onScanSuccess('aws');
         }
@@ -360,6 +365,7 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
     } catch (e) {
       setAwsItems([]);
       setAwsSummary([]);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -400,16 +406,11 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
         items: selected,
         defaults: {},
         cleanup:
-          cleanupObsolete && lastScanSources.length > 0
+          cleanupObsolete && lastScanId
             ? {
                 enabled: true,
                 provider: 'aws',
-                scannedSources: lastScanSources,
-                // All rediscovered locations (whole scan, not just selection)
-                // so unselected-but-still-present items are never deleted.
-                scannedLocations: awsItems
-                  .map(it => it.location)
-                  .filter(Boolean),
+                scanId: lastScanId,
               }
             : undefined,
       });
@@ -504,18 +505,28 @@ const ImportAWSForm = React.forwardRef(function ImportAWSForm(
           <Checkbox
             isChecked={cleanupObsolete}
             onChange={e => setCleanupObsolete(e.target.checked)}
-            isDisabled={awsRegion !== 'all-regions' && awsRegion !== 'global'}
+            isDisabled={!lastScanId}
             size='sm'
             colorScheme='red'
           >
             Remove previously imported items no longer found at the source
           </Checkbox>
           <Text fontSize='xs' color={helpTextColor} pl={6}>
-            Only available for &quot;All Regions + Global&quot; or &quot;Global
-            (IAM only)&quot; scans. AWS secrets and certificates can exist in
-            any region, so a single-region scan never sees enough of the account
-            to safely judge what is obsolete.
+            Only available for a &quot;Global (IAM only)&quot; scan, or a single
+            specific region, right after that scan completes. Each region is
+            checked independently, so a single scan_id can only certify what it
+            actually covered; an &quot;All Regions&quot; sweep makes one backend
+            call per region and has no single scan record to attach cleanup to
+            yet.
           </Text>
+          {lastScanId && awsSummary.some(s => s.complete === false) ? (
+            <Text fontSize='xs' color='orange.400' pl={6}>
+              The last scan didn't fully complete for every item type above (see
+              the errors below). The backend will only clean up item types it
+              confirmed were fully scanned; nothing incomplete or errored is
+              ever touched.
+            </Text>
+          ) : null}
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
               Deletes previously imported items of the item types scanned above

--- a/apps/dashboard/src/components/imports/ImportAzureForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAzureForm.jsx
@@ -97,6 +97,8 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // The backend-authoritative scan record cleanup is driven from.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsAzure.size);
@@ -130,6 +132,7 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
       const items = Array.isArray(res?.items) ? res.items : [];
       setAzureItems(items);
       setAzureSummary(Array.isArray(res?.summary) ? res.summary : []);
+      setLastScanId(res?.scan_id || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('azure');
       }
@@ -143,6 +146,7 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
     } catch (e) {
       setAzureItems([]);
       setAzureSummary([]);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -182,24 +186,14 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
         workspaceId,
         items: selected,
         defaults: {},
-        cleanup: cleanupObsolete
-          ? {
-              enabled: true,
-              provider: 'azure',
-              // Azure Key Vault scans always cover all three kinds, so
-              // cleanup is always safe to scope to all of them.
-              scannedSources: [
-                'azure-key-vault-secret',
-                'azure-key-vault-certificate',
-                'azure-key-vault-key',
-              ],
-              // All rediscovered locations (whole scan, not just selection)
-              // so unselected-but-still-present items are never deleted.
-              scannedLocations: azureItems
-                .map(it => it.location)
-                .filter(Boolean),
-            }
-          : undefined,
+        cleanup:
+          cleanupObsolete && lastScanId
+            ? {
+                enabled: true,
+                provider: 'azure',
+                scanId: lastScanId,
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -294,14 +288,29 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
             onChange={e => setCleanupObsolete(e.target.checked)}
             size='sm'
             colorScheme='red'
+            isDisabled={!lastScanId}
           >
             Remove previously imported items no longer found at the source
           </Checkbox>
+          {!lastScanId ? (
+            <Text fontSize='xs' color={helpTextColor} pl={6}>
+              Run a scan first; cleanup is driven by the backend's record of
+              what that scan covered.
+            </Text>
+          ) : azureSummary.some(s => s.complete === false) ? (
+            <Text fontSize='xs' color='orange.400' pl={6}>
+              The last scan didn't fully complete for every item type above (see
+              the errors below). The backend will only clean up secrets,
+              certificates, or keys it confirmed were fully scanned; nothing
+              incomplete or errored is ever touched.
+            </Text>
+          ) : null}
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
               Deletes previously imported secrets, certificates, and keys from
               this Key Vault that no longer appear anywhere in this scan's
               results, regardless of which items you select for import below.
+              Item types this scan couldn't fully complete are never affected.
               This cannot be undone.
             </Text>
           ) : null}

--- a/apps/dashboard/src/components/imports/ImportAzureForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAzureForm.jsx
@@ -7,6 +7,7 @@ import {
   Input,
   Button,
   Badge,
+  Checkbox,
   InputGroup,
   InputRightElement,
   IconButton,
@@ -95,6 +96,7 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
   const [showSecret, setShowSecret] = React.useState(false);
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsAzure.size);
@@ -180,6 +182,24 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup: cleanupObsolete
+          ? {
+              enabled: true,
+              provider: 'azure',
+              // Azure Key Vault scans always cover all three kinds, so
+              // cleanup is always safe to scope to all of them.
+              scannedSources: [
+                'azure-key-vault-secret',
+                'azure-key-vault-certificate',
+                'azure-key-vault-key',
+              ],
+              // All rediscovered locations (whole scan, not just selection)
+              // so unselected-but-still-present items are never deleted.
+              scannedLocations: azureItems
+                .map(it => it.location)
+                .filter(Boolean),
+            }
+          : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -267,6 +287,26 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
           Scan
         </Button>
       </HStack>
+      <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+        <VStack align='stretch' spacing={2}>
+          <Checkbox
+            isChecked={cleanupObsolete}
+            onChange={e => setCleanupObsolete(e.target.checked)}
+            size='sm'
+            colorScheme='red'
+          >
+            Remove previously imported items no longer found at the source
+          </Checkbox>
+          {cleanupObsolete ? (
+            <Text fontSize='xs' color='red.400' pl={6}>
+              Deletes previously imported secrets, certificates, and keys
+              from this Key Vault that no longer appear anywhere in this
+              scan's results, regardless of which items you select for
+              import below. This cannot be undone.
+            </Text>
+          ) : null}
+        </VStack>
+      </Box>
       {azureSummary.length > 0 && (
         <Box
           border='1px solid'

--- a/apps/dashboard/src/components/imports/ImportAzureForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAzureForm.jsx
@@ -186,6 +186,10 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/components/imports/ImportAzureForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportAzureForm.jsx
@@ -299,10 +299,10 @@ const ImportAzureForm = React.forwardRef(function ImportAzureForm(
           </Checkbox>
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
-              Deletes previously imported secrets, certificates, and keys
-              from this Key Vault that no longer appear anywhere in this
-              scan's results, regardless of which items you select for
-              import below. This cannot be undone.
+              Deletes previously imported secrets, certificates, and keys from
+              this Key Vault that no longer appear anywhere in this scan's
+              results, regardless of which items you select for import below.
+              This cannot be undone.
             </Text>
           ) : null}
         </VStack>

--- a/apps/dashboard/src/components/imports/ImportGCPForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGCPForm.jsx
@@ -182,6 +182,10 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/components/imports/ImportGCPForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGCPForm.jsx
@@ -7,6 +7,7 @@ import {
   Input,
   Button,
   Badge,
+  Checkbox,
   InputGroup,
   InputRightElement,
   IconButton,
@@ -91,6 +92,7 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
   const [showSecret, setShowSecret] = React.useState(false);
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsGcp.size);
@@ -176,6 +178,19 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
         workspaceId,
         items: selected,
         defaults: {},
+        cleanup: cleanupObsolete
+          ? {
+              enabled: true,
+              provider: 'gcp',
+              // GCP scans always cover Secret Manager secrets only.
+              scannedSources: ['gcp-secret-manager'],
+              // All rediscovered locations (whole scan, not just selection)
+              // so unselected-but-still-present items are never deleted.
+              scannedLocations: gcpItems
+                .map(it => it.location)
+                .filter(Boolean),
+            }
+          : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -257,6 +272,26 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
           Scan
         </Button>
       </HStack>
+      <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+        <VStack align='stretch' spacing={2}>
+          <Checkbox
+            isChecked={cleanupObsolete}
+            onChange={e => setCleanupObsolete(e.target.checked)}
+            size='sm'
+            colorScheme='red'
+          >
+            Remove previously imported secrets no longer found at the source
+          </Checkbox>
+          {cleanupObsolete ? (
+            <Text fontSize='xs' color='red.400' pl={6}>
+              Deletes previously imported secrets from this GCP project that
+              no longer appear anywhere in this scan's results, regardless
+              of which items you select for import below. This cannot be
+              undone.
+            </Text>
+          ) : null}
+        </VStack>
+      </Box>
       {gcpSummary.length > 0 && (
         <Box
           border='1px solid'

--- a/apps/dashboard/src/components/imports/ImportGCPForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGCPForm.jsx
@@ -93,6 +93,8 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
   const [bulkSection, setBulkSection] = React.useState('');
   const [bulkContactGroupId, setBulkContactGroupId] = React.useState('');
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // The backend-authoritative scan record cleanup is driven from.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   React.useEffect(() => {
     onSelectionChange && onSelectionChange(selectedRowsGcp.size);
@@ -126,6 +128,7 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
       const items = Array.isArray(res?.items) ? res.items : [];
       setGcpItems(items);
       setGcpSummary(Array.isArray(res?.summary) ? res.summary : []);
+      setLastScanId(res?.scan_id || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('gcp');
       }
@@ -139,6 +142,7 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
     } catch (e) {
       setGcpItems([]);
       setGcpSummary([]);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -178,17 +182,14 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
         workspaceId,
         items: selected,
         defaults: {},
-        cleanup: cleanupObsolete
-          ? {
-              enabled: true,
-              provider: 'gcp',
-              // GCP scans always cover Secret Manager secrets only.
-              scannedSources: ['gcp-secret-manager'],
-              // All rediscovered locations (whole scan, not just selection)
-              // so unselected-but-still-present items are never deleted.
-              scannedLocations: gcpItems.map(it => it.location).filter(Boolean),
-            }
-          : undefined,
+        cleanup:
+          cleanupObsolete && lastScanId
+            ? {
+                enabled: true,
+                provider: 'gcp',
+                scanId: lastScanId,
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -277,9 +278,21 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
             onChange={e => setCleanupObsolete(e.target.checked)}
             size='sm'
             colorScheme='red'
+            isDisabled={!lastScanId}
           >
             Remove previously imported secrets no longer found at the source
           </Checkbox>
+          {!lastScanId ? (
+            <Text fontSize='xs' color={helpTextColor} pl={6}>
+              Run a scan first; cleanup is driven by the backend's record of
+              what that scan covered.
+            </Text>
+          ) : gcpSummary.some(s => s.complete === false) ? (
+            <Text fontSize='xs' color='orange.400' pl={6}>
+              The last scan didn't fully complete (see the errors below). The
+              backend refuses to clean up an incomplete or truncated scan.
+            </Text>
+          ) : null}
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
               Deletes previously imported secrets from this GCP project that no

--- a/apps/dashboard/src/components/imports/ImportGCPForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGCPForm.jsx
@@ -186,9 +186,7 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
               scannedSources: ['gcp-secret-manager'],
               // All rediscovered locations (whole scan, not just selection)
               // so unselected-but-still-present items are never deleted.
-              scannedLocations: gcpItems
-                .map(it => it.location)
-                .filter(Boolean),
+              scannedLocations: gcpItems.map(it => it.location).filter(Boolean),
             }
           : undefined,
       });
@@ -284,10 +282,9 @@ const ImportGCPForm = React.forwardRef(function ImportGCPForm(
           </Checkbox>
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
-              Deletes previously imported secrets from this GCP project that
-              no longer appear anywhere in this scan's results, regardless
-              of which items you select for import below. This cannot be
-              undone.
+              Deletes previously imported secrets from this GCP project that no
+              longer appear anywhere in this scan's results, regardless of which
+              items you select for import below. This cannot be undone.
             </Text>
           ) : null}
         </VStack>

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -130,8 +130,9 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
   const [filterRules, setFilterRules] = React.useState([]);
   const [filterSummary, setFilterSummary] = React.useState(null);
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
-  // Source kinds included in the last scan; cleanup only touches these.
-  const [lastScanSources, setLastScanSources] = React.useState([]);
+  // The backend-authoritative scan record cleanup is driven from; the
+  // backend (not this form) decides which sub-scopes are safe to clean.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   // Restore persisted rules from auto-sync scan_params
   React.useEffect(() => {
@@ -203,11 +204,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
       setGithubItems(items);
       setGithubSummary(Array.isArray(res?.summary) ? res.summary : []);
       setFilterSummary(res?.filterSummary || null);
-      const scannedSources = [];
-      if (githubIncludeSSHKeys) scannedSources.push('github-ssh-key');
-      if (githubIncludeDeployKeys) scannedSources.push('github-deploy-key');
-      if (githubIncludeSecrets) scannedSources.push('github-secret');
-      setLastScanSources(scannedSources);
+      setLastScanId(res?.scan_id || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('github');
       }
@@ -225,6 +222,7 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
       setGithubItems([]);
       setGithubSummary([]);
       setFilterSummary(null);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -298,16 +296,11 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
         items: selected,
         defaults: {},
         cleanup:
-          cleanupObsolete && lastScanSources.length > 0
+          cleanupObsolete && lastScanId
             ? {
                 enabled: true,
                 provider: 'github',
-                scannedSources: lastScanSources,
-                // All rediscovered locations (whole scan, not just selection)
-                // so unselected-but-still-present tokens are never deleted.
-                scannedLocations: githubItems
-                  .map(it => it.location)
-                  .filter(Boolean),
+                scanId: lastScanId,
               }
             : undefined,
       });
@@ -449,15 +442,30 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
             onChange={e => setCleanupObsolete(e.target.checked)}
             size='sm'
             colorScheme='red'
+            isDisabled={!lastScanId}
           >
             Remove previously imported tokens no longer found at the source
           </Checkbox>
+          {!lastScanId ? (
+            <Text fontSize='xs' color={helpTextColor} pl={6}>
+              Run a scan first; cleanup is driven by the backend's record of
+              what that scan covered.
+            </Text>
+          ) : githubSummary.some(s => s.complete === false) ? (
+            <Text fontSize='xs' color='orange.400' pl={6}>
+              The last scan didn't fully complete for every item type above (see
+              the errors below). The backend will only clean up the item types
+              and scopes it confirmed were fully scanned; nothing incomplete or
+              errored is ever touched.
+            </Text>
+          ) : null}
           {cleanupObsolete ? (
             <Text fontSize='xs' color='red.400' pl={6}>
               Deletes previously imported tokens of the item types scanned above
               that no longer appear anywhere in this scan's results, regardless
               of which items you select for import below. Item types you did not
-              scan for are never affected. This cannot be undone.
+              scan for, or that this scan couldn't fully complete, are never
+              affected. This cannot be undone.
             </Text>
           ) : null}
         </VStack>

--- a/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitHubForm.jsx
@@ -295,6 +295,10 @@ const ImportGitHubForm = React.forwardRef(function ImportGitHubForm(
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -132,8 +132,8 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
   const [filterRules, setFilterRules] = React.useState([]);
   const [filterSummary, setFilterSummary] = React.useState(null);
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
-  // Source kinds included in the last scan; cleanup only touches these.
-  const [lastScanSources, setLastScanSources] = React.useState([]);
+  // The backend-authoritative scan record cleanup is driven from.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   // Restore persisted rules from auto-sync scan_params
   React.useEffect(() => {
@@ -223,16 +223,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
       setGitlabItems(items);
       setGitlabSummary(Array.isArray(res?.summary) ? res.summary : []);
       setFilterSummary(res?.filterSummary || null);
-      const scannedSources = [];
-      if (gitlabIncludePATs) scannedSources.push('gitlab-pat');
-      if (gitlabIncludeProjectTokens)
-        scannedSources.push('gitlab-project-token');
-      if (gitlabIncludeGroupTokens) scannedSources.push('gitlab-group-token');
-      if (gitlabIncludeDeployTokens) scannedSources.push('gitlab-deploy-token');
-      if (gitlabIncludeTriggerTokens)
-        scannedSources.push('gitlab-trigger-token');
-      if (gitlabIncludeSSHKeys) scannedSources.push('gitlab-ssh-key');
-      setLastScanSources(scannedSources);
+      setLastScanId(res?.scan_id || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('gitlab');
       }
@@ -250,6 +241,7 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
       setGitlabItems([]);
       setGitlabSummary([]);
       setFilterSummary(null);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -322,18 +314,14 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
         workspaceId,
         items: selected,
         defaults: {},
-        cleanup: cleanupObsolete
-          ? {
-              enabled: true,
-              provider: 'gitlab',
-              scannedSources: lastScanSources,
-              // All rediscovered locations (whole scan, not just selection)
-              // so unselected-but-still-present tokens are never deleted.
-              scannedLocations: gitlabItems
-                .map(it => it.location)
-                .filter(Boolean),
-            }
-          : undefined,
+        cleanup:
+          cleanupObsolete && lastScanId
+            ? {
+                enabled: true,
+                provider: 'gitlab',
+                scanId: lastScanId,
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -531,16 +519,30 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
                 onChange={e => setCleanupObsolete(e.target.checked)}
                 size='sm'
                 colorScheme='red'
+                isDisabled={!lastScanId}
               >
                 Remove previously imported tokens no longer found at the source
               </Checkbox>
+              {!lastScanId ? (
+                <Text fontSize='xs' color={helpTextColor} pl={6}>
+                  Run a scan first; cleanup is driven by the backend's record of
+                  what that scan covered.
+                </Text>
+              ) : gitlabSummary.some(s => s.complete === false) ? (
+                <Text fontSize='xs' color='orange.400' pl={6}>
+                  The last scan didn't fully complete for every token type above
+                  (see the errors below). The backend will only clean up the
+                  token types and scopes it confirmed were fully scanned;
+                  nothing incomplete or errored is ever touched.
+                </Text>
+              ) : null}
               {cleanupObsolete ? (
                 <Text fontSize='xs' color='red.400' pl={6}>
                   Deletes previously imported tokens of the token types scanned
                   above that no longer appear anywhere in this scan's results,
                   regardless of which items you select for import below. Token
-                  types you did not scan for are never affected. This cannot be
-                  undone.
+                  types you did not scan for, or that this scan couldn't fully
+                  complete, are never affected. This cannot be undone.
                 </Text>
               ) : null}
             </VStack>

--- a/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportGitLabForm.jsx
@@ -314,6 +314,10 @@ const ImportGitLabForm = React.forwardRef(function ImportGitLabForm(
         workspaceId,
         items: selected,
         defaults: {},
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -160,8 +160,8 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
   const [filterRules, setFilterRules] = React.useState([]);
   const [filterSummary, setFilterSummary] = React.useState(null);
   const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
-  // Source kinds included in the last scan; cleanup only touches these.
-  const [lastScanSources, setLastScanSources] = React.useState([]);
+  // The backend-authoritative scan record cleanup is driven from.
+  const [lastScanId, setLastScanId] = React.useState(null);
 
   const [isScanning, setIsScanning] = React.useState(false);
   const [vaultItems, setVaultItems] = React.useState([]);
@@ -280,10 +280,7 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
       setVaultItems(items);
       setSummary(Array.isArray(res?.summary) ? res.summary : []);
       setFilterSummary(res?.filterSummary || null);
-      const scannedSources = [];
-      if (includeKV) scannedSources.push('vault-kv');
-      if (includePKI) scannedSources.push('vault-pki');
-      setLastScanSources(scannedSources);
+      setLastScanId(res?.scan_id || null);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('vault');
       }
@@ -297,6 +294,7 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
     } catch (e) {
       setVaultItems([]);
       setSummary([]);
+      setLastScanId(null);
       if (isQuotaExceededError && isQuotaExceededError(e)) {
         onError && onError(formatQuotaError ? formatQuotaError(e) : e?.message);
       } else {
@@ -345,16 +343,11 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
         items: selected,
         defaults: vaultDefaults,
         cleanup:
-          cleanupObsolete && lastScanSources.length > 0
+          cleanupObsolete && lastScanId
             ? {
                 enabled: true,
                 provider: 'vault',
-                scannedSources: lastScanSources,
-                // All rediscovered locations (whole scan, not just selection)
-                // so unselected-but-still-present items are never deleted.
-                scannedLocations: vaultItems
-                  .map(it => it.location)
-                  .filter(Boolean),
+                scanId: lastScanId,
               }
             : undefined,
       });
@@ -548,16 +541,31 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
               onChange={e => setCleanupObsolete(e.target.checked)}
               size='sm'
               colorScheme='red'
+              isDisabled={!lastScanId}
             >
               Remove previously imported items no longer found at the source
             </Checkbox>
+            {!lastScanId ? (
+              <Text fontSize='xs' color={helpTextColor} pl={6}>
+                Run a scan first; cleanup is driven by the backend's record of
+                what that scan covered.
+              </Text>
+            ) : summary.some(s => s.complete === false) ? (
+              <Text fontSize='xs' color='orange.400' pl={6}>
+                The last scan didn't fully complete for every mount above (see
+                the errors below). The backend will only clean up mounts and
+                asset kinds it confirmed were fully scanned; nothing incomplete,
+                truncated, or errored is ever touched.
+              </Text>
+            ) : null}
             {cleanupObsolete ? (
               <Text fontSize='xs' color='red.400' pl={6}>
                 Deletes previously imported items of the asset kinds scanned
                 above (KV, PKI, or both) that no longer appear anywhere in this
                 scan's results, regardless of which items you select for import
-                below. Asset kinds you did not scan for are never affected. This
-                cannot be undone.
+                below. Asset kinds or mounts you did not scan for, or that this
+                scan couldn't fully complete, are never affected. This cannot be
+                undone.
               </Text>
             ) : null}
           </VStack>

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -536,7 +536,12 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
           </Text>
         </Box>
 
-        <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+        <Box
+          border='1px solid'
+          borderColor={borderColor}
+          borderRadius='md'
+          p={3}
+        >
           <VStack align='stretch' spacing={2}>
             <Checkbox
               isChecked={cleanupObsolete}
@@ -549,10 +554,10 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
             {cleanupObsolete ? (
               <Text fontSize='xs' color='red.400' pl={6}>
                 Deletes previously imported items of the asset kinds scanned
-                above (KV, PKI, or both) that no longer appear anywhere in
-                this scan's results, regardless of which items you select for
-                import below. Asset kinds you did not scan for are never
-                affected. This cannot be undone.
+                above (KV, PKI, or both) that no longer appear anywhere in this
+                scan's results, regardless of which items you select for import
+                below. Asset kinds you did not scan for are never affected. This
+                cannot be undone.
               </Text>
             ) : null}
           </VStack>

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -159,6 +159,9 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
 
   const [filterRules, setFilterRules] = React.useState([]);
   const [filterSummary, setFilterSummary] = React.useState(null);
+  const [cleanupObsolete, setCleanupObsolete] = React.useState(false);
+  // Source kinds included in the last scan; cleanup only touches these.
+  const [lastScanSources, setLastScanSources] = React.useState([]);
 
   const [isScanning, setIsScanning] = React.useState(false);
   const [vaultItems, setVaultItems] = React.useState([]);
@@ -277,6 +280,10 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
       setVaultItems(items);
       setSummary(Array.isArray(res?.summary) ? res.summary : []);
       setFilterSummary(res?.filterSummary || null);
+      const scannedSources = [];
+      if (includeKV) scannedSources.push('vault-kv');
+      if (includePKI) scannedSources.push('vault-pki');
+      setLastScanSources(scannedSources);
       if (items.length > 0) {
         onScanSuccess && onScanSuccess('vault');
       }
@@ -337,6 +344,19 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
         workspaceId,
         items: selected,
         defaults: vaultDefaults,
+        cleanup:
+          cleanupObsolete && lastScanSources.length > 0
+            ? {
+                enabled: true,
+                provider: 'vault',
+                scannedSources: lastScanSources,
+                // All rediscovered locations (whole scan, not just selection)
+                // so unselected-but-still-present items are never deleted.
+                scannedLocations: vaultItems
+                  .map(it => it.location)
+                  .filter(Boolean),
+              }
+            : undefined,
       });
       onImportComplete && onImportComplete(selected);
     } catch (e) {
@@ -514,6 +534,28 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
             All kinds are scanned by default. Uncheck a kind to skip it, e.g.
             uncheck Secrets &amp; keys to only import certificates.
           </Text>
+        </Box>
+
+        <Box border='1px solid' borderColor={borderColor} borderRadius='md' p={3}>
+          <VStack align='stretch' spacing={2}>
+            <Checkbox
+              isChecked={cleanupObsolete}
+              onChange={e => setCleanupObsolete(e.target.checked)}
+              size='sm'
+              colorScheme='red'
+            >
+              Remove previously imported items no longer found at the source
+            </Checkbox>
+            {cleanupObsolete ? (
+              <Text fontSize='xs' color='red.400' pl={6}>
+                Deletes previously imported items of the asset kinds scanned
+                above (KV, PKI, or both) that no longer appear anywhere in
+                this scan's results, regardless of which items you select for
+                import below. Asset kinds you did not scan for are never
+                affected. This cannot be undone.
+              </Text>
+            ) : null}
+          </VStack>
         </Box>
 
         {/* Advanced options - collapsible */}

--- a/apps/dashboard/src/components/imports/ImportVaultForm.jsx
+++ b/apps/dashboard/src/components/imports/ImportVaultForm.jsx
@@ -342,6 +342,10 @@ const ImportVaultForm = React.forwardRef(function ImportVaultForm(
         workspaceId,
         items: selected,
         defaults: vaultDefaults,
+        // scan_id is sent whenever this import followed a scan, regardless
+        // of whether cleanup is enabled -- provenance attribution must not
+        // depend on the cleanup toggle (see apiClient.js).
+        scanId: lastScanId || undefined,
         cleanup:
           cleanupObsolete && lastScanId
             ? {

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -1203,13 +1203,19 @@ export const vaultAPI = {
       throw new Error(handleApiError(e, 'Failed to load mounts'));
     }
   },
-  import: async ({ workspaceId, items, defaults = {}, cleanup }) => {
+  import: async ({ workspaceId, items, defaults = {}, cleanup, scanId }) => {
     try {
       const payload = {
         items,
         default_category: defaults.category,
         default_type: defaults.type,
         contact_group_id: defaults.contact_group_id || null,
+        // scan_id is sent independently of cleanup so every scan-backed
+        // import gets provenance attribution, whether or not the user opted
+        // into deletion this time -- otherwise a later cleanup-enabled
+        // import can never adopt this row (see importCleanup.js's "ambiguous
+        // legacy rows" policy) and ends up creating a duplicate instead.
+        ...(scanId ? { scan_id: scanId } : {}),
         ...(cleanup && cleanup.enabled === true ? { cleanup } : {}),
       };
       const res = await apiClient.post(
@@ -1528,6 +1534,7 @@ export const integrationAPI = {
     defaults = {},
     filterRules,
     cleanup,
+    scanId,
   }) => {
     try {
       const payload = {
@@ -1538,6 +1545,12 @@ export const integrationAPI = {
         ...(Array.isArray(filterRules) && filterRules.length > 0
           ? { filterRules }
           : {}),
+        // scan_id is sent independently of cleanup so every scan-backed
+        // import gets provenance attribution, whether or not the user opted
+        // into deletion this time -- otherwise a later cleanup-enabled
+        // import can never adopt this row (see importCleanup.js's "ambiguous
+        // legacy rows" policy) and ends up creating a duplicate instead.
+        ...(scanId ? { scan_id: scanId } : {}),
         ...(cleanup && cleanup.enabled === true ? { cleanup } : {}),
       };
       const res = await apiClient.post(

--- a/apps/dashboard/src/utils/apiClient.js
+++ b/apps/dashboard/src/utils/apiClient.js
@@ -1203,13 +1203,14 @@ export const vaultAPI = {
       throw new Error(handleApiError(e, 'Failed to load mounts'));
     }
   },
-  import: async ({ workspaceId, items, defaults = {} }) => {
+  import: async ({ workspaceId, items, defaults = {}, cleanup }) => {
     try {
       const payload = {
         items,
         default_category: defaults.category,
         default_type: defaults.type,
         contact_group_id: defaults.contact_group_id || null,
+        ...(cleanup && cleanup.enabled === true ? { cleanup } : {}),
       };
       const res = await apiClient.post(
         API_ENDPOINTS.VAULT_IMPORT(workspaceId),
@@ -1217,12 +1218,17 @@ export const vaultAPI = {
       );
       const createdCount = res?.data?.created_count || 0;
       const updatedCount = res?.data?.updated_count || 0;
+      const deletedCount = res?.data?.deleted_count || 0;
+      const deletedSuffix =
+        deletedCount > 0
+          ? `, removed ${deletedCount} obsolete item${deletedCount !== 1 ? 's' : ''}`
+          : '';
       if (updatedCount > 0) {
         showSuccessMessage(
-          `Imported ${createdCount} new items, updated ${updatedCount} existing items`
+          `Imported ${createdCount} new items, updated ${updatedCount} existing items${deletedSuffix}`
         );
       } else {
-        showSuccessMessage(`Imported ${createdCount} items`);
+        showSuccessMessage(`Imported ${createdCount} items${deletedSuffix}`);
       }
       return res.data;
     } catch (e) {

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -353,7 +353,7 @@ async function runAutoSync() {
               cleanup = {
                 enabled: true,
                 provider,
-                scan_id: scanId,
+                scanId,
                 reason: "auto_sync_cleanup",
               };
             } else if (cleanupObsolete && !scanId) {

--- a/apps/worker/src/auto-sync-worker.js
+++ b/apps/worker/src/auto-sync-worker.js
@@ -221,6 +221,7 @@ async function runAutoSync() {
           schedule_tz,
           last_sync_status: previousStatus,
           created_by: createdBy,
+          cleanup_obsolete: cleanupObsoleteFlag,
         } = config;
         logger.info(`Syncing ${provider} for workspace ${workspace_id}`);
 
@@ -324,6 +325,7 @@ async function runAutoSync() {
           });
           const scanResult = scanResponse.data;
           const itemsCount = scanResult?.items?.length || 0;
+          const scanId = scanResult?.scan_id || null;
 
           // 2. Import: delegate to the existing import endpoint so deduplication,
           //    sanitization, type validation, and audit logging are identical to
@@ -332,49 +334,36 @@ async function runAutoSync() {
           let importErrorCount = 0;
           let importErrors = [];
           let deletedCount = 0;
-          if (itemsCount > 0) {
+          const cleanupObsolete =
+            cleanupObsoleteFlag === true || scan_params?.cleanupObsolete === true;
+          // A scan that legitimately finds zero items in a fully-scanned,
+          // complete scope is still a real "everything here is now obsolete"
+          // result -- it must still reach the import endpoint (with an empty
+          // items array) so the cleanup engine gets a chance to run, not be
+          // silently skipped just because there was nothing new to import.
+          if (itemsCount > 0 || (cleanupObsolete && scanId)) {
             const importUrl = `${apiUrl}/api/v1/integrations/import?workspace_id=${workspace_id}`;
-            // Cleanup of obsolete tokens is only attempted when the scan
-            // returned at least one item, so an empty/broken scan can never
-            // mass-delete a workspace.
+            // The cleanup request itself is fully provider-agnostic: it just
+            // points the shared cleanup engine at this scan's scan_id,
+            // exactly like a manual import does. The engine (not this
+            // worker) is the one place that knows which sub-scopes are
+            // complete and safe to clean.
             let cleanup;
-            if (scan_params?.cleanupObsolete === true) {
-              const scannedSources = [];
-              if (provider === "gitlab") {
-                const f = scan_params?.filters || {};
-                if (f.includePATs !== false) scannedSources.push("gitlab-pat");
-                if (f.includeProjectTokens !== false)
-                  scannedSources.push("gitlab-project-token");
-                if (f.includeGroupTokens !== false)
-                  scannedSources.push("gitlab-group-token");
-                if (f.includeDeployTokens !== false)
-                  scannedSources.push("gitlab-deploy-token");
-                if (f.includeTriggerTokens === true)
-                  scannedSources.push("gitlab-trigger-token");
-                if (f.includeSSHKeys === true)
-                  scannedSources.push("gitlab-ssh-key");
-              } else if (provider === "github") {
-                const inc = scan_params?.include || {
-                  tokens: true,
-                  sshKeys: true,
-                  deployKeys: true,
-                  secrets: true,
-                };
-                if (inc.sshKeys) scannedSources.push("github-ssh-key");
-                if (inc.deployKeys) scannedSources.push("github-deploy-key");
-                if (inc.secrets) scannedSources.push("github-secret");
-              }
-              if (scannedSources.length > 0) {
-                cleanup = {
-                  enabled: true,
-                  provider,
-                  scannedSources,
-                  scannedLocations: (scanResult.items || [])
-                    .map((it) => it.location)
-                    .filter(Boolean),
-                  reason: "auto_sync_cleanup",
-                };
-              }
+            if (cleanupObsolete && scanId) {
+              cleanup = {
+                enabled: true,
+                provider,
+                scan_id: scanId,
+                reason: "auto_sync_cleanup",
+              };
+            } else if (cleanupObsolete && !scanId) {
+              // The scan endpoint didn't persist a scan record (e.g. it
+              // couldn't resolve identity for this provider) -- refuse to
+              // guess at scope rather than skip cleanup silently.
+              logger.warn(
+                `Auto-sync cleanup requested for ${provider} but the scan did not return a scan_id; skipping cleanup this run`,
+                { workspace_id, configId: id },
+              );
             }
             const importResponse = await axios.post(
               importUrl,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@aws-sdk/client-acm':
         specifier: 3.1045.0
         version: 3.1045.0
+      '@aws-sdk/client-ec2':
+        specifier: 3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-iam':
         specifier: 3.1045.0
         version: 3.1045.0
@@ -427,6 +430,10 @@ packages:
     resolution: {integrity: sha512-l3b5FNvcPtMH/B/WqT7F1i7TmadFOJnqL5eM1wCl9VLVnD69qqzBzIF/Vn+LIh8g1jqIXGZUz3ntPun2GcL5bQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-ec2@3.1045.0':
+    resolution: {integrity: sha512-/ShpsuHZbpwiNBSRc6rupxFRh/NqKTaxAZv34w58tPFOgghpJ8vPX2VV+FZiZJWHqrdQfwk7PhStxRpOz+ru+w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-iam@3.1045.0':
     resolution: {integrity: sha512-1kCDjvkOUyZ7MxQu2ybgXxYDW+8PG+cHjVCk0IXZwYy5R2dhAeHLLlDGJB9jA/KeSh6+XcN5uMlApqJGP1zbUg==}
     engines: {node: '>=20.0.0'}
@@ -441,6 +448,10 @@ packages:
 
   '@aws-sdk/core@3.974.8':
     resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.34':
@@ -487,6 +498,10 @@ packages:
     resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-ec2@3.972.58':
+    resolution: {integrity: sha512-k1yW3bEUcy/e9oxIH0zT81sbPCqgERdNf0bOsBZg/tXP75tyEKp8kp8BG9xag64+u9fF8064fLDUdIItWgQxWw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.972.37':
     resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
     engines: {node: '>=20.0.0'}
@@ -513,6 +528,10 @@ packages:
 
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -543,8 +562,16 @@ packages:
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
@@ -1493,6 +1520,10 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
@@ -1573,12 +1604,20 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.13':
     resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -4869,6 +4908,52 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-ec2@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-ec2': 3.972.58
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-iam@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -5020,6 +5105,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -5145,6 +5241,15 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-ec2@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-sdk-s3@3.972.37':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -5251,6 +5356,11 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
@@ -5290,7 +5400,14 @@ snapshots:
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.3': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -6168,6 +6285,11 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -6301,6 +6423,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.13':
     dependencies:
       '@smithy/core': 3.23.17
@@ -6312,6 +6440,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
     dependencies:
       tslib: 2.8.1
 

--- a/tests/integration/github-integration-extended.unit.test.js
+++ b/tests/integration/github-integration-extended.unit.test.js
@@ -1,0 +1,139 @@
+const { expect } = require("chai");
+const Module = require("module");
+const path = require("path");
+
+function resolveGithubModule() {
+  const candidates = [
+    path.join(__dirname, "..", "..", "apps", "api", "services", "githubIntegration"),
+    path.join(__dirname, "..", "..", "apps", "saas", "integrations", "githubIntegration"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return require.resolve(candidate);
+    } catch (_) {}
+  }
+  throw new Error("Unable to resolve githubIntegration module");
+}
+
+function requireWithMocks(modulePath, mocks) {
+  const resolved = require.resolve(modulePath);
+  delete require.cache[resolved];
+  const originalLoad = Module._load;
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "test";
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    return require(modulePath);
+  } finally {
+    Module._load = originalLoad;
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+}
+
+// Builds a mocked GitHub API responder for a single authenticated user with
+// one SSH key, one repo secret, and one deploy key -- enough to exercise
+// every sourceKind the scan produces.
+function buildAxiosMock({ userId, sshKeyId = 501, repoId = 900 }) {
+  return async (config) => {
+    const { pathname } = new URL(config.url);
+    if (pathname === "/user") {
+      return { data: { id: userId, login: `user-${userId}` } };
+    }
+    if (pathname === "/user/keys") {
+      return { data: [{ id: sshKeyId, title: "laptop" }] };
+    }
+    if (pathname === "/user/repos") {
+      return {
+        data: [
+          {
+            id: repoId,
+            name: "repo",
+            full_name: `user-${userId}/repo`,
+            owner: { login: `user-${userId}` },
+          },
+        ],
+      };
+    }
+    if (pathname === `/repos/user-${userId}/repo/actions/secrets`) {
+      return { data: { secrets: [{ name: "DEPLOY_SECRET" }] } };
+    }
+    if (pathname === `/repos/user-${userId}/repo/keys`) {
+      return { data: [{ id: 700, title: "ci-deploy-key" }] };
+    }
+    return { data: [] };
+  };
+}
+
+describe("GitHub integration host and owner attribution", () => {
+  // Regression guard: two GitHub Enterprise instances can easily assign the
+  // same numeric user/repo ids to unrelated accounts. If the scan's
+  // provenance only carried the owner id (not the host), a cleanup driven
+  // by a scan against instance A could delete tokens that were actually
+  // imported from instance B. scanGitHub must return a `host` that reflects
+  // which server was actually scanned, independent of the numeric owner id.
+  it("returns a distinct host per GitHub Enterprise instance even when owner/repo ids collide", async () => {
+    const github = requireWithMocks(resolveGithubModule(), {
+      axios: buildAxiosMock({ userId: 42, repoId: 900 }),
+    });
+    const resultA = await github.scanGitHub({
+      baseUrl: "https://ghe-a.example.com/api/v3",
+      token: "token-a",
+      include: { tokens: false, sshKeys: true, deployKeys: true, secrets: true },
+    });
+
+    const githubB = requireWithMocks(resolveGithubModule(), {
+      axios: buildAxiosMock({ userId: 42, repoId: 900 }),
+    });
+    const resultB = await githubB.scanGitHub({
+      baseUrl: "https://ghe-b.example.com/api/v3",
+      token: "token-b",
+      include: { tokens: false, sshKeys: true, deployKeys: true, secrets: true },
+    });
+
+    expect(resultA.host).to.equal("ghe-a.example.com");
+    expect(resultB.host).to.equal("ghe-b.example.com");
+    expect(resultA.host).to.not.equal(resultB.host);
+    // Same colliding numeric owner id on both instances -- host is what
+    // must keep their cleanup scopes apart.
+    expect(resultA.ownerKey).to.equal(resultB.ownerKey);
+  });
+
+  it("uses the authenticated user's immutable numeric id as ownerKey, not the mutable login", async () => {
+    const github = requireWithMocks(resolveGithubModule(), {
+      axios: buildAxiosMock({ userId: 4242 }),
+    });
+    const result = await github.scanGitHub({
+      baseUrl: "https://api.github.com",
+      token: "token",
+      include: { tokens: false, sshKeys: true, deployKeys: false, secrets: false },
+    });
+    expect(result.ownerKey).to.equal("4242");
+  });
+
+  it("tags every scanned item with an explicit sourceKind and sourceObjectId", async () => {
+    const github = requireWithMocks(resolveGithubModule(), {
+      axios: buildAxiosMock({ userId: 7, repoId: 900 }),
+    });
+    const result = await github.scanGitHub({
+      baseUrl: "https://api.github.com",
+      token: "token",
+      include: { tokens: false, sshKeys: true, deployKeys: true, secrets: true },
+    });
+
+    const sshKey = result.items.find((i) => i.source === "github-ssh-key");
+    const secret = result.items.find((i) => i.source === "github-secret");
+    const deployKey = result.items.find((i) => i.source === "github-deploy-key");
+
+    expect(sshKey.sourceKind).to.equal("github-ssh-key");
+    expect(sshKey.sourceObjectId).to.equal("501");
+    expect(secret.sourceKind).to.equal("github-secret");
+    expect(secret.sourceObjectId).to.equal("900:DEPLOY_SECRET");
+    expect(deployKey.sourceKind).to.equal("github-deploy-key");
+    expect(deployKey.sourceObjectId).to.equal("900:700");
+  });
+});

--- a/tests/integration/gitlab-integration-extended.unit.test.js
+++ b/tests/integration/gitlab-integration-extended.unit.test.js
@@ -405,4 +405,119 @@ describe("GitLab integration helper coverage", () => {
       "revoked-deploy-token",
     ]);
   });
+
+  // Regression guard: two self-hosted GitLab instances can easily assign the
+  // same numeric user/project ids to unrelated accounts. If the scan's
+  // provenance only carried the owner id (not the host), a cleanup driven
+  // by a scan against instance A could delete tokens actually imported from
+  // instance B. scanGitLab must return a `host` reflecting which server was
+  // actually scanned, independent of the numeric owner id.
+  it("returns a distinct host per self-hosted GitLab instance even when owner ids collide", async () => {
+    const buildAxiosMock = () =>
+      async (config) => {
+        const { pathname } = new URL(config.url);
+        if (pathname === "/api/v4/user") {
+          return { data: { id: 99, username: "bot", is_admin: false } };
+        }
+        return { data: [], headers: {} };
+      };
+
+    const gitlabA = requireWithMocks(resolveGitlabModule(), {
+      axios: buildAxiosMock(),
+    });
+    const resultA = await gitlabA.scanGitLab({
+      baseUrl: "https://gitlab-a.example.com",
+      token: "token-a",
+      include: { tokens: false, keys: false },
+      filters: {
+        includePATs: false,
+        includeProjectTokens: false,
+        includeGroupTokens: false,
+        includeDeployTokens: false,
+        includeTriggerTokens: false,
+        includeSSHKeys: false,
+        excludeUserPATs: false,
+        includeExpired: false,
+        includeRevoked: false,
+      },
+    });
+
+    const gitlabB = requireWithMocks(resolveGitlabModule(), {
+      axios: buildAxiosMock(),
+    });
+    const resultB = await gitlabB.scanGitLab({
+      baseUrl: "https://gitlab-b.example.com",
+      token: "token-b",
+      include: { tokens: false, keys: false },
+      filters: {
+        includePATs: false,
+        includeProjectTokens: false,
+        includeGroupTokens: false,
+        includeDeployTokens: false,
+        includeTriggerTokens: false,
+        includeSSHKeys: false,
+        excludeUserPATs: false,
+        includeExpired: false,
+        includeRevoked: false,
+      },
+    });
+
+    expect(resultA.host).to.equal("gitlab-a.example.com");
+    expect(resultB.host).to.equal("gitlab-b.example.com");
+    expect(resultA.host).to.not.equal(resultB.host);
+    // Same colliding numeric owner id on both instances -- host is what
+    // must keep their cleanup scopes apart.
+    expect(resultA.ownerKey).to.equal(resultB.ownerKey);
+  });
+
+  it("tags scanned items with an explicit sourceKind and sourceObjectId", async () => {
+    const axiosMock = async (config) => {
+      const { pathname } = new URL(config.url);
+      if (pathname === "/api/v4/user") {
+        return { data: { id: 1, username: "alice", is_admin: false } };
+      }
+      if (pathname === "/api/v4/projects") {
+        return { data: [{ id: 10, name: "proj", path_with_namespace: "g/proj" }] };
+      }
+      if (pathname === "/api/v4/projects/10/access_tokens") {
+        return {
+          data: [
+            { id: 100, name: "proj-token", active: true, scopes: ["api"] },
+          ],
+        };
+      }
+      if (pathname === "/api/v4/user/keys") {
+        return { data: [{ id: 55, title: "laptop" }] };
+      }
+      return { data: [] };
+    };
+    const gitlab = requireWithMocks(resolveGitlabModule(), {
+      axios: axiosMock,
+    });
+    const { items } = await gitlab.scanGitLab({
+      baseUrl: "https://gitlab.example.com",
+      token: "token",
+      include: { tokens: true, keys: true },
+      filters: {
+        includePATs: false,
+        includeProjectTokens: true,
+        includeGroupTokens: false,
+        includeDeployTokens: false,
+        includeTriggerTokens: false,
+        includeSSHKeys: true,
+        excludeUserPATs: false,
+        includeExpired: false,
+        includeRevoked: false,
+      },
+    });
+
+    const projectToken = items.find((i) => i.source === "gitlab-project-token");
+    const sshKey = items.find((i) => i.source === "gitlab-ssh-key");
+
+    expect(projectToken.sourceKind).to.equal("gitlab-project-token");
+    expect(projectToken.sourceObjectId).to.equal("10:100");
+    expect(sshKey.sourceKind).to.equal("gitlab-ssh-key");
+    expect(sshKey.sourceObjectId).to.equal("55");
+  });
 });
+

--- a/tests/integration/gitlab-integration-extended.unit.test.js
+++ b/tests/integration/gitlab-integration-extended.unit.test.js
@@ -117,7 +117,7 @@ describe("GitLab integration helper coverage", () => {
     const gitlab = requireWithMocks(resolveGitlabModule(), {
       axios: axiosMock,
     });
-    const projects = await gitlab._test.listProjects({
+    const { projects } = await gitlab._test.listProjects({
       baseUrl: "https://gitlab.example.com",
       token: "token",
       maxItems: 3,

--- a/tests/integration/import-cleanup-route.test.js
+++ b/tests/integration/import-cleanup-route.test.js
@@ -1,0 +1,237 @@
+"use strict";
+
+/**
+ * HTTP-route-layer regression coverage for the import-cleanup contract.
+ *
+ * tests/integration/import-cleanup-scan-lifecycle.test.js drives
+ * cleanupObsoleteTokens() directly and covers the deletion engine's safety
+ * properties. It never goes through the actual route handler, so it cannot
+ * catch a request-shape mismatch between a real caller (like the auto-sync
+ * worker) and what the route accepts. These tests post to the real HTTP
+ * routes with a body shaped exactly like a real caller sends, so a
+ * contract mismatch at the route boundary shows up here even if the
+ * cleanup engine itself is perfectly correct.
+ */
+
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { request, expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+
+const Token = require("../../apps/api/db/models/Token");
+const { persistScan } = require("../../apps/api/services/integrationScans");
+
+const BASE = process.env.TEST_API_URL || "http://localhost:4000";
+
+describe("Import cleanup contract at the HTTP route layer", function () {
+  this.timeout(60000);
+
+  let adminUser;
+  let adminSession;
+  let workspaceId;
+
+  before(async () => {
+    await runMigrations();
+    adminUser = await TestUtils.createVerifiedTestUser();
+    adminSession = await TestUtils.loginTestUser(
+      adminUser.email,
+      "SecureTest123!@#",
+    );
+    const ws = await TestUtils.execQuery(
+      "SELECT id FROM workspaces WHERE created_by = $1 LIMIT 1",
+      [adminUser.id],
+    );
+    workspaceId = ws.rows[0].id;
+  });
+
+  after(async () => {
+    await TestUtils.cleanupTestUser(adminUser.email, adminSession.cookie);
+  });
+
+  async function createProvenanceToken({
+    name,
+    provider,
+    instance,
+    ownerKey,
+    kind,
+    objectId,
+  }) {
+    return Token.create({
+      userId: adminUser.id,
+      workspaceId,
+      created_by: adminUser.id,
+      name,
+      expiration: "2099-12-31",
+      type: "secret",
+      category: "key_secret",
+      location: `${provider}:${objectId}`,
+      imported_at: new Date(),
+      source_provider: provider,
+      source_instance: instance,
+      source_owner_key: ownerKey,
+      source_owner_display: ownerKey,
+      source_kind: kind,
+      source_dimensions: {},
+      source_object_id: objectId,
+    });
+  }
+
+  async function tokenStillExists(id) {
+    const res = await TestUtils.execQuery(
+      "SELECT id FROM tokens WHERE id = $1",
+      [id],
+    );
+    return res.rows.length > 0;
+  }
+
+  async function makeCompleteScan(provider, kind) {
+    const instance = `${provider}-route-${crypto.randomUUID()}.example.com`;
+    return persistScan({
+      workspaceId,
+      provider,
+      identityContext: { host: instance, address: instance, ownerKey: instance },
+      items: [],
+      subScopes: [{ sourceKind: kind, dimensions: {}, complete: true }],
+    }).then((scan) => ({ scan, instance }));
+  }
+
+  it("accepts the exact empty-items + camelCase-scanId payload the auto-sync worker sends and runs cleanup", async () => {
+    const { scan, instance } = await makeCompleteScan("github", "github-ssh-key");
+    const obsolete = await createProvenanceToken({
+      name: "route-github-key-gone",
+      provider: "github",
+      instance,
+      ownerKey: instance,
+      kind: "github-ssh-key",
+      objectId: `route-${crypto.randomUUID()}`,
+    });
+
+    // This is exactly the shape apps/worker/src/auto-sync-worker.js builds:
+    // an empty items array (the scan legitimately found nothing new) plus
+    // a `cleanup` object carrying `scanId` (camelCase) and
+    // reason: "auto_sync_cleanup".
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({
+        items: [],
+        cleanup: {
+          enabled: true,
+          provider: "github",
+          scanId: scan.scanId,
+          reason: "auto_sync_cleanup",
+        },
+      });
+
+    expect(res.status).to.equal(201);
+    expect(res.body.created_count).to.equal(0);
+    expect(res.body.deleted_count).to.equal(1);
+    expect(res.body.deleted.map((d) => d.id)).to.include(obsolete.id);
+    expect(await tokenStillExists(obsolete.id)).to.equal(false);
+  });
+
+  it("normalizes a nested snake_case cleanup.scan_id as a defense-in-depth fallback", async () => {
+    const { scan, instance } = await makeCompleteScan("gitlab", "gitlab-pat");
+    const obsolete = await createProvenanceToken({
+      name: "route-gitlab-pat-gone",
+      provider: "gitlab",
+      instance,
+      ownerKey: instance,
+      kind: "gitlab-pat",
+      objectId: `route-${crypto.randomUUID()}`,
+    });
+
+    // A caller that mirrors the request body's own snake_case convention
+    // when building the nested `cleanup` object (the exact shape that used
+    // to reject the whole import request with a 400) must still work.
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({
+        items: [],
+        cleanup: {
+          enabled: true,
+          provider: "gitlab",
+          scan_id: scan.scanId,
+          reason: "auto_sync_cleanup",
+        },
+      });
+
+    expect(res.status).to.equal(201);
+    expect(res.body.deleted_count).to.equal(1);
+    expect(res.body.deleted.map((d) => d.id)).to.include(obsolete.id);
+    expect(await tokenStillExists(obsolete.id)).to.equal(false);
+  });
+
+  it("rejects empty items with no cleanup requested (no regression)", async () => {
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({ items: [] });
+
+    expect(res.status).to.equal(400);
+    expect(res.body.error).to.match(/items array required/);
+  });
+
+  it("rejects empty items when cleanup is present but disabled (no regression)", async () => {
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({ items: [], cleanup: { enabled: false, provider: "github" } });
+
+    expect(res.status).to.equal(400);
+    expect(res.body.error).to.match(/items array required/);
+  });
+
+  it("Vault import route: accepts empty items + enabled cleanup with a valid scan_id and runs cleanup", async () => {
+    const instance = `vault-route-${crypto.randomUUID()}.example.com`;
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: instance },
+      items: [],
+      subScopes: [{ sourceKind: "vault-kv", dimensions: {}, complete: true }],
+    });
+    const obsolete = await createProvenanceToken({
+      name: "route-vault-secret-gone",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: `secret/data/route-${crypto.randomUUID()}`,
+    });
+
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/vault/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({
+        items: [],
+        cleanup: {
+          enabled: true,
+          provider: "vault",
+          scanId: scan.scanId,
+          reason: "import_cleanup",
+        },
+      });
+
+    expect(res.status).to.equal(201);
+    expect(res.body.deleted_count).to.equal(1);
+    expect(res.body.deleted.map((d) => d.id)).to.include(obsolete.id);
+    expect(await tokenStillExists(obsolete.id)).to.equal(false);
+  });
+
+  it("Vault import route: rejects empty items with no cleanup requested (no regression)", async () => {
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/vault/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({ items: [] });
+
+    expect(res.status).to.equal(400);
+    expect(res.body.error).to.match(/items array required/);
+  });
+});

--- a/tests/integration/import-cleanup-route.test.js
+++ b/tests/integration/import-cleanup-route.test.js
@@ -225,6 +225,62 @@ describe("Import cleanup contract at the HTTP route layer", function () {
     expect(await tokenStillExists(obsolete.id)).to.equal(false);
   });
 
+  it("Vault import route: attributes a newly imported item to the scan that discovered it", async () => {
+    // Regression for a route-layer bug found during live UI verification:
+    // both import routes destructured a bare top-level `scan_id` for
+    // item-scan binding instead of the resolved `effectiveCleanup.scanId`,
+    // so a request shaped exactly like the real dashboard form (which only
+    // ever nests the id as `cleanup.scanId`) silently bound zero items.
+    // Every freshly imported token stayed unattributed ("legacy") and was
+    // therefore permanently excluded from cleanup, regardless of the
+    // checkbox -- this is the one test in this file that actually imports
+    // a non-empty item and checks its resulting provenance, rather than
+    // only exercising cleanup's empty-items branch.
+    const objectId = `secret/data/route-bound-${crypto.randomUUID()}`;
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: "https://vault.route-bound.example.com" },
+      items: [{ sourceKind: "vault-kv", sourceObjectId: objectId, dimensions: {} }],
+      subScopes: [{ sourceKind: "vault-kv", dimensions: {}, complete: true }],
+    });
+    const name = `route-bound-item-${crypto.randomUUID()}`;
+
+    const res = await request(BASE)
+      .post(`/api/v1/integrations/vault/import?workspace_id=${workspaceId}`)
+      .set("Cookie", adminSession.cookie)
+      .send({
+        items: [
+          {
+            name,
+            location: `vault:${objectId}`,
+            category: "key_secret",
+            type: "secret",
+            sourceKind: "vault-kv",
+          },
+        ],
+        cleanup: {
+          enabled: true,
+          provider: "vault",
+          scanId: scan.scanId,
+        },
+      });
+
+    expect(res.status).to.equal(201);
+    expect(res.body.created_count).to.equal(1);
+
+    const row = await TestUtils.execQuery(
+      `SELECT source_provider, source_instance, source_owner_key, source_kind, source_object_id
+       FROM tokens WHERE workspace_id = $1 AND name = $2`,
+      [workspaceId, name],
+    );
+    expect(row.rows.length).to.equal(1);
+    expect(row.rows[0].source_provider).to.equal("vault");
+    expect(row.rows[0].source_instance).to.equal(scan.instance);
+    expect(row.rows[0].source_kind).to.equal("vault-kv");
+    expect(row.rows[0].source_object_id).to.equal(objectId);
+  });
+
   it("Vault import route: rejects empty items with no cleanup requested (no regression)", async () => {
     const res = await request(BASE)
       .post(`/api/v1/integrations/vault/import?workspace_id=${workspaceId}`)

--- a/tests/integration/import-cleanup-scan-lifecycle.test.js
+++ b/tests/integration/import-cleanup-scan-lifecycle.test.js
@@ -1,0 +1,495 @@
+"use strict";
+
+/**
+ * DB-backed destructive test matrix for the scan-backed cleanup engine.
+ * Unlike tests/unit/import-cleanup.unit.test.js (pure-function coverage for
+ * validateCleanupRequest/buildDimensionFilterSql), these tests drive real
+ * PostgreSQL transactions through persistScan()/cleanupObsoleteTokens() to
+ * verify the actual safety properties: per-instance/per-owner scoping,
+ * per-sub-scope completeness gating, the anti-join against recorded scan
+ * items, the observation fence, and the single-use scan claim.
+ */
+
+const crypto = require("crypto");
+
+const { loadRootEnv } = require("../../scripts/load-root-env");
+
+loadRootEnv();
+
+const { expect, TestUtils } = require("./setup");
+const { requireMigrateModule } = require("./variant-paths");
+const { runMigrations } = requireMigrateModule();
+
+const { pool } = require("../../apps/api/db/database");
+const Token = require("../../apps/api/db/models/Token");
+const { persistScan, getScan } = require("../../apps/api/services/integrationScans");
+const { cleanupObsoleteTokens } = require("../../apps/api/services/importCleanup");
+
+describe("Import cleanup scan lifecycle (real database)", function () {
+  this.timeout(60000);
+
+  let ownerId;
+  let workspaceId;
+
+  before(async () => {
+    await runMigrations();
+
+    const email = `cleanup-scan-${Date.now()}-${crypto.randomUUID()}@example.com`;
+    const owner = await TestUtils.execQuery(
+      `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+       VALUES ($1, $2, 'Cleanup Scan Test', 'unused', 'local', TRUE)
+       RETURNING id`,
+      [email.toLowerCase(), email],
+    );
+    ownerId = owner.rows[0].id;
+
+    workspaceId = crypto.randomUUID();
+    await TestUtils.execQuery(
+      `INSERT INTO workspaces (id, name, created_by, plan)
+       VALUES ($1, 'Cleanup Scan WS', $2, 'oss')`,
+      [workspaceId, ownerId],
+    );
+  });
+
+  after(async () => {
+    if (workspaceId) {
+      await TestUtils.execQuery(
+        "DELETE FROM audit_events WHERE workspace_id = $1",
+        [workspaceId],
+      );
+      await TestUtils.execQuery("DELETE FROM workspaces WHERE id = $1", [
+        workspaceId,
+      ]);
+    }
+    if (ownerId) {
+      await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+    }
+  });
+
+  /**
+   * Creates a provenance-attributed token directly (bypassing the import
+   * route, since these tests exercise cleanupObsoleteTokens() directly).
+   */
+  async function createProvenanceToken({
+    name,
+    provider,
+    instance,
+    ownerKey,
+    kind,
+    objectId,
+    dimensions = {},
+    observedAt = null,
+  }) {
+    return Token.create({
+      userId: ownerId,
+      workspaceId,
+      created_by: ownerId,
+      name,
+      expiration: "2099-12-31",
+      type: "secret",
+      category: "key_secret",
+      location: `${provider}:${objectId}`,
+      imported_at: new Date(),
+      source_provider: provider,
+      source_instance: instance,
+      source_owner_key: ownerKey,
+      source_owner_display: ownerKey,
+      source_kind: kind,
+      source_dimensions: dimensions,
+      source_object_id: objectId,
+      source_observed_at: observedAt,
+    });
+  }
+
+  async function tokenStillExists(id) {
+    const res = await TestUtils.execQuery(
+      "SELECT id FROM tokens WHERE id = $1",
+      [id],
+    );
+    return res.rows.length > 0;
+  }
+
+  it("deletes a not-rediscovered token in a scope the scan reported complete", async () => {
+    const instance = `vault-${crypto.randomUUID()}.example.com`;
+    const survivor = await createProvenanceToken({
+      name: "kept-secret",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "secret/data/kept",
+      dimensions: { mount: "secret/", path: "kept", category: "generic" },
+    });
+    const obsolete = await createProvenanceToken({
+      name: "obsolete-secret",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "secret/data/gone",
+      dimensions: { mount: "secret/", path: "gone", category: "generic" },
+    });
+
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: instance },
+      items: [
+        {
+          sourceKind: "vault-kv",
+          sourceObjectId: "secret/data/kept",
+          dimensions: { mount: "secret/", path: "kept", category: "generic" },
+        },
+      ],
+      subScopes: [
+        {
+          sourceKind: "vault-kv",
+          dimensions: { mount: "secret/" },
+          complete: true,
+        },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "vault", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.include(obsolete.id);
+    expect(deleted.map((d) => d.id)).to.not.include(survivor.id);
+    expect(await tokenStillExists(survivor.id)).to.equal(true);
+    expect(await tokenStillExists(obsolete.id)).to.equal(false);
+  });
+
+  it("never touches a different instance of the same provider, even with colliding owner keys", async () => {
+    const ownerKey = "42";
+    const instanceA = `github-a-${crypto.randomUUID()}.example.com`;
+    const instanceB = `github-b-${crypto.randomUUID()}.example.com`;
+
+    const tokenA = await createProvenanceToken({
+      name: "instance-a-key",
+      provider: "github",
+      instance: instanceA,
+      ownerKey,
+      kind: "github-ssh-key",
+      objectId: "111",
+    });
+    const tokenB = await createProvenanceToken({
+      name: "instance-b-key",
+      provider: "github",
+      instance: instanceB,
+      ownerKey,
+      kind: "github-ssh-key",
+      objectId: "222",
+    });
+
+    // A scan of instance A, discovering nothing, must never delete
+    // instance B's token even though both share the same numeric owner key.
+    const scan = await persistScan({
+      workspaceId,
+      provider: "github",
+      identityContext: { host: instanceA, ownerKey },
+      items: [],
+      subScopes: [
+        { sourceKind: "github-ssh-key", dimensions: {}, complete: true },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "github", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.include(tokenA.id);
+    expect(deleted.map((d) => d.id)).to.not.include(tokenB.id);
+    expect(await tokenStillExists(tokenB.id)).to.equal(true);
+  });
+
+  it("never deletes anything from a sub-scope the scan reported incomplete", async () => {
+    const instance = `aws-${crypto.randomUUID()}`;
+    const obsolete = await createProvenanceToken({
+      name: "aws-secret-truncated-region",
+      provider: "aws",
+      instance,
+      ownerKey: instance,
+      kind: "aws-secrets-manager",
+      objectId: "arn:aws:secretsmanager:us-east-1:123:secret:x",
+      dimensions: { region: "us-east-1", service: "secretsmanager" },
+    });
+
+    const scan = await persistScan({
+      workspaceId,
+      provider: "aws",
+      identityContext: { accountId: instance },
+      items: [],
+      subScopes: [
+        {
+          sourceKind: "aws-secrets-manager",
+          dimensions: { region: "us-east-1", service: "secretsmanager" },
+          complete: false,
+          reason: "describe_failures",
+        },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "aws", scanId: scan.scanId },
+    });
+
+    expect(deleted).to.have.length(0);
+    expect(await tokenStillExists(obsolete.id)).to.equal(true);
+  });
+
+  it("deletes everything in a scope when a fully complete scan legitimately finds zero items", async () => {
+    const instance = `gcp-${crypto.randomUUID()}`;
+    const obsolete = await createProvenanceToken({
+      name: "gcp-secret-now-gone",
+      provider: "gcp",
+      instance,
+      ownerKey: instance,
+      kind: "gcp-secret-manager",
+      objectId: "projects/x/secrets/gone",
+    });
+
+    const scan = await persistScan({
+      workspaceId,
+      provider: "gcp",
+      identityContext: { projectId: instance },
+      items: [],
+      subScopes: [
+        { sourceKind: "gcp-secret-manager", dimensions: {}, complete: true },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "gcp", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.include(obsolete.id);
+    expect(await tokenStillExists(obsolete.id)).to.equal(false);
+  });
+
+  it("refuses to replay a scan_id for a second destructive cleanup", async () => {
+    const instance = `gitlab-${crypto.randomUUID()}.example.com`;
+    const obsolete = await createProvenanceToken({
+      name: "gitlab-pat-gone",
+      provider: "gitlab",
+      instance,
+      ownerKey: "7",
+      kind: "gitlab-pat",
+      objectId: "555",
+    });
+
+    const scan = await persistScan({
+      workspaceId,
+      provider: "gitlab",
+      identityContext: { host: instance, ownerKey: "7" },
+      items: [],
+      subScopes: [{ sourceKind: "gitlab-pat", dimensions: {}, complete: true }],
+    });
+
+    const first = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "gitlab", scanId: scan.scanId },
+    });
+    expect(first.deleted.map((d) => d.id)).to.include(obsolete.id);
+
+    // A second token that would otherwise be a valid cleanup candidate
+    // must NOT be deleted by replaying the already-consumed scan_id.
+    const secondObsolete = await createProvenanceToken({
+      name: "gitlab-pat-also-gone",
+      provider: "gitlab",
+      instance,
+      ownerKey: "7",
+      kind: "gitlab-pat",
+      objectId: "556",
+    });
+
+    const replay = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "gitlab", scanId: scan.scanId },
+    });
+    expect(replay.deleted).to.have.length(0);
+    expect(await tokenStillExists(secondObsolete.id)).to.equal(true);
+
+    const scanRow = await getScan({
+      scanId: scan.scanId,
+      workspaceId,
+      provider: "gitlab",
+    });
+    expect(scanRow.cleanup_consumed_at).to.not.equal(null);
+  });
+
+  it("observation fence: never deletes a token observed after the cleanup-driving scan started", async () => {
+    const instance = `azure-${crypto.randomUUID()}.vault.azure.net`;
+    const obsolete = await createProvenanceToken({
+      name: "kv-secret-recently-rediscovered",
+      provider: "azure",
+      instance,
+      ownerKey: instance,
+      kind: "azure-key-vault-secret",
+      objectId: "https://kv.example/secrets/rediscovered",
+    });
+
+    // Simulate a slower, older scan (started_at in the past) that never
+    // saw this token, racing against a newer concurrent scan that just
+    // (re)discovered it. Set source_observed_at to "now" (newer than the
+    // older scan's started_at) to model that race deterministically.
+    await TestUtils.execQuery(
+      "UPDATE tokens SET source_observed_at = NOW() WHERE id = $1",
+      [obsolete.id],
+    );
+
+    const olderScanRes = await TestUtils.execQuery(
+      `INSERT INTO integration_scans (workspace_id, provider, source_instance, source_owner_key, started_at, completed_at, cleanup_scope)
+       VALUES ($1, 'azure', $2, $2, NOW() - INTERVAL '10 minutes', NOW() - INTERVAL '9 minutes', $3::jsonb)
+       RETURNING id`,
+      [
+        workspaceId,
+        instance,
+        JSON.stringify({
+          subScopes: [
+            {
+              sourceKind: "azure-key-vault-secret",
+              dimensions: {},
+              complete: true,
+            },
+          ],
+        }),
+      ],
+    );
+    const olderScanId = olderScanRes.rows[0].id;
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "azure", scanId: olderScanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.not.include(obsolete.id);
+    expect(await tokenStillExists(obsolete.id)).to.equal(true);
+  });
+
+  it("never touches legacy tokens with no provenance attribution", async () => {
+    const legacy = await Token.create({
+      userId: ownerId,
+      workspaceId,
+      created_by: ownerId,
+      name: "legacy-ambiguous-token",
+      expiration: "2099-12-31",
+      type: "secret",
+      category: "key_secret",
+      location: "vault/legacy/path",
+      imported_at: new Date(),
+    });
+
+    const instance = `vault-legacy-${crypto.randomUUID()}.example.com`;
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: instance },
+      items: [],
+      subScopes: [{ sourceKind: "vault-kv", dimensions: {}, complete: true }],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "vault", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.not.include(legacy.id);
+    expect(await tokenStillExists(legacy.id)).to.equal(true);
+  });
+
+  it("narrows Vault cleanup to the scanned mount, sparing an unscanned mount", async () => {
+    const instance = `vault-narrow-${crypto.randomUUID()}.example.com`;
+    const scannedMountObsolete = await createProvenanceToken({
+      name: "secret-mount-gone",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "secret/data/gone",
+      dimensions: { mount: "secret/", path: "gone", category: "generic" },
+    });
+    const otherMountToken = await createProvenanceToken({
+      name: "kv2-mount-untouched",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "kv2/data/untouched",
+      dimensions: { mount: "kv2/", path: "untouched", category: "generic" },
+    });
+
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: instance },
+      items: [],
+      subScopes: [
+        {
+          sourceKind: "vault-kv",
+          dimensions: { mount: "secret/" },
+          complete: true,
+        },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "vault", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.include(scannedMountObsolete.id);
+    expect(deleted.map((d) => d.id)).to.not.include(otherMountToken.id);
+    expect(await tokenStillExists(otherMountToken.id)).to.equal(true);
+  });
+
+  it("does not confuse a KV secret at a PKI-shaped path with an actual PKI certificate", async () => {
+    // A KV secret stored at a path that merely looks PKI-shaped (e.g.
+    // "kv/data/cert/my-app") must be scoped by its real source_kind
+    // (vault-kv), never inferred from the path string.
+    const instance = `vault-kvpki-${crypto.randomUUID()}.example.com`;
+    const kvSecretAtCertLikePath = await createProvenanceToken({
+      name: "kv-secret-cert-shaped-path",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "secret/data/cert/my-app",
+      dimensions: { mount: "secret/", path: "cert/my-app", category: "generic" },
+    });
+
+    // A scan that only completed the PKI sub-scope (not KV) must never
+    // delete the KV-kind token, even though its path looks PKI-shaped.
+    const scan = await persistScan({
+      workspaceId,
+      provider: "vault",
+      identityContext: { address: instance },
+      items: [],
+      subScopes: [
+        { sourceKind: "vault-pki", dimensions: { mount: "pki/" }, complete: true },
+      ],
+    });
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "vault", scanId: scan.scanId },
+    });
+
+    expect(deleted.map((d) => d.id)).to.not.include(kvSecretAtCertLikePath.id);
+    expect(await tokenStillExists(kvSecretAtCertLikePath.id)).to.equal(true);
+  });
+});

--- a/tests/integration/import-cleanup-scan-lifecycle.test.js
+++ b/tests/integration/import-cleanup-scan-lifecycle.test.js
@@ -22,7 +22,13 @@ const { runMigrations } = requireMigrateModule();
 
 const { pool } = require("../../apps/api/db/database");
 const Token = require("../../apps/api/db/models/Token");
-const { persistScan, getScan } = require("../../apps/api/services/integrationScans");
+const {
+  persistScan,
+  getScan,
+  createScan,
+  recordScanItems,
+  finalizeScan,
+} = require("../../apps/api/services/integrationScans");
 const { cleanupObsoleteTokens } = require("../../apps/api/services/importCleanup");
 
 describe("Import cleanup scan lifecycle (real database)", function () {
@@ -207,8 +213,7 @@ describe("Import cleanup scan lifecycle (real database)", function () {
     expect(await tokenStillExists(tokenB.id)).to.equal(true);
   });
 
-  it("never deletes anything from a sub-scope the scan reported incomplete", async () => {
-    const instance = `aws-${crypto.randomUUID()}`;
+  it("never deletes anything from a sub-scope the scan reported incomplete", async () => {    const instance = `aws-${crypto.randomUUID()}`;
     const obsolete = await createProvenanceToken({
       name: "aws-secret-truncated-region",
       provider: "aws",
@@ -491,5 +496,101 @@ describe("Import cleanup scan lifecycle (real database)", function () {
 
     expect(deleted.map((d) => d.id)).to.not.include(kvSecretAtCertLikePath.id);
     expect(await tokenStillExists(kvSecretAtCertLikePath.id)).to.equal(true);
+  });
+
+  it("survives a rediscovery race: an older scan's cleanup must not delete a token a newer, concurrent scan just rediscovered", async () => {
+    // Regression test for the observation-fence race: recordScanItems() must
+    // bump source_observed_at on rediscovery immediately (at scan time), not
+    // only later via a separate import step, or an older/slower scan's
+    // cleanup could win the race and delete a token a newer scan just saw.
+    const instance = `vault-race-${crypto.randomUUID()}.example.com`;
+    const objectId = "secret/data/racy";
+    const token = await createProvenanceToken({
+      name: "racy-secret",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId,
+      dimensions: { mount: "secret/", path: "racy", category: "generic" },
+      // Simulate a token whose last observation predates both scans below.
+      observedAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    // Control: a second, genuinely obsolete token in the same scope that no
+    // scan ever rediscovers. It must still be deleted by scan A's cleanup,
+    // proving the assertions below aren't a vacuous "cleanup did nothing".
+    const genuinelyObsolete = await createProvenanceToken({
+      name: "genuinely-obsolete-secret",
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      kind: "vault-kv",
+      objectId: "secret/data/actually-gone",
+      dimensions: { mount: "secret/", path: "actually-gone", category: "generic" },
+      observedAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    // Scan A starts first (older / slower) and discovers nothing -- it will
+    // want to delete the token as obsolete.
+    const scanA = await createScan({
+      workspaceId,
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+    });
+
+    // Scan B starts after A, rediscovers the token (item recorded ->
+    // source_observed_at bumped immediately), and finishes before A's
+    // cleanup runs -- even though B's own import step hasn't run yet.
+    const scanB = await createScan({
+      workspaceId,
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+    });
+    await recordScanItems(
+      scanB.id,
+      [
+        {
+          sourceKind: "vault-kv",
+          sourceObjectId: objectId,
+          dimensions: { mount: "secret/", path: "racy", category: "generic" },
+        },
+      ],
+      {
+        workspaceId,
+        provider: "vault",
+        instance,
+        ownerKey: instance,
+        observedAt: scanB.startedAt,
+      },
+    );
+    await finalizeScan(scanB.id, [
+      { sourceKind: "vault-kv", dimensions: { mount: "secret/" }, complete: true },
+    ]);
+
+    // Scan A finalizes (still having recorded zero items) and its cleanup
+    // runs after B's rediscovery was already persisted.
+    await recordScanItems(scanA.id, [], {
+      workspaceId,
+      provider: "vault",
+      instance,
+      ownerKey: instance,
+      observedAt: scanA.startedAt,
+    });
+    await finalizeScan(scanA.id, [
+      { sourceKind: "vault-kv", dimensions: { mount: "secret/" }, complete: true },
+    ]);
+
+    const { deleted } = await cleanupObsoleteTokens({
+      workspaceId,
+      actorUserId: ownerId,
+      cleanup: { enabled: true, provider: "vault", scanId: scanA.id },
+    });
+
+    expect(deleted.map((d) => d.id)).to.not.include(token.id);
+    expect(await tokenStillExists(token.id)).to.equal(true);
+    expect(deleted.map((d) => d.id)).to.include(genuinelyObsolete.id);
+    expect(await tokenStillExists(genuinelyObsolete.id)).to.equal(false);
   });
 });

--- a/tests/integration/provider-services-extended.unit.test.js
+++ b/tests/integration/provider-services-extended.unit.test.js
@@ -72,8 +72,8 @@ describe("Provider services extended unit coverage", () => {
       token: "token",
       maxItems: 10,
     });
-    expect(certs).to.deep.equal([]);
-    expect(keys).to.deep.equal([]);
+    expect(certs.items).to.deep.equal([]);
+    expect(keys.items).to.deep.equal([]);
   });
 
   it("azure scan returns empty result when endpoints return 403/404-style failures", async () => {
@@ -120,7 +120,7 @@ describe("Provider services extended unit coverage", () => {
       token: "header.payload.signature",
       maxItems: 10,
     });
-    expect(sps.map((s) => s.id)).to.deep.equal(["sp-1", "sp-2"]);
+    expect(sps.items.map((s) => s.id)).to.deep.equal(["sp-1", "sp-2"]);
   });
 
   it("azure AD refuses service principal pagination URLs off graph.microsoft.com", async () => {

--- a/tests/integration/provider-services.unit.test.js
+++ b/tests/integration/provider-services.unit.test.js
@@ -77,6 +77,44 @@ async function expectReject(promiseFactory, pattern) {
   }
 }
 
+// Builds a JWT-shaped (but unsigned) token string containing a `tid` claim
+// of at least `minLength` characters, since scanAzureAD now requires a
+// tenant id to attribute scan results (see sourceIdentity.js) and refuses
+// tokens that don't decode to one.
+function fakeAzureAdToken(minLength = 0) {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString(
+    "base64",
+  );
+  let padLength = 0;
+  let token;
+  do {
+    const payload = Buffer.from(
+      JSON.stringify({
+        tid: "11111111-1111-1111-1111-111111111111",
+        aud: "https://graph.microsoft.com",
+        pad: "x".repeat(padLength),
+      }),
+    ).toString("base64");
+    token = `${header}.${payload}.signature`;
+    padLength += 100;
+  } while (token.length < minLength);
+  return token;
+}
+
+// Every scanAWS() call now resolves the STS account id up front (it anchors
+// AWS token provenance -- see sourceIdentity.js), so any test that reaches
+// past input validation needs this mocked regardless of which AWS service
+// it's actually exercising.
+function mockSts(accountId = "123456789012") {
+  class GetCallerIdentityCommand {}
+  class STSClient {
+    async send() {
+      return { Account: accountId, Arn: "arn:aws:iam::123456789012:user/test" };
+    }
+  }
+  return { "@aws-sdk/client-sts": { STSClient, GetCallerIdentityCommand } };
+}
+
 describe("Provider service unit coverage", () => {
   describe("AWS integration", () => {
     it("validates required credentials", async () => {
@@ -93,16 +131,19 @@ describe("Provider service unit coverage", () => {
     // GetSessionToken credentials (e.g. with session tags or chained roles)
     // with "Invalid sessionToken format" before any AWS call was made.
     it("accepts a sessionToken above the old 2000-char cap", async () => {
-      const aws = require(resolveServiceModule("awsIntegration"));
-      const result = await aws.scanAWS({
-        accessKeyId: "AKIAEXAMPLE123",
-        secretAccessKey: "super-secret-key",
-        sessionToken: "x".repeat(3500),
-        region: "us-east-1",
-        // Skip every scan type so this stays a pure validation test with no
-        // AWS SDK client instantiation or network calls.
-        include: { secrets: false, iam: false, certificates: false },
-      });
+      const stsMocks = mockSts();
+      const aws = requireWithMocks(resolveServiceModule("awsIntegration"), stsMocks);
+      const result = await withPatchedLoad(stsMocks, () =>
+        aws.scanAWS({
+          accessKeyId: "AKIAEXAMPLE123",
+          secretAccessKey: "super-secret-key",
+          sessionToken: "x".repeat(3500),
+          region: "us-east-1",
+          // Skip every scan type so this stays a pure validation test with no
+          // AWS SDK client instantiation or network calls.
+          include: { secrets: false, iam: false, certificates: false },
+        }),
+      );
       expect(result).to.have.property("items").that.is.an("array");
       expect(result).to.have.property("summary").that.is.an("array");
     });
@@ -256,6 +297,7 @@ describe("Provider service unit coverage", () => {
           ListCertificatesCommand,
           DescribeCertificateCommand,
         },
+        ...mockSts(),
       };
       const aws = requireWithMocks(
         resolveServiceModule("awsIntegration"),
@@ -351,6 +393,7 @@ describe("Provider service unit coverage", () => {
           ListCertificatesCommand,
           DescribeCertificateCommand,
         },
+        ...mockSts(),
       };
       const aws = requireWithMocks(
         resolveServiceModule("awsIntegration"),
@@ -422,7 +465,7 @@ describe("Provider service unit coverage", () => {
         token: "test-token",
         maxItems: 10,
       });
-      expect(result).to.deep.equal([]);
+      expect(result.items).to.deep.equal([]);
     });
 
     it("returns null on 404 for getSecret", async () => {
@@ -536,7 +579,7 @@ describe("Provider service unit coverage", () => {
         token: "test-token",
         maxItems: 10,
       });
-      expect(secrets.map((s) => s.id)).to.deep.equal(["s1", "s2"]);
+      expect(secrets.items.map((s) => s.id)).to.deep.equal(["s1", "s2"]);
       expect(requestedUrls[1]).to.match(/vault\.example\.com/);
       expect(requestedUrls[1]).to.match(/skiptoken=abc/);
     });
@@ -595,7 +638,7 @@ describe("Provider service unit coverage", () => {
         token: "header.payload.signature",
         maxItems: 10,
       });
-      expect(apps.map((a) => a.id)).to.deep.equal(["app-1", "app-2"]);
+      expect(apps.items.map((a) => a.id)).to.deep.equal(["app-1", "app-2"]);
       // Regression guard: @odata.nextLink already contains the /v1.0 prefix.
       // Re-prepending the Graph base URL produced /v1.0/v1.0/... which 404s
       // and silently truncated tenants with more than one page of apps.
@@ -647,7 +690,7 @@ describe("Provider service unit coverage", () => {
         { axios: axiosMock },
       );
       const result = await azureAd.scanAzureAD({
-        token: "x".repeat(4000),
+        token: fakeAzureAdToken(4000),
         include: { applications: true, servicePrincipals: false },
       });
       expect(result).to.have.property("items").that.is.an("array");

--- a/tests/integration/provider-services.unit.test.js
+++ b/tests/integration/provider-services.unit.test.js
@@ -740,7 +740,7 @@ describe("Provider service unit coverage", () => {
         accessToken: "token",
         maxItems: 5,
       });
-      expect(secrets).to.deep.equal([]);
+      expect(secrets.items).to.deep.equal([]);
     });
 
     it("returns null on 404 for getSecretVersion", async () => {

--- a/tests/integration/vault-scan-multicert.unit.test.js
+++ b/tests/integration/vault-scan-multicert.unit.test.js
@@ -355,6 +355,93 @@ describe("Vault KV scan behavior", () => {
     });
   });
 
+  describe("scanVault truncation during key enumeration (regression)", () => {
+    // Regression for a bug found during live cleanup verification: the KV
+    // key-listing walk (listKvV2KeysRecursive) enforces `maxItemsPerMount`
+    // as a hard cap on how many keys it even enumerates, stopping the walk
+    // before it reaches later folders. If the read loop downstream never
+    // sees more keys than that cap, it never observes a "too many items"
+    // condition either, so the mount was reported `truncated: false,
+    // complete: true` even though real secrets in a later folder
+    // ("team-a/") were never looked at. Cleanup treating that scan as
+    // complete deleted secrets that still existed upstream.
+    const routes = {
+      "GET /v1/sys/mounts": {
+        status: 200,
+        body: {
+          data: { "secret/": { type: "kv", options: { version: "2" } } },
+        },
+      },
+      // Alphabetically-first folder holds exactly `maxItemsPerMount` items,
+      // so the walk's own cap trips while still inside this folder and
+      // never even lists the sibling "team-a/" folder below.
+      "LIST /v1/secret/metadata/": {
+        status: 200,
+        body: { data: { keys: ["cert/", "team-a/"] } },
+      },
+      "LIST /v1/secret/metadata/cert/": {
+        status: 200,
+        body: { data: { keys: ["one", "two"] } },
+      },
+      "LIST /v1/secret/metadata/team-a/": {
+        status: 200,
+        body: { data: { keys: ["token"] } },
+      },
+      "GET /v1/secret/data/cert/one": {
+        status: 200,
+        body: {
+          data: {
+            data: { password: "a" },
+            metadata: { created_time: "2026-01-01T00:00:00Z" },
+          },
+        },
+      },
+      "GET /v1/secret/data/cert/two": {
+        status: 200,
+        body: {
+          data: {
+            data: { password: "b" },
+            metadata: { created_time: "2026-01-01T00:00:00Z" },
+          },
+        },
+      },
+      "GET /v1/secret/data/team-a/token": {
+        status: 200,
+        body: {
+          data: {
+            data: { password: "c" },
+            metadata: { created_time: "2026-01-01T00:00:00Z" },
+          },
+        },
+      },
+    };
+
+    let vault;
+
+    before(async () => {
+      vault = await startFakeVault(routes);
+    });
+
+    after(async () => {
+      if (vault) await vault.close();
+    });
+
+    it("reports truncated (never complete) when the key cap is hit mid-listing, even though the read loop itself never overflows", async () => {
+      const res = await mod.scanVault({
+        address: vault.address,
+        token: "test-token",
+        include: { kv: true, pki: false },
+        maxItemsPerMount: 2,
+      });
+      // Only the 2 keys under cert/ were enumerated; team-a/token was never
+      // even listed, let alone read -- exactly the silently-dropped case.
+      expect(res.items).to.have.length(2);
+      const summary = res.summary.find((s) => s.mount === "secret/");
+      expect(summary.truncated).to.equal(true);
+      expect(summary.complete).to.equal(false);
+    });
+  });
+
   describe("scanVault category filtering", () => {
     const routes = {
       "GET /v1/sys/mounts": {

--- a/tests/integration/vault-scan-multicert.unit.test.js
+++ b/tests/integration/vault-scan-multicert.unit.test.js
@@ -313,7 +313,7 @@ describe("Vault KV scan behavior", () => {
           complete: true,
           hasErrors: false,
           sourceKind: "vault-kv",
-          dimensions: { mount: "secret/", path: null, category: null },
+          dimensions: { mount: "secret/", pathPrefix: null, categories: null },
         },
       ]);
     });
@@ -511,7 +511,7 @@ describe("Vault KV scan behavior", () => {
           complete: true,
           hasErrors: false,
           sourceKind: "vault-kv",
-          dimensions: { mount: "secret/", path: null, category: "cert" },
+          dimensions: { mount: "secret/", pathPrefix: null, categories: ["cert"] },
         },
       ]);
     });

--- a/tests/integration/vault-scan-multicert.unit.test.js
+++ b/tests/integration/vault-scan-multicert.unit.test.js
@@ -305,7 +305,16 @@ describe("Vault KV scan behavior", () => {
       expect(res.items).to.have.length(3);
       expect(res.items.filter((i) => i.category === "cert")).to.have.length(2);
       expect(res.summary).to.deep.equal([
-        { mount: "secret/", type: "kv", found: 3, truncated: false },
+        {
+          mount: "secret/",
+          type: "kv",
+          found: 3,
+          truncated: false,
+          complete: true,
+          hasErrors: false,
+          sourceKind: "vault-kv",
+          dimensions: { mount: "secret/", path: null, category: null },
+        },
       ]);
     });
 
@@ -407,7 +416,16 @@ describe("Vault KV scan behavior", () => {
       expect(res.items).to.have.length(1);
       expect(res.items[0].category).to.equal("cert");
       expect(res.summary).to.deep.equal([
-        { mount: "secret/", type: "kv", found: 1, truncated: false },
+        {
+          mount: "secret/",
+          type: "kv",
+          found: 1,
+          truncated: false,
+          complete: true,
+          hasErrors: false,
+          sourceKind: "vault-kv",
+          dimensions: { mount: "secret/", path: null, category: "cert" },
+        },
       ]);
     });
 

--- a/tests/unit/certops-migration.test.js
+++ b/tests/unit/certops-migration.test.js
@@ -1646,7 +1646,7 @@ describe("migration 46 alert_queue agent-health anchor", () => {
     for (let i = 1; i < sorted.length; i += 1) {
       assert.equal(sorted[i], sorted[i - 1] + 1, `migration versions must be sequential (gap before version ${sorted[i]})`);
     }
-    assert.equal(sorted[sorted.length - 1], 49);
+    assert.equal(sorted[sorted.length - 1], 50);
   });
 });
 
@@ -1780,6 +1780,100 @@ describe("migration 48 trust-anchor installation agent linkage", () => {
     assert.match(
       migration.sql,
       /CREATE INDEX IF NOT EXISTS idx_certops_trust_anchor_installations_next_reconcile\s+ON certops_trust_anchor_installations\(next_reconcile_at\)\s+WHERE next_reconcile_at IS NOT NULL;/,
+    );
+  });
+
+  it("uses only additive DDL (no DROP TABLE/DROP COLUMN)", () => {
+    assert.doesNotMatch(migration.sql, /DROP TABLE/i);
+    assert.doesNotMatch(migration.sql, /DROP COLUMN/i);
+  });
+});
+
+describe("migration 50 import cleanup scan provenance", () => {
+  const migration = migrations.find((entry) => entry.version === 50);
+
+  it("exists with the expected name", () => {
+    assert.ok(migration);
+    assert.equal(migration.name, "import_cleanup_scan_provenance");
+  });
+
+  it("adds provenance columns to tokens; owner_key is NOT NULL DEFAULT '' so the sentinel value participates correctly in the unique index below, the rest nullable so existing rows stay valid", () => {
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_provider TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_instance TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_owner_key TEXT NOT NULL DEFAULT ''/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_owner_display TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_kind TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_dimensions JSONB NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_object_id TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS source_observed_at TIMESTAMPTZ NULL/,
+    );
+  });
+
+  it("scopes the upsert identity index to rows that actually have a source_object_id", () => {
+    assert.match(
+      migration.sql,
+      /CREATE UNIQUE INDEX IF NOT EXISTS uq_tokens_source_identity\s+ON tokens \(workspace_id, source_provider, source_instance, source_owner_key, source_kind, source_object_id\)\s+WHERE source_object_id IS NOT NULL/,
+    );
+  });
+
+  it("creates integration_scans with a single-use cleanup claim column", () => {
+    assert.match(
+      migration.sql,
+      /CREATE TABLE IF NOT EXISTS integration_scans/,
+    );
+    assert.match(migration.sql, /cleanup_consumed_at TIMESTAMPTZ NULL/);
+    assert.match(
+      migration.sql,
+      /workspace_id UUID NOT NULL REFERENCES workspaces\(id\) ON DELETE CASCADE/,
+    );
+  });
+
+  it("creates integration_scan_items keyed uniquely per scan/kind/object", () => {
+    assert.match(
+      migration.sql,
+      /CREATE TABLE IF NOT EXISTS integration_scan_items/,
+    );
+    assert.match(
+      migration.sql,
+      /scan_id UUID NOT NULL REFERENCES integration_scans\(id\) ON DELETE CASCADE/,
+    );
+    assert.match(
+      migration.sql,
+      /CREATE UNIQUE INDEX IF NOT EXISTS uq_integration_scan_items_identity\s+ON integration_scan_items\(scan_id, source_kind, source_object_id\)/,
+    );
+  });
+
+  it("adds an opt-in cleanup flag and connection_key to auto_sync_configs, defaulted safely", () => {
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS connection_key TEXT NULL/,
+    );
+    assert.match(
+      migration.sql,
+      /ADD COLUMN IF NOT EXISTS cleanup_obsolete BOOLEAN NOT NULL DEFAULT FALSE/,
     );
   });
 

--- a/tests/unit/import-cleanup.unit.test.js
+++ b/tests/unit/import-cleanup.unit.test.js
@@ -1,18 +1,18 @@
 "use strict";
 
 /**
- * Unit tests for importCleanup validation and scope patterns.
- * DB-dependent deletion behavior is covered by integration tests.
- * Only the pure exports are exercised here; requiring the module creates a
- * pg Pool but never connects.
+ * Unit tests for importCleanup's pure exports: request validation and the
+ * dimension-filter SQL builder used by the scan-scoped anti-join. DB-backed
+ * deletion behavior (claim, anti-join, observation fence, transaction) is
+ * covered by integration tests since it requires a real database.
  */
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const {
+  KNOWN_PROVIDERS,
   validateCleanupRequest,
-  SOURCE_LOCATION_PATTERNS,
-  PROVIDER_PREFIXES,
+  buildDimensionFilterSql,
 } = require("../../apps/api/services/importCleanup");
 
 describe("importCleanup.validateCleanupRequest", () => {
@@ -29,267 +29,135 @@ describe("importCleanup.validateCleanupRequest", () => {
   it("ignores payloads with enabled !== true", () => {
     assert.strictEqual(validateCleanupRequest({ enabled: false }), null);
     assert.strictEqual(validateCleanupRequest({}), null);
-  });
-
-  it("requires a known provider when enabled", () => {
-    assert.match(
-      validateCleanupRequest({ enabled: true, provider: "bitbucket" }),
-      /provider must be one of/,
-    );
-  });
-
-  it("requires non-empty scannedSources with known kinds", () => {
-    assert.match(
-      validateCleanupRequest({
-        enabled: true,
-        provider: "gitlab",
-        scannedSources: [],
-      }),
-      /non-empty array/,
-    );
-    assert.match(
-      validateCleanupRequest({
-        enabled: true,
-        provider: "gitlab",
-        scannedSources: ["gitlab-unknown"],
-      }),
-      /unknown source kind/,
-    );
-  });
-
-  it("requires scannedLocations array", () => {
-    assert.match(
-      validateCleanupRequest({
-        enabled: true,
-        provider: "gitlab",
-        scannedSources: ["gitlab-pat"],
-        scannedLocations: "gitlab:x",
-      }),
-      /must be an array/,
-    );
-  });
-
-  it("accepts a valid payload", () => {
+    // Even a garbage provider/scanId is ignored when cleanup isn't enabled --
+    // this must never be a backdoor to validate an otherwise-inert payload.
     assert.strictEqual(
-      validateCleanupRequest({
-        enabled: true,
-        provider: "gitlab",
-        scannedSources: ["gitlab-pat", "gitlab-deploy-token"],
-        scannedLocations: ["gitlab:personal_access_tokens/1"],
-      }),
+      validateCleanupRequest({ enabled: false, provider: "nope" }),
       null,
     );
   });
 
-  it("accepts valid payloads for every non-git provider", () => {
-    const validByProvider = {
-      vault: ["vault-kv", "vault-pki"],
-      aws: ["aws-secrets-manager", "aws-acm", "aws-iam-key"],
-      azure: [
-        "azure-key-vault-secret",
-        "azure-key-vault-certificate",
-        "azure-key-vault-key",
-      ],
-      "azure-ad": [
-        "azure-ad-client-secret",
-        "azure-ad-certificate",
-        "azure-ad-sp-secret",
-        "azure-ad-sp-certificate",
-      ],
-      gcp: ["gcp-secret-manager"],
-    };
-    for (const [provider, scannedSources] of Object.entries(
-      validByProvider,
-    )) {
+  it("requires a known provider when enabled", () => {
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "bitbucket",
+        scanId: "11111111-1111-1111-1111-111111111111",
+      }),
+      /provider must be one of/,
+    );
+  });
+
+  it("requires a non-empty scanId string when enabled", () => {
+    assert.match(
+      validateCleanupRequest({ enabled: true, provider: "gitlab" }),
+      /scanId is required/,
+    );
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scanId: "",
+      }),
+      /scanId is required/,
+    );
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scanId: "   ",
+      }),
+      /scanId is required/,
+    );
+    assert.match(
+      validateCleanupRequest({
+        enabled: true,
+        provider: "gitlab",
+        scanId: 12345,
+      }),
+      /scanId is required/,
+    );
+  });
+
+  it("accepts a valid payload for every known provider", () => {
+    for (const provider of KNOWN_PROVIDERS) {
       assert.strictEqual(
         validateCleanupRequest({
           enabled: true,
           provider,
-          scannedSources,
-          scannedLocations: [],
+          scanId: "11111111-1111-1111-1111-111111111111",
         }),
         null,
-        `${provider} should accept its own source kinds`,
+        `${provider} should accept a valid scanId payload`,
       );
     }
+  });
+
+  it("KNOWN_PROVIDERS covers exactly the seven supported integrations", () => {
+    assert.deepStrictEqual(
+      [...KNOWN_PROVIDERS].sort(),
+      [
+        "aws",
+        "azure",
+        "azure-ad",
+        "gcp",
+        "github",
+        "gitlab",
+        "vault",
+      ].sort(),
+    );
   });
 });
 
-describe("importCleanup.SOURCE_LOCATION_PATTERNS", () => {
-  it("gitlab-pat matches both PAT location shapes", () => {
-    const p = SOURCE_LOCATION_PATTERNS["gitlab-pat"];
-    assert.strictEqual(p.test("gitlab:personal_access_tokens/42"), true);
-    assert.strictEqual(
-      p.test("gitlab:users/alice/personal_access_tokens/42"),
-      true,
-    );
-    assert.strictEqual(p.test("gitlab:projects/7/access_tokens/42"), false);
+describe("importCleanup.buildDimensionFilterSql", () => {
+  it("returns an empty filter for no dimensions", () => {
+    const { sql, params } = buildDimensionFilterSql(null, 5);
+    assert.strictEqual(sql, "");
+    assert.deepStrictEqual(params, []);
   });
 
-  it("gitlab token type patterns are mutually exclusive", () => {
-    const samples = {
-      "gitlab-project-token": "gitlab:projects/7/access_tokens/1",
-      "gitlab-group-token": "gitlab:groups/3/access_tokens/1",
-      "gitlab-deploy-token": "gitlab:projects/7/deploy_tokens/1",
-      "gitlab-trigger-token": "gitlab:projects/7/triggers/1",
-      "gitlab-ssh-key": "gitlab:user/keys/1",
-    };
-    for (const [kind, location] of Object.entries(samples)) {
-      assert.strictEqual(
-        SOURCE_LOCATION_PATTERNS[kind].test(location),
-        true,
-        `${kind} should match ${location}`,
-      );
-      for (const [otherKind, pattern] of Object.entries(
-        SOURCE_LOCATION_PATTERNS,
-      )) {
-        if (otherKind === kind || !otherKind.startsWith("gitlab-")) continue;
-        assert.strictEqual(
-          pattern.test(location),
-          false,
-          `${otherKind} should not match ${location}`,
-        );
-      }
-    }
+  it("skips null/undefined/empty-string dimension values", () => {
+    const { sql, params } = buildDimensionFilterSql(
+      { region: null, service: undefined, mount: "" },
+      5,
+    );
+    assert.strictEqual(sql, "");
+    assert.deepStrictEqual(params, []);
   });
 
-  it("github patterns match the integration location shapes", () => {
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["github-ssh-key"].test("github:user/keys/9"),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["github-secret"].test(
-        "github:repos/org/repo/actions/secrets/MY_SECRET",
-      ),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["github-deploy-key"].test(
-        "github:repos/org/repo/keys/12",
-      ),
-      true,
-    );
+  it("builds an exact-match clause for a plain dimension key", () => {
+    const { sql, params } = buildDimensionFilterSql({ region: "us-east-1" }, 3);
+    assert.match(sql, /\(t\.source_dimensions->>'region'\) = \$3/);
+    assert.deepStrictEqual(params, ["us-east-1"]);
   });
 
-  it("vault-kv and vault-pki are mutually exclusive", () => {
-    const kvLocation = "vault:secret/data/myapp/apikey";
-    const pkiLocation = "vault:pki/cert/39:dd:7a:1b";
-
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["vault-kv"].test(kvLocation),
-      true,
+  it("builds a prefix-match clause against the token's own 'path' for pathPrefix", () => {
+    const { sql, params } = buildDimensionFilterSql(
+      { pathPrefix: "staging/db" },
+      2,
     );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["vault-pki"].test(kvLocation),
-      false,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["vault-pki"].test(pkiLocation),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["vault-kv"].test(pkiLocation),
-      false,
-    );
+    assert.match(sql, /\(t\.source_dimensions->>'path'\) LIKE \$2/);
+    assert.deepStrictEqual(params, ["staging/db%"]);
   });
 
-  it("aws source patterns are scoped by kind, not region", () => {
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["aws-secrets-manager"].test(
-        "aws:secretsmanager:us-east-1:arn:aws:secretsmanager:us-east-1:123:secret:foo",
-      ),
-      true,
+  it("combines multiple dimensions with AND and sequential placeholders", () => {
+    const { sql, params } = buildDimensionFilterSql(
+      { mount: "secret/", pathPrefix: "app1", category: "cert" },
+      1,
     );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["aws-acm"].test(
-        "aws:acm:eu-west-1:arn:aws:acm:eu-west-1:123:certificate/abc",
-      ),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["aws-iam-key"].test(
-        "aws:iam:us-east-1:someuser/AKIAEXAMPLE",
-      ),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["aws-iam-key"].test(
-        "aws:secretsmanager:us-east-1:arn:...",
-      ),
-      false,
-    );
+    assert.match(sql, / AND /);
+    assert.match(sql, /\$1/);
+    assert.match(sql, /\$2/);
+    assert.match(sql, /\$3/);
+    assert.deepStrictEqual(params, ["secret/", "app1%", "cert"]);
   });
 
-  it("azure key vault patterns distinguish secrets/certificates/keys", () => {
-    const secret = "azure:https://my-vault.vault.azure.net/secrets/foo";
-    const cert = "azure:https://my-vault.vault.azure.net/certificates/foo";
-    const key = "azure:https://my-vault.vault.azure.net/keys/foo";
-
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-key-vault-secret"].test(secret),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-key-vault-certificate"].test(cert),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-key-vault-key"].test(key),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-key-vault-secret"].test(cert),
-      false,
-    );
-  });
-
-  it("azure-ad patterns distinguish apps/service-principals and secrets/certs", () => {
-    const appSecret = "azure-ad:applications/app-1/secrets/key-1";
-    const appCert = "azure-ad:applications/app-1/certificates/key-1";
-    const spSecret = "azure-ad:servicePrincipals/sp-1/secrets/key-1";
-    const spCert = "azure-ad:servicePrincipals/sp-1/certificates/key-1";
-
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-ad-client-secret"].test(appSecret),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-ad-certificate"].test(appCert),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-ad-sp-secret"].test(spSecret),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-ad-sp-certificate"].test(spCert),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["azure-ad-client-secret"].test(spSecret),
-      false,
-    );
-  });
-
-  it("gcp-secret-manager matches Secret Manager locations", () => {
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["gcp-secret-manager"].test(
-        "gcp:my-project-123/secrets/foo",
-      ),
-      true,
-    );
-    assert.strictEqual(
-      SOURCE_LOCATION_PATTERNS["gcp-secret-manager"].test(
-        "gcp:my-project-123/other/foo",
-      ),
-      false,
-    );
-  });
-
-  it("every provider prefix has a colon suffix", () => {
-    for (const prefix of Object.values(PROVIDER_PREFIXES)) {
-      assert.strictEqual(prefix.endsWith(":"), true);
-    }
+  it("sanitizes non-pathPrefix dimension keys to a safe identifier", () => {
+    // Defense in depth: dimension keys ultimately come from scan-recorded
+    // data, not raw user input, but the SQL builder must never interpolate
+    // an unsanitized key into the query string regardless.
+    const { sql } = buildDimensionFilterSql({ "bad key'; --": "x" }, 1);
+    assert.doesNotMatch(sql, /'; --/);
+    assert.match(sql, /badkey/);
   });
 });

--- a/tests/unit/import-cleanup.unit.test.js
+++ b/tests/unit/import-cleanup.unit.test.js
@@ -80,6 +80,39 @@ describe("importCleanup.validateCleanupRequest", () => {
       null,
     );
   });
+
+  it("accepts valid payloads for every non-git provider", () => {
+    const validByProvider = {
+      vault: ["vault-kv", "vault-pki"],
+      aws: ["aws-secrets-manager", "aws-acm", "aws-iam-key"],
+      azure: [
+        "azure-key-vault-secret",
+        "azure-key-vault-certificate",
+        "azure-key-vault-key",
+      ],
+      "azure-ad": [
+        "azure-ad-client-secret",
+        "azure-ad-certificate",
+        "azure-ad-sp-secret",
+        "azure-ad-sp-certificate",
+      ],
+      gcp: ["gcp-secret-manager"],
+    };
+    for (const [provider, scannedSources] of Object.entries(
+      validByProvider,
+    )) {
+      assert.strictEqual(
+        validateCleanupRequest({
+          enabled: true,
+          provider,
+          scannedSources,
+          scannedLocations: [],
+        }),
+        null,
+        `${provider} should accept its own source kinds`,
+      );
+    }
+  });
 });
 
 describe("importCleanup.SOURCE_LOCATION_PATTERNS", () => {
@@ -136,6 +169,121 @@ describe("importCleanup.SOURCE_LOCATION_PATTERNS", () => {
         "github:repos/org/repo/keys/12",
       ),
       true,
+    );
+  });
+
+  it("vault-kv and vault-pki are mutually exclusive", () => {
+    const kvLocation = "vault:secret/data/myapp/apikey";
+    const pkiLocation = "vault:pki/cert/39:dd:7a:1b";
+
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["vault-kv"].test(kvLocation),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["vault-pki"].test(kvLocation),
+      false,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["vault-pki"].test(pkiLocation),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["vault-kv"].test(pkiLocation),
+      false,
+    );
+  });
+
+  it("aws source patterns are scoped by kind, not region", () => {
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["aws-secrets-manager"].test(
+        "aws:secretsmanager:us-east-1:arn:aws:secretsmanager:us-east-1:123:secret:foo",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["aws-acm"].test(
+        "aws:acm:eu-west-1:arn:aws:acm:eu-west-1:123:certificate/abc",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["aws-iam-key"].test(
+        "aws:iam:us-east-1:someuser/AKIAEXAMPLE",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["aws-iam-key"].test(
+        "aws:secretsmanager:us-east-1:arn:...",
+      ),
+      false,
+    );
+  });
+
+  it("azure key vault patterns distinguish secrets/certificates/keys", () => {
+    const secret = "azure:https://my-vault.vault.azure.net/secrets/foo";
+    const cert = "azure:https://my-vault.vault.azure.net/certificates/foo";
+    const key = "azure:https://my-vault.vault.azure.net/keys/foo";
+
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-key-vault-secret"].test(secret),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-key-vault-certificate"].test(cert),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-key-vault-key"].test(key),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-key-vault-secret"].test(cert),
+      false,
+    );
+  });
+
+  it("azure-ad patterns distinguish apps/service-principals and secrets/certs", () => {
+    const appSecret = "azure-ad:applications/app-1/secrets/key-1";
+    const appCert = "azure-ad:applications/app-1/certificates/key-1";
+    const spSecret = "azure-ad:servicePrincipals/sp-1/secrets/key-1";
+    const spCert = "azure-ad:servicePrincipals/sp-1/certificates/key-1";
+
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-ad-client-secret"].test(appSecret),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-ad-certificate"].test(appCert),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-ad-sp-secret"].test(spSecret),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-ad-sp-certificate"].test(spCert),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["azure-ad-client-secret"].test(spSecret),
+      false,
+    );
+  });
+
+  it("gcp-secret-manager matches Secret Manager locations", () => {
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["gcp-secret-manager"].test(
+        "gcp:my-project-123/secrets/foo",
+      ),
+      true,
+    );
+    assert.strictEqual(
+      SOURCE_LOCATION_PATTERNS["gcp-secret-manager"].test(
+        "gcp:my-project-123/other/foo",
+      ),
+      false,
     );
   });
 

--- a/tests/unit/import-cleanup.unit.test.js
+++ b/tests/unit/import-cleanup.unit.test.js
@@ -160,4 +160,22 @@ describe("importCleanup.buildDimensionFilterSql", () => {
     assert.doesNotMatch(sql, /'; --/);
     assert.match(sql, /badkey/);
   });
+
+  it("builds a membership-match clause against the token's own 'category' for categories", () => {
+    const { sql, params } = buildDimensionFilterSql(
+      { categories: ["cert", "generic"] },
+      4,
+    );
+    assert.match(
+      sql,
+      /\(t\.source_dimensions->>'category'\) = ANY\(\$4::text\[\]\)/,
+    );
+    assert.deepStrictEqual(params, [["cert", "generic"]]);
+  });
+
+  it("skips categories when the array is empty", () => {
+    const { sql, params } = buildDimensionFilterSql({ categories: [] }, 1);
+    assert.strictEqual(sql, "");
+    assert.deepStrictEqual(params, []);
+  });
 });


### PR DESCRIPTION
## Summary

This redesigns obsolete-token cleanup for all seven import providers (GitHub, GitLab, Vault, AWS, Azure Key Vault, Azure AD, GCP Secret Manager) so that a destructive cleanup can never run against the wrong instance, the wrong owner, or a scope the backend didn't actually finish checking.

Previously, cleanup scope was reconstructed from client-supplied `scannedSources`/`scannedLocations` strings and matched against tokens via `location LIKE` patterns. That made cleanup only as trustworthy as whatever the browser tab happened to send, and provided no way to tell a narrow scan (one Vault mount, one AWS region, one Azure Key Vault) from a full one.

### Backend-authoritative scan records

- Every scan (manual import or auto-sync) is now persisted server-side as an `integration_scans` row plus `integration_scan_items` rows recording exactly what was found, keyed by a UUID `scan_id`.
- Import requests reference that `scan_id`; the backend re-derives cleanup scope and discovered items from its own record instead of trusting anything the client echoes back. A client can no longer self-attribute provenance for an item it submits.

### Per-instance, per-owner, per-kind attribution

- Tokens now carry structured provenance (`source_provider`, `source_instance`, `source_owner_key`, `source_kind`, `source_dimensions`, `source_object_id`) instead of a single opaque `location` string. `source_owner_key` is always an immutable principal id (numeric user/org/account/tenant id), never a mutable username.
- A new `source identity resolver` centralizes how each provider's instance/owner/dimensions are derived, used identically by manual import and auto-sync so there's one source of truth instead of duplicated logic.
- Cleanup only ever considers tokens matching the scan's exact provider + instance + owner, so two GitHub Enterprise or self-hosted GitLab instances (or two AWS accounts, two Vault servers, etc.) can never cross-delete each other's tokens even if internal object ids collide.

### Per-scope completeness gating

- Each scan reports completeness per sub-scope (e.g. per Vault mount, per AWS region/service, per Azure Key Vault source kind, per Azure AD object type). Cleanup only runs against sub-scopes the scan reported fully complete; anything truncated, errored, or skipped is left untouched.
- A fully successful scan that legitimately finds zero items in a complete scope is still allowed to clean up everything in that scope, since that's a true "nothing here anymore" result, not treated the same as an incomplete one.
- Vault's KV vs PKI distinction is now tracked explicitly per item rather than inferred from the path shape, so a KV secret stored at a path that merely looks certificate-shaped can never be swept up by a PKI-only cleanup.
- AWS scans now enumerate actually-enabled regions and resolve the account id up front, and mark scope incomplete if any intended region/service check failed rather than silently under-scanning.

### Safety mechanics

- Cleanup candidates are selected via an anti-join against the scan's recorded items (no giant client-supplied ID lists), atomically claimed via a single-use consumption marker so the same scan can never drive a second destructive cleanup, and gated by an observation fence so a slower, older scan's cleanup can never delete a token a newer concurrent scan just rediscovered.
- Pre-existing tokens imported before this shipped, where instance/owner can't be safely inferred from the old `location` string, are deliberately left alone: rediscovery inserts a new fully-attributed row rather than guessing at the old row's provenance.
- The full candidate-select, delete, and audit steps run in a single database transaction.

### Frontend and auto-sync

- The dashboard's import forms and modal now drive the cleanup checkbox off the backend's `scan_id` and the scan's reported completeness, disabling or warning instead of trusting client-side state.
- The auto-sync worker uses the same scan-backed engine for every provider (previously only GitHub/GitLab had a cleanup path there), driven by a per-config `cleanup_obsolete` flag.

## Post-review fixes

A post-review pass on this branch caught two defects that made the cleanup-on-import contract unreachable for its main real caller (auto-sync) and for a legitimate empty-scan case:

- The auto-sync worker sent its scan id under a different field name than the route validator required, which caused every auto-sync cycle with cleanup enabled to fail its entire import request, not just the cleanup step. Fixed at both the worker (now sends the field name the validator actually expects) and the route (a single shared normalization helper now accepts either accepted spelling as a fallback, so this class of mismatch can't silently break an import request again).
- Both import routes unconditionally rejected an empty items array, even when cleanup was enabled and valid, so a scan that legitimately found nothing left to import could never trigger the "clean up everything in this proven-complete scope" case. Both routes now allow that specific case through while still rejecting an empty items array with no cleanup requested.

Added HTTP-route-layer regression tests covering both fixes, including a request shaped exactly like the auto-sync worker's real payload.

## Test plan

- [x] `test:unit` — full suite green (1708 passing), including a rewritten `import-cleanup.unit.test.js` for the new scan-based validation and dimension-filter SQL builder
- [x] New DB-backed integration suite (`import-cleanup-scan-lifecycle.test.js`) against a real Postgres database covering: per-instance/per-owner scoping including host collisions, per-sub-scope completeness gating, Vault mount narrowing, KV-vs-PKI kind disambiguation, legacy-row exclusion, single-use scan claim (replay protection), the observation fence, and the zero-result-but-complete-scan deletion case
- [x] Route-level integration tests (generic import endpoint, integrations route matrix, auto-sync import/dedup) re-run green against the live API/DB
- [x] New HTTP-route-layer regression suite (`import-cleanup-route.test.js`) covering the two post-review fixes above, against a live API/DB
- [x] Provider-service unit/extended tests updated for new return shapes (Vault, AWS, Azure Key Vault, Azure AD, GCP) plus new GitHub/GitLab host-collision and sourceKind/sourceObjectId attribution regression tests
- [x] Dashboard lint, prettier, type-check, build; worker lint; API lint; `pnpm audit`
- [x] Backend contract checks (`check:contracts`, `check:contracts:integrity`, `check:lockfile-overrides`, `check:secret-logging`, `test:contracts`)
- [x] Helm chart validation and Compose config validation
- [ ] Manual scan/import round-trip against live Vault, AWS, Azure, and GCP accounts before release
