### PR TITLE
fix(dev): bind-mount packages/contracts into the api dev container

### DIFF
--- a/deploy/compose/docker-compose.dev.yml
+++ b/deploy/compose/docker-compose.dev.yml
@@ -96,6 +96,13 @@ services:
     volumes:
       - ../../apps/api:/app/apps/api
       - ../../packages/contracts/openapi:/contracts/openapi:ro
+      # Everything apps/api requires by relative path from packages/contracts
+      # (CertOps agent-protocol schema, canonical-json signing module, etc)
+      # is baked into the image at build time only; without this bind mount
+      # a contracts change never reaches a running dev container until the
+      # image is rebuilt, so requests silently validate against a stale
+      # schema instead of failing loudly.
+      - ../../packages/contracts:/app/packages/contracts:ro
       - /app/node_modules
       - /app/apps/api/node_modules
     working_dir: /app/apps/api


### PR DESCRIPTION
## Summary
- The `api` dev-compose service only bind-mounted `packages/contracts/openapi`. Everything else `apps/api` requires from `packages/contracts` by relative path (the CertOps agent-protocol schema, the canonical-json signing module) was baked into the image at build time only.
- A `packages/contracts` change therefore never reached a running dev container until the image was rebuilt: requests silently validated against a stale schema instead of failing loudly, and there was no error surfaced pointing at the real cause.
- Adds a bind mount for the whole `packages/contracts` directory (read-only) alongside the existing openapi-only mount.

## Test plan
- [x] `docker compose -f deploy/compose/docker-compose.dev.yml config --quiet` validates cleanly
- [x] Rebuild/restart the dev stack and confirm a local edit to `packages/contracts/certops/agent-protocol.schema.json` is picked up by a running `api` container without an image rebuild
