### PR TITLE
fix(certops): 0.14.1 correctness fixes + trust-anchor installations endpoint

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -100,6 +100,7 @@ const {
   listCertificateJobLog,
   listCertificateJobs,
   manualRenewalJobCreator,
+  preflightManualRenewalJob,
 } = require("../services/certops/jobs");
 const {
   AUTO_RENEW_DISABLED_PROFILE_STATUSES,
@@ -941,14 +942,14 @@ const BULK_RENEW_ALLOWED_BODY_FIELDS = Object.freeze([
 const BULK_RENEW_IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 
 function bulkRenewItemIdempotencyKey(idempotencyKey, certificateId) {
-  // Non-dry-run bulk creates must always carry a stable per-certificate key
-  // so client retries cannot enqueue duplicate renew jobs. When the caller
-  // omits a request key, derive one from the certificate id alone (scoped
-  // by the workspace-scoped unique index on the jobs table's idempotency key).
+  // No auto-derived fallback: the jobs table's (workspace_id,
+  // idempotency_key) uniqueness has no time component, so a key derived from
+  // the certificate id alone would make that certificate renewable exactly
+  // once, forever. Retry safety is opt-in instead, via a caller-supplied key.
   if (idempotencyKey) {
     return `bulk-renew:${idempotencyKey}:${certificateId}`;
   }
-  return `bulk-renew:auto:${certificateId}`;
+  return null;
 }
 
 /**
@@ -1042,17 +1043,22 @@ function parseBulkRenewRequest(body) {
  * An optional request-level idempotencyKey makes retries safe: each item is
  * created with a derived "bulk-renew:<key>:<certificateId>" job key, so a
  * replayed batch returns the already-created jobs (marked replayed: true)
- * instead of enqueueing duplicates.
+ * instead of enqueueing duplicates. Omitting the key leaves items without
+ * one, so a replayed POST enqueues fresh jobs.
  *
  * Dry run preflights each certificate without writing: existence, renewable
- * inventory status, the same payload validation the real run applies, and
- * whether a non-terminal renew job is already in flight (reported as
- * activeJobId so callers can spot double-renewals before committing).
+ * inventory status, resolution of that certificate's stored renewal profile
+ * into the payload the real run would insert (so an incomplete or invalid
+ * profile fails the item here rather than at real-run time), and whether a
+ * non-terminal renew job is already in flight (reported as activeJobId so
+ * callers can spot double-renewals before committing). Capacity is not
+ * checked: a dry run must not reserve per-CA capacity.
  */
 function bulkRenewCertificatesHandler({
   manualJobCreator = createManualCertificateJob,
   certificateLoader = getManagedCertificate,
   activeJobFinder = findActiveJobForSubject,
+  renewalPreflight = preflightManualRenewalJob,
 } = {}) {
   return async function bulkRenewCertificatesHandler(req, res) {
     const parsed = parseBulkRenewRequest(req.body);
@@ -1108,6 +1114,11 @@ function bulkRenewCertificatesHandler({
         }
 
         if (parsed.dryRun) {
+          await renewalPreflight({
+            workspaceId: req.workspace.id,
+            certificateId,
+            payload: parsed.payload,
+          });
           const activeJob = await activeJobFinder({
             workspaceId: req.workspace.id,
             subjectType: "managed_certificate",

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -155,6 +155,7 @@ const {
   CERTOPS_TARGET_AGENT_NOT_FOUND,
   createTrustAnchor,
   listTrustAnchors,
+  listInstallationsForAnchor,
   manualTrustJobCreator,
   retireTrustAnchor,
 } = require("../services/certops/trustAnchors");
@@ -2485,6 +2486,43 @@ router.post(
       });
       return res.status(500).json({
         error: "Failed to retire trust anchor",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+// Read-only: intentionally omits requireWorkspaceCertOpsActive (unlike the
+// two mutating trust-anchor routes above) so an operator diagnosing a
+// frozen/deactivated workspace can still see where a trust anchor landed.
+router.get(
+  "/api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  authorize("certops.trust_anchor.manage"),
+  async (req, res) => {
+    const anchorId = trustAnchorIdFromParams(req, res);
+    if (!anchorId) return null;
+
+    try {
+      const items = await listInstallationsForAnchor({
+        workspaceId: req.workspace.id,
+        trustAnchorId: anchorId,
+      });
+      return res.json({ items });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps trust anchor installations list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        anchorId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list trust anchor installations",
         code: "INTERNAL_ERROR",
       });
     }

--- a/apps/api/services/certops/jobs.js
+++ b/apps/api/services/certops/jobs.js
@@ -1359,6 +1359,34 @@ async function loadManagedCertificateForRenewal({ db, workspaceId, certificateId
 }
 
 /**
+ * Single materializer for a manual/bulk renew payload: reads the certificate
+ * with its linked profile and resolves the stored renewal profile into the
+ * same payload the scheduler would build. Read-only. Shared by the real
+ * creation path and its dry-run preflight so the two cannot drift.
+ */
+async function materializeManualRenewalPayload({
+  db,
+  workspaceId,
+  certificateId,
+  overrides,
+  loadCertificate = loadManagedCertificateForRenewal,
+}) {
+  const certificate = await loadCertificate({
+    db,
+    workspaceId,
+    certificateId,
+  });
+  if (!certificate) {
+    throw serviceError("Certificate not found", CERTOPS_CERTIFICATE_NOT_FOUND);
+  }
+  return buildManualRenewalJobPayload({
+    certificate,
+    defaultReason: MANUAL_RENEWAL_DEFAULT_REASON,
+    overrides,
+  });
+}
+
+/**
  * jobCreator swapped in (by routes/certops.js) for a renew job whose
  * subject is an existing managed certificate, for both single manual and
  * bulk creation. Materializes the payload the same way the scheduler does
@@ -1375,22 +1403,12 @@ function manualRenewalJobCreator({
 } = {}) {
   return async function manualRenewalJobCreator(options) {
     const { client, workspaceId } = options;
-    const certificate = await loadCertificate({
+    const payload = await materializeManualRenewalPayload({
       db: client,
       workspaceId,
       certificateId,
-    });
-    if (!certificate) {
-      throw serviceError(
-        "Certificate not found",
-        CERTOPS_CERTIFICATE_NOT_FOUND,
-      );
-    }
-
-    const payload = buildManualRenewalJobPayload({
-      certificate,
-      defaultReason: MANUAL_RENEWAL_DEFAULT_REASON,
       overrides: options.payload,
+      loadCertificate,
     });
 
     return createJob({
@@ -1401,6 +1419,32 @@ function manualRenewalJobCreator({
       payload,
     });
   };
+}
+
+/**
+ * Read-only twin of manualRenewalJobCreator's materialization step: resolves
+ * the certificate's stored renewal profile, builds the renew payload from it
+ * and runs the same payload validation createCertificateJob runs. Writes
+ * nothing, takes no lock and reserves no per-CA capacity, so a bulk dry run
+ * can reject the certificates a real run would reject (notably
+ * CERTOPS_RENEWAL_PROFILE_INCOMPLETE / CERTOPS_RENEWAL_PROFILE_INVALID)
+ * without side effects. Returns the payload the real run would insert.
+ */
+async function preflightManualRenewalJob({
+  client,
+  workspaceId,
+  certificateId,
+  payload,
+  loadCertificate = loadManagedCertificateForRenewal,
+} = {}) {
+  const materialized = await materializeManualRenewalPayload({
+    db: client || pool,
+    workspaceId,
+    certificateId,
+    overrides: payload,
+    loadCertificate,
+  });
+  return validateJobPayloadForOperation(materialized, "renew");
 }
 
 function jobFromRow(row) {
@@ -2338,6 +2382,7 @@ module.exports = {
   normalizePublicObject,
   normalizeRequiredId,
   normalizeWorkspaceId,
+  preflightManualRenewalJob,
   serviceError,
   updateCertificateJobStatus,
   validateJobPayloadForOperation,

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -680,6 +680,41 @@ function installationFromRow(row) {
 }
 
 /**
+ * Read-only listing of every installation row for one trust anchor, for a
+ * future admin UI to see where an anchor actually landed (agent, store,
+ * transition state, provenance, last error) before revoking/distributing
+ * it further. Filters on workspace_id AND trust_anchor_id in the same
+ * WHERE clause, mirroring getTrustAnchorById's own tenant-isolation style
+ * above, so a cross-workspace read is impossible by construction rather
+ * than merely checked after the fact.
+ */
+async function listInstallationsForAnchor(options = {}) {
+  const db = options.client || pool;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const trustAnchorId = normalizeRequiredId(
+    options.trustAnchorId,
+    CERTOPS_TRUST_ANCHOR_INVALID,
+  );
+
+  const anchor = await getTrustAnchorById(db, workspaceId, trustAnchorId);
+  if (!anchor) {
+    throw trustAnchorError(
+      "Trust anchor not found",
+      CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+    );
+  }
+
+  const result = await db.query(
+    `SELECT ${INSTALLATION_SELECT_FIELDS}
+       FROM certops_trust_anchor_installations
+      WHERE workspace_id = $1 AND trust_anchor_id = $2
+      ORDER BY updated_at DESC`,
+    [workspaceId, trustAnchorId],
+  );
+  return result.rows.map(installationFromRow);
+}
+
+/**
  * Locks (or creates, if absent) the ownership-reference row for
  * (workspace, agent, store, fingerprint, owner) inside the caller's
  * transaction. SELECT ... FOR UPDATE serializes concurrent requests on this
@@ -2156,6 +2191,7 @@ module.exports = {
   listTrustAnchors,
   getTrustAnchorById,
   retireTrustAnchor,
+  listInstallationsForAnchor,
   anchorFromRow,
   installationFromRow,
   normalizeStore,

--- a/apps/worker/src/certops-metrics.js
+++ b/apps/worker/src/certops-metrics.js
@@ -73,3 +73,14 @@ export const gCertopsTrustAnchorReconciliation = new client.Gauge({
   labelNames: ["outcome"],
   registers: [metricsRegister],
 });
+
+/**
+ * Which sweeps in a runIsolated results object ended "failed". "skipped" means
+ * an operator disabled the sweep, so it must never turn a CronJob run red.
+ * Kept here, dependency-free, so it is testable without the worker's I/O.
+ */
+export function identifyFailedSweeps(results) {
+  return Object.entries(results || {})
+    .filter(([, sweepResult]) => sweepResult?.status === "failed")
+    .map(([key]) => key);
+}

--- a/apps/worker/src/certops-worker.js
+++ b/apps/worker/src/certops-worker.js
@@ -50,6 +50,7 @@ import {
   gCertopsDiagnosticAgentsRetired,
   gCertopsAgentHealthAlerts,
   gCertopsTrustAnchorReconciliation,
+  identifyFailedSweeps,
 } from "./certops-metrics.js";
 import { safeInc } from "./shared/safeMetrics.js";
 import { createRequire } from "module";
@@ -88,6 +89,7 @@ const { writeAudit } = require("../../api/services/audit.js");
 const {
   JOB_STATUSES,
   isTerminalJobStatus,
+  isTrustAnchorOperation,
 } = require("../../api/services/certops/jobs.js");
 
 const {
@@ -106,6 +108,7 @@ const { resolveRenewalPathsForWorkspace } = require(
 // service, not this worker).
 const {
   sweepOverdueTrustInstallations,
+  onTrustJobTerminalTransition,
 } = require("../../api/services/certops/trustAnchors.js");
 
 // Single source of truth for the 10-minute agent liveness threshold, shared
@@ -602,6 +605,7 @@ export async function reapExpiredLeases({
   log = logger,
   recordOutboxEvent = enqueueOutboxEvent,
   auditWriter = writeAudit,
+  trustTerminalHook = onTrustJobTerminalTransition,
 } = {}) {
   const summary = { scanned: 0, requeued: 0, failed: 0, deferred: 0 };
 
@@ -791,6 +795,18 @@ export async function reapExpiredLeases({
             WHERE id = $1`,
           [row.id, errorCode],
         );
+
+        // A lease-reaped trust job is a terminal-negative transition like any
+        // other. Unwinding in this transaction, not later via the
+        // reconciliation sweep an operator can disable, keeps the job's failed
+        // status and the installation's unwound state from being observed apart.
+        if (isTrustAnchorOperation(row.operation)) {
+          await trustTerminalHook({
+            client,
+            job: { ...row, status: "failed" },
+          });
+        }
+
         await insertJobLog(client, row, {
           eventType: "job.failed",
           status: "failed",
@@ -1724,6 +1740,19 @@ export async function runCertOpsMaintenance({
   await pushMetricsFn("certops").catch((e) =>
     log.warn("Failed to push metrics", { error: e.message }),
   );
+
+  // Metrics push first so a failing run stays observable. Without the throw the
+  // process exits 0 and CronJob / Compose supervision calls a run healthy while
+  // every sweep in it fails.
+  const failedSweeps = identifyFailedSweeps(results);
+  if (failedSweeps.length > 0) {
+    const error = new Error(
+      `certops-worker: ${failedSweeps.length} sweep(s) failed: ${failedSweeps.join(", ")}`,
+    );
+    error.code = "CERTOPS_MAINTENANCE_SWEEP_FAILED";
+    error.results = results;
+    throw error;
+  }
 
   return results;
 }

--- a/docs/certops/CONTEXT.md
+++ b/docs/certops/CONTEXT.md
@@ -278,10 +278,14 @@ the shared detector scans every outbound envelope.
 - **Bulk renew** - `POST .../certops/jobs/bulk-renew`: many certificates
   through the same creation path as single renew (validation, approval
   gates, kill switch identical) with a per-item partial-failure envelope.
-  Items without an explicit `idempotencyKey` derive a stable one
-  (`bulk-renew:auto:<certificateId>`), which is permanent: re-running after
-  cancelling the created jobs returns the original terminal jobs instead of
-  creating new ones. Pass a fresh key to force a genuine re-run.
+  Retry safety is opt-in: supply an `idempotencyKey` and each item gets
+  `bulk-renew:<key>:<certificateId>`, so a replayed batch returns the
+  already-created jobs. Omit it and items carry no key, so each call
+  enqueues fresh jobs (a certificate must stay renewable more than once,
+  and the jobs table's idempotency uniqueness has no time component).
+  `dryRun` additionally resolves each certificate's stored renewal profile
+  read-only, so an incomplete or invalid profile fails that item in the dry
+  run instead of only at real-run time.
 
 ## Dashboard certificate visibility
 

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -87,6 +87,7 @@ const {
   deleteBootstrapEnvFile,
   listConfiguredDnsProviderIds,
   resolveAcmeAccountCredentials,
+  DEFAULT_REQUIRE_SIGNED_AGENT_ID,
 } = require("./config");
 const { loadPolicyConfig, createPolicyEngine } = require("./policy");
 const { isWindows, clearWindowsServiceBootstrapToken } = require("./platform");
@@ -1486,8 +1487,11 @@ async function reportStepEvidence(client, jobId, items, claimId = null) {
  *   verification still runs, only the post-verdict action differs
  * @param {string} params.boundAgentId this agent's own registered agentId
  *   (ADR-0012 decision 3, gate step 11)
- * @param {boolean} [params.requireSignedAgentId] effective runtime value
- *   of CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID (default false)
+ * @param {boolean} [params.requireSignedAgentId] effective runtime value of
+ *   CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID as resolved by loadAgentConfig.
+ *   Falls back to config's DEFAULT_REQUIRE_SIGNED_AGENT_ID rather than to a
+ *   literal here, so omitting it can never be more permissive than what a
+ *   real agent resolves, and the default cannot drift out of sync.
  * @param {(msg: string) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
@@ -1497,7 +1501,7 @@ async function handleClaimedJob({
   client,
   executionContext = null,
   boundAgentId,
-  requireSignedAgentId = false,
+  requireSignedAgentId = DEFAULT_REQUIRE_SIGNED_AGENT_ID,
   log = null,
 }) {
   const executionEnabled =
@@ -1712,8 +1716,9 @@ function verifyClaimedJobEnvelope({
  * @param {boolean} params.executionEnabled
  * @param {string} params.boundAgentId this agent's own registered agentId
  *   (ADR-0012 decision 3, gate step 11)
- * @param {boolean} [params.requireSignedAgentId] effective runtime value
- *   of CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID (default false)
+ * @param {boolean} [params.requireSignedAgentId] effective runtime value of
+ *   CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID as resolved by loadAgentConfig;
+ *   same fail-closed fallback as handleClaimedJob's
  * @param {(msg: string, details?: *) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
@@ -1724,7 +1729,7 @@ async function handleSignedJob({
   executionContext,
   executionEnabled,
   boundAgentId,
-  requireSignedAgentId = false,
+  requireSignedAgentId = DEFAULT_REQUIRE_SIGNED_AGENT_ID,
   log,
 }) {
   const pinnedSigningKey = executionEnabled

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -75,6 +75,7 @@ const {
   writeSigningKeyPin,
   readSigningKeyPin,
   listConfiguredDnsProviderIds,
+  DEFAULT_REQUIRE_SIGNED_AGENT_ID,
 } = require("./config");
 const {
   generateSigningKeyPair,
@@ -1026,6 +1027,10 @@ describe("signed-job dispatch chain (handleClaimedJob with executionContext)", (
       schemaVersion: 1,
       jobId: overrides.jobId || "job-signed-1",
       workspaceId: "11111111-2222-3333-4444-555555555555",
+      // Signed dispatch always binds a job to one agent identity, so the
+      // fixture carries it too; tests that probe the binding gate itself
+      // override or drop this field deliberately.
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "cert-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },
@@ -2406,6 +2411,7 @@ describe("observe-only signature verification (ADR-0012 decision 2 Finding B clo
       schemaVersion: 1,
       jobId: "job-observe-1",
       workspaceId: "11111111-2222-3333-4444-555555555555",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "cert-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },
@@ -2843,7 +2849,7 @@ describe("agentId absence-tolerant rollback: control plane omits agentId entirel
     );
   });
 
-  it("requireSignedAgentId defaulted to true (no override): the identical no-agentId job now fails closed at the gate", async () => {
+  it("requireSignedAgentId explicitly true: the identical no-agentId job now fails closed at the gate", async () => {
     const client = createRecordingClient();
     const job = makeSignedJobV1NoAgentId();
 
@@ -2857,6 +2863,32 @@ describe("agentId absence-tolerant rollback: control plane omits agentId entirel
       log: silentLog,
     });
 
+    assert.equal(outcome.status, "failed");
+    assert.equal(
+      outcome.rejectionReason,
+      AGENT_ID_BINDING_REJECTION_REASONS.AGENT_ID_REQUIRED_BUT_MISSING,
+    );
+    assert.equal(client.calls.reportResult.length, 0);
+    assert.equal(client.calls.reportEvidence.length, 0);
+  });
+
+  // A caller that forgets the argument must not silently get the permissive
+  // decoder: the parameter default has to track config's compiled-in default,
+  // which fails closed.
+  it("requireSignedAgentId omitted entirely: fails closed exactly as if true were passed, never the absence-tolerant branch", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJobV1NoAgentId();
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      boundAgentId: AGENT_B,
+      log: silentLog,
+    });
+
+    assert.equal(DEFAULT_REQUIRE_SIGNED_AGENT_ID, true);
     assert.equal(outcome.status, "failed");
     assert.equal(
       outcome.rejectionReason,
@@ -3248,6 +3280,7 @@ describe("lease fail-closed + side-effect journal + multi-target transaction", (
       jobId: "job-lease-journal",
       attemptId: "attempt-1",
       workspaceId: "11111111-1111-4111-8111-111111111111",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "certificate-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },

--- a/packages/agent/src/runtime/runtime.test.js
+++ b/packages/agent/src/runtime/runtime.test.js
@@ -125,6 +125,7 @@ describe("agent runtime: lease, journal, multi-target transaction", () => {
       jobId: "job-lease-journal",
       attemptId: "attempt-1",
       workspaceId: "11111111-1111-4111-8111-111111111111",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "certificate-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -5394,6 +5394,66 @@ paths:
                 code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/trust-anchors/{anchorId}/installations:
+    get:
+      tags: [CertOps]
+      summary: List installations for a CertOps trust anchor
+      operationId: listCertOpsTrustAnchorInstallations
+      description: >-
+        Returns every certops_trust_anchor_installations row for one trust
+        anchor (agent, store, transition state, provenance, last error), so
+        an operator can see where the anchor actually landed before
+        revoking or distributing it further. Manager-only, same as the
+        other trust-anchor routes. Read-only: unlike the mutating
+        trust-anchor routes, this route does not require the workspace's
+        CertOps state to be active, since an operator diagnosing a paused
+        workspace still needs to see current installations.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: anchorId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Trust anchor record id (UUID).
+      responses:
+        "200":
+          description: Installation list for this trust anchor
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsTrustAnchorInstallationListResponse"
+        "400":
+          description: Trust anchor identifier is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Trust anchor identifier is invalid
+                code: CERTOPS_TRUST_ANCHOR_INVALID
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: CertOps is disabled, or the trust anchor was not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                certopsDisabled:
+                  value:
+                    error: Endpoint not found
+                    code: NOT_FOUND
+                anchorNotFound:
+                  value:
+                    error: Trust anchor not found
+                    code: CERTOPS_TRUST_ANCHOR_NOT_FOUND
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/agents/{agentId}/alert-settings:
     patch:
       tags: [CertOps]
@@ -9776,6 +9836,101 @@ components:
         retiredNow:
           type: boolean
           description: False when the anchor was already revoked before this request (idempotent no-op).
+    CertOpsTrustAnchorInstallation:
+      type: object
+      additionalProperties: false
+      description: >-
+        One certops_trust_anchor_installations reference row: where a trust
+        anchor's CA certificate is (or was) tracked in one agent's OS trust
+        store, for one owner. Reference-counted per (agent, trust anchor,
+        store, owner); see CertOpsJobCreateRequest's owner description.
+      required:
+        - id
+        - workspaceId
+        - trustAnchorId
+        - host
+        - store
+        - fingerprintSha256
+        - owner
+        - transitionState
+        - provenance
+        - agentId
+        - transitionGeneration
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        trustAnchorId:
+          type: string
+          format: uuid
+        host:
+          type: string
+          description: Agent-identifying host label the installation was recorded under.
+        store:
+          type: string
+          description: OS-level trust store label ("Root" or "CA"), derived from the anchor's anchorType.
+        fingerprintSha256:
+          type: string
+          description: Lowercase hex SHA-256 fingerprint of the tracked CA certificate.
+        owner:
+          type: string
+          description: Caller-supplied label identifying who holds this reference on this agent.
+        transitionState:
+          type: string
+          enum: [pending_install, installed, pending_remove, removed]
+        provenance:
+          type: string
+          enum: [preexisting, tokentimer_installed]
+          description: >-
+            Whether TokenTimer itself performed the install (tokentimer_installed)
+            or the material was already present before TokenTimer tracked it
+            (preexisting).
+        agentId:
+          type: string
+          format: uuid
+          description: The certops_agents.id this installation is tracked against.
+        lastJobId:
+          type: string
+          format: uuid
+          nullable: true
+        transitionGeneration:
+          type: integer
+          description: Monotonically increasing per-row generation; a stale generation's late result is rejected.
+        lastAttemptAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastError:
+          type: string
+          nullable: true
+        nextReconcileAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the reconciliation sweep should next revisit a pending row. Null once settled.
+        publicMetadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CertOpsTrustAnchorInstallationListResponse:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsTrustAnchorInstallation"
     CertOpsDiagnosticBootstrapRequest:
       type: object
       additionalProperties: false

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -7909,7 +7909,10 @@ components:
           default: false
           description: >-
             True validates each certificate and reports per-item outcomes
-            without creating any jobs.
+            without creating any jobs. Each item's stored renewal profile is
+            resolved read-only, so a certificate whose profile is incomplete
+            or invalid fails the dry run instead of only failing the real
+            run. Per-CA capacity is not checked and not reserved.
         requiresApproval:
           type: boolean
           default: false
@@ -7925,8 +7928,9 @@ components:
             Optional request-level idempotency key. Combined with each
             certificateId to derive a per-item key
             (bulk-renew:<idempotencyKey>:<certificateId>), so retrying the
-            same bulk request is safe. When omitted, the server derives
-            bulk-renew:auto:<certificateId> instead.
+            same bulk request is safe. When omitted, items are created with
+            no idempotency key at all, so a replayed request enqueues fresh
+            renew jobs; pass a key if you need retry safety.
         payload:
           allOf:
             - $ref: "#/components/schemas/CertOpsPublicObject"

--- a/tests/integration/certops-trust-anchors.test.js
+++ b/tests/integration/certops-trust-anchors.test.js
@@ -4,6 +4,8 @@ const crypto = require("crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { createRequire } = require("module");
+const supertest = require("supertest");
 
 const { loadRootEnv } = require("../../scripts/load-root-env");
 
@@ -16,10 +18,17 @@ const { pool } = require("../../apps/api/db/database");
 const {
   validateSignedJob,
 } = require("../../packages/contracts/certops/validate-signed-job.cjs");
+const certOpsRouter = require("../../apps/api/routes/certops");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
 
 const {
   createTrustAnchor,
   listTrustAnchors,
+  listInstallationsForAnchor,
   retireTrustAnchor,
   createTrustJob,
   onTrustJobTerminalTransition,
@@ -28,6 +37,7 @@ const {
   sweepOverdueTrustInstallations,
   TRUST_JOB_TERMINAL_NEGATIVE_STATUSES,
   CERTOPS_TRUST_ANCHOR_NOT_ACTIVE,
+  CERTOPS_TRUST_ANCHOR_NOT_FOUND,
   CERTOPS_TRUST_ANCHOR_TYPE_IMMUTABLE,
   CERTOPS_TRUST_RESULT_MISMATCH,
   CERTOPS_TRUST_RESULT_STALE_GENERATION,
@@ -3233,5 +3243,306 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
       removedRow.transition_generation,
       "the rejected attempt must not mutate the row at all",
     );
+  });
+
+  // --- listInstallationsForAnchor (read-only installation listing) ---------
+
+  describe("listInstallationsForAnchor", () => {
+    // Runs in its own fresh workspace: CA_CERTS is a small fixed pool, and by
+    // this point in the suite anchorCounter has wrapped around it many times
+    // over, so a "fresh" anchor drawn from the shared workspaceId can land on
+    // a fingerprint some earlier test already attached installations to (see
+    // withFreshWorkspace's own doc comment above). Isolation here is scoped
+    // by (workspace_id, fingerprint_sha256), so a just-created workspace
+    // sidesteps that collision entirely.
+    it("returns every installation row for the anchor, newest updated_at first, with the full installation shape", async () => {
+      await withFreshWorkspace(async (freshWorkspaceId) => {
+        const anchor = await createTrustAnchor({
+          workspaceId: freshWorkspaceId,
+          name: "List Installations Anchor",
+          anchorType: "root",
+          pem: trustAnchorPemFor(anchorCounter++),
+          createdByUserId: ownerId,
+        });
+        const agentA = await createAgent({ workspaceIdOverride: freshWorkspaceId });
+        const agentB = await createAgent({ workspaceIdOverride: freshWorkspaceId });
+
+        const optionsFor = (agent, idempotencyKey) => ({
+          workspaceId: freshWorkspaceId,
+          operation: "distribute-trust",
+          trustAnchorId: anchor.id,
+          agentId: agent.id,
+          store: "Root",
+          owner: "workspace-policy",
+          idempotencyKey,
+          requestedByUserId: ownerId,
+        });
+
+        // A is created then ingested (installed): its row's updated_at moves
+        // to the ingest time. B is created afterwards, so its updated_at is
+        // the later of the two and must sort first under ORDER BY
+        // updated_at DESC.
+        const outcomeA = await createTrustJob(
+          optionsFor(agentA, `list-installations-a-${crypto.randomUUID()}`),
+        );
+        const jobA = await getJobRow(outcomeA.job.id);
+        const installationA = await getInstallationById(outcomeA.installation.id);
+        await withTx((client) =>
+          ingestTrustJobResult({
+            client,
+            job: jobA,
+            result: buildResult({
+              agent: agentA,
+              job: jobA,
+              installationRow: installationA,
+              outcome: "installed",
+            }),
+          }),
+        );
+
+        const outcomeB = await createTrustJob(
+          optionsFor(agentB, `list-installations-b-${crypto.randomUUID()}`),
+        );
+
+        const items = await listInstallationsForAnchor({
+          workspaceId: freshWorkspaceId,
+          trustAnchorId: anchor.id,
+        });
+
+        expect(items).to.have.lengthOf(2);
+        const ids = items.map((item) => item.id);
+        expect(ids.indexOf(String(outcomeB.installation.id))).to.be.lessThan(
+          ids.indexOf(String(outcomeA.installation.id)),
+        );
+
+        const returnedB = items[ids.indexOf(String(outcomeB.installation.id))];
+        expect(Object.keys(returnedB).sort()).to.deep.equal(
+          [
+            "id",
+            "workspaceId",
+            "trustAnchorId",
+            "host",
+            "store",
+            "fingerprintSha256",
+            "owner",
+            "transitionState",
+            "provenance",
+            "agentId",
+            "lastJobId",
+            "transitionGeneration",
+            "lastAttemptAt",
+            "lastError",
+            "nextReconcileAt",
+            "publicMetadata",
+            "createdAt",
+            "updatedAt",
+          ].sort(),
+        );
+        expect(returnedB).to.include({
+          id: String(outcomeB.installation.id),
+          workspaceId: String(freshWorkspaceId),
+          trustAnchorId: String(anchor.id),
+          agentId: String(agentB.id),
+          store: "Root",
+          transitionState: "pending_install",
+          provenance: "preexisting",
+          lastError: null,
+        });
+      });
+    });
+
+    it("returns an empty array for an anchor with no installations", async () => {
+      await withFreshWorkspace(async (freshWorkspaceId) => {
+        const anchor = await createTrustAnchor({
+          workspaceId: freshWorkspaceId,
+          name: "Empty Installations Anchor",
+          anchorType: "root",
+          pem: trustAnchorPemFor(anchorCounter++),
+          createdByUserId: ownerId,
+        });
+
+        const items = await listInstallationsForAnchor({
+          workspaceId: freshWorkspaceId,
+          trustAnchorId: anchor.id,
+        });
+
+        expect(items).to.deep.equal([]);
+      });
+    });
+
+    it("rejects with CERTOPS_TRUST_ANCHOR_NOT_FOUND for an anchor id that belongs to another workspace", async () => {
+      await withFreshWorkspace(async (otherWorkspaceId) => {
+        const pem = trustAnchorPemFor(anchorCounter++);
+        const anchorInOtherWorkspace = await createTrustAnchor({
+          workspaceId: otherWorkspaceId,
+          name: "Cross-workspace anchor",
+          anchorType: "root",
+          pem,
+          createdByUserId: ownerId,
+        });
+
+        await expectServiceError(
+          listInstallationsForAnchor({
+            workspaceId,
+            trustAnchorId: anchorInOtherWorkspace.id,
+          }),
+          CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+        );
+      });
+    });
+
+    it("rejects with CERTOPS_TRUST_ANCHOR_NOT_FOUND for a well-formed but nonexistent anchor id", async () => {
+      await expectServiceError(
+        listInstallationsForAnchor({
+          workspaceId,
+          trustAnchorId: crypto.randomUUID(),
+        }),
+        CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+      );
+    });
+  });
+});
+
+/**
+ * Route-level coverage for GET .../trust-anchors/:anchorId/installations.
+ * The suite above exercises listInstallationsForAnchor directly; this block
+ * exercises the actual router (rate limiter, requireCertOpsEnabled,
+ * authorize("certops.trust_anchor.manage")) the same way
+ * certops-controller-provisioning.test.js's createHumanProvisioningApp does,
+ * since RBAC and the rollout gate live in the route, not the service.
+ */
+describe("GET /api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations (route)", function () {
+  this.timeout(60000);
+
+  let ownerId;
+  let workspaceId;
+  let previousCertOpsEnabled;
+
+  function buildApp({ workspaceRole = "admin", userId = ownerId } = {}) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.workspace = { id: workspaceId };
+      if (userId) req.user = { id: userId };
+      req.authz = { workspaceRole };
+      next();
+    });
+    app.use(certOpsRouter);
+    return app;
+  }
+
+  function getInstallations(app, anchorId) {
+    return supertest(app).get(
+      `/api/v1/workspaces/${workspaceId}/certops/trust-anchors/${anchorId}/installations`,
+    );
+  }
+
+  before(async () => {
+    previousCertOpsEnabled = process.env.CERTOPS_ENABLED;
+    process.env.CERTOPS_ENABLED = "true";
+    await runMigrations();
+
+    const email = `trust-anchor-route-${Date.now()}-${crypto.randomUUID()}@example.com`;
+    const owner = await TestUtils.execQuery(
+      `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+       VALUES ($1, $2, 'Trust Anchor Route Test', 'unused', 'local', TRUE)
+       RETURNING id`,
+      [email.toLowerCase(), email],
+    );
+    ownerId = owner.rows[0].id;
+
+    workspaceId = crypto.randomUUID();
+    await TestUtils.execQuery(
+      `INSERT INTO workspaces (id, name, created_by, plan)
+       VALUES ($1, 'Trust Anchor Route Test WS', $2, 'oss')`,
+      [workspaceId, ownerId],
+    );
+  });
+
+  after(async () => {
+    if (previousCertOpsEnabled === undefined) delete process.env.CERTOPS_ENABLED;
+    else process.env.CERTOPS_ENABLED = previousCertOpsEnabled;
+
+    if (workspaceId) {
+      await TestUtils.execQuery("DELETE FROM workspaces WHERE id = $1", [
+        workspaceId,
+      ]);
+    }
+    if (ownerId) {
+      // Same ordering as the suite above: audit_events is update-immutable,
+      // so the rows this suite wrote must go before the user they reference.
+      await TestUtils.execQuery(
+        `DELETE FROM audit_events
+          WHERE actor_user_id = $1 OR subject_user_id = $1`,
+        [ownerId],
+      );
+      await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+    }
+  });
+
+  it("returns { items: [] } for an admin on an anchor with no installations", async () => {
+    const pem = trustAnchorPemFor(0);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (empty)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+
+    const response = await getInstallations(buildApp(), anchor.id).expect(200);
+    expect(response.body).to.deep.equal({ items: [] });
+  });
+
+  it("returns 404 for an anchor id that does not exist in this workspace", async () => {
+    await getInstallations(buildApp(), crypto.randomUUID()).expect(404);
+  });
+
+  it("rejects a viewer and a workspace_manager with 403, and allows admin", async () => {
+    const pem = trustAnchorPemFor(1);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (rbac)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+
+    await getInstallations(
+      buildApp({ workspaceRole: "viewer" }),
+      anchor.id,
+    ).expect(403);
+    await getInstallations(
+      buildApp({ workspaceRole: "workspace_manager" }),
+      anchor.id,
+    ).expect(403);
+    await getInstallations(
+      buildApp({ workspaceRole: "admin" }),
+      anchor.id,
+    ).expect(200);
+  });
+
+  it("omits requireWorkspaceCertOpsActive: a paused workspace can still be read", async () => {
+    const pem = trustAnchorPemFor(2);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (paused)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+    await TestUtils.execQuery(
+      `UPDATE workspaces SET certops_paused = TRUE WHERE id = $1`,
+      [workspaceId],
+    );
+
+    try {
+      await getInstallations(buildApp(), anchor.id).expect(200);
+    } finally {
+      await TestUtils.execQuery(
+        `UPDATE workspaces SET certops_paused = FALSE WHERE id = $1`,
+        [workspaceId],
+      );
+    }
   });
 });

--- a/tests/unit/certops-bulk-renew-route.test.js
+++ b/tests/unit/certops-bulk-renew-route.test.js
@@ -28,12 +28,25 @@ const { CERTOPS_CERTIFICATE_NOT_FOUND } = require(
 const { CERTOPS_JOB_INVALID } = require(
   path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
 );
-const { CERTOPS_RENEWAL_OVERRIDE_INVALID } = require(
+const {
+  CERTOPS_RENEWAL_OVERRIDE_INVALID,
+  CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+} = require(
   path.resolve(__dirname, "../../apps/api/services/certops/renewalProfile.js"),
 );
 
 const { bulkRenewCertificatesHandler, parseBulkRenewRequest } =
   certOpsRouter._test;
+
+// Every handler under test gets stubbed DB-backed collaborators: the real
+// defaults would reach the pool.
+function makeHandler(overrides = {}) {
+  return bulkRenewCertificatesHandler({
+    activeJobFinder: async () => null,
+    renewalPreflight: async () => ({}),
+    ...overrides,
+  });
+}
 
 function uuid(n) {
   return `aaaaaaaa-0000-4000-8000-${String(n).padStart(12, "0")}`;
@@ -66,7 +79,7 @@ describe("CertOps bulk-renew route", () => {
   it("creates a renew job per certificate and reports an all-success envelope", async () => {
     const creatorCalls = [];
     let jobCounter = 0;
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
@@ -106,33 +119,39 @@ describe("CertOps bulk-renew route", () => {
       assert.strictEqual(call.requiresApproval, false);
       assert.strictEqual(call.requestedByUserId, 42);
       assert.strictEqual(call.actorUserId, 42);
-      assert.strictEqual(
-        call.idempotencyKey,
-        `bulk-renew:auto:${uuid(index + 1)}`,
-      );
+      assert.strictEqual(call.idempotencyKey, null);
     }
   });
 
-  it("derives a stable auto idempotency key when the caller omits one", async () => {
+  it("leaves the per-item idempotency key unset when the caller omits one, so the same certificate stays renewable", async () => {
     const { bulkRenewItemIdempotencyKey } = certOpsRouter._test;
-    assert.strictEqual(
-      bulkRenewItemIdempotencyKey(undefined, uuid(1)),
-      `bulk-renew:auto:${uuid(1)}`,
-    );
+    assert.strictEqual(bulkRenewItemIdempotencyKey(undefined, uuid(1)), null);
+    assert.strictEqual(bulkRenewItemIdempotencyKey(null, uuid(1)), null);
     assert.strictEqual(
       bulkRenewItemIdempotencyKey("client-key", uuid(1)),
       `bulk-renew:client-key:${uuid(1)}`,
     );
 
+    // Two sequential bulk renews of the same certificate without a client
+    // key must both reach creation with no key, so neither collides with the
+    // other on the jobs table's (workspace, idempotency_key) uniqueness.
     const creatorCalls = [];
-    const handler = bulkRenewCertificatesHandler({
+    const usedKeys = new Set();
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
-        return {
-          job: { id: `job-${creatorCalls.length}` },
-          created: creatorCalls.length === 1,
-        };
+        if (options.idempotencyKey) {
+          if (usedKeys.has(options.idempotencyKey)) {
+            const err = new Error(
+              "Idempotency key was already used with a different CertOps job request",
+            );
+            err.code = "CERTOPS_JOB_IDEMPOTENCY_CONFLICT";
+            throw err;
+          }
+          usedKeys.add(options.idempotencyKey);
+        }
+        return { job: { id: `job-${creatorCalls.length}` }, created: true };
       },
     });
 
@@ -141,21 +160,52 @@ describe("CertOps bulk-renew route", () => {
     const second = responseRecorder();
     await handler(makeRequest({ certificateIds: [uuid(9)] }), second);
 
-    assert.strictEqual(first.statusCode, 200);
-    assert.strictEqual(second.statusCode, 200);
     assert.strictEqual(creatorCalls.length, 2);
+    assert.strictEqual(creatorCalls[0].idempotencyKey, null);
+    assert.strictEqual(creatorCalls[1].idempotencyKey, null);
+    assert.deepStrictEqual(first.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1" },
+    ]);
+    assert.deepStrictEqual(second.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-2" },
+    ]);
+  });
+
+  it("derives a per-certificate key from a caller-supplied request key so a replayed batch is a no-op", async () => {
+    const created = new Map();
+    const creatorCalls = [];
+    const handler = makeHandler({
+      certificateLoader: async () => ({ id: "found" }),
+      manualJobCreator: async (options) => {
+        creatorCalls.push(options);
+        const existing = created.get(options.idempotencyKey);
+        if (existing) return { job: existing, created: false };
+        const job = { id: `job-${created.size + 1}` };
+        created.set(options.idempotencyKey, job);
+        return { job, created: true };
+      },
+    });
+
+    const body = { certificateIds: [uuid(9)], idempotencyKey: "batch-1" };
+    const first = responseRecorder();
+    await handler(makeRequest(body), first);
+    const second = responseRecorder();
+    await handler(makeRequest(body), second);
+
     assert.strictEqual(
       creatorCalls[0].idempotencyKey,
-      creatorCalls[1].idempotencyKey,
+      `bulk-renew:batch-1:${uuid(9)}`,
     );
-    assert.strictEqual(
-      creatorCalls[0].idempotencyKey,
-      `bulk-renew:auto:${uuid(9)}`,
-    );
+    assert.deepStrictEqual(first.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1" },
+    ]);
+    assert.deepStrictEqual(second.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1", replayed: true },
+    ]);
   });
 
   it("reports a mixed envelope where item failures never abort the batch", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async ({ certId }) =>
         certId === uuid(2) ? null : { id: certId },
       manualJobCreator: async ({ subjectId }) => {
@@ -210,7 +260,7 @@ describe("CertOps bulk-renew route", () => {
   });
 
   it("keeps the disabled-rollout 404 posture instead of a per-item failure", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async () => {
         const err = new Error("CertOps is not enabled");
@@ -228,10 +278,9 @@ describe("CertOps bulk-renew route", () => {
 
   it("validates and reports without creating jobs on dryRun", async () => {
     let creatorCalls = 0;
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async ({ certId }) =>
         certId === uuid(2) ? null : { id: certId },
-      activeJobFinder: async () => null,
       manualJobCreator: async () => {
         creatorCalls += 1;
         return { job: { id: "must-not-exist" } };
@@ -259,9 +308,81 @@ describe("CertOps bulk-renew route", () => {
     assert.strictEqual(res.body.results[1].ok, false);
   });
 
+  it("fails a dry-run item whose stored renewal profile is incomplete, instead of reporting it as renewable", async () => {
+    const preflightCalls = [];
+    const handler = makeHandler({
+      certificateLoader: async ({ certId }) => ({ id: certId }),
+      renewalPreflight: async (options) => {
+        preflightCalls.push(options);
+        if (options.certificateId === uuid(2)) {
+          const err = new Error("Certificate has no linked renewal profile");
+          err.code = CERTOPS_RENEWAL_PROFILE_INCOMPLETE;
+          throw err;
+        }
+        return {};
+      },
+      manualJobCreator: async () => {
+        throw new Error("creator must not run on a dry run");
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({
+        certificateIds: [uuid(1), uuid(2)],
+        dryRun: true,
+        payload: { reason: "audit" },
+      }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body.summary, {
+      requested: 2,
+      succeeded: 1,
+      failed: 1,
+    });
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true },
+      {
+        certificateId: uuid(2),
+        ok: false,
+        errorCode: CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+        message: "Certificate has no linked renewal profile",
+      },
+    ]);
+    // Preflight receives the same override payload the real run would build
+    // the job payload from.
+    assert.deepStrictEqual(preflightCalls[0], {
+      workspaceId: "workspace-1",
+      certificateId: uuid(1),
+      payload: { reason: "audit" },
+    });
+  });
+
+  it("reports an in-flight renew job as activeJobId on a dry run that otherwise passes preflight", async () => {
+    const handler = makeHandler({
+      certificateLoader: async ({ certId }) => ({ id: certId }),
+      activeJobFinder: async () => ({ id: "job-in-flight" }),
+      manualJobCreator: async () => {
+        throw new Error("creator must not run on a dry run");
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({ certificateIds: [uuid(1)], dryRun: true }),
+      res,
+    );
+
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true, activeJobId: "job-in-flight" },
+    ]);
+  });
+
   it("passes requiresApproval and an allowlisted payload override through to the service path", async () => {
     const creatorCalls = [];
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
@@ -287,7 +408,7 @@ describe("CertOps bulk-renew route", () => {
   });
 
   it("rejects a non-allowlisted payload override with 400 before any item runs", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => {
         throw new Error("loader must not run on a rejected override");
       },
@@ -329,7 +450,7 @@ describe("CertOps bulk-renew route", () => {
     ];
 
     for (const body of badBodies) {
-      const handler = bulkRenewCertificatesHandler({
+      const handler = makeHandler({
         certificateLoader: async () => {
           throw new Error("loader must not run on a 400 request");
         },

--- a/tests/unit/certops-jobs.test.js
+++ b/tests/unit/certops-jobs.test.js
@@ -2758,4 +2758,71 @@ describe("CertOps jobs service - manualRenewalJobCreator (canonical manual/bulk 
     );
     assert.equal(client.jobs.length, 0);
   });
+
+  it("preflight returns the payload the real creation path would insert, without writing anything", async () => {
+    const { preflightManualRenewalJob } = require(
+      path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+    );
+    const certificate = certificateRow();
+    const client = createManualRenewalMemoryClient({
+      certificates: [certificate],
+    });
+
+    const payload = await preflightManualRenewalJob({
+      client,
+      workspaceId: WORKSPACE_A,
+      certificateId: MANUAL_RENEWAL_CERT_ID,
+      payload: { reason: "pre-audit" },
+    });
+
+    assert.equal(payload.reason, "pre-audit");
+    assert.equal(payload.certificateId, MANUAL_RENEWAL_CERT_ID);
+    assert.equal(payload.commandRef, "acme-renew-default");
+    assert.ok(payload.renewalProfile);
+    assert.equal(client.jobs.length, 0);
+  });
+
+  it("preflight surfaces an incomplete stored renewal profile with the same code the real run raises", async () => {
+    const { CERTOPS_RENEWAL_PROFILE_INCOMPLETE } = require(
+      path.resolve(
+        __dirname,
+        "../../apps/api/services/certops/renewalProfile.js",
+      ),
+    );
+    const { preflightManualRenewalJob } = require(
+      path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+    );
+    const client = createManualRenewalMemoryClient({
+      certificates: [certificateRow({ profile_id: null })],
+    });
+
+    await assert.rejects(
+      () =>
+        preflightManualRenewalJob({
+          client,
+          workspaceId: WORKSPACE_A,
+          certificateId: MANUAL_RENEWAL_CERT_ID,
+        }),
+      (error) => error?.code === CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+    );
+    assert.equal(client.jobs.length, 0);
+  });
+
+  it("preflight rejects an unknown certificate the same way the real run does", async () => {
+    const { CERTOPS_CERTIFICATE_NOT_FOUND, preflightManualRenewalJob } =
+      require(
+        path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+      );
+    const client = createManualRenewalMemoryClient({ certificates: [] });
+
+    await assert.rejects(
+      () =>
+        preflightManualRenewalJob({
+          client,
+          workspaceId: WORKSPACE_A,
+          certificateId: MANUAL_RENEWAL_CERT_ID,
+        }),
+      (error) => error?.code === CERTOPS_CERTIFICATE_NOT_FOUND,
+    );
+  });
 });

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -163,6 +163,7 @@ describe("CertOps route hardening", () => {
       "GET /api/v1/workspaces/:id/certops/settings",
       "GET /api/v1/workspaces/:id/certops/targets",
       "GET /api/v1/workspaces/:id/certops/trust-anchors",
+      "GET /api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations",
       "PATCH /api/v1/workspaces/:id/certops/agents/:agentId/alert-settings",
       "PATCH /api/v1/workspaces/:id/certops/profiles/:profileId",
       "POST /api/v1/workspaces/:id/certops/agent-bootstrap-tokens",

--- a/tests/unit/certops-trust-anchors.test.js
+++ b/tests/unit/certops-trust-anchors.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   CERTOPS_TRUST_ANCHOR_INVALID,
+  CERTOPS_TRUST_ANCHOR_NOT_FOUND,
   CERTOPS_TRUST_ANCHOR_PEM_INVALID,
   CERTOPS_TRUST_JOB_IDEMPOTENCY_KEY_REQUIRED,
   CERTOPS_TARGET_AGENT_INVALID,
@@ -17,6 +18,7 @@ const {
   normalizeAgentId,
   normalizeIdempotencyKey,
   assertTargetAgentRegistered,
+  listInstallationsForAnchor,
 } = require(
   path.resolve(__dirname, "../../apps/api/services/certops/trustAnchors.js"),
 );
@@ -255,6 +257,143 @@ describe("assertTargetAgentRegistered (dispatching a trust job to a nonexistent/
     );
   });
 });
+
+describe("listInstallationsForAnchor (read-only installation listing for a trust anchor)", () => {
+  const WORKSPACE_ID = "11111111-1111-1111-1111-111111111111";
+  const ANCHOR_ID = "22222222-2222-2222-2222-222222222222";
+  const INSTALLATION_ID = "33333333-3333-3333-3333-333333333333";
+  const AGENT_ID = "44444444-4444-4444-4444-444444444444";
+
+  function anchorRow(overrides = {}) {
+    return {
+      id: ANCHOR_ID,
+      workspace_id: WORKSPACE_ID,
+      name: "Test Anchor",
+      anchor_type: "root",
+      fingerprint_sha256: "a".repeat(64),
+      subject_common_name: null,
+      status: "active",
+      source: "api",
+      public_metadata: {},
+      created_by: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+      revoked_at: null,
+      ...overrides,
+    };
+  }
+
+  function installationRow(overrides = {}) {
+    return {
+      id: INSTALLATION_ID,
+      workspace_id: WORKSPACE_ID,
+      trust_anchor_id: ANCHOR_ID,
+      host: AGENT_ID,
+      store: "Root",
+      fingerprint_sha256: "a".repeat(64),
+      owner: "workspace-policy",
+      transition_state: "installed",
+      provenance: "tokentimer_installed",
+      agent_id: AGENT_ID,
+      last_job_id: null,
+      transition_generation: 2,
+      last_attempt_at: new Date(),
+      last_error: null,
+      next_reconcile_at: null,
+      public_metadata: {},
+      created_at: new Date(),
+      updated_at: new Date(),
+      ...overrides,
+    };
+  }
+
+  // Distinguishes the two queries by table name substring; the anchor
+  // lookup must be checked with a stricter regex since
+  // "certops_trust_anchors" is a substring of
+  // "certops_trust_anchor_installations".
+  function makeClient({ anchor = null, installationRows = [] } = {}) {
+    const calls = [];
+    return {
+      calls,
+      query: async (sql, params) => {
+        calls.push({ sql, params });
+        if (/certops_trust_anchor_installations/.test(sql)) {
+          return { rows: installationRows };
+        }
+        if (/certops_trust_anchors\b/.test(sql)) {
+          return { rows: anchor ? [anchor] : [] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+  }
+
+  it("throws CERTOPS_TRUST_ANCHOR_NOT_FOUND when the anchor does not exist in this workspace, without ever querying installations", async () => {
+    const client = makeClient({ anchor: null });
+    await assert.rejects(
+      () =>
+        listInstallationsForAnchor({
+          client,
+          workspaceId: WORKSPACE_ID,
+          trustAnchorId: ANCHOR_ID,
+        }),
+      (error) => error?.code === CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+    );
+    assert.equal(
+      client.calls.some((call) => /certops_trust_anchor_installations/.test(call.sql)),
+      false,
+    );
+  });
+
+  it("scopes the installation query to both workspace_id AND trust_anchor_id, ordered by updated_at DESC", async () => {
+    const client = makeClient({
+      anchor: anchorRow(),
+      installationRows: [installationRow()],
+    });
+    await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    const installationCall = client.calls.find((call) =>
+      /certops_trust_anchor_installations/.test(call.sql),
+    );
+    assert.ok(installationCall, "expected an installations query");
+    assert.match(installationCall.sql, /workspace_id\s*=\s*\$1/);
+    assert.match(installationCall.sql, /trust_anchor_id\s*=\s*\$2/);
+    assert.match(installationCall.sql, /ORDER BY updated_at DESC/);
+    assert.deepEqual(installationCall.params, [WORKSPACE_ID, ANCHOR_ID]);
+  });
+
+  it("returns an empty array for an anchor with no installations", async () => {
+    const client = makeClient({ anchor: anchorRow(), installationRows: [] });
+    const result = await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("maps installation rows through installationFromRow (agent, store, transition state, provenance, lastError)", async () => {
+    const row = installationRow({ last_error: "boom" });
+    const client = makeClient({ anchor: anchorRow(), installationRows: [row] });
+    const result = await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    assert.equal(result.length, 1);
+    const [installation] = result;
+    assert.equal(installation.id, INSTALLATION_ID);
+    assert.equal(installation.agentId, AGENT_ID);
+    assert.equal(installation.store, "Root");
+    assert.equal(installation.transitionState, "installed");
+    assert.equal(installation.provenance, "tokentimer_installed");
+    assert.equal(installation.lastError, "boom");
+  });
+});
+
 
 describe("trust result wire carriage", () => {
   const agentProtocolSchema = require(

--- a/tests/unit/certops-worker.test.js
+++ b/tests/unit/certops-worker.test.js
@@ -17,6 +17,18 @@ const workerUrl = pathToFileURL(
   ),
 ).href;
 
+const metricsUrl = pathToFileURL(
+  path.join(
+    __dirname,
+    "..",
+    "..",
+    "apps",
+    "worker",
+    "src",
+    "certops-metrics.js",
+  ),
+).href;
+
 const silentLogger = {
   info() {},
   warn() {},
@@ -63,6 +75,18 @@ function createReaperClient(rows) {
       return { rows: [] };
     },
   };
+}
+
+// runCertOpsMaintenance rejects when any sweep failed, so a failing run exits
+// non-zero. Tests that assert on per-sweep outcomes rather than on that exit
+// signal read the results off the rejection.
+async function runMaintenanceResults(worker, options) {
+  try {
+    return await worker.runCertOpsMaintenance(options);
+  } catch (error) {
+    if (error?.code !== "CERTOPS_MAINTENANCE_SWEEP_FAILED") throw error;
+    return error.results;
+  }
 }
 
 describe("certops maintenance worker", () => {
@@ -372,6 +396,113 @@ describe("certops maintenance worker", () => {
     assert.strictEqual(auditEvents[0].metadata.jobStatus, "failed");
     assert.strictEqual(auditEvents[0].metadata.errorCode, "agent_offline");
     assert.strictEqual(auditEvents[0].metadata.needsOperatorReconciliation, false);
+  });
+
+  it("unwinds a lease-reaped trust job in the reaper's own transaction", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-trust",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "distribute-trust",
+        subject_type: "trust_anchor",
+        subject_id: "anchor-1",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+    const unwinds = [];
+
+    const summary = await worker.reapExpiredLeases({
+      client,
+      log: silentLogger,
+      auditWriter: async () => {},
+      trustTerminalHook: async (args) => {
+        unwinds.push(args);
+        return { action: "deleted" };
+      },
+    });
+
+    assert.strictEqual(summary.failed, 1);
+    assert.strictEqual(unwinds.length, 1, "expected one trust unwind");
+    assert.strictEqual(unwinds[0].client, client);
+    assert.strictEqual(unwinds[0].job.id, "job-trust");
+    assert.strictEqual(unwinds[0].job.status, "failed");
+    assert.strictEqual(unwinds[0].job.operation, "distribute-trust");
+    assert.strictEqual(unwinds[0].job.workspace_id, "ws-1");
+
+    // The unwind must land between the failed UPDATE and the COMMIT, so the
+    // job status and the installation state cannot be observed apart.
+    const updateIndex = client.queries.findIndex((q) =>
+      q.sql.startsWith("UPDATE certificate_jobs SET status = 'failed'"),
+    );
+    const commitIndex = client.queries.findIndex((q) => q.sql === "COMMIT");
+    assert.ok(updateIndex >= 0 && commitIndex > updateIndex);
+  });
+
+  it("does not unwind non-trust jobs the reaper fails", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-renew",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "renew",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+    let unwindCalls = 0;
+
+    await worker.reapExpiredLeases({
+      client,
+      log: silentLogger,
+      auditWriter: async () => {},
+      trustTerminalHook: async () => {
+        unwindCalls += 1;
+      },
+    });
+
+    assert.strictEqual(unwindCalls, 0);
+  });
+
+  it("rolls the whole reaper transaction back when a trust unwind fails", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-trust-broken",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "revoke-trust",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+
+    await assert.rejects(
+      () =>
+        worker.reapExpiredLeases({
+          client,
+          log: silentLogger,
+          auditWriter: async () => {},
+          trustTerminalHook: async () => {
+            throw new Error("installation row locked");
+          },
+        }),
+      /installation row locked/,
+    );
+
+    assert.strictEqual(client.queries.at(-1).sql, "ROLLBACK");
   });
 
   it("never requeues running jobs; marks them orphaned_unknown_effect instead", async () => {
@@ -1260,7 +1391,7 @@ describe("certops maintenance worker", () => {
     let nonceCalls = 0;
     let renewalCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {},
       log: silentLogger,
       // Lease reaper and stale-agent sweep both explode.
@@ -1301,7 +1432,7 @@ describe("certops maintenance worker", () => {
     let renewalCalls = 0;
     let clientCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
       CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
       CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "0",
@@ -1342,7 +1473,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     let renewalCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_TIMEOUT_MS: "20",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1389,7 +1520,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     const seenClients = [];
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {},
       log: silentLogger,
       withClientFn: async (fn) =>
@@ -1424,7 +1555,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     const seenClients = [];
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1451,7 +1582,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     let replayCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1470,5 +1601,84 @@ describe("certops maintenance worker", () => {
 
     assert.strictEqual(results.registrationReplaySweep.status, "skipped");
     assert.strictEqual(replayCalls, 0);
+  });
+
+  it("rejects with a sweep-failure code so a failing run exits non-zero", async () => {
+    const worker = await import(workerUrl);
+    let metricsPushed = 0;
+
+    await assert.rejects(
+      () =>
+        worker.runCertOpsMaintenance({
+          env: {
+            CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
+            CERTOPS_SWEEP_AGENT_RECOVERY_ALERTS_ENABLED: "false",
+            CERTOPS_SWEEP_NONCE_ENABLED: "false",
+            CERTOPS_SWEEP_REGISTRATION_REPLAY_ENABLED: "false",
+            CERTOPS_SWEEP_RENEWAL_SCHEDULER_ENABLED: "false",
+            CERTOPS_SWEEP_OUTBOX_DRAIN_ENABLED: "false",
+            CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_ENABLED: "false",
+            CERTOPS_SWEEP_TRUST_ANCHOR_RECONCILIATION_ENABLED: "false",
+          },
+          log: silentLogger,
+          withClientFn: async () => {
+            throw new Error("db down");
+          },
+          pushMetricsFn: async () => {
+            metricsPushed += 1;
+          },
+        }),
+      (err) => {
+        assert.strictEqual(err.code, "CERTOPS_MAINTENANCE_SWEEP_FAILED");
+        assert.match(err.message, /1 sweep\(s\) failed: leaseReaper/);
+        assert.strictEqual(err.results.leaseReaper.status, "failed");
+        return true;
+      },
+    );
+
+    // Metrics must still ship for a failing run, otherwise the failure is
+    // invisible in the series that would explain it.
+    assert.strictEqual(metricsPushed, 1);
+  });
+
+  it("does not fail the run when sweeps are only skipped", async () => {
+    const worker = await import(workerUrl);
+
+    const results = await worker.runCertOpsMaintenance({
+      env: {
+        CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
+        CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
+        CERTOPS_SWEEP_AGENT_RECOVERY_ALERTS_ENABLED: "false",
+        CERTOPS_SWEEP_REGISTRATION_REPLAY_ENABLED: "false",
+        CERTOPS_SWEEP_RENEWAL_SCHEDULER_ENABLED: "false",
+        CERTOPS_SWEEP_OUTBOX_DRAIN_ENABLED: "false",
+        CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_ENABLED: "false",
+        CERTOPS_SWEEP_TRUST_ANCHOR_RECONCILIATION_ENABLED: "false",
+      },
+      log: silentLogger,
+      dbPool: { marker: "pool" },
+      nonceSweeper: async () => 2,
+      pushMetricsFn: async () => {},
+    });
+
+    assert.strictEqual(results.leaseReaper.status, "skipped");
+    assert.strictEqual(results.trustAnchorReconciliation.status, "skipped");
+    assert.strictEqual(results.nonceSweep.status, "success");
+  });
+
+  it("treats only failed sweeps as a failed run", async () => {
+    const metrics = await import(metricsUrl);
+
+    assert.deepStrictEqual(metrics.identifyFailedSweeps({}), []);
+    assert.deepStrictEqual(metrics.identifyFailedSweeps(undefined), []);
+    assert.deepStrictEqual(
+      metrics.identifyFailedSweeps({
+        a: { status: "success" },
+        b: { status: "skipped" },
+        c: { status: "failed" },
+        d: { status: "failed" },
+      }),
+      ["c", "d"],
+    );
   });
 });


### PR DESCRIPTION
## Summary

CertOps 0.14.1 correctness fixes plus the trust-anchor installations read endpoint, per the cross-edition review after the 0.14.0 release.

- **Worker exit code**: `certops-worker` maintenance entrypoint now exits non-zero when any sweep fails (ported `identifyFailedSweeps` from Cloud), and the lease reaper now calls the trust terminal-transition unwind directly instead of relying solely on the optional reconciliation sweep.
- **Bulk-renew idempotency**: stopped synthesizing `bulk-renew:auto:<certificateId>` (which permanently blocked a second renewal of the same certificate), and added a shared read-only preflight so bulk-renew `dryRun` actually resolves the renewal profile instead of reporting false positives.
- **Agent signed-ID defaults**: fixed stale `requireSignedAgentId` JSDoc (said "default false", compiled default is `true`) and the two unreachable-but-fail-open `= false` parameter defaults in `packages/agent/src/index.js`.
- **New**: `GET /api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations` — read-only listing of every installation row for a trust anchor (agent, store, transition state, provenance, last error), needed by the upcoming trust-anchor UI. Admin-gated, intentionally omits `requireWorkspaceCertOpsActive` so a paused workspace can still be read.

## Test plan

- [x] `pnpm run test:unit` — 1779/1779 passing
- [x] DB-backed integration suite for the new endpoint (`tests/integration/certops-trust-anchors.test.js`) — 73/73 passing, including RBAC, cross-workspace 404, and paused-workspace read
- [x] `pnpm run check:contracts` / `check:contracts:integrity` — ok, no manual digest edits needed
- [x] `node scripts/ci-guards/leak-scan.cjs` — ok
