### PR TITLE
Fix High Grype finding: build subfinder against golang.org/x/crypto 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The agent's local outbox retried a repeatedly-failing entry on every poll tick forever. It now backs off exponentially (15s, 30s, 60s, capped at 30 minutes). A failure the agent can classify as permanent (a 4xx other than 408/429/401/403) is quarantined into a `dead-letter` subdirectory immediately; an unclassified transient failure only after at least 8 delivery attempts **and** 48 hours measured from the entry's first attempt, so an agent powered off for a week still gets a full retry window instead of being dead-lettered on its first post-restart failure. Both directories are retention-capped (5000 entries; 7 days for the outbox, 30 days for dead-letter), dead-letter age is measured from when the entry was quarantined rather than when the job finished, and an entry too corrupt to parse is aged off its file mtime so a poisoned file cannot occupy the directory indefinitely. There is no automatic replay: inspect `dead-letter/` if a job's result never reaches the control plane.
 - `@tokentimer/contracts` now declares `ajv`/`ajv-formats` as its own runtime dependencies instead of relying on a sibling workspace package's copy, which a production, workspace-filtered install (as the release Docker images use) does not make resolvable.
 
+### Security
+
+- The `subfinder` binary built into the API image is now compiled against `golang.org/x/crypto` 0.55.0 (from 0.53.0), clearing [GO-2026-6303](https://pkg.go.dev/vuln/GO-2026-6303) / CVE-2026-56854, a High finding where an SSH `source-address` restriction was not enforced for non-public-key auth callbacks. TokenTimer does not run an SSH server, so the affected code path was never reachable; the pin moves forward so image scans stay clean. `golang.org/x/net` (0.57.0), `golang.org/x/sys` (0.47.0) and `golang.org/x/text` (0.41.0) move with it to keep the module graph consistent.
+
 ## [0.13.3] - 2026-08-26
 
 ### Added

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,9 +9,9 @@ RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/sub
 
 WORKDIR /src/cmd/subfinder
 RUN go get \
-      golang.org/x/crypto@v0.52.0 \
-      golang.org/x/net@v0.55.0 \
-      golang.org/x/sys@v0.45.0 \
+      golang.org/x/crypto@v0.55.0 \
+      golang.org/x/net@v0.57.0 \
+      golang.org/x/sys@v0.47.0 \
       github.com/cloudflare/circl@v1.6.3 \
       github.com/klauspost/compress@v1.18.7 && \
     go mod tidy && \

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -8,9 +8,9 @@ RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/sub
 
 WORKDIR /src/cmd/subfinder
 RUN go get \
-      golang.org/x/crypto@v0.52.0 \
-      golang.org/x/net@v0.55.0 \
-      golang.org/x/sys@v0.45.0 \
+      golang.org/x/crypto@v0.55.0 \
+      golang.org/x/net@v0.57.0 \
+      golang.org/x/sys@v0.47.0 \
       github.com/cloudflare/circl@v1.6.3 \
       github.com/klauspost/compress@v1.18.7 && \
     go mod tidy && \

--- a/deploy/compose/Dockerfile.api
+++ b/deploy/compose/Dockerfile.api
@@ -8,10 +8,10 @@ RUN git clone --depth 1 --branch v2.14.0 https://github.com/projectdiscovery/sub
 
 WORKDIR /src/cmd/subfinder
 RUN go get \
-      golang.org/x/crypto@v0.53.0 \
-      golang.org/x/net@v0.56.0 \
-      golang.org/x/sys@v0.46.0 \
-      golang.org/x/text@v0.39.0 \
+      golang.org/x/crypto@v0.55.0 \
+      golang.org/x/net@v0.57.0 \
+      golang.org/x/sys@v0.47.0 \
+      golang.org/x/text@v0.41.0 \
       github.com/yuin/goldmark@v1.7.17 \
       github.com/cloudflare/circl@v1.6.3 \
       github.com/klauspost/compress@v1.18.7 && \


### PR DESCRIPTION
## Summary

Grype flagged `GO-2026-6303` / `CVE-2026-56854` (**High**) against the API image on the v0.14.0 merge commit, failing the `Docker Build & Security Scan` job and blocking the release tag. The advisory was published on 2026-08-28, after this repo's last green CI run, so this is newly-disclosed rather than a regression introduced by v0.14.0.

The flaw is that an SSH `source-address` critical option was not enforced for non-public-key auth callbacks in `golang.org/x/crypto/ssh`. TokenTimer runs no SSH server, and the only consumer of this module is the `subfinder` subdomain-enumeration binary built into the API image, so the affected code path was never reachable. The pin still moves forward rather than being suppressed in `.grype.yaml`, so image scans stay clean on their own terms instead of accumulating an exclusion for a genuinely fixable finding.

## Changes

### Docker images

- `deploy/compose/Dockerfile.api` (the image CI builds and scans), `apps/api/Dockerfile`, `apps/api/Dockerfile.dev`: `golang.org/x/crypto` `0.53.0`/`0.52.0` → `0.55.0`.
- `golang.org/x/net` → `0.57.0`, `golang.org/x/sys` → `0.47.0`, `golang.org/x/text` → `0.41.0`.

`x/crypto@0.55.0` requires `x/net@0.57.0`, which in turn requires `x/sys@0.47.0` and `x/text@0.41.0`. Bumping `x/crypto` alone fails the build outright with `go: golang.org/x/crypto@v0.55.0 requires golang.org/x/net@v0.57.0, not golang.org/x/net@v0.56.0`, so all four move together.

### Docs / metadata

- `CHANGELOG.md`: new `### Security` entry under `[0.14.0]`.

## Test plan

- Built the `subfinder-builder` stage of `deploy/compose/Dockerfile.api` for `linux/amd64` — resolves and compiles cleanly.
- `go version -m /go/bin/subfinder` confirms the embedded versions are `x/crypto v0.55.0`, `x/net v0.57.0`, `x/sys v0.47.0`, `x/text v0.41.0` — this is the metadata Grype reads, so the finding clears at the source.
- `subfinder -version` in the built stage still reports `v2.14.0`, confirming the dependency bump did not break the binary.
- No application code changed, so the rest of the suite is unaffected; the authoritative check is the post-merge `main` CI run, which re-runs the Grype scan that failed.
