### PR TITLE
Release TokenTimer Core v0.14.1 with CertOps Contracts Dependency Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-08-31
+
+### Fixed
+
+- A trust-anchor job result reported by an agent could fail ingestion with `Cannot find module 'ajv'` on a production install. `apps/api`'s and `apps/worker`'s `package.json` never declared a dependency on the workspace's own `packages/contracts`, so a production (`--filter`, non-hoisted) install never provisioned that package's `node_modules`, and both apps reach it by relative `require()`. Only surfaced once an agent actually reported a trust-anchor result on a production-built image; a full unfiltered `pnpm install` (dev, CI unit tests) always masked it.
+
 ## [0.14.0] - 2026-08-30
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/api",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "description": "TokenTimer API Service",
   "license": "AGPL-3.0-or-later",
@@ -19,6 +19,7 @@
     "@aws-sdk/client-iam": "3.1045.0",
     "@aws-sdk/client-secrets-manager": "3.1045.0",
     "@aws-sdk/client-sts": "3.1045.0",
+    "@tokentimer/contracts": "workspace:*",
     "@tokentimer/log-scrub": "workspace:*",
     "@tokentimer/node-compat": "workspace:*",
     "@tokentimer/webhook-safety": "workspace:*",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/dashboard",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",

--- a/apps/k8s-controller/package.json
+++ b/apps/k8s-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/k8s-controller",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "main": "src/index.js",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/worker",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@11.13.0",
@@ -27,6 +27,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@tokentimer/contracts": "workspace:*",
     "@tokentimer/log-scrub": "workspace:*",
     "@tokentimer/node-compat": "workspace:*",
     "@tokentimer/webhook-safety": "workspace:*",

--- a/contracts.manifest.json
+++ b/contracts.manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "repo": "tokentimer-core",
   "contractsPackage": "@tokentimer/contracts",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "namespaces": [
     {
       "name": "queue",

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tokentimer
 description: Token, certificate, and secret expiration management for teams
 type: application
-version: 0.14.0
-appVersion: "0.14.0"
+version: 0.14.1
+appVersion: "0.14.1"
 kubeVersion: ">=1.29.0-0"
 keywords:
   - token

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,7 @@ api:
   image:
     registry: ""
     repository: tokentimer-core-api
-    tag: "0.14.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.14.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""    # takes precedence over tag; pin from release-manifest.json for reproducible deploys (:latest is not the source of truth)
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ dashboard:
   image:
     registry: ""
     repository: tokentimer-core-dashboard
-    tag: "0.14.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.14.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -158,7 +158,7 @@ worker:
   image:
     registry: ""
     repository: tokentimer-core-worker
-    tag: "0.14.0"  # align with Chart.appVersion; release workflow updates this per tag
+    tag: "0.14.1"  # align with Chart.appVersion; release workflow updates this per tag
     digest: ""
     pullPolicy: IfNotPresent
 
@@ -303,7 +303,7 @@ certops:
     image:
       registry: ""
       repository: tokentimer-core-k8s-controller
-      tag: "0.14.0"  # align with Chart.appVersion; release workflow updates this per tag
+      tag: "0.14.1"  # align with Chart.appVersion; release workflow updates this per tag
       digest: ""
       pullPolicy: IfNotPresent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentimer-core",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "description": "TokenTimer Core - Self-hosted token, certificate, and secret expiration management",
   "scripts": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/agent",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "description": "TokenTimer Agent - outbound-only execution-plane process for CertOps",
   "license": "AGPL-3.0-or-later",

--- a/packages/contracts/api/auth-route-compat.contract.json
+++ b/packages/contracts/api/auth-route-compat.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "api.auth-route-compat",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Canonical auth route compatibility guarantees across core and consumers.",
   "guarantees": {
     "stableRoutes": [

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: TokenTimer Core API Contract
-  version: 0.14.0
+  version: 0.14.1
   description: |
     TokenTimer Core API for authentication, workspaces, token lifecycle management,
     alerts, audit, and integration import/scan workflows.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokentimer/contracts",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "description": "API and queue schema contracts for TokenTimer",

--- a/packages/contracts/runtime-extensions/plugin-context.contract.json
+++ b/packages/contracts/runtime-extensions/plugin-context.contract.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Expected plugin context hooks exposed by core to runtime extensions.",
   "hooks": {
     "setAuthFeaturesProvider": {

--- a/packages/contracts/runtime-extensions/plugin-context.example.json
+++ b/packages/contracts/runtime-extensions/plugin-context.example.json
@@ -1,6 +1,6 @@
 {
   "contractName": "runtime-extensions.plugin-context",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "hooks": {
     "setAuthFeaturesProvider": {
       "signature": "(handler: (req, res) => void) => void",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: 3.1045.0
         version: 3.1045.0
+      '@tokentimer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@tokentimer/log-scrub':
         specifier: workspace:*
         version: link:../../packages/log-scrub
@@ -326,6 +329,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@tokentimer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@tokentimer/log-scrub':
         specifier: workspace:*
         version: link:../../packages/log-scrub


### PR DESCRIPTION
## Summary
Fixes a production-only bug where an agent's trust-anchor job result could crash ingestion with Cannot find module 'ajv'. \pps/api\ and \pps/worker\ never declared \@tokentimer/contracts\ as a dependency even though both require it by relative path (trust-result validation, canonical-json signing, the agent-protocol schema), so pnpm's filtered production install never provisioned that workspace package's own \
ode_modules\. A full unfiltered dev/CI install always masked this.

Found while verifying Enterprise's real trust-anchor end-to-end test against a production-built image.

## Changes

### apps/api, apps/worker
- Added \@tokentimer/contracts\: \workspace:*\ to both \package.json\ dependency lists.

### Verification
- Reproduced the exact \Cannot find module 'ajv'\ crash on a clean \deploy/compose/Dockerfile.api\ build without the fix (via \getAjv()\ -> \alidateTrustResult\).
- Confirmed the fix resolves it in all three affected Dockerfiles built for real: \deploy/compose/Dockerfile.api\, \deploy/compose/Dockerfile.worker\, \pps/api/Dockerfile\ — \alidateTrustResult({})\ now returns real Ajv schema errors instead of crashing.

### Docs / metadata
- Version bumped to 0.14.1 across all manifests (package.json, contracts, Helm chart/values).
- CHANGELOG: genuine \Fixed\ entry for a real post-0.14.0 regression.

## Test plan
- Local fast gate: audit/lint/unit (1763/1763 pass)/contracts all green.
- Real Docker builds of the affected images, before/after, proving the crash and the fix.
