### PR TITLE
feat(certops): add trust-anchor management UI (dashboard)

### DIFF
--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -100,6 +100,7 @@ const {
   listCertificateJobLog,
   listCertificateJobs,
   manualRenewalJobCreator,
+  preflightManualRenewalJob,
 } = require("../services/certops/jobs");
 const {
   AUTO_RENEW_DISABLED_PROFILE_STATUSES,
@@ -941,14 +942,14 @@ const BULK_RENEW_ALLOWED_BODY_FIELDS = Object.freeze([
 const BULK_RENEW_IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 
 function bulkRenewItemIdempotencyKey(idempotencyKey, certificateId) {
-  // Non-dry-run bulk creates must always carry a stable per-certificate key
-  // so client retries cannot enqueue duplicate renew jobs. When the caller
-  // omits a request key, derive one from the certificate id alone (scoped
-  // by the workspace-scoped unique index on the jobs table's idempotency key).
+  // No auto-derived fallback: the jobs table's (workspace_id,
+  // idempotency_key) uniqueness has no time component, so a key derived from
+  // the certificate id alone would make that certificate renewable exactly
+  // once, forever. Retry safety is opt-in instead, via a caller-supplied key.
   if (idempotencyKey) {
     return `bulk-renew:${idempotencyKey}:${certificateId}`;
   }
-  return `bulk-renew:auto:${certificateId}`;
+  return null;
 }
 
 /**
@@ -1042,17 +1043,22 @@ function parseBulkRenewRequest(body) {
  * An optional request-level idempotencyKey makes retries safe: each item is
  * created with a derived "bulk-renew:<key>:<certificateId>" job key, so a
  * replayed batch returns the already-created jobs (marked replayed: true)
- * instead of enqueueing duplicates.
+ * instead of enqueueing duplicates. Omitting the key leaves items without
+ * one, so a replayed POST enqueues fresh jobs.
  *
  * Dry run preflights each certificate without writing: existence, renewable
- * inventory status, the same payload validation the real run applies, and
- * whether a non-terminal renew job is already in flight (reported as
- * activeJobId so callers can spot double-renewals before committing).
+ * inventory status, resolution of that certificate's stored renewal profile
+ * into the payload the real run would insert (so an incomplete or invalid
+ * profile fails the item here rather than at real-run time), and whether a
+ * non-terminal renew job is already in flight (reported as activeJobId so
+ * callers can spot double-renewals before committing). Capacity is not
+ * checked: a dry run must not reserve per-CA capacity.
  */
 function bulkRenewCertificatesHandler({
   manualJobCreator = createManualCertificateJob,
   certificateLoader = getManagedCertificate,
   activeJobFinder = findActiveJobForSubject,
+  renewalPreflight = preflightManualRenewalJob,
 } = {}) {
   return async function bulkRenewCertificatesHandler(req, res) {
     const parsed = parseBulkRenewRequest(req.body);
@@ -1108,6 +1114,11 @@ function bulkRenewCertificatesHandler({
         }
 
         if (parsed.dryRun) {
+          await renewalPreflight({
+            workspaceId: req.workspace.id,
+            certificateId,
+            payload: parsed.payload,
+          });
           const activeJob = await activeJobFinder({
             workspaceId: req.workspace.id,
             subjectType: "managed_certificate",

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -155,6 +155,7 @@ const {
   CERTOPS_TARGET_AGENT_NOT_FOUND,
   createTrustAnchor,
   listTrustAnchors,
+  listInstallationsForAnchor,
   manualTrustJobCreator,
   retireTrustAnchor,
 } = require("../services/certops/trustAnchors");
@@ -2485,6 +2486,43 @@ router.post(
       });
       return res.status(500).json({
         error: "Failed to retire trust anchor",
+        code: "INTERNAL_ERROR",
+      });
+    }
+  },
+);
+
+// Read-only: intentionally omits requireWorkspaceCertOpsActive (unlike the
+// two mutating trust-anchor routes above) so an operator diagnosing a
+// frozen/deactivated workspace can still see where a trust anchor landed.
+router.get(
+  "/api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations",
+  getApiLimiter(),
+  requireCertOpsEnabled,
+  authorize("certops.trust_anchor.manage"),
+  async (req, res) => {
+    const anchorId = trustAnchorIdFromParams(req, res);
+    if (!anchorId) return null;
+
+    try {
+      const items = await listInstallationsForAnchor({
+        workspaceId: req.workspace.id,
+        trustAnchorId: anchorId,
+      });
+      return res.json({ items });
+    } catch (err) {
+      const handled = handleCertOpsError(res, err);
+      if (handled) return handled;
+
+      logger.error("CertOps trust anchor installations list failed", {
+        error: err.message,
+        code: err.code || null,
+        workspaceId: req.workspace?.id,
+        anchorId,
+        userId: req.user?.id,
+      });
+      return res.status(500).json({
+        error: "Failed to list trust anchor installations",
         code: "INTERNAL_ERROR",
       });
     }

--- a/apps/api/services/certops/jobs.js
+++ b/apps/api/services/certops/jobs.js
@@ -1359,6 +1359,34 @@ async function loadManagedCertificateForRenewal({ db, workspaceId, certificateId
 }
 
 /**
+ * Single materializer for a manual/bulk renew payload: reads the certificate
+ * with its linked profile and resolves the stored renewal profile into the
+ * same payload the scheduler would build. Read-only. Shared by the real
+ * creation path and its dry-run preflight so the two cannot drift.
+ */
+async function materializeManualRenewalPayload({
+  db,
+  workspaceId,
+  certificateId,
+  overrides,
+  loadCertificate = loadManagedCertificateForRenewal,
+}) {
+  const certificate = await loadCertificate({
+    db,
+    workspaceId,
+    certificateId,
+  });
+  if (!certificate) {
+    throw serviceError("Certificate not found", CERTOPS_CERTIFICATE_NOT_FOUND);
+  }
+  return buildManualRenewalJobPayload({
+    certificate,
+    defaultReason: MANUAL_RENEWAL_DEFAULT_REASON,
+    overrides,
+  });
+}
+
+/**
  * jobCreator swapped in (by routes/certops.js) for a renew job whose
  * subject is an existing managed certificate, for both single manual and
  * bulk creation. Materializes the payload the same way the scheduler does
@@ -1375,22 +1403,12 @@ function manualRenewalJobCreator({
 } = {}) {
   return async function manualRenewalJobCreator(options) {
     const { client, workspaceId } = options;
-    const certificate = await loadCertificate({
+    const payload = await materializeManualRenewalPayload({
       db: client,
       workspaceId,
       certificateId,
-    });
-    if (!certificate) {
-      throw serviceError(
-        "Certificate not found",
-        CERTOPS_CERTIFICATE_NOT_FOUND,
-      );
-    }
-
-    const payload = buildManualRenewalJobPayload({
-      certificate,
-      defaultReason: MANUAL_RENEWAL_DEFAULT_REASON,
       overrides: options.payload,
+      loadCertificate,
     });
 
     return createJob({
@@ -1401,6 +1419,32 @@ function manualRenewalJobCreator({
       payload,
     });
   };
+}
+
+/**
+ * Read-only twin of manualRenewalJobCreator's materialization step: resolves
+ * the certificate's stored renewal profile, builds the renew payload from it
+ * and runs the same payload validation createCertificateJob runs. Writes
+ * nothing, takes no lock and reserves no per-CA capacity, so a bulk dry run
+ * can reject the certificates a real run would reject (notably
+ * CERTOPS_RENEWAL_PROFILE_INCOMPLETE / CERTOPS_RENEWAL_PROFILE_INVALID)
+ * without side effects. Returns the payload the real run would insert.
+ */
+async function preflightManualRenewalJob({
+  client,
+  workspaceId,
+  certificateId,
+  payload,
+  loadCertificate = loadManagedCertificateForRenewal,
+} = {}) {
+  const materialized = await materializeManualRenewalPayload({
+    db: client || pool,
+    workspaceId,
+    certificateId,
+    overrides: payload,
+    loadCertificate,
+  });
+  return validateJobPayloadForOperation(materialized, "renew");
 }
 
 function jobFromRow(row) {
@@ -2338,6 +2382,7 @@ module.exports = {
   normalizePublicObject,
   normalizeRequiredId,
   normalizeWorkspaceId,
+  preflightManualRenewalJob,
   serviceError,
   updateCertificateJobStatus,
   validateJobPayloadForOperation,

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -680,6 +680,41 @@ function installationFromRow(row) {
 }
 
 /**
+ * Read-only listing of every installation row for one trust anchor, for a
+ * future admin UI to see where an anchor actually landed (agent, store,
+ * transition state, provenance, last error) before revoking/distributing
+ * it further. Filters on workspace_id AND trust_anchor_id in the same
+ * WHERE clause, mirroring getTrustAnchorById's own tenant-isolation style
+ * above, so a cross-workspace read is impossible by construction rather
+ * than merely checked after the fact.
+ */
+async function listInstallationsForAnchor(options = {}) {
+  const db = options.client || pool;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
+  const trustAnchorId = normalizeRequiredId(
+    options.trustAnchorId,
+    CERTOPS_TRUST_ANCHOR_INVALID,
+  );
+
+  const anchor = await getTrustAnchorById(db, workspaceId, trustAnchorId);
+  if (!anchor) {
+    throw trustAnchorError(
+      "Trust anchor not found",
+      CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+    );
+  }
+
+  const result = await db.query(
+    `SELECT ${INSTALLATION_SELECT_FIELDS}
+       FROM certops_trust_anchor_installations
+      WHERE workspace_id = $1 AND trust_anchor_id = $2
+      ORDER BY updated_at DESC`,
+    [workspaceId, trustAnchorId],
+  );
+  return result.rows.map(installationFromRow);
+}
+
+/**
  * Locks (or creates, if absent) the ownership-reference row for
  * (workspace, agent, store, fingerprint, owner) inside the caller's
  * transaction. SELECT ... FOR UPDATE serializes concurrent requests on this
@@ -2156,6 +2191,7 @@ module.exports = {
   listTrustAnchors,
   getTrustAnchorById,
   retireTrustAnchor,
+  listInstallationsForAnchor,
   anchorFromRow,
   installationFromRow,
   normalizeStore,

--- a/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
+++ b/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
@@ -47,8 +47,35 @@ import {
 } from './certopsJobsFormat';
 import { useCertOpsAgents } from './useCertOpsAgents.js';
 import { useCertOpsControllerClusters } from './useCertOpsControllerClusters.js';
+import { useCertOpsIsWorkspaceAdmin } from './useCertOps.js';
 import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
 import { showError, showSuccess } from '../../utils/toast.js';
+
+/**
+ * Client-side idempotency key for a trust-op submission. `crypto.randomUUID`
+ * is available in every browser this dashboard supports; the fallback only
+ * guards against a test/SSR environment without a `crypto` global.
+ */
+function generateIdempotencyKey() {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return `trust-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// Installation transitionStates that still represent a live reference; a
+// 'removed' row has nothing left to revoke, so it is excluded from the
+// revoke-trust owner picker (distribute's "existing owner" list still
+// includes it, since re-distributing to a previously-removed owner is
+// exactly re-establishing that reference).
+const LIVE_INSTALLATION_STATES = new Set([
+  'pending_install',
+  'installed',
+  'pending_remove',
+]);
 
 const SUBJECT_ID_MAX_LENGTH = 128;
 const MANUAL_JOB_SUBJECT_SUGGESTIONS_LIST_ID =
@@ -196,13 +223,30 @@ function createJobErrorMessage(err) {
   const code = err?.response?.data?.code;
   const status = err?.response?.status;
   if (status === 403 || code === 'INSUFFICIENT_ROLE') {
-    return 'You need workspace manager permission to create a job.';
+    return 'You need workspace manager permission to create a job. Trust-anchor operations need workspace admin.';
   }
   if (code === 'PRIVATE_KEY_MATERIAL_REJECTED') {
     return 'Private key or secret material is not accepted in job fields.';
   }
   if (code === 'CERTOPS_JOB_IDEMPOTENCY_CONFLICT') {
     return 'This idempotency key was already used with different job details.';
+  }
+  if (code === 'CERTOPS_TRUST_JOB_IDEMPOTENCY_CONFLICT') {
+    return 'This idempotency key was already used with a different trust-anchor job. Retry to generate a new one.';
+  }
+  if (code === 'CERTOPS_TRUST_ANCHOR_NOT_ACTIVE') {
+    return 'This trust anchor was retired and can no longer be distributed.';
+  }
+  if (code === 'CERTOPS_TARGET_AGENT_INVALID') {
+    return 'The selected agent id is not well-formed.';
+  }
+  if (code === 'CERTOPS_TARGET_AGENT_NOT_FOUND') {
+    return 'That agent was not found in this workspace. It may have been retired.';
+  }
+  if (code === 'CERTOPS_TRUST_ANCHOR_INVALID') {
+    return (
+      err?.response?.data?.error || 'This trust-anchor job request is invalid.'
+    );
   }
   if (code === 'CERTOPS_CONTROLLER_PROVISIONING_TERMINAL_IDENTITY') {
     return 'This certificate/secret name was already retired in this namespace and cannot be reactivated by provisioning. Choose a different certificate or secret name.';
@@ -220,8 +264,20 @@ function createJobErrorMessage(err) {
  * Manual job creation modal: the exception path for creating
  * a CertOps job before the certops-scheduler exists. Always posts with
  * source "api"; the server never accepts a client-supplied source.
+ *
+ * `trustOp` puts the modal in its narrower trust-anchor mode: opened from
+ * TrustAnchorsPanel with the anchor and operation already chosen, so this
+ * modal never needs its own anchor picker. Shape:
+ * `{ anchorId, anchorName, anchorFingerprint, operation, installations }`,
+ * where `installations` is the panel's already-fetched list for that
+ * anchor (this modal never fetches its own).
  */
-export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
+export default function CreateManualJobModal({
+  isOpen,
+  onClose,
+  onCreated,
+  trustOp,
+}) {
   const {
     overlayProps,
     headerProps,
@@ -234,6 +290,9 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
   const { workspaceId } = useWorkspace();
   const { agents } = useCertOpsAgents();
   const { clusters: controllerClusters } = useCertOpsControllerClusters();
+  const isWorkspaceAdmin = useCertOpsIsWorkspaceAdmin();
+  const isTrustOp = Boolean(trustOp?.anchorId);
+  const isDistributeTrust = trustOp?.operation === 'distribute-trust';
   const [operation, setOperation] = useState('');
   const [executor, setExecutor] = useState('agent');
   const [subjectType, setSubjectType] = useState('');
@@ -264,6 +323,13 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
   );
   const [controllerIssuerName, setControllerIssuerName] = useState('');
   const [controllerDnsNames, setControllerDnsNames] = useState('');
+  // Trust-op-only state: irrelevant (and left at defaults) outside isTrustOp.
+  const [trustAgentId, setTrustAgentId] = useState('');
+  const [trustOwnerMode, setTrustOwnerMode] = useState('existing');
+  const [trustExistingOwner, setTrustExistingOwner] = useState('');
+  const [trustNewOwner, setTrustNewOwner] = useState('');
+  const [trustInstallationId, setTrustInstallationId] = useState('');
+  const [trustKeyEdited, setTrustKeyEdited] = useState(false);
 
   // "issue" has no existing subject to act on (ADR-0008): the control
   // plane creates the managed_certificate row itself, so passing
@@ -319,6 +385,99 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
     if (hidesAgentField) setAssignedAgentId('');
   }, [hidesAgentField]);
 
+  // Distinct owner strings across every installation the panel handed in
+  // for this anchor (any agent/store), for the "existing owner" picker on
+  // distribute. Case preserved for display; collision detection below
+  // folds case, matching the dangling-reference hazard this UI exists to
+  // prevent (see plan: "Distribute as Team-A, revoke as team-a...").
+  const trustExistingOwners = Array.from(
+    new Set(
+      (trustOp?.installations || []).map(row => row.owner).filter(Boolean)
+    )
+  );
+
+  // revoke-trust only ever targets a still-live reference: a 'removed' row
+  // has nothing left for a job to release, so offering it would just
+  // produce a confusing no-op 200 ownershipReleased response.
+  const trustRevocableInstallations = (trustOp?.installations || []).filter(
+    row => LIVE_INSTALLATION_STATES.has(row.transitionState)
+  );
+
+  const trustSelectedInstallation = trustRevocableInstallations.find(
+    row => row.id === trustInstallationId
+  );
+
+  // Resolves to the agentId/owner pair the request will actually submit:
+  // for distribute, the separately-picked target agent plus either the
+  // selected existing owner or the typed new owner; for revoke, both come
+  // from the one installation row selected above (revoke always targets
+  // an existing reference, never a free-typed owner).
+  const trustResolvedAgentId = isDistributeTrust
+    ? trustAgentId
+    : trustSelectedInstallation?.agentId || '';
+  const trustResolvedOwner = isDistributeTrust
+    ? trustOwnerMode === 'new'
+      ? trustNewOwner.trim()
+      : trustExistingOwner
+    : trustSelectedInstallation?.owner || '';
+
+  // Case-insensitive near-duplicate warning, not a hard block: the same
+  // owner label legitimately recurs across different agents, so only flag
+  // it when it is not already the exact string being reused deliberately.
+  const trustNewOwnerCollision =
+    isDistributeTrust && trustOwnerMode === 'new' && trustNewOwner.trim()
+      ? trustExistingOwners.find(
+          existing =>
+            existing.toLowerCase() === trustNewOwner.trim().toLowerCase() &&
+            existing !== trustNewOwner.trim()
+        )
+      : null;
+
+  // Re-seeds every trust-op field whenever the modal opens in trust mode,
+  // or the panel hands it a different anchor/operation without a full
+  // close/reopen (e.g. clicking Distribute on anchor B while the modal
+  // instance persists across renders). Regenerating the idempotency key
+  // here, not just on open, matters because 0.14.0 scopes a trust job's
+  // conflict key to the full target tuple (operation+anchor+agent+owner):
+  // reusing a stale key against a new tuple would just 409.
+  useEffect(() => {
+    if (!isOpen || !isTrustOp) return;
+    setTrustAgentId('');
+    setTrustOwnerMode('existing');
+    setTrustExistingOwner('');
+    setTrustNewOwner('');
+    setTrustInstallationId('');
+    setTrustKeyEdited(false);
+    setIdempotencyKey(generateIdempotencyKey());
+    setRequiresApproval(false);
+  }, [isOpen, isTrustOp, trustOp?.anchorId, trustOp?.operation]);
+
+  // Regenerates the auto-filled key as the target tuple changes, unless
+  // the admin has already typed their own override (trustKeyEdited).
+  useEffect(() => {
+    if (!isOpen || !isTrustOp || trustKeyEdited) return;
+    setIdempotencyKey(generateIdempotencyKey());
+    // trustResolvedAgentId/Owner intentionally drive this effect even
+    // though they are derived, not state: the key must track the actual
+    // submission target, and re-deriving them here would duplicate the
+    // resolution logic above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isOpen,
+    isTrustOp,
+    trustKeyEdited,
+    trustResolvedAgentId,
+    trustResolvedOwner,
+  ]);
+
+  const trustCanSubmit =
+    isTrustOp &&
+    isWorkspaceAdmin &&
+    Boolean(trustResolvedAgentId) &&
+    Boolean(trustResolvedOwner) &&
+    Boolean(idempotencyKey.trim()) &&
+    !(isDistributeTrust && trustOwnerMode === 'new' && !trustNewOwner.trim());
+
   const resetForm = () => {
     setOperation('');
     setExecutor('agent');
@@ -346,6 +505,12 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
     setControllerIssuerName('');
     setControllerDnsNames('');
     setSubjectSuggestions([]);
+    setTrustAgentId('');
+    setTrustOwnerMode('existing');
+    setTrustExistingOwner('');
+    setTrustNewOwner('');
+    setTrustInstallationId('');
+    setTrustKeyEdited(false);
   };
 
   const handleClose = () => {
@@ -422,16 +587,17 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
       controllerDnsNamesList.length > 0
     );
 
-  const canSubmit =
-    Boolean(operation) &&
-    Boolean(workspaceId) &&
-    !submitting &&
-    fieldsRequiredForIssueMet &&
-    controllerFieldsMet &&
-    (isIssue
-      ? Boolean(idempotencyKey.trim()) &&
-        (isControllerIssue || payloadMode === 'fields' || !payloadError)
-      : subjectPairComplete && (payloadMode === 'fields' || !payloadError));
+  const canSubmit = isTrustOp
+    ? trustCanSubmit && !submitting
+    : Boolean(operation) &&
+      Boolean(workspaceId) &&
+      !submitting &&
+      fieldsRequiredForIssueMet &&
+      controllerFieldsMet &&
+      (isIssue
+        ? Boolean(idempotencyKey.trim()) &&
+          (isControllerIssue || payloadMode === 'fields' || !payloadError)
+        : subjectPairComplete && (payloadMode === 'fields' || !payloadError));
 
   const handlePayloadChange = event => {
     const text = event.target.value;
@@ -497,6 +663,31 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
     if (!canSubmit) return;
     setSubmitting(true);
     try {
+      if (isTrustOp) {
+        const result = await createJob(workspaceId, {
+          operation: trustOp.operation,
+          subjectType: 'trust_anchor',
+          subjectId: trustOp.anchorId,
+          agentId: trustResolvedAgentId,
+          owner: trustResolvedOwner,
+          idempotencyKey: idempotencyKey.trim(),
+        });
+        if (result?.ownershipReleased) {
+          showSuccess(
+            'Reference released, no agent job dispatched',
+            'Another owner still references this anchor on this agent, so the OS trust store was not touched.'
+          );
+        } else {
+          showSuccess(
+            'Job created',
+            result?.job?.id ? `Job ID: ${truncateId(result.job.id)}` : undefined
+          );
+        }
+        resetForm();
+        onClose();
+        onCreated?.();
+        return;
+      }
       if (isControllerIssue) {
         const result = await createControllerProvisionIntent(workspaceId, {
           idempotencyKey: idempotencyKey.trim(),
@@ -562,489 +753,170 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
       <ModalOverlay {...overlayProps} />
       <DashboardModalFrame maxW={{ base: 'calc(100vw - 24px)', md: '640px' }}>
         <ModalHeader {...headerProps}>
-          <DashboardModalTitle>Create manual job</DashboardModalTitle>
+          <DashboardModalTitle>
+            {isTrustOp
+              ? `${jobOperationLabel(trustOp.operation)} trust anchor`
+              : 'Create manual job'}
+          </DashboardModalTitle>
           <DashboardModalDescription>
-            Manual job creation is an exception path for driving certificate
-            operations before automated scheduling ships.
+            {isTrustOp
+              ? `${trustOp.anchorName || 'Trust anchor'}${
+                  trustOp.anchorFingerprint
+                    ? ` (${truncateId(trustOp.anchorFingerprint, { head: 12, tail: 6 })})`
+                    : ''
+                }. The job is recorded with source "api".`
+              : 'Manual job creation is an exception path for driving certificate operations before automated scheduling ships.'}
           </DashboardModalDescription>
         </ModalHeader>
         <ModalCloseButton {...closeButtonProps} isDisabled={submitting} />
         <ModalBody {...bodyProps}>
-          <VStack align='stretch' spacing={4}>
-            <Alert status='info' variant='subtle' borderRadius='md'>
-              <AlertIcon boxSize={4} />
-              <AlertDescription fontSize='sm'>
-                The job is recorded with source &quot;api&quot; and appears at
-                the start of the job&apos;s history.
-              </AlertDescription>
-            </Alert>
-            <FormControl isRequired>
-              <FormLabel fontSize='sm'>Operation</FormLabel>
-              <Select
-                size='sm'
-                placeholder='Select an operation'
-                value={operation}
-                onChange={handleOperationChange}
-              >
-                {CERTOPS_JOB_OPERATIONS.map(op => (
-                  <option key={op} value={op}>
-                    {jobOperationLabel(op)}
-                  </option>
-                ))}
-              </Select>
-              {isIssue ? (
-                <FormHelperText>
-                  Issue creates a new managed certificate; TokenTimer assigns
-                  its ID once the request is accepted, so subject fields below
-                  are hidden.
-                </FormHelperText>
+          {isTrustOp ? (
+            <VStack align='stretch' spacing={4}>
+              {!isWorkspaceAdmin ? (
+                <Alert status='warning' variant='subtle' borderRadius='md'>
+                  <AlertIcon boxSize={4} />
+                  <AlertDescription fontSize='sm'>
+                    Trust-anchor operations require workspace admin.
+                  </AlertDescription>
+                </Alert>
               ) : null}
-            </FormControl>
-            {isIssue ? (
-              <FormControl>
-                <FormLabel fontSize='sm'>Executor</FormLabel>
-                <ButtonGroup size='sm' isAttached variant='outline'>
-                  {JOB_EXECUTORS.map(option => (
-                    <Button
-                      key={option.value}
-                      colorScheme={
-                        executor === option.value ? 'blue' : undefined
-                      }
-                      variant={executor === option.value ? 'solid' : 'outline'}
-                      onClick={() => setExecutor(option.value)}
-                    >
-                      {option.label}
-                    </Button>
-                  ))}
-                </ButtonGroup>
-                <FormHelperText>
-                  {isControllerIssue
-                    ? 'Hands a strict public desired state (namespace, certificate/secret name, issuer, DNS names) to a controller bound to the chosen cluster. No manifest, Secret data, CSR, or private key material is ever sent.'
-                    : 'The default path: an agent runs the ACME/DNS-01 issuance below.'}
-                </FormHelperText>
-              </FormControl>
-            ) : null}
-            {isControllerIssue ? (
-              <>
-                <FormControl isRequired>
-                  <FormLabel fontSize='sm'>Cluster</FormLabel>
+              <FormControl isRequired>
+                <FormLabel fontSize='sm'>Target agent</FormLabel>
+                {isDistributeTrust ? (
                   <Select
                     size='sm'
-                    placeholder={
-                      controllerClusters.length
-                        ? 'Select a cluster'
-                        : 'No controller-bound clusters found'
-                    }
-                    value={controllerClusterId}
-                    onChange={event =>
-                      setControllerClusterId(event.target.value)
-                    }
-                    isDisabled={controllerClusters.length === 0}
+                    placeholder='Select an agent'
+                    value={trustAgentId}
+                    onChange={event => setTrustAgentId(event.target.value)}
                   >
-                    {controllerClusters.map(clusterId => (
-                      <option key={clusterId} value={clusterId}>
-                        {clusterId}
+                    {assignableAgents.map(agent => (
+                      <option key={agent.id} value={agent.id}>
+                        {agentSelectLabel(agent)}
                       </option>
                     ))}
                   </Select>
-                  <FormHelperText>
-                    {controllerClusters.length
-                      ? 'Only clusters with an active API token scoped to certops:observations:write or certops:provision:execute appear here.'
-                      : 'Create an API token scoped to a cluster on the API Tokens tab first, then come back here.'}
-                  </FormHelperText>
-                </FormControl>
-                <SimpleGrid columns={2} spacing={2}>
-                  <FormControl isRequired>
-                    <FormLabel fontSize='sm'>Namespace</FormLabel>
-                    <Input
-                      size='sm'
-                      value={controllerNamespace}
-                      onChange={event =>
-                        setControllerNamespace(event.target.value)
-                      }
-                      placeholder='e.g. default'
-                      autoComplete='off'
-                    />
-                  </FormControl>
-                  <FormControl isRequired>
-                    <FormLabel fontSize='sm'>Certificate name</FormLabel>
-                    <Input
-                      size='sm'
-                      value={controllerCertificateName}
-                      onChange={event =>
-                        setControllerCertificateName(event.target.value)
-                      }
-                      placeholder='e.g. example-web-tls'
-                      autoComplete='off'
-                    />
-                  </FormControl>
-                </SimpleGrid>
-                <FormControl isRequired>
-                  <FormLabel fontSize='sm'>Secret name</FormLabel>
-                  <Input
+                ) : (
+                  <Select
                     size='sm'
-                    value={controllerSecretName}
+                    placeholder='Select an installation to revoke'
+                    value={trustInstallationId}
                     onChange={event =>
-                      setControllerSecretName(event.target.value)
+                      setTrustInstallationId(event.target.value)
                     }
-                    placeholder='e.g. example-web-tls'
-                    autoComplete='off'
-                  />
-                  <FormHelperText>
-                    The Kubernetes Secret the cert-manager Certificate will
-                    write to. Only its metadata is ever read back by TokenTimer.
-                  </FormHelperText>
-                </FormControl>
-                <SimpleGrid columns={2} spacing={2}>
-                  <FormControl isRequired>
-                    <FormLabel fontSize='sm'>Issuer kind</FormLabel>
+                  >
+                    {trustRevocableInstallations.map(row => {
+                      const agent = agents.find(a => a.id === row.agentId);
+                      return (
+                        <option key={row.id} value={row.id}>
+                          {`${row.owner} — ${agent ? agentSelectLabel(agent) : row.host} (${row.store})`}
+                        </option>
+                      );
+                    })}
+                  </Select>
+                )}
+                <FormHelperText>
+                  {isDistributeTrust
+                    ? 'The agent whose OS trust store will receive this anchor.'
+                    : trustRevocableInstallations.length
+                      ? 'Revoke always targets an existing installation reference, not a free-typed owner.'
+                      : 'No live installations to revoke for this anchor.'}
+                </FormHelperText>
+              </FormControl>
+              {isDistributeTrust ? (
+                <FormControl isRequired>
+                  <FormLabel fontSize='sm'>Owner</FormLabel>
+                  <ButtonGroup size='sm' isAttached variant='outline' mb={2}>
+                    <Button
+                      colorScheme={
+                        trustOwnerMode === 'existing' ? 'blue' : undefined
+                      }
+                      variant={
+                        trustOwnerMode === 'existing' ? 'solid' : 'outline'
+                      }
+                      onClick={() => setTrustOwnerMode('existing')}
+                      isDisabled={trustExistingOwners.length === 0}
+                    >
+                      Existing owner
+                    </Button>
+                    <Button
+                      colorScheme={
+                        trustOwnerMode === 'new' ? 'blue' : undefined
+                      }
+                      variant={trustOwnerMode === 'new' ? 'solid' : 'outline'}
+                      onClick={() => setTrustOwnerMode('new')}
+                    >
+                      New owner
+                    </Button>
+                  </ButtonGroup>
+                  {trustOwnerMode === 'existing' ? (
                     <Select
                       size='sm'
-                      value={controllerIssuerKind}
-                      onChange={event =>
-                        setControllerIssuerKind(event.target.value)
+                      placeholder={
+                        trustExistingOwners.length
+                          ? 'Select an existing owner'
+                          : 'No existing owners for this anchor yet'
                       }
+                      value={trustExistingOwner}
+                      onChange={event =>
+                        setTrustExistingOwner(event.target.value)
+                      }
+                      isDisabled={trustExistingOwners.length === 0}
                     >
-                      {CONTROLLER_ISSUER_KINDS.map(kind => (
-                        <option key={kind} value={kind}>
-                          {kind}
+                      {trustExistingOwners.map(owner => (
+                        <option key={owner} value={owner}>
+                          {owner}
                         </option>
                       ))}
                     </Select>
-                  </FormControl>
-                  <FormControl isRequired>
-                    <FormLabel fontSize='sm'>Issuer name</FormLabel>
+                  ) : (
                     <Input
                       size='sm'
-                      value={controllerIssuerName}
-                      onChange={event =>
-                        setControllerIssuerName(event.target.value)
-                      }
-                      placeholder='e.g. letsencrypt-prod'
+                      value={trustNewOwner}
+                      onChange={event => setTrustNewOwner(event.target.value)}
+                      placeholder='e.g. a team or system label'
+                      maxLength={128}
                       autoComplete='off'
                     />
-                  </FormControl>
-                </SimpleGrid>
-                <FormControl isRequired>
-                  <FormLabel fontSize='sm'>DNS names</FormLabel>
-                  <Textarea
-                    size='sm'
-                    rows={2}
-                    value={controllerDnsNames}
-                    onChange={event =>
-                      setControllerDnsNames(event.target.value)
-                    }
-                    placeholder='Comma or newline separated, e.g. example.com, www.example.com'
-                  />
-                  <FormHelperText>
-                    At least one DNS name is required; wildcards (e.g.
-                    *.example.com) are accepted.
-                  </FormHelperText>
-                </FormControl>
-              </>
-            ) : null}
-            {isIssue ? null : (
-              <>
-                <FormControl
-                  isRequired={
-                    subjectRequiredForOperation || Boolean(subjectId.trim())
-                  }
-                >
-                  <FormLabel fontSize='sm'>Subject type</FormLabel>
-                  <Select
-                    size='sm'
-                    placeholder='No subject'
-                    value={subjectType}
-                    onChange={event => {
-                      setSubjectType(event.target.value);
-                      setSubjectId('');
-                    }}
+                  )}
+                  <FormHelperText
+                    color={trustNewOwnerCollision ? 'orange.500' : undefined}
                   >
-                    {MANUAL_JOB_SUBJECT_TYPES.map(type => (
-                      <option key={type} value={type}>
-                        {subjectTypeLabel(type)}
-                      </option>
-                    ))}
-                  </Select>
-                  <FormHelperText>
-                    {subjectRequiredForOperation
-                      ? 'Required for this operation, together with subject ID.'
-                      : 'Required together with subject ID, or leave both empty.'}
+                    {trustNewOwnerCollision
+                      ? `Close to existing owner "${trustNewOwnerCollision}" (case differs only). Reference counting is exact-match, so this would create a separate, dangling reference. Consider reusing the existing owner instead.`
+                      : 'Picked from an existing reference on this agent/anchor, or a new label. Reference counting matches this string exactly, including case.'}
                   </FormHelperText>
                 </FormControl>
-                <FormControl
-                  isRequired={
-                    subjectRequiredForOperation || Boolean(subjectType)
-                  }
-                >
-                  <FormLabel fontSize='sm'>Subject ID</FormLabel>
+              ) : (
+                <FormControl>
+                  <FormLabel fontSize='sm'>Owner</FormLabel>
                   <Input
                     size='sm'
-                    value={subjectId}
-                    onChange={event => setSubjectId(event.target.value)}
-                    maxLength={SUBJECT_ID_MAX_LENGTH}
-                    placeholder={
-                      SUBJECT_ID_PLACEHOLDERS[subjectType] ||
-                      DEFAULT_SUBJECT_ID_PLACEHOLDER
-                    }
-                    list={
-                      subjectSuggestions.length
-                        ? MANUAL_JOB_SUBJECT_SUGGESTIONS_LIST_ID
-                        : undefined
-                    }
-                    autoComplete='off'
+                    value={trustSelectedInstallation?.owner || ''}
+                    isReadOnly
+                    isDisabled
                   />
                   <FormHelperText>
-                    {subjectRequiredForOperation
-                      ? 'Required for this operation, together with subject type.'
-                      : 'Required together with subject type, or leave both empty.'}
+                    Owner is fixed to the installation selected above.
                   </FormHelperText>
-                  {subjectSuggestions.length ? (
-                    <datalist id={MANUAL_JOB_SUBJECT_SUGGESTIONS_LIST_ID}>
-                      {subjectSuggestions.map(item => (
-                        <option
-                          key={item.id}
-                          value={item.id}
-                          label={item.label}
-                        />
-                      ))}
-                    </datalist>
-                  ) : null}
                 </FormControl>
-              </>
-            )}
-            {hidesAgentField ? null : (
-              <FormControl>
-                <FormLabel fontSize='sm'>Agent</FormLabel>
-                <Select
+              )}
+              <FormControl isRequired>
+                <FormLabel fontSize='sm'>Idempotency key</FormLabel>
+                <Input
                   size='sm'
-                  placeholder='Any eligible agent (default)'
-                  value={assignedAgentId}
-                  onChange={event => setAssignedAgentId(event.target.value)}
-                >
-                  {assignableAgents.map(agent => (
-                    <option key={agent.id} value={agent.id}>
-                      {agentSelectLabel(agent)}
-                    </option>
-                  ))}
-                </Select>
+                  value={idempotencyKey}
+                  onChange={event => {
+                    setTrustKeyEdited(true);
+                    setIdempotencyKey(event.target.value);
+                  }}
+                  autoComplete='off'
+                />
                 <FormHelperText>
-                  Optional. Leave unset to let any agent whose declared
-                  selectors/profiles/DNS providers match claim the job first;
-                  pin to one agent to force a specific host to run it.
+                  Auto-generated per target; regenerates while unedited if the
+                  agent/owner selection changes. Override only if you need a
+                  specific retry key.
                 </FormHelperText>
               </FormControl>
-            )}
-            <FormControl isRequired={isIssue}>
-              <FormLabel fontSize='sm'>Idempotency key</FormLabel>
-              <Input
-                size='sm'
-                value={idempotencyKey}
-                onChange={event => setIdempotencyKey(event.target.value)}
-                placeholder='e.g. a client-generated request id'
-                autoComplete='off'
-              />
-              <FormHelperText>
-                {isIssue
-                  ? 'Required for issue: a retried request with the same key returns the existing job instead of provisioning a second certificate.'
-                  : 'Optional. Reusing a key returns the existing job instead of creating a duplicate.'}
-              </FormHelperText>
-            </FormControl>
-            {isControllerIssue ? null : (
-              <FormControl
-                isInvalid={payloadMode === 'json' && Boolean(payloadError)}
-              >
-                <HStack justify='space-between' align='center' mb={1}>
-                  <FormLabel fontSize='sm' mb={0}>
-                    Payload
-                  </FormLabel>
-                  <ButtonGroup size='sm' isAttached variant='outline'>
-                    <Button
-                      colorScheme={
-                        payloadMode === 'fields' ? 'blue' : undefined
-                      }
-                      variant={payloadMode === 'fields' ? 'solid' : 'outline'}
-                      onClick={() => setPayloadMode('fields')}
-                    >
-                      Fields
-                    </Button>
-                    <Button
-                      colorScheme={payloadMode === 'json' ? 'blue' : undefined}
-                      variant={payloadMode === 'json' ? 'solid' : 'outline'}
-                      onClick={() => {
-                        // Switching to JSON seeds the textarea from whatever
-                        // was entered in the fields tab, so nothing is lost
-                        // and an operator can start from the structured
-                        // fields and drop into raw JSON only to add what the
-                        // fields do not cover.
-                        const seeded = buildFieldsPayload();
-                        if (Object.keys(seeded).length && !payloadText.trim()) {
-                          setPayloadText(JSON.stringify(seeded, null, 2));
-                        }
-                        setPayloadMode('json');
-                      }}
-                    >
-                      JSON
-                    </Button>
-                  </ButtonGroup>
-                </HStack>
-                {payloadMode === 'fields' ? (
-                  isRenew ? (
-                    <VStack align='stretch' spacing={2}>
-                      <FormControl>
-                        <FormLabel fontSize='xs' mb={0.5}>
-                          Reason
-                        </FormLabel>
-                        <Input
-                          size='sm'
-                          value={fieldReason}
-                          onChange={event => setFieldReason(event.target.value)}
-                          placeholder='e.g. manual renewal requested by ops'
-                          autoComplete='off'
-                        />
-                      </FormControl>
-                      <FormHelperText>
-                        Optional. The only overridable field for a renew job:
-                        target, SANs, ACME command, CA, DNS-01 zone/provider,
-                        and deploy path always come from the certificate&apos;s
-                        stored renewal profile and cannot be set here.
-                      </FormHelperText>
-                    </VStack>
-                  ) : (
-                    <VStack align='stretch' spacing={2}>
-                      <FormControl isRequired={isIssue}>
-                        <FormLabel fontSize='xs' mb={0.5}>
-                          Target domain
-                        </FormLabel>
-                        <Input
-                          size='sm'
-                          value={fieldTarget}
-                          onChange={event => setFieldTarget(event.target.value)}
-                          placeholder='e.g. example.com'
-                          autoComplete='off'
-                        />
-                      </FormControl>
-                      <FormControl>
-                        <FormLabel fontSize='xs' mb={0.5}>
-                          SANs
-                        </FormLabel>
-                        <Input
-                          size='sm'
-                          value={fieldSans}
-                          onChange={event => setFieldSans(event.target.value)}
-                          placeholder='Comma or newline separated (defaults to target)'
-                          autoComplete='off'
-                        />
-                      </FormControl>
-                      <SimpleGrid columns={2} spacing={2}>
-                        <FormControl isRequired={isIssue}>
-                          <FormLabel fontSize='xs' mb={0.5}>
-                            Command ref
-                          </FormLabel>
-                          <Input
-                            size='sm'
-                            value={fieldCommandRef}
-                            onChange={event =>
-                              setFieldCommandRef(event.target.value)
-                            }
-                            placeholder='e.g. certbot-csr'
-                            autoComplete='off'
-                          />
-                        </FormControl>
-                        <FormControl isRequired={isIssue}>
-                          <FormLabel fontSize='xs' mb={0.5}>
-                            DNS provider
-                          </FormLabel>
-                          <Input
-                            size='sm'
-                            value={fieldDnsProvider}
-                            onChange={event =>
-                              setFieldDnsProvider(event.target.value)
-                            }
-                            placeholder='e.g. cloudflare'
-                            autoComplete='off'
-                          />
-                        </FormControl>
-                      </SimpleGrid>
-                      <FormControl isRequired={isIssue}>
-                        <FormLabel fontSize='xs' mb={0.5}>
-                          CA endpoint
-                        </FormLabel>
-                        <Input
-                          size='sm'
-                          value={fieldCaEndpoint}
-                          onChange={event =>
-                            setFieldCaEndpoint(event.target.value)
-                          }
-                          placeholder='e.g. https://acme-v02.api.letsencrypt.org/directory'
-                          autoComplete='off'
-                        />
-                      </FormControl>
-                      <SimpleGrid columns={2} spacing={2}>
-                        <FormControl isRequired={isIssue}>
-                          <FormLabel fontSize='xs' mb={0.5}>
-                            DNS zone
-                          </FormLabel>
-                          <Input
-                            size='sm'
-                            value={fieldDnsZone}
-                            onChange={event =>
-                              setFieldDnsZone(event.target.value)
-                            }
-                            placeholder='e.g. example.com'
-                            autoComplete='off'
-                          />
-                        </FormControl>
-                        <FormControl isRequired={isIssue}>
-                          <FormLabel fontSize='xs' mb={0.5}>
-                            Cert file path
-                          </FormLabel>
-                          <Input
-                            size='sm'
-                            value={fieldCertPath}
-                            onChange={event =>
-                              setFieldCertPath(event.target.value)
-                            }
-                            placeholder='e.g. /etc/ssl/example.com.pem'
-                            autoComplete='off'
-                          />
-                        </FormControl>
-                      </SimpleGrid>
-                      <FormHelperText>
-                        {isIssue
-                          ? 'Required for issue: target, command ref, CA endpoint, DNS zone, DNS provider, and cert path.'
-                          : 'Optional. Fills the same execution payload keys a deploy/reload job reads. Switch to JSON for anything not listed here.'}
-                      </FormHelperText>
-                    </VStack>
-                  )
-                ) : (
-                  <>
-                    <Textarea
-                      size='sm'
-                      fontFamily='mono'
-                      fontSize='xs'
-                      rows={6}
-                      value={payloadText}
-                      onChange={handlePayloadChange}
-                      placeholder={
-                        isRenew
-                          ? RENEW_PAYLOAD_JSON_EXAMPLE
-                          : PAYLOAD_JSON_EXAMPLE
-                      }
-                    />
-                    <FormHelperText>
-                      {payloadError ||
-                        (isIssue
-                          ? 'Required: target, commandRef, caEndpoint, dnsZone, dnsProvider, and certPath. sans defaults to [target] when omitted.'
-                          : isRenew
-                            ? "Optional. Only 'reason' is accepted here; every other execution field comes from the certificate's stored renewal profile."
-                            : 'Optional. Free-form JSON merged into the job payload.')}
-                    </FormHelperText>
-                  </>
-                )}
-              </FormControl>
-            )}
-            {isControllerIssue ? null : (
               <FormControl>
                 <Checkbox
                   size='sm'
@@ -1058,11 +930,521 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
                 <FormHelperText>
                   The job starts at &quot;Pending approval&quot; instead of
                   claimable; an authorized workspace member other than you must
-                  approve it from this page before an agent can pick it up.
+                  approve it before an agent can pick it up.
                 </FormHelperText>
               </FormControl>
-            )}
-          </VStack>
+            </VStack>
+          ) : (
+            <VStack align='stretch' spacing={4}>
+              <Alert status='info' variant='subtle' borderRadius='md'>
+                <AlertIcon boxSize={4} />
+                <AlertDescription fontSize='sm'>
+                  The job is recorded with source &quot;api&quot; and appears at
+                  the start of the job&apos;s history.
+                </AlertDescription>
+              </Alert>
+              <FormControl isRequired>
+                <FormLabel fontSize='sm'>Operation</FormLabel>
+                <Select
+                  size='sm'
+                  placeholder='Select an operation'
+                  value={operation}
+                  onChange={handleOperationChange}
+                >
+                  {CERTOPS_JOB_OPERATIONS.map(op => (
+                    <option key={op} value={op}>
+                      {jobOperationLabel(op)}
+                    </option>
+                  ))}
+                </Select>
+                {isIssue ? (
+                  <FormHelperText>
+                    Issue creates a new managed certificate; TokenTimer assigns
+                    its ID once the request is accepted, so subject fields below
+                    are hidden.
+                  </FormHelperText>
+                ) : null}
+              </FormControl>
+              {isIssue ? (
+                <FormControl>
+                  <FormLabel fontSize='sm'>Executor</FormLabel>
+                  <ButtonGroup size='sm' isAttached variant='outline'>
+                    {JOB_EXECUTORS.map(option => (
+                      <Button
+                        key={option.value}
+                        colorScheme={
+                          executor === option.value ? 'blue' : undefined
+                        }
+                        variant={
+                          executor === option.value ? 'solid' : 'outline'
+                        }
+                        onClick={() => setExecutor(option.value)}
+                      >
+                        {option.label}
+                      </Button>
+                    ))}
+                  </ButtonGroup>
+                  <FormHelperText>
+                    {isControllerIssue
+                      ? 'Hands a strict public desired state (namespace, certificate/secret name, issuer, DNS names) to a controller bound to the chosen cluster. No manifest, Secret data, CSR, or private key material is ever sent.'
+                      : 'The default path: an agent runs the ACME/DNS-01 issuance below.'}
+                  </FormHelperText>
+                </FormControl>
+              ) : null}
+              {isControllerIssue ? (
+                <>
+                  <FormControl isRequired>
+                    <FormLabel fontSize='sm'>Cluster</FormLabel>
+                    <Select
+                      size='sm'
+                      placeholder={
+                        controllerClusters.length
+                          ? 'Select a cluster'
+                          : 'No controller-bound clusters found'
+                      }
+                      value={controllerClusterId}
+                      onChange={event =>
+                        setControllerClusterId(event.target.value)
+                      }
+                      isDisabled={controllerClusters.length === 0}
+                    >
+                      {controllerClusters.map(clusterId => (
+                        <option key={clusterId} value={clusterId}>
+                          {clusterId}
+                        </option>
+                      ))}
+                    </Select>
+                    <FormHelperText>
+                      {controllerClusters.length
+                        ? 'Only clusters with an active API token scoped to certops:observations:write or certops:provision:execute appear here.'
+                        : 'Create an API token scoped to a cluster on the API Tokens tab first, then come back here.'}
+                    </FormHelperText>
+                  </FormControl>
+                  <SimpleGrid columns={2} spacing={2}>
+                    <FormControl isRequired>
+                      <FormLabel fontSize='sm'>Namespace</FormLabel>
+                      <Input
+                        size='sm'
+                        value={controllerNamespace}
+                        onChange={event =>
+                          setControllerNamespace(event.target.value)
+                        }
+                        placeholder='e.g. default'
+                        autoComplete='off'
+                      />
+                    </FormControl>
+                    <FormControl isRequired>
+                      <FormLabel fontSize='sm'>Certificate name</FormLabel>
+                      <Input
+                        size='sm'
+                        value={controllerCertificateName}
+                        onChange={event =>
+                          setControllerCertificateName(event.target.value)
+                        }
+                        placeholder='e.g. example-web-tls'
+                        autoComplete='off'
+                      />
+                    </FormControl>
+                  </SimpleGrid>
+                  <FormControl isRequired>
+                    <FormLabel fontSize='sm'>Secret name</FormLabel>
+                    <Input
+                      size='sm'
+                      value={controllerSecretName}
+                      onChange={event =>
+                        setControllerSecretName(event.target.value)
+                      }
+                      placeholder='e.g. example-web-tls'
+                      autoComplete='off'
+                    />
+                    <FormHelperText>
+                      The Kubernetes Secret the cert-manager Certificate will
+                      write to. Only its metadata is ever read back by
+                      TokenTimer.
+                    </FormHelperText>
+                  </FormControl>
+                  <SimpleGrid columns={2} spacing={2}>
+                    <FormControl isRequired>
+                      <FormLabel fontSize='sm'>Issuer kind</FormLabel>
+                      <Select
+                        size='sm'
+                        value={controllerIssuerKind}
+                        onChange={event =>
+                          setControllerIssuerKind(event.target.value)
+                        }
+                      >
+                        {CONTROLLER_ISSUER_KINDS.map(kind => (
+                          <option key={kind} value={kind}>
+                            {kind}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <FormControl isRequired>
+                      <FormLabel fontSize='sm'>Issuer name</FormLabel>
+                      <Input
+                        size='sm'
+                        value={controllerIssuerName}
+                        onChange={event =>
+                          setControllerIssuerName(event.target.value)
+                        }
+                        placeholder='e.g. letsencrypt-prod'
+                        autoComplete='off'
+                      />
+                    </FormControl>
+                  </SimpleGrid>
+                  <FormControl isRequired>
+                    <FormLabel fontSize='sm'>DNS names</FormLabel>
+                    <Textarea
+                      size='sm'
+                      rows={2}
+                      value={controllerDnsNames}
+                      onChange={event =>
+                        setControllerDnsNames(event.target.value)
+                      }
+                      placeholder='Comma or newline separated, e.g. example.com, www.example.com'
+                    />
+                    <FormHelperText>
+                      At least one DNS name is required; wildcards (e.g.
+                      *.example.com) are accepted.
+                    </FormHelperText>
+                  </FormControl>
+                </>
+              ) : null}
+              {isIssue ? null : (
+                <>
+                  <FormControl
+                    isRequired={
+                      subjectRequiredForOperation || Boolean(subjectId.trim())
+                    }
+                  >
+                    <FormLabel fontSize='sm'>Subject type</FormLabel>
+                    <Select
+                      size='sm'
+                      placeholder='No subject'
+                      value={subjectType}
+                      onChange={event => {
+                        setSubjectType(event.target.value);
+                        setSubjectId('');
+                      }}
+                    >
+                      {MANUAL_JOB_SUBJECT_TYPES.map(type => (
+                        <option key={type} value={type}>
+                          {subjectTypeLabel(type)}
+                        </option>
+                      ))}
+                    </Select>
+                    <FormHelperText>
+                      {subjectRequiredForOperation
+                        ? 'Required for this operation, together with subject ID.'
+                        : 'Required together with subject ID, or leave both empty.'}
+                    </FormHelperText>
+                  </FormControl>
+                  <FormControl
+                    isRequired={
+                      subjectRequiredForOperation || Boolean(subjectType)
+                    }
+                  >
+                    <FormLabel fontSize='sm'>Subject ID</FormLabel>
+                    <Input
+                      size='sm'
+                      value={subjectId}
+                      onChange={event => setSubjectId(event.target.value)}
+                      maxLength={SUBJECT_ID_MAX_LENGTH}
+                      placeholder={
+                        SUBJECT_ID_PLACEHOLDERS[subjectType] ||
+                        DEFAULT_SUBJECT_ID_PLACEHOLDER
+                      }
+                      list={
+                        subjectSuggestions.length
+                          ? MANUAL_JOB_SUBJECT_SUGGESTIONS_LIST_ID
+                          : undefined
+                      }
+                      autoComplete='off'
+                    />
+                    <FormHelperText>
+                      {subjectRequiredForOperation
+                        ? 'Required for this operation, together with subject type.'
+                        : 'Required together with subject type, or leave both empty.'}
+                    </FormHelperText>
+                    {subjectSuggestions.length ? (
+                      <datalist id={MANUAL_JOB_SUBJECT_SUGGESTIONS_LIST_ID}>
+                        {subjectSuggestions.map(item => (
+                          <option
+                            key={item.id}
+                            value={item.id}
+                            label={item.label}
+                          />
+                        ))}
+                      </datalist>
+                    ) : null}
+                  </FormControl>
+                </>
+              )}
+              {hidesAgentField ? null : (
+                <FormControl>
+                  <FormLabel fontSize='sm'>Agent</FormLabel>
+                  <Select
+                    size='sm'
+                    placeholder='Any eligible agent (default)'
+                    value={assignedAgentId}
+                    onChange={event => setAssignedAgentId(event.target.value)}
+                  >
+                    {assignableAgents.map(agent => (
+                      <option key={agent.id} value={agent.id}>
+                        {agentSelectLabel(agent)}
+                      </option>
+                    ))}
+                  </Select>
+                  <FormHelperText>
+                    Optional. Leave unset to let any agent whose declared
+                    selectors/profiles/DNS providers match claim the job first;
+                    pin to one agent to force a specific host to run it.
+                  </FormHelperText>
+                </FormControl>
+              )}
+              <FormControl isRequired={isIssue}>
+                <FormLabel fontSize='sm'>Idempotency key</FormLabel>
+                <Input
+                  size='sm'
+                  value={idempotencyKey}
+                  onChange={event => setIdempotencyKey(event.target.value)}
+                  placeholder='e.g. a client-generated request id'
+                  autoComplete='off'
+                />
+                <FormHelperText>
+                  {isIssue
+                    ? 'Required for issue: a retried request with the same key returns the existing job instead of provisioning a second certificate.'
+                    : 'Optional. Reusing a key returns the existing job instead of creating a duplicate.'}
+                </FormHelperText>
+              </FormControl>
+              {isControllerIssue ? null : (
+                <FormControl
+                  isInvalid={payloadMode === 'json' && Boolean(payloadError)}
+                >
+                  <HStack justify='space-between' align='center' mb={1}>
+                    <FormLabel fontSize='sm' mb={0}>
+                      Payload
+                    </FormLabel>
+                    <ButtonGroup size='sm' isAttached variant='outline'>
+                      <Button
+                        colorScheme={
+                          payloadMode === 'fields' ? 'blue' : undefined
+                        }
+                        variant={payloadMode === 'fields' ? 'solid' : 'outline'}
+                        onClick={() => setPayloadMode('fields')}
+                      >
+                        Fields
+                      </Button>
+                      <Button
+                        colorScheme={
+                          payloadMode === 'json' ? 'blue' : undefined
+                        }
+                        variant={payloadMode === 'json' ? 'solid' : 'outline'}
+                        onClick={() => {
+                          // Switching to JSON seeds the textarea from whatever
+                          // was entered in the fields tab, so nothing is lost
+                          // and an operator can start from the structured
+                          // fields and drop into raw JSON only to add what the
+                          // fields do not cover.
+                          const seeded = buildFieldsPayload();
+                          if (
+                            Object.keys(seeded).length &&
+                            !payloadText.trim()
+                          ) {
+                            setPayloadText(JSON.stringify(seeded, null, 2));
+                          }
+                          setPayloadMode('json');
+                        }}
+                      >
+                        JSON
+                      </Button>
+                    </ButtonGroup>
+                  </HStack>
+                  {payloadMode === 'fields' ? (
+                    isRenew ? (
+                      <VStack align='stretch' spacing={2}>
+                        <FormControl>
+                          <FormLabel fontSize='xs' mb={0.5}>
+                            Reason
+                          </FormLabel>
+                          <Input
+                            size='sm'
+                            value={fieldReason}
+                            onChange={event =>
+                              setFieldReason(event.target.value)
+                            }
+                            placeholder='e.g. manual renewal requested by ops'
+                            autoComplete='off'
+                          />
+                        </FormControl>
+                        <FormHelperText>
+                          Optional. The only overridable field for a renew job:
+                          target, SANs, ACME command, CA, DNS-01 zone/provider,
+                          and deploy path always come from the
+                          certificate&apos;s stored renewal profile and cannot
+                          be set here.
+                        </FormHelperText>
+                      </VStack>
+                    ) : (
+                      <VStack align='stretch' spacing={2}>
+                        <FormControl isRequired={isIssue}>
+                          <FormLabel fontSize='xs' mb={0.5}>
+                            Target domain
+                          </FormLabel>
+                          <Input
+                            size='sm'
+                            value={fieldTarget}
+                            onChange={event =>
+                              setFieldTarget(event.target.value)
+                            }
+                            placeholder='e.g. example.com'
+                            autoComplete='off'
+                          />
+                        </FormControl>
+                        <FormControl>
+                          <FormLabel fontSize='xs' mb={0.5}>
+                            SANs
+                          </FormLabel>
+                          <Input
+                            size='sm'
+                            value={fieldSans}
+                            onChange={event => setFieldSans(event.target.value)}
+                            placeholder='Comma or newline separated (defaults to target)'
+                            autoComplete='off'
+                          />
+                        </FormControl>
+                        <SimpleGrid columns={2} spacing={2}>
+                          <FormControl isRequired={isIssue}>
+                            <FormLabel fontSize='xs' mb={0.5}>
+                              Command ref
+                            </FormLabel>
+                            <Input
+                              size='sm'
+                              value={fieldCommandRef}
+                              onChange={event =>
+                                setFieldCommandRef(event.target.value)
+                              }
+                              placeholder='e.g. certbot-csr'
+                              autoComplete='off'
+                            />
+                          </FormControl>
+                          <FormControl isRequired={isIssue}>
+                            <FormLabel fontSize='xs' mb={0.5}>
+                              DNS provider
+                            </FormLabel>
+                            <Input
+                              size='sm'
+                              value={fieldDnsProvider}
+                              onChange={event =>
+                                setFieldDnsProvider(event.target.value)
+                              }
+                              placeholder='e.g. cloudflare'
+                              autoComplete='off'
+                            />
+                          </FormControl>
+                        </SimpleGrid>
+                        <FormControl isRequired={isIssue}>
+                          <FormLabel fontSize='xs' mb={0.5}>
+                            CA endpoint
+                          </FormLabel>
+                          <Input
+                            size='sm'
+                            value={fieldCaEndpoint}
+                            onChange={event =>
+                              setFieldCaEndpoint(event.target.value)
+                            }
+                            placeholder='e.g. https://acme-v02.api.letsencrypt.org/directory'
+                            autoComplete='off'
+                          />
+                        </FormControl>
+                        <SimpleGrid columns={2} spacing={2}>
+                          <FormControl isRequired={isIssue}>
+                            <FormLabel fontSize='xs' mb={0.5}>
+                              DNS zone
+                            </FormLabel>
+                            <Input
+                              size='sm'
+                              value={fieldDnsZone}
+                              onChange={event =>
+                                setFieldDnsZone(event.target.value)
+                              }
+                              placeholder='e.g. example.com'
+                              autoComplete='off'
+                            />
+                          </FormControl>
+                          <FormControl isRequired={isIssue}>
+                            <FormLabel fontSize='xs' mb={0.5}>
+                              Cert file path
+                            </FormLabel>
+                            <Input
+                              size='sm'
+                              value={fieldCertPath}
+                              onChange={event =>
+                                setFieldCertPath(event.target.value)
+                              }
+                              placeholder='e.g. /etc/ssl/example.com.pem'
+                              autoComplete='off'
+                            />
+                          </FormControl>
+                        </SimpleGrid>
+                        <FormHelperText>
+                          {isIssue
+                            ? 'Required for issue: target, command ref, CA endpoint, DNS zone, DNS provider, and cert path.'
+                            : 'Optional. Fills the same execution payload keys a deploy/reload job reads. Switch to JSON for anything not listed here.'}
+                        </FormHelperText>
+                      </VStack>
+                    )
+                  ) : (
+                    <>
+                      <Textarea
+                        size='sm'
+                        fontFamily='mono'
+                        fontSize='xs'
+                        rows={6}
+                        value={payloadText}
+                        onChange={handlePayloadChange}
+                        placeholder={
+                          isRenew
+                            ? RENEW_PAYLOAD_JSON_EXAMPLE
+                            : PAYLOAD_JSON_EXAMPLE
+                        }
+                      />
+                      <FormHelperText>
+                        {payloadError ||
+                          (isIssue
+                            ? 'Required: target, commandRef, caEndpoint, dnsZone, dnsProvider, and certPath. sans defaults to [target] when omitted.'
+                            : isRenew
+                              ? "Optional. Only 'reason' is accepted here; every other execution field comes from the certificate's stored renewal profile."
+                              : 'Optional. Free-form JSON merged into the job payload.')}
+                      </FormHelperText>
+                    </>
+                  )}
+                </FormControl>
+              )}
+              {isControllerIssue ? null : (
+                <FormControl>
+                  <Checkbox
+                    size='sm'
+                    isChecked={requiresApproval}
+                    onChange={event =>
+                      setRequiresApproval(event.target.checked)
+                    }
+                  >
+                    <Text as='span' fontSize='sm'>
+                      Require approval before this job can run
+                    </Text>
+                  </Checkbox>
+                  <FormHelperText>
+                    The job starts at &quot;Pending approval&quot; instead of
+                    claimable; an authorized workspace member other than you
+                    must approve it from this page before an agent can pick it
+                    up.
+                  </FormHelperText>
+                </FormControl>
+              )}
+            </VStack>
+          )}
         </ModalBody>
         <ModalFooter {...footerProps}>
           <Button
@@ -1080,7 +1462,11 @@ export default function CreateManualJobModal({ isOpen, onClose, onCreated }) {
             isLoading={submitting}
             loadingText='Creating'
           >
-            {isControllerIssue ? 'Create provisioning intent' : 'Create job'}
+            {isControllerIssue
+              ? 'Create provisioning intent'
+              : isTrustOp
+                ? jobOperationLabel(trustOp.operation)
+                : 'Create job'}
           </Button>
         </ModalFooter>
       </DashboardModalFrame>

--- a/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
+++ b/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
@@ -755,7 +755,9 @@ export default function CreateManualJobModal({
         <ModalHeader {...headerProps}>
           <DashboardModalTitle>
             {isTrustOp
-              ? `${jobOperationLabel(trustOp.operation)} trust anchor`
+              ? // jobOperationLabel already ends in "trust" (e.g. "Distribute
+                // trust"), so appending the full "trust anchor" would stutter.
+                `${jobOperationLabel(trustOp.operation)} anchor`
               : 'Create manual job'}
           </DashboardModalTitle>
           <DashboardModalDescription>
@@ -1465,7 +1467,7 @@ export default function CreateManualJobModal({
             {isControllerIssue
               ? 'Create provisioning intent'
               : isTrustOp
-                ? jobOperationLabel(trustOp.operation)
+                ? `${jobOperationLabel(trustOp.operation)} anchor`
                 : 'Create job'}
           </Button>
         </ModalFooter>

--- a/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
+++ b/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
@@ -1,0 +1,727 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Collapse,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  HStack,
+  Icon,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Select,
+  Spinner,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Textarea,
+  Th,
+  Thead,
+  Tr,
+  useColorModeValue,
+  VStack,
+} from '@chakra-ui/react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  DashboardModalDescription,
+  DashboardModalFrame,
+  DashboardModalTitle,
+  useDashboardModalProps,
+} from '../DashboardModalFrame.jsx';
+import {
+  DashboardActionButton,
+  DashboardErrorAlert,
+} from '../DashboardPrimitives.jsx';
+import CopyableId from '../CopyableId.jsx';
+import CreateManualJobModal from './CreateManualJobModal.jsx';
+import {
+  CERTOPS_TRUST_ANCHOR_TYPES,
+  createTrustAnchor,
+  retireTrustAnchor,
+} from './certopsTrustAnchorsApi.js';
+import {
+  useCertOpsTrustAnchorInstallations,
+  useCertOpsTrustAnchors,
+} from './useCertOpsTrustAnchors.js';
+import { formatDateTime, truncateId } from './certopsJobsFormat';
+import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
+import { showSuccess } from '../../utils/toast.js';
+
+const ANCHOR_STATUS_SCHEME = { active: 'green', revoked: 'gray' };
+const ANCHOR_TYPE_LABEL = { root: 'Root', intermediate: 'Intermediate' };
+
+const LIVE_INSTALLATION_STATE_SET = new Set([
+  'pending_install',
+  'installed',
+  'pending_remove',
+]);
+
+const INSTALLATION_STATE_SCHEME = {
+  pending_install: 'orange',
+  installed: 'green',
+  pending_remove: 'orange',
+  removed: 'gray',
+};
+const INSTALLATION_STATE_LABEL = {
+  pending_install: 'Pending install',
+  installed: 'Installed',
+  pending_remove: 'Pending remove',
+  removed: 'Removed',
+};
+
+function AnchorStatusBadge({ status }) {
+  const key = String(status || '').toLowerCase();
+  return (
+    <Badge
+      colorScheme={ANCHOR_STATUS_SCHEME[key] || 'gray'}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+    >
+      {key === 'active'
+        ? 'Active'
+        : key === 'revoked'
+          ? 'Revoked'
+          : status || 'Unknown'}
+    </Badge>
+  );
+}
+
+function InstallationStateBadge({ state }) {
+  const key = String(state || '').toLowerCase();
+  return (
+    <Badge
+      colorScheme={INSTALLATION_STATE_SCHEME[key] || 'gray'}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+    >
+      {INSTALLATION_STATE_LABEL[key] || (state ? String(state) : 'Unknown')}
+    </Badge>
+  );
+}
+
+const ANCHOR_TRUST_ANCHOR_PEM_ERROR_MESSAGE =
+  'That does not look like a single CA certificate (Basic Constraints CA=true). Bundles and leaf/server certificates are rejected.';
+
+function createTrustAnchorErrorMessage(err) {
+  const code = err?.response?.data?.code;
+  if (code === 'CERTOPS_TRUST_ANCHOR_PEM_INVALID') {
+    return ANCHOR_TRUST_ANCHOR_PEM_ERROR_MESSAGE;
+  }
+  if (err?.response?.status === 403) {
+    return 'Trust-anchor management requires workspace admin.';
+  }
+  return err?.response?.data?.error || 'Could not approve this trust anchor.';
+}
+
+/**
+ * Approve a CA certificate as a workspace trust anchor. Re-submitting the
+ * same fingerprint (e.g. to fix a typo'd name) updates the row in place
+ * rather than creating a duplicate; the server does not distinguish this
+ * case in its response, so this form always shows a plain success toast.
+ */
+function CreateTrustAnchorModal({ isOpen, onClose, onCreated }) {
+  const {
+    overlayProps,
+    headerProps,
+    bodyProps,
+    footerProps,
+    closeButtonProps,
+    outlineButtonProps,
+    primaryButtonProps,
+  } = useDashboardModalProps();
+
+  const [name, setName] = useState('');
+  const [anchorType, setAnchorType] = useState(CERTOPS_TRUST_ANCHOR_TYPES[0]);
+  const [pem, setPem] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setName('');
+      setAnchorType(CERTOPS_TRUST_ANCHOR_TYPES[0]);
+      setPem('');
+      setSubmitting(false);
+      setError('');
+    }
+  }, [isOpen]);
+
+  const canSubmit = Boolean(name.trim() && anchorType && pem.trim());
+
+  const handleSubmit = async () => {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await onCreated({ name: name.trim(), anchorType, pem: pem.trim() });
+    } catch (err) {
+      setError(createTrustAnchorErrorMessage(err));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered scrollBehavior='inside'>
+      <ModalOverlay {...overlayProps} />
+      <DashboardModalFrame maxW={{ base: 'calc(100vw - 24px)', md: '560px' }}>
+        <ModalHeader {...headerProps}>
+          <DashboardModalTitle>Approve a trust anchor</DashboardModalTitle>
+          <DashboardModalDescription>
+            Only the public CA certificate is ever sent or stored; a private key
+            is never accepted here.
+          </DashboardModalDescription>
+        </ModalHeader>
+        <ModalCloseButton {...closeButtonProps} isDisabled={submitting} />
+        <ModalBody {...bodyProps}>
+          <VStack align='stretch' spacing={4}>
+            <FormControl isRequired>
+              <FormLabel fontSize='sm'>Name</FormLabel>
+              <Input
+                size='sm'
+                value={name}
+                onChange={event => setName(event.target.value)}
+                placeholder='e.g. Internal Root CA 2026'
+                maxLength={255}
+                autoComplete='off'
+              />
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel fontSize='sm'>Anchor type</FormLabel>
+              <Select
+                size='sm'
+                value={anchorType}
+                onChange={event => setAnchorType(event.target.value)}
+              >
+                {CERTOPS_TRUST_ANCHOR_TYPES.map(type => (
+                  <option key={type} value={type}>
+                    {ANCHOR_TYPE_LABEL[type] || type}
+                  </option>
+                ))}
+              </Select>
+              <FormHelperText>
+                Determines which OS store a distribute-trust job installs into
+                (Root vs. intermediate/CA); this cannot be changed after
+                creation.
+              </FormHelperText>
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel fontSize='sm'>CA certificate (PEM)</FormLabel>
+              <Textarea
+                size='sm'
+                fontFamily='mono'
+                fontSize='xs'
+                rows={8}
+                value={pem}
+                onChange={event => setPem(event.target.value)}
+                placeholder='-----BEGIN CERTIFICATE-----...'
+              />
+              <FormHelperText>
+                Exactly one certificate with Basic Constraints CA=true. Bundles
+                and leaf/server certificates are rejected.
+              </FormHelperText>
+            </FormControl>
+            {error ? (
+              <Alert status='error' borderRadius='md' variant='left-accent'>
+                <AlertIcon />
+                <AlertDescription fontSize='sm'>{error}</AlertDescription>
+              </Alert>
+            ) : null}
+          </VStack>
+        </ModalBody>
+        <ModalFooter {...footerProps}>
+          <Button
+            {...outlineButtonProps}
+            onClick={onClose}
+            isDisabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            {...primaryButtonProps}
+            ml={3}
+            onClick={handleSubmit}
+            isDisabled={!canSubmit}
+            isLoading={submitting}
+            loadingText='Approving'
+          >
+            Approve anchor
+          </Button>
+        </ModalFooter>
+      </DashboardModalFrame>
+    </Modal>
+  );
+}
+
+/**
+ * Retire a trust anchor (idempotent server-side: retiring an
+ * already-revoked anchor just returns retiredNow: false). Does not touch
+ * anything already installed on an agent; that requires a separate
+ * revoke-trust job per installation.
+ */
+function RetireTrustAnchorModal({ isOpen, onClose, anchor, onRetire }) {
+  const {
+    overlayProps,
+    headerProps,
+    bodyProps,
+    footerProps,
+    closeButtonProps,
+    dangerButtonProps,
+    outlineButtonProps,
+  } = useDashboardModalProps();
+
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setReason('');
+      setSubmitting(false);
+      setError('');
+    }
+  }, [isOpen]);
+
+  const handleConfirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await onRetire({ reason: reason.trim() || undefined });
+    } catch (err) {
+      setError(
+        err?.response?.data?.error || 'Could not retire this trust anchor.'
+      );
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered scrollBehavior='inside'>
+      <ModalOverlay {...overlayProps} />
+      <DashboardModalFrame
+        type='danger'
+        maxW={{ base: 'calc(100vw - 24px)', md: '480px' }}
+      >
+        <ModalHeader {...headerProps}>
+          <DashboardModalTitle>Retire trust anchor</DashboardModalTitle>
+          <DashboardModalDescription>
+            Marks this anchor as no longer approved for new distribute-trust
+            jobs. It does not remove anything already installed on an agent;
+            revoke each installation separately if it must come off the hosts it
+            already reached.
+          </DashboardModalDescription>
+        </ModalHeader>
+        <ModalCloseButton {...closeButtonProps} isDisabled={submitting} />
+        <ModalBody {...bodyProps}>
+          <VStack align='stretch' spacing={3}>
+            {anchor?.name ? (
+              <Text fontSize='sm' fontWeight='semibold'>
+                Anchor: {anchor.name}
+              </Text>
+            ) : null}
+            <FormControl>
+              <FormLabel fontSize='sm'>Reason (optional)</FormLabel>
+              <Textarea
+                size='sm'
+                rows={2}
+                value={reason}
+                onChange={event => setReason(event.target.value)}
+                placeholder='e.g. CA replaced, rotated ahead of expiry'
+              />
+            </FormControl>
+            {error ? (
+              <Alert status='error' borderRadius='md' variant='left-accent'>
+                <AlertIcon />
+                <AlertDescription fontSize='sm'>{error}</AlertDescription>
+              </Alert>
+            ) : null}
+          </VStack>
+        </ModalBody>
+        <ModalFooter {...footerProps}>
+          <Button
+            {...outlineButtonProps}
+            onClick={onClose}
+            isDisabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            {...dangerButtonProps}
+            ml={3}
+            onClick={handleConfirm}
+            isLoading={submitting}
+            loadingText='Retiring'
+          >
+            Retire anchor
+          </Button>
+        </ModalFooter>
+      </DashboardModalFrame>
+    </Modal>
+  );
+}
+
+/**
+ * Anchor row's expanded body: installation rows for that anchor, loaded
+ * on demand (only while expanded), plus the distribute/revoke actions
+ * that open CreateManualJobModal in trust mode with this data.
+ */
+function AnchorInstallationsBody({
+  anchor,
+  onDistribute,
+  onRevoke,
+  isWorkspaceAdmin,
+}) {
+  const { installations, loading, error, refresh } =
+    useCertOpsTrustAnchorInstallations(anchor.id);
+  const muted = useColorModeValue('gray.600', 'gray.400');
+
+  return (
+    <VStack align='stretch' spacing={3}>
+      <HStack justify='space-between' align='center' flexWrap='wrap'>
+        <Text fontSize='xs' color={muted}>
+          Where this anchor has been distributed and its current state on each
+          host.
+        </Text>
+        {isWorkspaceAdmin ? (
+          <Button
+            size='xs'
+            colorScheme='blue'
+            variant='outline'
+            onClick={() => onDistribute(anchor, installations)}
+            isDisabled={anchor.status !== 'active'}
+          >
+            Distribute to an agent
+          </Button>
+        ) : null}
+      </HStack>
+      {error ? <DashboardErrorAlert>{error}</DashboardErrorAlert> : null}
+      {loading ? (
+        <HStack spacing={2} color={muted} py={2} justify='center'>
+          <Spinner size='sm' />
+          <Text fontSize='sm'>Loading installations...</Text>
+        </HStack>
+      ) : null}
+      {!loading && !error && installations.length === 0 ? (
+        <Text fontSize='sm' color={muted} py={1}>
+          Not distributed to any agent yet.
+        </Text>
+      ) : null}
+      {!loading && installations.length > 0 ? (
+        <Table size='sm' variant='simple'>
+          <Thead>
+            <Tr>
+              <Th>Owner</Th>
+              <Th>Host</Th>
+              <Th>Store</Th>
+              <Th>State</Th>
+              <Th>Last attempt</Th>
+              {isWorkspaceAdmin ? <Th textAlign='right'>Actions</Th> : null}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {installations.map(row => (
+              <Tr key={row.id}>
+                <Td>
+                  <Text fontSize='sm'>{row.owner}</Text>
+                </Td>
+                <Td>
+                  <Text fontSize='sm'>{row.host || '--'}</Text>
+                </Td>
+                <Td>
+                  <Text fontSize='sm' fontFamily='mono'>
+                    {row.store}
+                  </Text>
+                </Td>
+                <Td>
+                  <VStack align='flex-start' spacing={0.5}>
+                    <InstallationStateBadge state={row.transitionState} />
+                    {row.lastError ? (
+                      <Text fontSize='xs' color='red.500' noOfLines={1}>
+                        {row.lastError}
+                      </Text>
+                    ) : null}
+                  </VStack>
+                </Td>
+                <Td>
+                  <Text
+                    fontSize='sm'
+                    color={muted}
+                    title={formatDateTime(row.lastAttemptAt)}
+                  >
+                    {row.lastAttemptAt
+                      ? formatDateTime(row.lastAttemptAt)
+                      : '--'}
+                  </Text>
+                </Td>
+                {isWorkspaceAdmin ? (
+                  <Td textAlign='right'>
+                    {LIVE_INSTALLATION_STATE_SET.has(row.transitionState) ? (
+                      <Button
+                        size='xs'
+                        colorScheme='red'
+                        variant='outline'
+                        onClick={() => onRevoke(anchor, installations)}
+                      >
+                        Revoke
+                      </Button>
+                    ) : (
+                      <Text fontSize='xs' color={muted}>
+                        --
+                      </Text>
+                    )}
+                  </Td>
+                ) : null}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      ) : null}
+      <Box>
+        <Button size='xs' variant='ghost' onClick={refresh}>
+          Refresh
+        </Button>
+      </Box>
+    </VStack>
+  );
+}
+
+/**
+ * Trust-anchor management panel (0.14.1): approve/retire CA certificates as
+ * workspace trust anchors, and drive distribute-trust/revoke-trust jobs
+ * against them through CreateManualJobModal's narrower trustOp mode.
+ *
+ * Gated on workspace admin, matching the certops.trust_anchor.manage bar
+ * every trust-anchor route enforces server-side; non-admins see nothing
+ * here (same pattern as the workspace kill switch), rather than a 403
+ * banner for a surface they can't act on anyway.
+ */
+export default function TrustAnchorsPanel() {
+  const { workspaceId } = useWorkspace();
+  const { enabled, isAdmin, anchors, loading, error, refresh } =
+    useCertOpsTrustAnchors();
+  const [expandedId, setExpandedId] = useState(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [retireTarget, setRetireTarget] = useState(null);
+  const [jobModalTarget, setJobModalTarget] = useState(null);
+
+  const muted = useColorModeValue('gray.600', 'gray.400');
+  const titleColor = useColorModeValue('gray.700', 'gray.200');
+  const infoBg = useColorModeValue('blue.50', 'blue.900');
+  const infoBorder = useColorModeValue('blue.200', 'blue.700');
+  const infoText = useColorModeValue('blue.800', 'blue.100');
+
+  if (enabled !== true || !isAdmin) return null;
+
+  return (
+    <Stack spacing={4} align='stretch'>
+      <HStack justify='space-between' align='start' spacing={4} flexWrap='wrap'>
+        <Box minW={0}>
+          <Text fontSize='md' fontWeight='bold' color={titleColor}>
+            Trust anchors
+          </Text>
+        </Box>
+        <DashboardActionButton
+          colorScheme='blue'
+          onClick={() => setCreateOpen(true)}
+        >
+          Approve a trust anchor
+        </DashboardActionButton>
+      </HStack>
+
+      <Alert
+        status='info'
+        variant='subtle'
+        borderRadius='md'
+        bg={infoBg}
+        border='1px solid'
+        borderColor={infoBorder}
+        py={2}
+        px={3}
+        w='100%'
+      >
+        <AlertIcon boxSize={4} />
+        <AlertDescription fontSize='sm' color={infoText} lineHeight='short'>
+          A trust anchor is a CA certificate approved for distribution to
+          agent-managed OS trust stores. Retiring an anchor stops new
+          distribute-trust jobs; it does not remove anything already installed
+          on a host.
+        </AlertDescription>
+      </Alert>
+
+      {error ? <DashboardErrorAlert>{error}</DashboardErrorAlert> : null}
+
+      {loading ? (
+        <HStack spacing={2} color={muted} py={4} justify='center'>
+          <Spinner size='sm' />
+          <Text fontSize='sm'>Loading trust anchors...</Text>
+        </HStack>
+      ) : null}
+
+      {!loading && !error && anchors.length === 0 ? (
+        <Box py={6} textAlign='center'>
+          <Text fontSize='sm' fontWeight='semibold' color={titleColor}>
+            No trust anchors approved yet.
+          </Text>
+          <Text fontSize='sm' color={muted} mt={1}>
+            Approve a CA certificate above to make it distributable to agents.
+          </Text>
+        </Box>
+      ) : null}
+
+      {!loading && anchors.length > 0 ? (
+        <VStack align='stretch' spacing={1}>
+          {anchors.map(anchor => {
+            const isOpen = expandedId === anchor.id;
+            return (
+              <Box key={anchor.id}>
+                <HStack
+                  w='full'
+                  spacing={2}
+                  px={2}
+                  py={2}
+                  borderRadius='md'
+                  cursor='pointer'
+                  role='button'
+                  tabIndex={0}
+                  aria-expanded={isOpen}
+                  onClick={() =>
+                    setExpandedId(current =>
+                      current === anchor.id ? null : anchor.id
+                    )
+                  }
+                  onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setExpandedId(current =>
+                        current === anchor.id ? null : anchor.id
+                      );
+                    }
+                  }}
+                >
+                  <Icon
+                    as={isOpen ? ChevronDown : ChevronRight}
+                    boxSize={3.5}
+                    color={muted}
+                    flexShrink={0}
+                  />
+                  <Box minW={0} flex='1'>
+                    <Text fontSize='sm' fontWeight='semibold' noOfLines={1}>
+                      {anchor.name}
+                    </Text>
+                    <HStack
+                      spacing={2}
+                      onClick={event => event.stopPropagation()}
+                    >
+                      <Text fontSize='xs' color={muted}>
+                        {ANCHOR_TYPE_LABEL[anchor.anchorType] ||
+                          anchor.anchorType}
+                      </Text>
+                      <CopyableId
+                        id={anchor.fingerprintSha256}
+                        display={truncateId(anchor.fingerprintSha256, {
+                          head: 12,
+                          tail: 6,
+                        })}
+                      />
+                    </HStack>
+                  </Box>
+                  <AnchorStatusBadge status={anchor.status} />
+                  <Text fontSize='xs' color={muted} flexShrink={0}>
+                    {formatDateTime(anchor.createdAt)}
+                  </Text>
+                  {anchor.status === 'active' ? (
+                    <Box
+                      flexShrink={0}
+                      onClick={event => event.stopPropagation()}
+                    >
+                      <Button
+                        size='xs'
+                        colorScheme='red'
+                        variant='outline'
+                        onClick={() => setRetireTarget(anchor)}
+                      >
+                        Retire
+                      </Button>
+                    </Box>
+                  ) : null}
+                </HStack>
+                <Collapse in={isOpen} animateOpacity>
+                  <Box mt={1} mb={2} ml={5} pl={3} py={2}>
+                    {isOpen ? (
+                      <AnchorInstallationsBody
+                        anchor={anchor}
+                        isWorkspaceAdmin={isAdmin}
+                        onDistribute={(target, installations) =>
+                          setJobModalTarget({
+                            anchorId: target.id,
+                            anchorName: target.name,
+                            anchorFingerprint: target.fingerprintSha256,
+                            operation: 'distribute-trust',
+                            installations,
+                          })
+                        }
+                        onRevoke={(target, installations) =>
+                          setJobModalTarget({
+                            anchorId: target.id,
+                            anchorName: target.name,
+                            anchorFingerprint: target.fingerprintSha256,
+                            operation: 'revoke-trust',
+                            installations,
+                          })
+                        }
+                      />
+                    ) : null}
+                  </Box>
+                </Collapse>
+              </Box>
+            );
+          })}
+        </VStack>
+      ) : null}
+
+      <CreateTrustAnchorModal
+        isOpen={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={async ({ name, anchorType, pem }) => {
+          await createTrustAnchor(workspaceId, { name, anchorType, pem });
+          showSuccess('Trust anchor approved');
+          setCreateOpen(false);
+          refresh();
+        }}
+      />
+      <RetireTrustAnchorModal
+        isOpen={Boolean(retireTarget)}
+        onClose={() => setRetireTarget(null)}
+        anchor={retireTarget}
+        onRetire={async ({ reason }) => {
+          await retireTrustAnchor(workspaceId, retireTarget.id, { reason });
+          showSuccess('Trust anchor retired');
+          setRetireTarget(null);
+          refresh();
+        }}
+      />
+      <CreateManualJobModal
+        isOpen={Boolean(jobModalTarget)}
+        onClose={() => setJobModalTarget(null)}
+        trustOp={jobModalTarget}
+        onCreated={() => setJobModalTarget(null)}
+      />
+    </Stack>
+  );
+}

--- a/apps/dashboard/src/components/certops/certopsJobsApi.js
+++ b/apps/dashboard/src/components/certops/certopsJobsApi.js
@@ -150,8 +150,15 @@ export async function listJobEvidence(
 /**
  * Create a manual CertOps job through the session-authenticated workspace
  * surface. source is always forced to "api" by the server. Requires
- * workspace_manager role or above.
- * @returns {Promise<{ job: object }>}
+ * workspace_manager role or above (distribute-trust/revoke-trust require
+ * the stricter certops.trust_anchor.manage admin bar, checked server-side).
+ *
+ * `agentId` and `assignedAgentId` are distinct wire fields, not aliases:
+ * `agentId` targets a trust-anchor job's specific agent (required for
+ * distribute-trust/revoke-trust, read directly by the route handler),
+ * while `assignedAgentId` is the optional pin-to-agent override every other
+ * operation accepts. A trust-op request supplies only `agentId`.
+ * @returns {Promise<{ job: object }|{ ownershipReleased: boolean, installation: object }>}
  */
 export async function createJob(
   workspaceId,
@@ -163,6 +170,8 @@ export async function createJob(
     idempotencyKey,
     requiresApproval,
     assignedAgentId,
+    agentId,
+    owner,
   } = {}
 ) {
   const body = { operation };
@@ -172,6 +181,8 @@ export async function createJob(
   if (idempotencyKey !== undefined) body.idempotencyKey = idempotencyKey;
   if (requiresApproval !== undefined) body.requiresApproval = requiresApproval;
   if (assignedAgentId !== undefined) body.assignedAgentId = assignedAgentId;
+  if (agentId !== undefined) body.agentId = agentId;
+  if (owner !== undefined) body.owner = owner;
 
   const res = await apiClient.post(`${workspaceBase(workspaceId)}/jobs`, body);
   return res.data;

--- a/apps/dashboard/src/components/certops/certopsJobsFormat.js
+++ b/apps/dashboard/src/components/certops/certopsJobsFormat.js
@@ -33,6 +33,8 @@ const JOB_OPERATION_LABELS = {
   reload: 'Reload',
   revoke: 'Revoke',
   noop: 'No-op',
+  'distribute-trust': 'Distribute trust',
+  'revoke-trust': 'Revoke trust',
 };
 
 const EVENT_TYPE_LABELS = {
@@ -74,6 +76,7 @@ const SUBJECT_TYPE_LABELS = {
   domain: 'Domain',
   endpoint: 'Endpoint',
   external: 'External',
+  trust_anchor: 'Trust anchor',
 };
 
 const REDACTED_LITERAL = '[REDACTED]';

--- a/apps/dashboard/src/components/certops/certopsTrustAnchorsApi.js
+++ b/apps/dashboard/src/components/certops/certopsTrustAnchorsApi.js
@@ -1,0 +1,95 @@
+import apiClient from '../../utils/apiClient';
+
+/**
+ * CertOps trust-anchor API helpers (session surface).
+ *
+ * Additive module scoped to `/api/v1/workspaces/:id/certops/trust-anchors*`,
+ * following the certopsAgentsApi.js style. Every route here is admin-only
+ * server-side (certops.trust_anchor.manage, above workspace_manager) and
+ * returns 404 while `certops.enabled` is off.
+ */
+
+/** Trust-anchor types a CA certificate can be approved as. */
+export const CERTOPS_TRUST_ANCHOR_TYPES = ['root', 'intermediate'];
+
+/** Trust-anchor lifecycle statuses reported by the list. */
+export const CERTOPS_TRUST_ANCHOR_STATUSES = ['active', 'revoked'];
+
+function workspaceBase(workspaceId) {
+  return `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/certops`;
+}
+
+/**
+ * List approved trust anchors for a workspace. Items carry: id, name,
+ * anchorType (root/intermediate), fingerprintSha256, subjectCommonName,
+ * status (active/revoked), source, publicMetadata, createdAt/updatedAt/
+ * revokedAt.
+ * @returns {Promise<{ items: object[] }>}
+ */
+export async function listTrustAnchors(workspaceId, { status, signal } = {}) {
+  const params = {};
+  if (status !== undefined) params.status = status;
+  const res = await apiClient.get(
+    `${workspaceBase(workspaceId)}/trust-anchors`,
+    { params, signal }
+  );
+  return res.data;
+}
+
+/**
+ * Approve a CA certificate as a trust anchor. Re-submitting the same
+ * fingerprint updates the existing row in place and reactivates it if it
+ * was previously retired, rather than creating a duplicate.
+ * @returns {Promise<{ trustAnchor: object }>}
+ */
+export async function createTrustAnchor(
+  workspaceId,
+  { name, anchorType, pem, metadata } = {}
+) {
+  const body = { name, anchorType, pem };
+  if (metadata !== undefined) body.metadata = metadata;
+  const res = await apiClient.post(
+    `${workspaceBase(workspaceId)}/trust-anchors`,
+    body
+  );
+  return res.data;
+}
+
+/**
+ * Retire a trust anchor (idempotent server-side; `retiredNow: false` when
+ * it was already revoked). Does not remove any material already installed
+ * on an agent; that requires a separate revoke-trust job.
+ * @returns {Promise<{ trustAnchor: object, retiredNow: boolean }>}
+ */
+export async function retireTrustAnchor(
+  workspaceId,
+  anchorId,
+  { reason } = {}
+) {
+  const body = {};
+  if (reason) body.reason = reason;
+  const res = await apiClient.post(
+    `${workspaceBase(workspaceId)}/trust-anchors/${encodeURIComponent(anchorId)}/retire`,
+    body
+  );
+  return res.data;
+}
+
+/**
+ * List every installation reference row for one trust anchor: where it
+ * landed (agent, store), transitionState, provenance, and lastError. Used
+ * to show an admin what a distribute/revoke action will actually affect
+ * before they take it.
+ * @returns {Promise<{ items: object[] }>}
+ */
+export async function listTrustAnchorInstallations(
+  workspaceId,
+  anchorId,
+  { signal } = {}
+) {
+  const res = await apiClient.get(
+    `${workspaceBase(workspaceId)}/trust-anchors/${encodeURIComponent(anchorId)}/installations`,
+    { signal }
+  );
+  return res.data;
+}

--- a/apps/dashboard/src/components/certops/useCertOpsTrustAnchors.js
+++ b/apps/dashboard/src/components/certops/useCertOpsTrustAnchors.js
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useWorkspace } from '../../utils/WorkspaceContext.jsx';
+import {
+  listTrustAnchorInstallations,
+  listTrustAnchors,
+} from './certopsTrustAnchorsApi';
+import { useCertOpsEnabled, useCertOpsIsWorkspaceAdmin } from './useCertOps.js';
+
+/**
+ * Loads the trust-anchor list for the active workspace.
+ *
+ * Gated on admin, not manager: every trust-anchor route requires
+ * certops.trust_anchor.manage server-side, above the workspace_manager bar
+ * useCertOpsAgents uses, since a trust anchor changes what every
+ * certificate on a host is trusted against. Non-admins get an empty list
+ * instead of a 403 banner, same pattern as useCertOpsAgents for viewers.
+ *
+ * @returns {{ enabled: boolean|null, isAdmin: boolean, anchors: object[], loading: boolean, error: string, refresh: function }}
+ */
+export function useCertOpsTrustAnchors() {
+  const { workspaceId } = useWorkspace();
+  const enabled = useCertOpsEnabled();
+  const isAdmin = useCertOpsIsWorkspaceAdmin();
+  const [anchors, setAnchors] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadTick(tick => tick + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceId || enabled !== true || !isAdmin) {
+      setAnchors([]);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError('');
+
+    listTrustAnchors(workspaceId, { signal: controller.signal })
+      .then(data => {
+        if (!cancelled) {
+          setAnchors(Array.isArray(data?.items) ? data.items : []);
+        }
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setAnchors([]);
+        setError(
+          err?.response?.data?.error ||
+            err?.message ||
+            'Could not load trust anchors.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [workspaceId, enabled, isAdmin, reloadTick]);
+
+  return { enabled, isAdmin, anchors, loading, error, refresh };
+}
+
+/**
+ * Loads installation rows for one trust anchor, on demand (only while a
+ * row is expanded in TrustAnchorsPanel). `anchorId` null/undefined skips
+ * the fetch and clears state, so collapsing a row does not leave stale
+ * data around for the next one expanded.
+ *
+ * @param {string|null} anchorId
+ * @returns {{ installations: object[], loading: boolean, error: string, refresh: function }}
+ */
+export function useCertOpsTrustAnchorInstallations(anchorId) {
+  const { workspaceId } = useWorkspace();
+  const [installations, setInstallations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadTick(tick => tick + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceId || !anchorId) {
+      setInstallations([]);
+      setLoading(false);
+      setError('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError('');
+
+    listTrustAnchorInstallations(workspaceId, anchorId, {
+      signal: controller.signal,
+    })
+      .then(data => {
+        if (!cancelled) {
+          setInstallations(Array.isArray(data?.items) ? data.items : []);
+        }
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setInstallations([]);
+        setError(
+          err?.response?.data?.error ||
+            err?.message ||
+            'Could not load trust anchor installations.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [workspaceId, anchorId, reloadTick]);
+
+  return { installations, loading, error, refresh };
+}

--- a/apps/dashboard/src/pages/certops/CertOpsAgents.jsx
+++ b/apps/dashboard/src/pages/certops/CertOpsAgents.jsx
@@ -4,6 +4,7 @@ import { useOutletContext } from 'react-router';
 import AgentFleetPanel from '../../components/certops/AgentFleetPanel.jsx';
 import BootstrapTokenList from '../../components/certops/BootstrapTokenList.jsx';
 import DeployAgentModal from '../../components/certops/DeployAgentModal.jsx';
+import TrustAnchorsPanel from '../../components/certops/TrustAnchorsPanel.jsx';
 import { useCertOpsCanManage } from '../../components/certops/useCertOps.js';
 import {
   DashboardActionButton,
@@ -44,6 +45,9 @@ export default function CertOpsAgents() {
       </DashboardPanel>
       <DashboardPanel>
         <BootstrapTokenList />
+      </DashboardPanel>
+      <DashboardPanel>
+        <TrustAnchorsPanel />
       </DashboardPanel>
 
       <DeployAgentModal

--- a/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
+++ b/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
@@ -9,12 +9,14 @@ const {
   useWorkspaceMock,
   useCertOpsAgentsMock,
   useCertOpsControllerClustersMock,
+  useCertOpsIsWorkspaceAdminMock,
   createJobMock,
   createControllerProvisionIntentMock,
 } = vi.hoisted(() => ({
   useWorkspaceMock: vi.fn(),
   useCertOpsAgentsMock: vi.fn(),
   useCertOpsControllerClustersMock: vi.fn(),
+  useCertOpsIsWorkspaceAdminMock: vi.fn(),
   createJobMock: vi.fn(),
   createControllerProvisionIntentMock: vi.fn(),
 }));
@@ -29,6 +31,10 @@ vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
 
 vi.mock('../../src/components/certops/useCertOpsControllerClusters.js', () => ({
   useCertOpsControllerClusters: useCertOpsControllerClustersMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOps.js', () => ({
+  useCertOpsIsWorkspaceAdmin: useCertOpsIsWorkspaceAdminMock,
 }));
 
 vi.mock('../../src/components/certops/certopsJobsApi.js', async () => {
@@ -76,6 +82,7 @@ beforeEach(() => {
   useWorkspaceMock.mockReset();
   useCertOpsAgentsMock.mockReset();
   useCertOpsControllerClustersMock.mockReset();
+  useCertOpsIsWorkspaceAdminMock.mockReset();
   createJobMock.mockReset();
   createControllerProvisionIntentMock.mockReset();
   useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
@@ -87,6 +94,7 @@ beforeEach(() => {
     error: '',
     refresh: vi.fn(),
   });
+  useCertOpsIsWorkspaceAdminMock.mockReturnValue(true);
 });
 
 describe('CreateManualJobModal executor toggle', () => {
@@ -353,6 +361,223 @@ describe('CreateManualJobModal renew payload fields', () => {
         subjectType: 'managed_certificate',
         subjectId: 'cert-1',
       });
+    });
+  });
+});
+
+describe('CreateManualJobModal trustOp mode', () => {
+  const AGENT_A = { id: 'agent-a', name: 'Agent A', status: 'active' };
+  const AGENT_B = { id: 'agent-b', name: 'Agent B', status: 'active' };
+
+  const distributeTrustOp = {
+    anchorId: 'anchor-1',
+    anchorName: 'Internal Root CA',
+    anchorFingerprint: 'aa'.repeat(32),
+    operation: 'distribute-trust',
+    installations: [
+      {
+        id: 'install-1',
+        agentId: 'agent-a',
+        owner: 'team-a',
+        host: 'host-a',
+        store: 'root',
+        transitionState: 'installed',
+      },
+    ],
+  };
+
+  const revokeTrustOp = {
+    ...distributeTrustOp,
+    operation: 'revoke-trust',
+  };
+
+  beforeEach(() => {
+    useCertOpsAgentsMock.mockReturnValue({ agents: [AGENT_A, AGENT_B] });
+  });
+
+  it('renders the trust-op header instead of the generic manual-job form', () => {
+    renderModal({ trustOp: distributeTrustOp });
+
+    expect(
+      screen.getByText('Distribute trust trust anchor')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Operation')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Subject type/)).not.toBeInTheDocument();
+  });
+
+  it('disables submit until an agent and owner are chosen on distribute', () => {
+    renderModal({ trustOp: distributeTrustOp });
+
+    const submit = screen.getByRole('button', { name: 'Distribute trust' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Owner/), {
+      target: { value: 'team-a' },
+    });
+
+    expect(submit).toBeEnabled();
+  });
+
+  it('submits distribute-trust with agentId/owner/subjectType trust_anchor and an auto-generated idempotency key', async () => {
+    createJobMock.mockResolvedValue({ job: { id: 'job-1' } });
+
+    renderModal({ trustOp: distributeTrustOp });
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Owner/), {
+      target: { value: 'team-a' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+
+    await waitFor(() => {
+      expect(createJobMock).toHaveBeenCalledTimes(1);
+    });
+    const [workspaceId, body] = createJobMock.mock.calls[0];
+    expect(workspaceId).toBe('ws-1');
+    expect(body.operation).toBe('distribute-trust');
+    expect(body.subjectType).toBe('trust_anchor');
+    expect(body.subjectId).toBe('anchor-1');
+    expect(body.agentId).toBe('agent-b');
+    expect(body.owner).toBe('team-a');
+    expect(body.idempotencyKey).toBeTruthy();
+  });
+
+  it("offers only the anchor's existing owners on distribute, from the installations the panel passed in", () => {
+    renderModal({ trustOp: distributeTrustOp });
+
+    const ownerSelect = screen.getByLabelText(/^Owner/);
+    expect(ownerSelect.tagName).toBe('SELECT');
+    expect(screen.getByRole('option', { name: 'team-a' })).toBeInTheDocument();
+  });
+
+  it('switches to a free-text new-owner input and submits the typed value', async () => {
+    createJobMock.mockResolvedValue({ job: { id: 'job-1' } });
+
+    renderModal({ trustOp: distributeTrustOp });
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'New owner' }));
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. a team or system label'),
+      { target: { value: 'team-b' } }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+
+    await waitFor(() => {
+      expect(createJobMock).toHaveBeenCalledTimes(1);
+    });
+    expect(createJobMock.mock.calls[0][1].owner).toBe('team-b');
+  });
+
+  it('warns on a case-only near-duplicate of an existing owner without blocking submit', () => {
+    renderModal({ trustOp: distributeTrustOp });
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'New owner' }));
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. a team or system label'),
+      { target: { value: 'Team-A' } }
+    );
+
+    expect(
+      screen.getByText(/Close to existing owner "team-a"/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Distribute trust' })
+    ).toBeEnabled();
+  });
+
+  it('on revoke, only lists live installations and derives agentId/owner from the one selected', async () => {
+    createJobMock.mockResolvedValue({ ownershipReleased: true });
+
+    renderModal({ trustOp: revokeTrustOp });
+
+    expect(
+      screen.getByRole('option', {
+        name: /team-a — Agent A \(agent-a\) \(root\)/,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'install-1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke trust' }));
+
+    await waitFor(() => {
+      expect(createJobMock).toHaveBeenCalledTimes(1);
+    });
+    const body = createJobMock.mock.calls[0][1];
+    expect(body.operation).toBe('revoke-trust');
+    expect(body.agentId).toBe('agent-a');
+    expect(body.owner).toBe('team-a');
+  });
+
+  it('excludes a removed installation from the revoke picker', () => {
+    renderModal({
+      trustOp: {
+        ...revokeTrustOp,
+        installations: [
+          {
+            ...distributeTrustOp.installations[0],
+            transitionState: 'removed',
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.queryByRole('option', { name: /team-a/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('requires workspace admin to submit', () => {
+    useCertOpsIsWorkspaceAdminMock.mockReturnValue(false);
+    renderModal({ trustOp: distributeTrustOp });
+
+    expect(
+      screen.getByText('Trust-anchor operations require workspace admin.')
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Owner/), {
+      target: { value: 'team-a' },
+    });
+    expect(
+      screen.getByRole('button', { name: 'Distribute trust' })
+    ).toBeDisabled();
+  });
+
+  it('maps CERTOPS_TRUST_JOB_IDEMPOTENCY_CONFLICT to a friendly retry message', async () => {
+    createJobMock.mockRejectedValue({
+      response: {
+        status: 409,
+        data: {
+          error: 'idempotency conflict',
+          code: 'CERTOPS_TRUST_JOB_IDEMPOTENCY_CONFLICT',
+        },
+      },
+    });
+
+    renderModal({ trustOp: distributeTrustOp });
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Owner/), {
+      target: { value: 'team-a' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+
+    await waitFor(() => {
+      expect(createJobMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
+++ b/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
@@ -131,7 +131,9 @@ describe('CreateManualJobModal executor toggle', () => {
 
     renderModal();
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
 
     expect(screen.getByText('Cluster')).toBeInTheDocument();
     expect(screen.getByText('Namespace')).toBeInTheDocument();
@@ -160,10 +162,14 @@ describe('CreateManualJobModal executor toggle', () => {
 
     renderModal();
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
 
     expect(
-      screen.getByText('Create an API token scoped to a cluster on the API Tokens tab first, then come back here.')
+      screen.getByText(
+        'Create an API token scoped to a cluster on the API Tokens tab first, then come back here.'
+      )
     ).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /^Cluster/ })).toBeDisabled();
   });
@@ -171,7 +177,9 @@ describe('CreateManualJobModal executor toggle', () => {
   it('reverts to the Agent executor when the operation changes away from issue', () => {
     renderModal();
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
 
     selectOperation('renew');
     selectOperation('issue');
@@ -220,7 +228,9 @@ describe('CreateManualJobModal controller provisioning submission', () => {
   it('disables submit until the required controller fields are filled', () => {
     renderModal();
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
 
     expect(
       screen.getByRole('button', { name: 'Create provisioning intent' })
@@ -245,7 +255,9 @@ describe('CreateManualJobModal controller provisioning submission', () => {
 
     renderModal({ onClose, onCreated });
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
     fillControllerFields();
 
     fireEvent.click(
@@ -273,12 +285,12 @@ describe('CreateManualJobModal controller provisioning submission', () => {
   });
 
   it('surfaces the terminal-identity error with a friendly message', async () => {
-
     createControllerProvisionIntentMock.mockRejectedValue({
       response: {
         status: 409,
         data: {
-          error: 'Provisioning cannot reactivate a terminal managed certificate',
+          error:
+            'Provisioning cannot reactivate a terminal managed certificate',
           code: 'CERTOPS_CONTROLLER_PROVISIONING_TERMINAL_IDENTITY',
         },
       },
@@ -286,7 +298,9 @@ describe('CreateManualJobModal controller provisioning submission', () => {
 
     renderModal();
     selectOperation('issue');
-    fireEvent.click(screen.getByRole('button', { name: 'Controller (cluster)' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Controller (cluster)' })
+    );
     fillControllerFields();
 
     fireEvent.click(
@@ -398,8 +412,9 @@ describe('CreateManualJobModal trustOp mode', () => {
   it('renders the trust-op header instead of the generic manual-job form', () => {
     renderModal({ trustOp: distributeTrustOp });
 
+    // Title and submit button now share this text, so pin to the title's <p>.
     expect(
-      screen.getByText('Distribute trust trust anchor')
+      screen.getByText('Distribute trust anchor', { selector: 'p' })
     ).toBeInTheDocument();
     expect(screen.queryByText('Operation')).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^Subject type/)).not.toBeInTheDocument();
@@ -408,7 +423,9 @@ describe('CreateManualJobModal trustOp mode', () => {
   it('disables submit until an agent and owner are chosen on distribute', () => {
     renderModal({ trustOp: distributeTrustOp });
 
-    const submit = screen.getByRole('button', { name: 'Distribute trust' });
+    const submit = screen.getByRole('button', {
+      name: 'Distribute trust anchor',
+    });
     expect(submit).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText(/^Target agent/), {
@@ -432,7 +449,9 @@ describe('CreateManualJobModal trustOp mode', () => {
       target: { value: 'team-a' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Distribute trust anchor' })
+    );
 
     await waitFor(() => {
       expect(createJobMock).toHaveBeenCalledTimes(1);
@@ -468,7 +487,9 @@ describe('CreateManualJobModal trustOp mode', () => {
       { target: { value: 'team-b' } }
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Distribute trust anchor' })
+    );
 
     await waitFor(() => {
       expect(createJobMock).toHaveBeenCalledTimes(1);
@@ -491,7 +512,7 @@ describe('CreateManualJobModal trustOp mode', () => {
       screen.getByText(/Close to existing owner "team-a"/)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Distribute trust' })
+      screen.getByRole('button', { name: 'Distribute trust anchor' })
     ).toBeEnabled();
   });
 
@@ -509,7 +530,9 @@ describe('CreateManualJobModal trustOp mode', () => {
     fireEvent.change(screen.getByLabelText(/^Target agent/), {
       target: { value: 'install-1' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Revoke trust' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Revoke trust anchor' })
+    );
 
     await waitFor(() => {
       expect(createJobMock).toHaveBeenCalledTimes(1);
@@ -552,7 +575,7 @@ describe('CreateManualJobModal trustOp mode', () => {
       target: { value: 'team-a' },
     });
     expect(
-      screen.getByRole('button', { name: 'Distribute trust' })
+      screen.getByRole('button', { name: 'Distribute trust anchor' })
     ).toBeDisabled();
   });
 
@@ -574,7 +597,9 @@ describe('CreateManualJobModal trustOp mode', () => {
     fireEvent.change(screen.getByLabelText(/^Owner/), {
       target: { value: 'team-a' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Distribute trust' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Distribute trust anchor' })
+    );
 
     await waitFor(() => {
       expect(createJobMock).toHaveBeenCalledTimes(1);

--- a/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
@@ -47,6 +47,7 @@ vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
 vi.mock('../../src/components/certops/useCertOps.js', () => ({
   useCertOpsCanManage: useCertOpsCanManageMock,
   useCertOpsEnabled: () => true,
+  useCertOpsIsWorkspaceAdmin: () => false,
 }));
 
 vi.mock('../../src/components/certops/certopsJobsApi.js', async () => {

--- a/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import TrustAnchorsPanel from '../../src/components/certops/TrustAnchorsPanel.jsx';
+
+const {
+  useWorkspaceMock,
+  useCertOpsTrustAnchorsMock,
+  useCertOpsTrustAnchorInstallationsMock,
+  useCertOpsAgentsMock,
+  createTrustAnchorMock,
+  retireTrustAnchorMock,
+  createJobMock,
+} = vi.hoisted(() => ({
+  useWorkspaceMock: vi.fn(),
+  useCertOpsTrustAnchorsMock: vi.fn(),
+  useCertOpsTrustAnchorInstallationsMock: vi.fn(),
+  useCertOpsAgentsMock: vi.fn(),
+  createTrustAnchorMock: vi.fn(),
+  retireTrustAnchorMock: vi.fn(),
+  createJobMock: vi.fn(),
+}));
+
+vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
+  useWorkspace: useWorkspaceMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOpsTrustAnchors.js', () => ({
+  useCertOpsTrustAnchors: useCertOpsTrustAnchorsMock,
+  useCertOpsTrustAnchorInstallations: useCertOpsTrustAnchorInstallationsMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOpsAgents.js', () => ({
+  useCertOpsAgents: useCertOpsAgentsMock,
+}));
+
+vi.mock('../../src/components/certops/certopsTrustAnchorsApi.js', async () => {
+  const actual = await vi.importActual(
+    '../../src/components/certops/certopsTrustAnchorsApi.js'
+  );
+  return {
+    ...actual,
+    createTrustAnchor: createTrustAnchorMock,
+    retireTrustAnchor: retireTrustAnchorMock,
+  };
+});
+
+vi.mock('../../src/components/certops/certopsJobsApi.js', async () => {
+  const actual = await vi.importActual(
+    '../../src/components/certops/certopsJobsApi.js'
+  );
+  return {
+    ...actual,
+    createJob: createJobMock,
+  };
+});
+
+function renderPanel() {
+  return render(
+    <ChakraProvider>
+      <MemoryRouter>
+        <TrustAnchorsPanel />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+function anchorsState(overrides = {}) {
+  return {
+    enabled: true,
+    isAdmin: true,
+    anchors: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+function installationsState(overrides = {}) {
+  return {
+    installations: [],
+    loading: false,
+    error: '',
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+function sampleAnchor(overrides = {}) {
+  return {
+    id: 'anchor-1',
+    name: 'Internal Root CA',
+    anchorType: 'root',
+    fingerprintSha256: 'aa'.repeat(32),
+    status: 'active',
+    source: 'api',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('TrustAnchorsPanel', () => {
+  beforeEach(() => {
+    useWorkspaceMock.mockReset();
+    useCertOpsTrustAnchorsMock.mockReset();
+    useCertOpsTrustAnchorInstallationsMock.mockReset();
+    useCertOpsAgentsMock.mockReset();
+    createTrustAnchorMock.mockReset();
+    retireTrustAnchorMock.mockReset();
+    createJobMock.mockReset();
+
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState()
+    );
+    useCertOpsAgentsMock.mockReturnValue({
+      agents: [{ id: 'agent-a', name: 'Agent A', status: 'active' }],
+    });
+  });
+
+  it('renders nothing while disabled or for a non-admin', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ enabled: false })
+    );
+    const { container: disabledContainer } = renderPanel();
+    expect(disabledContainer.textContent).toBe('');
+
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ isAdmin: false })
+    );
+    const { container: nonAdminContainer } = renderPanel();
+    expect(nonAdminContainer.textContent).toBe('');
+  });
+
+  it('shows an empty state pointing to the approve action', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(anchorsState());
+
+    renderPanel();
+
+    expect(screen.getByText('No trust anchors approved yet.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Approve a trust anchor' })
+    ).toBeInTheDocument();
+  });
+
+  it('lists anchors with type, fingerprint, and status', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+
+    renderPanel();
+
+    expect(screen.getByText('Internal Root CA')).toBeInTheDocument();
+    expect(screen.getByText('Root')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('hides the Retire action for an already-revoked anchor', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor({ status: 'revoked' })] })
+    );
+
+    renderPanel();
+
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Retire' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('expands a row to show its installations, empty state included', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(
+      screen.getByText('Not distributed to any agent yet.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders installation rows with owner, host, store, and state', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'installed',
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(screen.getByText('team-a')).toBeInTheDocument();
+    expect(screen.getByText('host-a')).toBeInTheDocument();
+    expect(screen.getByText('Installed')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Revoke', hidden: true })
+    ).toBeInTheDocument();
+  });
+
+  it('opens the trust-op modal in distribute mode with the anchor pre-set', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Distribute to an agent',
+        hidden: true,
+      })
+    );
+
+    expect(
+      screen.getByText('Distribute trust trust anchor')
+    ).toBeInTheDocument();
+  });
+
+  it('opens the trust-op modal in revoke mode from an installation row', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'installed',
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Revoke', hidden: true })
+    );
+
+    expect(screen.getByText('Revoke trust trust anchor')).toBeInTheDocument();
+  });
+
+  it('disables distribute for a retired anchor', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor({ status: 'revoked' })] })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Distribute to an agent',
+        hidden: true,
+      })
+    ).toBeDisabled();
+  });
+
+  it('approves a new trust anchor and refreshes the list', async () => {
+    const refresh = vi.fn();
+    useCertOpsTrustAnchorsMock.mockReturnValue(anchorsState({ refresh }));
+    createTrustAnchorMock.mockResolvedValue({
+      trustAnchor: sampleAnchor(),
+    });
+
+    renderPanel();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Approve a trust anchor' })
+    );
+
+    fireEvent.change(screen.getByLabelText(/^Name/), {
+      target: { value: 'Internal Root CA' },
+    });
+    fireEvent.change(screen.getByLabelText(/^CA certificate/), {
+      target: { value: '-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve anchor' }));
+
+    await waitFor(() => {
+      expect(createTrustAnchorMock).toHaveBeenCalledWith('ws-1', {
+        name: 'Internal Root CA',
+        anchorType: 'root',
+        pem: '-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+      });
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+
+  it('surfaces a friendly message for an invalid PEM', async () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(anchorsState());
+    createTrustAnchorMock.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { code: 'CERTOPS_TRUST_ANCHOR_PEM_INVALID' },
+      },
+    });
+
+    renderPanel();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Approve a trust anchor' })
+    );
+    fireEvent.change(screen.getByLabelText(/^Name/), {
+      target: { value: 'Bad cert' },
+    });
+    fireEvent.change(screen.getByLabelText(/^CA certificate/), {
+      target: { value: 'not a cert' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve anchor' }));
+
+    expect(
+      await screen.findByText(/does not look like a single CA certificate/)
+    ).toBeInTheDocument();
+  });
+
+  it('retires an anchor through the confirm modal and refreshes', async () => {
+    const refresh = vi.fn();
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()], refresh })
+    );
+    retireTrustAnchorMock.mockResolvedValue({
+      trustAnchor: sampleAnchor({ status: 'revoked' }),
+      retiredNow: true,
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Retire' }));
+    expect(
+      await screen.findByText(/no longer approved for new distribute-trust/)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Retire anchor' }));
+
+    await waitFor(() => {
+      expect(retireTrustAnchorMock).toHaveBeenCalledWith('ws-1', 'anchor-1', {
+        reason: undefined,
+      });
+      expect(refresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
@@ -141,7 +141,9 @@ describe('TrustAnchorsPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByText('No trust anchors approved yet.')).toBeInTheDocument();
+    expect(
+      screen.getByText('No trust anchors approved yet.')
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Approve a trust anchor' })
     ).toBeInTheDocument();
@@ -230,7 +232,7 @@ describe('TrustAnchorsPanel', () => {
     );
 
     expect(
-      screen.getByText('Distribute trust trust anchor')
+      screen.getByText('Distribute trust anchor', { selector: 'p' })
     ).toBeInTheDocument();
   });
 
@@ -259,7 +261,9 @@ describe('TrustAnchorsPanel', () => {
       screen.getByRole('button', { name: 'Revoke', hidden: true })
     );
 
-    expect(screen.getByText('Revoke trust trust anchor')).toBeInTheDocument();
+    expect(
+      screen.getByText('Revoke trust anchor', { selector: 'p' })
+    ).toBeInTheDocument();
   });
 
   it('disables distribute for a retired anchor', () => {
@@ -294,7 +298,9 @@ describe('TrustAnchorsPanel', () => {
       target: { value: 'Internal Root CA' },
     });
     fireEvent.change(screen.getByLabelText(/^CA certificate/), {
-      target: { value: '-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----' },
+      target: {
+        value: '-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+      },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Approve anchor' }));
 

--- a/apps/dashboard/tests/unit/useCertOpsTrustAnchors.test.jsx
+++ b/apps/dashboard/tests/unit/useCertOpsTrustAnchors.test.jsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const {
+  useWorkspaceMock,
+  useCertOpsEnabledMock,
+  useCertOpsIsWorkspaceAdminMock,
+  listTrustAnchorsMock,
+  listTrustAnchorInstallationsMock,
+} = vi.hoisted(() => ({
+  useWorkspaceMock: vi.fn(),
+  useCertOpsEnabledMock: vi.fn(),
+  useCertOpsIsWorkspaceAdminMock: vi.fn(),
+  listTrustAnchorsMock: vi.fn(),
+  listTrustAnchorInstallationsMock: vi.fn(),
+}));
+
+vi.mock('../../src/utils/WorkspaceContext.jsx', () => ({
+  useWorkspace: useWorkspaceMock,
+}));
+
+vi.mock('../../src/components/certops/useCertOps.js', () => ({
+  useCertOpsEnabled: useCertOpsEnabledMock,
+  useCertOpsIsWorkspaceAdmin: useCertOpsIsWorkspaceAdminMock,
+}));
+
+vi.mock('../../src/components/certops/certopsTrustAnchorsApi.js', async () => {
+  const actual = await vi.importActual(
+    '../../src/components/certops/certopsTrustAnchorsApi.js'
+  );
+  return {
+    ...actual,
+    listTrustAnchors: listTrustAnchorsMock,
+    listTrustAnchorInstallations: listTrustAnchorInstallationsMock,
+  };
+});
+
+import {
+  useCertOpsTrustAnchorInstallations,
+  useCertOpsTrustAnchors,
+} from '../../src/components/certops/useCertOpsTrustAnchors.js';
+
+describe('useCertOpsTrustAnchors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+    useCertOpsEnabledMock.mockReturnValue(true);
+    useCertOpsIsWorkspaceAdminMock.mockReturnValue(true);
+  });
+
+  it('loads anchors for an admin viewer', async () => {
+    listTrustAnchorsMock.mockResolvedValue({
+      items: [{ id: 'anchor-1', name: 'Root CA' }],
+    });
+
+    const { result } = renderHook(() => useCertOpsTrustAnchors());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.anchors).toEqual([
+      { id: 'anchor-1', name: 'Root CA' },
+    ]);
+    expect(listTrustAnchorsMock).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({ signal: expect.anything() })
+    );
+  });
+
+  it('does not fetch and returns an empty list for a non-admin viewer', () => {
+    useCertOpsIsWorkspaceAdminMock.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCertOpsTrustAnchors());
+
+    expect(listTrustAnchorsMock).not.toHaveBeenCalled();
+    expect(result.current.anchors).toEqual([]);
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it('does not fetch while CertOps is disabled', () => {
+    useCertOpsEnabledMock.mockReturnValue(false);
+
+    renderHook(() => useCertOpsTrustAnchors());
+
+    expect(listTrustAnchorsMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a load failure as an error, with an empty anchor list', async () => {
+    listTrustAnchorsMock.mockRejectedValue({
+      response: { data: { error: 'Internal error' } },
+    });
+
+    const { result } = renderHook(() => useCertOpsTrustAnchors());
+
+    await waitFor(() => expect(result.current.error).toBe('Internal error'));
+    expect(result.current.anchors).toEqual([]);
+  });
+
+  it('refetches when refresh() is called', async () => {
+    listTrustAnchorsMock.mockResolvedValue({ items: [] });
+    const { result } = renderHook(() => useCertOpsTrustAnchors());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    result.current.refresh();
+
+    await waitFor(() =>
+      expect(listTrustAnchorsMock).toHaveBeenCalledTimes(2)
+    );
+  });
+});
+
+describe('useCertOpsTrustAnchorInstallations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceMock.mockReturnValue({ workspaceId: 'ws-1' });
+  });
+
+  it('loads installations for a given anchor id', async () => {
+    listTrustAnchorInstallationsMock.mockResolvedValue({
+      items: [{ id: 'install-1', owner: 'team-a' }],
+    });
+
+    const { result } = renderHook(() =>
+      useCertOpsTrustAnchorInstallations('anchor-1')
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.installations).toEqual([
+      { id: 'install-1', owner: 'team-a' },
+    ]);
+    expect(listTrustAnchorInstallationsMock).toHaveBeenCalledWith(
+      'ws-1',
+      'anchor-1',
+      expect.objectContaining({ signal: expect.anything() })
+    );
+  });
+
+  it('skips the fetch and clears state when anchorId is null (row collapsed)', () => {
+    const { result } = renderHook(() =>
+      useCertOpsTrustAnchorInstallations(null)
+    );
+
+    expect(listTrustAnchorInstallationsMock).not.toHaveBeenCalled();
+    expect(result.current.installations).toEqual([]);
+  });
+
+  it('surfaces a load failure as an error', async () => {
+    listTrustAnchorInstallationsMock.mockRejectedValue({
+      response: { data: { error: 'Anchor not found' } },
+    });
+
+    const { result } = renderHook(() =>
+      useCertOpsTrustAnchorInstallations('anchor-1')
+    );
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Anchor not found')
+    );
+    expect(result.current.installations).toEqual([]);
+  });
+});

--- a/apps/worker/src/certops-metrics.js
+++ b/apps/worker/src/certops-metrics.js
@@ -73,3 +73,14 @@ export const gCertopsTrustAnchorReconciliation = new client.Gauge({
   labelNames: ["outcome"],
   registers: [metricsRegister],
 });
+
+/**
+ * Which sweeps in a runIsolated results object ended "failed". "skipped" means
+ * an operator disabled the sweep, so it must never turn a CronJob run red.
+ * Kept here, dependency-free, so it is testable without the worker's I/O.
+ */
+export function identifyFailedSweeps(results) {
+  return Object.entries(results || {})
+    .filter(([, sweepResult]) => sweepResult?.status === "failed")
+    .map(([key]) => key);
+}

--- a/apps/worker/src/certops-worker.js
+++ b/apps/worker/src/certops-worker.js
@@ -50,6 +50,7 @@ import {
   gCertopsDiagnosticAgentsRetired,
   gCertopsAgentHealthAlerts,
   gCertopsTrustAnchorReconciliation,
+  identifyFailedSweeps,
 } from "./certops-metrics.js";
 import { safeInc } from "./shared/safeMetrics.js";
 import { createRequire } from "module";
@@ -88,6 +89,7 @@ const { writeAudit } = require("../../api/services/audit.js");
 const {
   JOB_STATUSES,
   isTerminalJobStatus,
+  isTrustAnchorOperation,
 } = require("../../api/services/certops/jobs.js");
 
 const {
@@ -106,6 +108,7 @@ const { resolveRenewalPathsForWorkspace } = require(
 // service, not this worker).
 const {
   sweepOverdueTrustInstallations,
+  onTrustJobTerminalTransition,
 } = require("../../api/services/certops/trustAnchors.js");
 
 // Single source of truth for the 10-minute agent liveness threshold, shared
@@ -602,6 +605,7 @@ export async function reapExpiredLeases({
   log = logger,
   recordOutboxEvent = enqueueOutboxEvent,
   auditWriter = writeAudit,
+  trustTerminalHook = onTrustJobTerminalTransition,
 } = {}) {
   const summary = { scanned: 0, requeued: 0, failed: 0, deferred: 0 };
 
@@ -791,6 +795,18 @@ export async function reapExpiredLeases({
             WHERE id = $1`,
           [row.id, errorCode],
         );
+
+        // A lease-reaped trust job is a terminal-negative transition like any
+        // other. Unwinding in this transaction, not later via the
+        // reconciliation sweep an operator can disable, keeps the job's failed
+        // status and the installation's unwound state from being observed apart.
+        if (isTrustAnchorOperation(row.operation)) {
+          await trustTerminalHook({
+            client,
+            job: { ...row, status: "failed" },
+          });
+        }
+
         await insertJobLog(client, row, {
           eventType: "job.failed",
           status: "failed",
@@ -1724,6 +1740,19 @@ export async function runCertOpsMaintenance({
   await pushMetricsFn("certops").catch((e) =>
     log.warn("Failed to push metrics", { error: e.message }),
   );
+
+  // Metrics push first so a failing run stays observable. Without the throw the
+  // process exits 0 and CronJob / Compose supervision calls a run healthy while
+  // every sweep in it fails.
+  const failedSweeps = identifyFailedSweeps(results);
+  if (failedSweeps.length > 0) {
+    const error = new Error(
+      `certops-worker: ${failedSweeps.length} sweep(s) failed: ${failedSweeps.join(", ")}`,
+    );
+    error.code = "CERTOPS_MAINTENANCE_SWEEP_FAILED";
+    error.results = results;
+    throw error;
+  }
 
   return results;
 }

--- a/docs/certops/CONTEXT.md
+++ b/docs/certops/CONTEXT.md
@@ -278,10 +278,14 @@ the shared detector scans every outbound envelope.
 - **Bulk renew** - `POST .../certops/jobs/bulk-renew`: many certificates
   through the same creation path as single renew (validation, approval
   gates, kill switch identical) with a per-item partial-failure envelope.
-  Items without an explicit `idempotencyKey` derive a stable one
-  (`bulk-renew:auto:<certificateId>`), which is permanent: re-running after
-  cancelling the created jobs returns the original terminal jobs instead of
-  creating new ones. Pass a fresh key to force a genuine re-run.
+  Retry safety is opt-in: supply an `idempotencyKey` and each item gets
+  `bulk-renew:<key>:<certificateId>`, so a replayed batch returns the
+  already-created jobs. Omit it and items carry no key, so each call
+  enqueues fresh jobs (a certificate must stay renewable more than once,
+  and the jobs table's idempotency uniqueness has no time component).
+  `dryRun` additionally resolves each certificate's stored renewal profile
+  read-only, so an incomplete or invalid profile fails that item in the dry
+  run instead of only at real-run time.
 
 ## Dashboard certificate visibility
 

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -87,6 +87,7 @@ const {
   deleteBootstrapEnvFile,
   listConfiguredDnsProviderIds,
   resolveAcmeAccountCredentials,
+  DEFAULT_REQUIRE_SIGNED_AGENT_ID,
 } = require("./config");
 const { loadPolicyConfig, createPolicyEngine } = require("./policy");
 const { isWindows, clearWindowsServiceBootstrapToken } = require("./platform");
@@ -1486,8 +1487,11 @@ async function reportStepEvidence(client, jobId, items, claimId = null) {
  *   verification still runs, only the post-verdict action differs
  * @param {string} params.boundAgentId this agent's own registered agentId
  *   (ADR-0012 decision 3, gate step 11)
- * @param {boolean} [params.requireSignedAgentId] effective runtime value
- *   of CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID (default false)
+ * @param {boolean} [params.requireSignedAgentId] effective runtime value of
+ *   CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID as resolved by loadAgentConfig.
+ *   Falls back to config's DEFAULT_REQUIRE_SIGNED_AGENT_ID rather than to a
+ *   literal here, so omitting it can never be more permissive than what a
+ *   real agent resolves, and the default cannot drift out of sync.
  * @param {(msg: string) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
@@ -1497,7 +1501,7 @@ async function handleClaimedJob({
   client,
   executionContext = null,
   boundAgentId,
-  requireSignedAgentId = false,
+  requireSignedAgentId = DEFAULT_REQUIRE_SIGNED_AGENT_ID,
   log = null,
 }) {
   const executionEnabled =
@@ -1712,8 +1716,9 @@ function verifyClaimedJobEnvelope({
  * @param {boolean} params.executionEnabled
  * @param {string} params.boundAgentId this agent's own registered agentId
  *   (ADR-0012 decision 3, gate step 11)
- * @param {boolean} [params.requireSignedAgentId] effective runtime value
- *   of CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID (default false)
+ * @param {boolean} [params.requireSignedAgentId] effective runtime value of
+ *   CERTOPS_AGENT_REQUIRE_SIGNED_AGENT_ID as resolved by loadAgentConfig;
+ *   same fail-closed fallback as handleClaimedJob's
  * @param {(msg: string, details?: *) => void} [params.log]
  * @returns {Promise<{ status: string, rejectionReason: string|null }>}
  */
@@ -1724,7 +1729,7 @@ async function handleSignedJob({
   executionContext,
   executionEnabled,
   boundAgentId,
-  requireSignedAgentId = false,
+  requireSignedAgentId = DEFAULT_REQUIRE_SIGNED_AGENT_ID,
   log,
 }) {
   const pinnedSigningKey = executionEnabled

--- a/packages/agent/src/index.test.js
+++ b/packages/agent/src/index.test.js
@@ -75,6 +75,7 @@ const {
   writeSigningKeyPin,
   readSigningKeyPin,
   listConfiguredDnsProviderIds,
+  DEFAULT_REQUIRE_SIGNED_AGENT_ID,
 } = require("./config");
 const {
   generateSigningKeyPair,
@@ -1026,6 +1027,10 @@ describe("signed-job dispatch chain (handleClaimedJob with executionContext)", (
       schemaVersion: 1,
       jobId: overrides.jobId || "job-signed-1",
       workspaceId: "11111111-2222-3333-4444-555555555555",
+      // Signed dispatch always binds a job to one agent identity, so the
+      // fixture carries it too; tests that probe the binding gate itself
+      // override or drop this field deliberately.
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "cert-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },
@@ -2406,6 +2411,7 @@ describe("observe-only signature verification (ADR-0012 decision 2 Finding B clo
       schemaVersion: 1,
       jobId: "job-observe-1",
       workspaceId: "11111111-2222-3333-4444-555555555555",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "cert-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },
@@ -2843,7 +2849,7 @@ describe("agentId absence-tolerant rollback: control plane omits agentId entirel
     );
   });
 
-  it("requireSignedAgentId defaulted to true (no override): the identical no-agentId job now fails closed at the gate", async () => {
+  it("requireSignedAgentId explicitly true: the identical no-agentId job now fails closed at the gate", async () => {
     const client = createRecordingClient();
     const job = makeSignedJobV1NoAgentId();
 
@@ -2857,6 +2863,32 @@ describe("agentId absence-tolerant rollback: control plane omits agentId entirel
       log: silentLog,
     });
 
+    assert.equal(outcome.status, "failed");
+    assert.equal(
+      outcome.rejectionReason,
+      AGENT_ID_BINDING_REJECTION_REASONS.AGENT_ID_REQUIRED_BUT_MISSING,
+    );
+    assert.equal(client.calls.reportResult.length, 0);
+    assert.equal(client.calls.reportEvidence.length, 0);
+  });
+
+  // A caller that forgets the argument must not silently get the permissive
+  // decoder: the parameter default has to track config's compiled-in default,
+  // which fails closed.
+  it("requireSignedAgentId omitted entirely: fails closed exactly as if true were passed, never the absence-tolerant branch", async () => {
+    const client = createRecordingClient();
+    const job = makeSignedJobV1NoAgentId();
+
+    const outcome = await handleClaimedJob({
+      job,
+      policyEngine: permissiveEngine(),
+      client,
+      executionContext: makeExecutionContext(),
+      boundAgentId: AGENT_B,
+      log: silentLog,
+    });
+
+    assert.equal(DEFAULT_REQUIRE_SIGNED_AGENT_ID, true);
     assert.equal(outcome.status, "failed");
     assert.equal(
       outcome.rejectionReason,
@@ -3248,6 +3280,7 @@ describe("lease fail-closed + side-effect journal + multi-target transaction", (
       jobId: "job-lease-journal",
       attemptId: "attempt-1",
       workspaceId: "11111111-1111-4111-8111-111111111111",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "certificate-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },

--- a/packages/agent/src/runtime/runtime.test.js
+++ b/packages/agent/src/runtime/runtime.test.js
@@ -125,6 +125,7 @@ describe("agent runtime: lease, journal, multi-target transaction", () => {
       jobId: "job-lease-journal",
       attemptId: "attempt-1",
       workspaceId: "11111111-1111-4111-8111-111111111111",
+      agentId: TEST_BOUND_AGENT_ID,
       certificateId: "certificate-1",
       action: "noop",
       target: { type: "domain", reference: "example.com" },

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -5394,6 +5394,66 @@ paths:
                 code: PRIVATE_KEY_MATERIAL_REJECTED
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/workspaces/{id}/certops/trust-anchors/{anchorId}/installations:
+    get:
+      tags: [CertOps]
+      summary: List installations for a CertOps trust anchor
+      operationId: listCertOpsTrustAnchorInstallations
+      description: >-
+        Returns every certops_trust_anchor_installations row for one trust
+        anchor (agent, store, transition state, provenance, last error), so
+        an operator can see where the anchor actually landed before
+        revoking or distributing it further. Manager-only, same as the
+        other trust-anchor routes. Read-only: unlike the mutating
+        trust-anchor routes, this route does not require the workspace's
+        CertOps state to be active, since an operator diagnosing a paused
+        workspace still needs to see current installations.
+      parameters:
+        - $ref: "#/components/parameters/workspaceIdParam"
+        - in: path
+          name: anchorId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Trust anchor record id (UUID).
+      responses:
+        "200":
+          description: Installation list for this trust anchor
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertOpsTrustAnchorInstallationListResponse"
+        "400":
+          description: Trust anchor identifier is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Trust anchor identifier is invalid
+                code: CERTOPS_TRUST_ANCHOR_INVALID
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: CertOps is disabled, or the trust anchor was not found in this workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                certopsDisabled:
+                  value:
+                    error: Endpoint not found
+                    code: NOT_FOUND
+                anchorNotFound:
+                  value:
+                    error: Trust anchor not found
+                    code: CERTOPS_TRUST_ANCHOR_NOT_FOUND
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/workspaces/{id}/certops/agents/{agentId}/alert-settings:
     patch:
       tags: [CertOps]
@@ -9776,6 +9836,101 @@ components:
         retiredNow:
           type: boolean
           description: False when the anchor was already revoked before this request (idempotent no-op).
+    CertOpsTrustAnchorInstallation:
+      type: object
+      additionalProperties: false
+      description: >-
+        One certops_trust_anchor_installations reference row: where a trust
+        anchor's CA certificate is (or was) tracked in one agent's OS trust
+        store, for one owner. Reference-counted per (agent, trust anchor,
+        store, owner); see CertOpsJobCreateRequest's owner description.
+      required:
+        - id
+        - workspaceId
+        - trustAnchorId
+        - host
+        - store
+        - fingerprintSha256
+        - owner
+        - transitionState
+        - provenance
+        - agentId
+        - transitionGeneration
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspaceId:
+          type: string
+          format: uuid
+        trustAnchorId:
+          type: string
+          format: uuid
+        host:
+          type: string
+          description: Agent-identifying host label the installation was recorded under.
+        store:
+          type: string
+          description: OS-level trust store label ("Root" or "CA"), derived from the anchor's anchorType.
+        fingerprintSha256:
+          type: string
+          description: Lowercase hex SHA-256 fingerprint of the tracked CA certificate.
+        owner:
+          type: string
+          description: Caller-supplied label identifying who holds this reference on this agent.
+        transitionState:
+          type: string
+          enum: [pending_install, installed, pending_remove, removed]
+        provenance:
+          type: string
+          enum: [preexisting, tokentimer_installed]
+          description: >-
+            Whether TokenTimer itself performed the install (tokentimer_installed)
+            or the material was already present before TokenTimer tracked it
+            (preexisting).
+        agentId:
+          type: string
+          format: uuid
+          description: The certops_agents.id this installation is tracked against.
+        lastJobId:
+          type: string
+          format: uuid
+          nullable: true
+        transitionGeneration:
+          type: integer
+          description: Monotonically increasing per-row generation; a stale generation's late result is rejected.
+        lastAttemptAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastError:
+          type: string
+          nullable: true
+        nextReconcileAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the reconciliation sweep should next revisit a pending row. Null once settled.
+        publicMetadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CertOpsTrustAnchorInstallationListResponse:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CertOpsTrustAnchorInstallation"
     CertOpsDiagnosticBootstrapRequest:
       type: object
       additionalProperties: false

--- a/packages/contracts/openapi/openapi.yaml
+++ b/packages/contracts/openapi/openapi.yaml
@@ -7909,7 +7909,10 @@ components:
           default: false
           description: >-
             True validates each certificate and reports per-item outcomes
-            without creating any jobs.
+            without creating any jobs. Each item's stored renewal profile is
+            resolved read-only, so a certificate whose profile is incomplete
+            or invalid fails the dry run instead of only failing the real
+            run. Per-CA capacity is not checked and not reserved.
         requiresApproval:
           type: boolean
           default: false
@@ -7925,8 +7928,9 @@ components:
             Optional request-level idempotency key. Combined with each
             certificateId to derive a per-item key
             (bulk-renew:<idempotencyKey>:<certificateId>), so retrying the
-            same bulk request is safe. When omitted, the server derives
-            bulk-renew:auto:<certificateId> instead.
+            same bulk request is safe. When omitted, items are created with
+            no idempotency key at all, so a replayed request enqueues fresh
+            renew jobs; pass a key if you need retry safety.
         payload:
           allOf:
             - $ref: "#/components/schemas/CertOpsPublicObject"

--- a/tests/integration/certops-trust-anchors.test.js
+++ b/tests/integration/certops-trust-anchors.test.js
@@ -4,6 +4,8 @@ const crypto = require("crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { createRequire } = require("module");
+const supertest = require("supertest");
 
 const { loadRootEnv } = require("../../scripts/load-root-env");
 
@@ -16,10 +18,17 @@ const { pool } = require("../../apps/api/db/database");
 const {
   validateSignedJob,
 } = require("../../packages/contracts/certops/validate-signed-job.cjs");
+const certOpsRouter = require("../../apps/api/routes/certops");
+
+const apiRequire = createRequire(
+  require.resolve("../../apps/api/package.json"),
+);
+const express = apiRequire("express");
 
 const {
   createTrustAnchor,
   listTrustAnchors,
+  listInstallationsForAnchor,
   retireTrustAnchor,
   createTrustJob,
   onTrustJobTerminalTransition,
@@ -28,6 +37,7 @@ const {
   sweepOverdueTrustInstallations,
   TRUST_JOB_TERMINAL_NEGATIVE_STATUSES,
   CERTOPS_TRUST_ANCHOR_NOT_ACTIVE,
+  CERTOPS_TRUST_ANCHOR_NOT_FOUND,
   CERTOPS_TRUST_ANCHOR_TYPE_IMMUTABLE,
   CERTOPS_TRUST_RESULT_MISMATCH,
   CERTOPS_TRUST_RESULT_STALE_GENERATION,
@@ -3233,5 +3243,306 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
       removedRow.transition_generation,
       "the rejected attempt must not mutate the row at all",
     );
+  });
+
+  // --- listInstallationsForAnchor (read-only installation listing) ---------
+
+  describe("listInstallationsForAnchor", () => {
+    // Runs in its own fresh workspace: CA_CERTS is a small fixed pool, and by
+    // this point in the suite anchorCounter has wrapped around it many times
+    // over, so a "fresh" anchor drawn from the shared workspaceId can land on
+    // a fingerprint some earlier test already attached installations to (see
+    // withFreshWorkspace's own doc comment above). Isolation here is scoped
+    // by (workspace_id, fingerprint_sha256), so a just-created workspace
+    // sidesteps that collision entirely.
+    it("returns every installation row for the anchor, newest updated_at first, with the full installation shape", async () => {
+      await withFreshWorkspace(async (freshWorkspaceId) => {
+        const anchor = await createTrustAnchor({
+          workspaceId: freshWorkspaceId,
+          name: "List Installations Anchor",
+          anchorType: "root",
+          pem: trustAnchorPemFor(anchorCounter++),
+          createdByUserId: ownerId,
+        });
+        const agentA = await createAgent({ workspaceIdOverride: freshWorkspaceId });
+        const agentB = await createAgent({ workspaceIdOverride: freshWorkspaceId });
+
+        const optionsFor = (agent, idempotencyKey) => ({
+          workspaceId: freshWorkspaceId,
+          operation: "distribute-trust",
+          trustAnchorId: anchor.id,
+          agentId: agent.id,
+          store: "Root",
+          owner: "workspace-policy",
+          idempotencyKey,
+          requestedByUserId: ownerId,
+        });
+
+        // A is created then ingested (installed): its row's updated_at moves
+        // to the ingest time. B is created afterwards, so its updated_at is
+        // the later of the two and must sort first under ORDER BY
+        // updated_at DESC.
+        const outcomeA = await createTrustJob(
+          optionsFor(agentA, `list-installations-a-${crypto.randomUUID()}`),
+        );
+        const jobA = await getJobRow(outcomeA.job.id);
+        const installationA = await getInstallationById(outcomeA.installation.id);
+        await withTx((client) =>
+          ingestTrustJobResult({
+            client,
+            job: jobA,
+            result: buildResult({
+              agent: agentA,
+              job: jobA,
+              installationRow: installationA,
+              outcome: "installed",
+            }),
+          }),
+        );
+
+        const outcomeB = await createTrustJob(
+          optionsFor(agentB, `list-installations-b-${crypto.randomUUID()}`),
+        );
+
+        const items = await listInstallationsForAnchor({
+          workspaceId: freshWorkspaceId,
+          trustAnchorId: anchor.id,
+        });
+
+        expect(items).to.have.lengthOf(2);
+        const ids = items.map((item) => item.id);
+        expect(ids.indexOf(String(outcomeB.installation.id))).to.be.lessThan(
+          ids.indexOf(String(outcomeA.installation.id)),
+        );
+
+        const returnedB = items[ids.indexOf(String(outcomeB.installation.id))];
+        expect(Object.keys(returnedB).sort()).to.deep.equal(
+          [
+            "id",
+            "workspaceId",
+            "trustAnchorId",
+            "host",
+            "store",
+            "fingerprintSha256",
+            "owner",
+            "transitionState",
+            "provenance",
+            "agentId",
+            "lastJobId",
+            "transitionGeneration",
+            "lastAttemptAt",
+            "lastError",
+            "nextReconcileAt",
+            "publicMetadata",
+            "createdAt",
+            "updatedAt",
+          ].sort(),
+        );
+        expect(returnedB).to.include({
+          id: String(outcomeB.installation.id),
+          workspaceId: String(freshWorkspaceId),
+          trustAnchorId: String(anchor.id),
+          agentId: String(agentB.id),
+          store: "Root",
+          transitionState: "pending_install",
+          provenance: "preexisting",
+          lastError: null,
+        });
+      });
+    });
+
+    it("returns an empty array for an anchor with no installations", async () => {
+      await withFreshWorkspace(async (freshWorkspaceId) => {
+        const anchor = await createTrustAnchor({
+          workspaceId: freshWorkspaceId,
+          name: "Empty Installations Anchor",
+          anchorType: "root",
+          pem: trustAnchorPemFor(anchorCounter++),
+          createdByUserId: ownerId,
+        });
+
+        const items = await listInstallationsForAnchor({
+          workspaceId: freshWorkspaceId,
+          trustAnchorId: anchor.id,
+        });
+
+        expect(items).to.deep.equal([]);
+      });
+    });
+
+    it("rejects with CERTOPS_TRUST_ANCHOR_NOT_FOUND for an anchor id that belongs to another workspace", async () => {
+      await withFreshWorkspace(async (otherWorkspaceId) => {
+        const pem = trustAnchorPemFor(anchorCounter++);
+        const anchorInOtherWorkspace = await createTrustAnchor({
+          workspaceId: otherWorkspaceId,
+          name: "Cross-workspace anchor",
+          anchorType: "root",
+          pem,
+          createdByUserId: ownerId,
+        });
+
+        await expectServiceError(
+          listInstallationsForAnchor({
+            workspaceId,
+            trustAnchorId: anchorInOtherWorkspace.id,
+          }),
+          CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+        );
+      });
+    });
+
+    it("rejects with CERTOPS_TRUST_ANCHOR_NOT_FOUND for a well-formed but nonexistent anchor id", async () => {
+      await expectServiceError(
+        listInstallationsForAnchor({
+          workspaceId,
+          trustAnchorId: crypto.randomUUID(),
+        }),
+        CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+      );
+    });
+  });
+});
+
+/**
+ * Route-level coverage for GET .../trust-anchors/:anchorId/installations.
+ * The suite above exercises listInstallationsForAnchor directly; this block
+ * exercises the actual router (rate limiter, requireCertOpsEnabled,
+ * authorize("certops.trust_anchor.manage")) the same way
+ * certops-controller-provisioning.test.js's createHumanProvisioningApp does,
+ * since RBAC and the rollout gate live in the route, not the service.
+ */
+describe("GET /api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations (route)", function () {
+  this.timeout(60000);
+
+  let ownerId;
+  let workspaceId;
+  let previousCertOpsEnabled;
+
+  function buildApp({ workspaceRole = "admin", userId = ownerId } = {}) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.workspace = { id: workspaceId };
+      if (userId) req.user = { id: userId };
+      req.authz = { workspaceRole };
+      next();
+    });
+    app.use(certOpsRouter);
+    return app;
+  }
+
+  function getInstallations(app, anchorId) {
+    return supertest(app).get(
+      `/api/v1/workspaces/${workspaceId}/certops/trust-anchors/${anchorId}/installations`,
+    );
+  }
+
+  before(async () => {
+    previousCertOpsEnabled = process.env.CERTOPS_ENABLED;
+    process.env.CERTOPS_ENABLED = "true";
+    await runMigrations();
+
+    const email = `trust-anchor-route-${Date.now()}-${crypto.randomUUID()}@example.com`;
+    const owner = await TestUtils.execQuery(
+      `INSERT INTO users (email, email_original, display_name, password_hash, auth_method, email_verified)
+       VALUES ($1, $2, 'Trust Anchor Route Test', 'unused', 'local', TRUE)
+       RETURNING id`,
+      [email.toLowerCase(), email],
+    );
+    ownerId = owner.rows[0].id;
+
+    workspaceId = crypto.randomUUID();
+    await TestUtils.execQuery(
+      `INSERT INTO workspaces (id, name, created_by, plan)
+       VALUES ($1, 'Trust Anchor Route Test WS', $2, 'oss')`,
+      [workspaceId, ownerId],
+    );
+  });
+
+  after(async () => {
+    if (previousCertOpsEnabled === undefined) delete process.env.CERTOPS_ENABLED;
+    else process.env.CERTOPS_ENABLED = previousCertOpsEnabled;
+
+    if (workspaceId) {
+      await TestUtils.execQuery("DELETE FROM workspaces WHERE id = $1", [
+        workspaceId,
+      ]);
+    }
+    if (ownerId) {
+      // Same ordering as the suite above: audit_events is update-immutable,
+      // so the rows this suite wrote must go before the user they reference.
+      await TestUtils.execQuery(
+        `DELETE FROM audit_events
+          WHERE actor_user_id = $1 OR subject_user_id = $1`,
+        [ownerId],
+      );
+      await TestUtils.execQuery("DELETE FROM users WHERE id = $1", [ownerId]);
+    }
+  });
+
+  it("returns { items: [] } for an admin on an anchor with no installations", async () => {
+    const pem = trustAnchorPemFor(0);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (empty)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+
+    const response = await getInstallations(buildApp(), anchor.id).expect(200);
+    expect(response.body).to.deep.equal({ items: [] });
+  });
+
+  it("returns 404 for an anchor id that does not exist in this workspace", async () => {
+    await getInstallations(buildApp(), crypto.randomUUID()).expect(404);
+  });
+
+  it("rejects a viewer and a workspace_manager with 403, and allows admin", async () => {
+    const pem = trustAnchorPemFor(1);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (rbac)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+
+    await getInstallations(
+      buildApp({ workspaceRole: "viewer" }),
+      anchor.id,
+    ).expect(403);
+    await getInstallations(
+      buildApp({ workspaceRole: "workspace_manager" }),
+      anchor.id,
+    ).expect(403);
+    await getInstallations(
+      buildApp({ workspaceRole: "admin" }),
+      anchor.id,
+    ).expect(200);
+  });
+
+  it("omits requireWorkspaceCertOpsActive: a paused workspace can still be read", async () => {
+    const pem = trustAnchorPemFor(2);
+    const anchor = await createTrustAnchor({
+      workspaceId,
+      name: "Route Test Anchor (paused)",
+      anchorType: "root",
+      pem,
+      createdByUserId: ownerId,
+    });
+    await TestUtils.execQuery(
+      `UPDATE workspaces SET certops_paused = TRUE WHERE id = $1`,
+      [workspaceId],
+    );
+
+    try {
+      await getInstallations(buildApp(), anchor.id).expect(200);
+    } finally {
+      await TestUtils.execQuery(
+        `UPDATE workspaces SET certops_paused = FALSE WHERE id = $1`,
+        [workspaceId],
+      );
+    }
   });
 });

--- a/tests/unit/certops-bulk-renew-route.test.js
+++ b/tests/unit/certops-bulk-renew-route.test.js
@@ -28,12 +28,25 @@ const { CERTOPS_CERTIFICATE_NOT_FOUND } = require(
 const { CERTOPS_JOB_INVALID } = require(
   path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
 );
-const { CERTOPS_RENEWAL_OVERRIDE_INVALID } = require(
+const {
+  CERTOPS_RENEWAL_OVERRIDE_INVALID,
+  CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+} = require(
   path.resolve(__dirname, "../../apps/api/services/certops/renewalProfile.js"),
 );
 
 const { bulkRenewCertificatesHandler, parseBulkRenewRequest } =
   certOpsRouter._test;
+
+// Every handler under test gets stubbed DB-backed collaborators: the real
+// defaults would reach the pool.
+function makeHandler(overrides = {}) {
+  return bulkRenewCertificatesHandler({
+    activeJobFinder: async () => null,
+    renewalPreflight: async () => ({}),
+    ...overrides,
+  });
+}
 
 function uuid(n) {
   return `aaaaaaaa-0000-4000-8000-${String(n).padStart(12, "0")}`;
@@ -66,7 +79,7 @@ describe("CertOps bulk-renew route", () => {
   it("creates a renew job per certificate and reports an all-success envelope", async () => {
     const creatorCalls = [];
     let jobCounter = 0;
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
@@ -106,33 +119,39 @@ describe("CertOps bulk-renew route", () => {
       assert.strictEqual(call.requiresApproval, false);
       assert.strictEqual(call.requestedByUserId, 42);
       assert.strictEqual(call.actorUserId, 42);
-      assert.strictEqual(
-        call.idempotencyKey,
-        `bulk-renew:auto:${uuid(index + 1)}`,
-      );
+      assert.strictEqual(call.idempotencyKey, null);
     }
   });
 
-  it("derives a stable auto idempotency key when the caller omits one", async () => {
+  it("leaves the per-item idempotency key unset when the caller omits one, so the same certificate stays renewable", async () => {
     const { bulkRenewItemIdempotencyKey } = certOpsRouter._test;
-    assert.strictEqual(
-      bulkRenewItemIdempotencyKey(undefined, uuid(1)),
-      `bulk-renew:auto:${uuid(1)}`,
-    );
+    assert.strictEqual(bulkRenewItemIdempotencyKey(undefined, uuid(1)), null);
+    assert.strictEqual(bulkRenewItemIdempotencyKey(null, uuid(1)), null);
     assert.strictEqual(
       bulkRenewItemIdempotencyKey("client-key", uuid(1)),
       `bulk-renew:client-key:${uuid(1)}`,
     );
 
+    // Two sequential bulk renews of the same certificate without a client
+    // key must both reach creation with no key, so neither collides with the
+    // other on the jobs table's (workspace, idempotency_key) uniqueness.
     const creatorCalls = [];
-    const handler = bulkRenewCertificatesHandler({
+    const usedKeys = new Set();
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
-        return {
-          job: { id: `job-${creatorCalls.length}` },
-          created: creatorCalls.length === 1,
-        };
+        if (options.idempotencyKey) {
+          if (usedKeys.has(options.idempotencyKey)) {
+            const err = new Error(
+              "Idempotency key was already used with a different CertOps job request",
+            );
+            err.code = "CERTOPS_JOB_IDEMPOTENCY_CONFLICT";
+            throw err;
+          }
+          usedKeys.add(options.idempotencyKey);
+        }
+        return { job: { id: `job-${creatorCalls.length}` }, created: true };
       },
     });
 
@@ -141,21 +160,52 @@ describe("CertOps bulk-renew route", () => {
     const second = responseRecorder();
     await handler(makeRequest({ certificateIds: [uuid(9)] }), second);
 
-    assert.strictEqual(first.statusCode, 200);
-    assert.strictEqual(second.statusCode, 200);
     assert.strictEqual(creatorCalls.length, 2);
+    assert.strictEqual(creatorCalls[0].idempotencyKey, null);
+    assert.strictEqual(creatorCalls[1].idempotencyKey, null);
+    assert.deepStrictEqual(first.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1" },
+    ]);
+    assert.deepStrictEqual(second.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-2" },
+    ]);
+  });
+
+  it("derives a per-certificate key from a caller-supplied request key so a replayed batch is a no-op", async () => {
+    const created = new Map();
+    const creatorCalls = [];
+    const handler = makeHandler({
+      certificateLoader: async () => ({ id: "found" }),
+      manualJobCreator: async (options) => {
+        creatorCalls.push(options);
+        const existing = created.get(options.idempotencyKey);
+        if (existing) return { job: existing, created: false };
+        const job = { id: `job-${created.size + 1}` };
+        created.set(options.idempotencyKey, job);
+        return { job, created: true };
+      },
+    });
+
+    const body = { certificateIds: [uuid(9)], idempotencyKey: "batch-1" };
+    const first = responseRecorder();
+    await handler(makeRequest(body), first);
+    const second = responseRecorder();
+    await handler(makeRequest(body), second);
+
     assert.strictEqual(
       creatorCalls[0].idempotencyKey,
-      creatorCalls[1].idempotencyKey,
+      `bulk-renew:batch-1:${uuid(9)}`,
     );
-    assert.strictEqual(
-      creatorCalls[0].idempotencyKey,
-      `bulk-renew:auto:${uuid(9)}`,
-    );
+    assert.deepStrictEqual(first.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1" },
+    ]);
+    assert.deepStrictEqual(second.body.results, [
+      { certificateId: uuid(9), ok: true, jobId: "job-1", replayed: true },
+    ]);
   });
 
   it("reports a mixed envelope where item failures never abort the batch", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async ({ certId }) =>
         certId === uuid(2) ? null : { id: certId },
       manualJobCreator: async ({ subjectId }) => {
@@ -210,7 +260,7 @@ describe("CertOps bulk-renew route", () => {
   });
 
   it("keeps the disabled-rollout 404 posture instead of a per-item failure", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async () => {
         const err = new Error("CertOps is not enabled");
@@ -228,10 +278,9 @@ describe("CertOps bulk-renew route", () => {
 
   it("validates and reports without creating jobs on dryRun", async () => {
     let creatorCalls = 0;
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async ({ certId }) =>
         certId === uuid(2) ? null : { id: certId },
-      activeJobFinder: async () => null,
       manualJobCreator: async () => {
         creatorCalls += 1;
         return { job: { id: "must-not-exist" } };
@@ -259,9 +308,81 @@ describe("CertOps bulk-renew route", () => {
     assert.strictEqual(res.body.results[1].ok, false);
   });
 
+  it("fails a dry-run item whose stored renewal profile is incomplete, instead of reporting it as renewable", async () => {
+    const preflightCalls = [];
+    const handler = makeHandler({
+      certificateLoader: async ({ certId }) => ({ id: certId }),
+      renewalPreflight: async (options) => {
+        preflightCalls.push(options);
+        if (options.certificateId === uuid(2)) {
+          const err = new Error("Certificate has no linked renewal profile");
+          err.code = CERTOPS_RENEWAL_PROFILE_INCOMPLETE;
+          throw err;
+        }
+        return {};
+      },
+      manualJobCreator: async () => {
+        throw new Error("creator must not run on a dry run");
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({
+        certificateIds: [uuid(1), uuid(2)],
+        dryRun: true,
+        payload: { reason: "audit" },
+      }),
+      res,
+    );
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.body.summary, {
+      requested: 2,
+      succeeded: 1,
+      failed: 1,
+    });
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true },
+      {
+        certificateId: uuid(2),
+        ok: false,
+        errorCode: CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+        message: "Certificate has no linked renewal profile",
+      },
+    ]);
+    // Preflight receives the same override payload the real run would build
+    // the job payload from.
+    assert.deepStrictEqual(preflightCalls[0], {
+      workspaceId: "workspace-1",
+      certificateId: uuid(1),
+      payload: { reason: "audit" },
+    });
+  });
+
+  it("reports an in-flight renew job as activeJobId on a dry run that otherwise passes preflight", async () => {
+    const handler = makeHandler({
+      certificateLoader: async ({ certId }) => ({ id: certId }),
+      activeJobFinder: async () => ({ id: "job-in-flight" }),
+      manualJobCreator: async () => {
+        throw new Error("creator must not run on a dry run");
+      },
+    });
+
+    const res = responseRecorder();
+    await handler(
+      makeRequest({ certificateIds: [uuid(1)], dryRun: true }),
+      res,
+    );
+
+    assert.deepStrictEqual(res.body.results, [
+      { certificateId: uuid(1), ok: true, activeJobId: "job-in-flight" },
+    ]);
+  });
+
   it("passes requiresApproval and an allowlisted payload override through to the service path", async () => {
     const creatorCalls = [];
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => ({ id: "found" }),
       manualJobCreator: async (options) => {
         creatorCalls.push(options);
@@ -287,7 +408,7 @@ describe("CertOps bulk-renew route", () => {
   });
 
   it("rejects a non-allowlisted payload override with 400 before any item runs", async () => {
-    const handler = bulkRenewCertificatesHandler({
+    const handler = makeHandler({
       certificateLoader: async () => {
         throw new Error("loader must not run on a rejected override");
       },
@@ -329,7 +450,7 @@ describe("CertOps bulk-renew route", () => {
     ];
 
     for (const body of badBodies) {
-      const handler = bulkRenewCertificatesHandler({
+      const handler = makeHandler({
         certificateLoader: async () => {
           throw new Error("loader must not run on a 400 request");
         },

--- a/tests/unit/certops-jobs.test.js
+++ b/tests/unit/certops-jobs.test.js
@@ -2758,4 +2758,71 @@ describe("CertOps jobs service - manualRenewalJobCreator (canonical manual/bulk 
     );
     assert.equal(client.jobs.length, 0);
   });
+
+  it("preflight returns the payload the real creation path would insert, without writing anything", async () => {
+    const { preflightManualRenewalJob } = require(
+      path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+    );
+    const certificate = certificateRow();
+    const client = createManualRenewalMemoryClient({
+      certificates: [certificate],
+    });
+
+    const payload = await preflightManualRenewalJob({
+      client,
+      workspaceId: WORKSPACE_A,
+      certificateId: MANUAL_RENEWAL_CERT_ID,
+      payload: { reason: "pre-audit" },
+    });
+
+    assert.equal(payload.reason, "pre-audit");
+    assert.equal(payload.certificateId, MANUAL_RENEWAL_CERT_ID);
+    assert.equal(payload.commandRef, "acme-renew-default");
+    assert.ok(payload.renewalProfile);
+    assert.equal(client.jobs.length, 0);
+  });
+
+  it("preflight surfaces an incomplete stored renewal profile with the same code the real run raises", async () => {
+    const { CERTOPS_RENEWAL_PROFILE_INCOMPLETE } = require(
+      path.resolve(
+        __dirname,
+        "../../apps/api/services/certops/renewalProfile.js",
+      ),
+    );
+    const { preflightManualRenewalJob } = require(
+      path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+    );
+    const client = createManualRenewalMemoryClient({
+      certificates: [certificateRow({ profile_id: null })],
+    });
+
+    await assert.rejects(
+      () =>
+        preflightManualRenewalJob({
+          client,
+          workspaceId: WORKSPACE_A,
+          certificateId: MANUAL_RENEWAL_CERT_ID,
+        }),
+      (error) => error?.code === CERTOPS_RENEWAL_PROFILE_INCOMPLETE,
+    );
+    assert.equal(client.jobs.length, 0);
+  });
+
+  it("preflight rejects an unknown certificate the same way the real run does", async () => {
+    const { CERTOPS_CERTIFICATE_NOT_FOUND, preflightManualRenewalJob } =
+      require(
+        path.resolve(__dirname, "../../apps/api/services/certops/jobs.js"),
+      );
+    const client = createManualRenewalMemoryClient({ certificates: [] });
+
+    await assert.rejects(
+      () =>
+        preflightManualRenewalJob({
+          client,
+          workspaceId: WORKSPACE_A,
+          certificateId: MANUAL_RENEWAL_CERT_ID,
+        }),
+      (error) => error?.code === CERTOPS_CERTIFICATE_NOT_FOUND,
+    );
+  });
 });

--- a/tests/unit/certops-routes-hardening.test.js
+++ b/tests/unit/certops-routes-hardening.test.js
@@ -163,6 +163,7 @@ describe("CertOps route hardening", () => {
       "GET /api/v1/workspaces/:id/certops/settings",
       "GET /api/v1/workspaces/:id/certops/targets",
       "GET /api/v1/workspaces/:id/certops/trust-anchors",
+      "GET /api/v1/workspaces/:id/certops/trust-anchors/:anchorId/installations",
       "PATCH /api/v1/workspaces/:id/certops/agents/:agentId/alert-settings",
       "PATCH /api/v1/workspaces/:id/certops/profiles/:profileId",
       "POST /api/v1/workspaces/:id/certops/agent-bootstrap-tokens",

--- a/tests/unit/certops-trust-anchors.test.js
+++ b/tests/unit/certops-trust-anchors.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   CERTOPS_TRUST_ANCHOR_INVALID,
+  CERTOPS_TRUST_ANCHOR_NOT_FOUND,
   CERTOPS_TRUST_ANCHOR_PEM_INVALID,
   CERTOPS_TRUST_JOB_IDEMPOTENCY_KEY_REQUIRED,
   CERTOPS_TARGET_AGENT_INVALID,
@@ -17,6 +18,7 @@ const {
   normalizeAgentId,
   normalizeIdempotencyKey,
   assertTargetAgentRegistered,
+  listInstallationsForAnchor,
 } = require(
   path.resolve(__dirname, "../../apps/api/services/certops/trustAnchors.js"),
 );
@@ -255,6 +257,143 @@ describe("assertTargetAgentRegistered (dispatching a trust job to a nonexistent/
     );
   });
 });
+
+describe("listInstallationsForAnchor (read-only installation listing for a trust anchor)", () => {
+  const WORKSPACE_ID = "11111111-1111-1111-1111-111111111111";
+  const ANCHOR_ID = "22222222-2222-2222-2222-222222222222";
+  const INSTALLATION_ID = "33333333-3333-3333-3333-333333333333";
+  const AGENT_ID = "44444444-4444-4444-4444-444444444444";
+
+  function anchorRow(overrides = {}) {
+    return {
+      id: ANCHOR_ID,
+      workspace_id: WORKSPACE_ID,
+      name: "Test Anchor",
+      anchor_type: "root",
+      fingerprint_sha256: "a".repeat(64),
+      subject_common_name: null,
+      status: "active",
+      source: "api",
+      public_metadata: {},
+      created_by: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+      revoked_at: null,
+      ...overrides,
+    };
+  }
+
+  function installationRow(overrides = {}) {
+    return {
+      id: INSTALLATION_ID,
+      workspace_id: WORKSPACE_ID,
+      trust_anchor_id: ANCHOR_ID,
+      host: AGENT_ID,
+      store: "Root",
+      fingerprint_sha256: "a".repeat(64),
+      owner: "workspace-policy",
+      transition_state: "installed",
+      provenance: "tokentimer_installed",
+      agent_id: AGENT_ID,
+      last_job_id: null,
+      transition_generation: 2,
+      last_attempt_at: new Date(),
+      last_error: null,
+      next_reconcile_at: null,
+      public_metadata: {},
+      created_at: new Date(),
+      updated_at: new Date(),
+      ...overrides,
+    };
+  }
+
+  // Distinguishes the two queries by table name substring; the anchor
+  // lookup must be checked with a stricter regex since
+  // "certops_trust_anchors" is a substring of
+  // "certops_trust_anchor_installations".
+  function makeClient({ anchor = null, installationRows = [] } = {}) {
+    const calls = [];
+    return {
+      calls,
+      query: async (sql, params) => {
+        calls.push({ sql, params });
+        if (/certops_trust_anchor_installations/.test(sql)) {
+          return { rows: installationRows };
+        }
+        if (/certops_trust_anchors\b/.test(sql)) {
+          return { rows: anchor ? [anchor] : [] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+  }
+
+  it("throws CERTOPS_TRUST_ANCHOR_NOT_FOUND when the anchor does not exist in this workspace, without ever querying installations", async () => {
+    const client = makeClient({ anchor: null });
+    await assert.rejects(
+      () =>
+        listInstallationsForAnchor({
+          client,
+          workspaceId: WORKSPACE_ID,
+          trustAnchorId: ANCHOR_ID,
+        }),
+      (error) => error?.code === CERTOPS_TRUST_ANCHOR_NOT_FOUND,
+    );
+    assert.equal(
+      client.calls.some((call) => /certops_trust_anchor_installations/.test(call.sql)),
+      false,
+    );
+  });
+
+  it("scopes the installation query to both workspace_id AND trust_anchor_id, ordered by updated_at DESC", async () => {
+    const client = makeClient({
+      anchor: anchorRow(),
+      installationRows: [installationRow()],
+    });
+    await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    const installationCall = client.calls.find((call) =>
+      /certops_trust_anchor_installations/.test(call.sql),
+    );
+    assert.ok(installationCall, "expected an installations query");
+    assert.match(installationCall.sql, /workspace_id\s*=\s*\$1/);
+    assert.match(installationCall.sql, /trust_anchor_id\s*=\s*\$2/);
+    assert.match(installationCall.sql, /ORDER BY updated_at DESC/);
+    assert.deepEqual(installationCall.params, [WORKSPACE_ID, ANCHOR_ID]);
+  });
+
+  it("returns an empty array for an anchor with no installations", async () => {
+    const client = makeClient({ anchor: anchorRow(), installationRows: [] });
+    const result = await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    assert.deepEqual(result, []);
+  });
+
+  it("maps installation rows through installationFromRow (agent, store, transition state, provenance, lastError)", async () => {
+    const row = installationRow({ last_error: "boom" });
+    const client = makeClient({ anchor: anchorRow(), installationRows: [row] });
+    const result = await listInstallationsForAnchor({
+      client,
+      workspaceId: WORKSPACE_ID,
+      trustAnchorId: ANCHOR_ID,
+    });
+    assert.equal(result.length, 1);
+    const [installation] = result;
+    assert.equal(installation.id, INSTALLATION_ID);
+    assert.equal(installation.agentId, AGENT_ID);
+    assert.equal(installation.store, "Root");
+    assert.equal(installation.transitionState, "installed");
+    assert.equal(installation.provenance, "tokentimer_installed");
+    assert.equal(installation.lastError, "boom");
+  });
+});
+
 
 describe("trust result wire carriage", () => {
   const agentProtocolSchema = require(

--- a/tests/unit/certops-worker.test.js
+++ b/tests/unit/certops-worker.test.js
@@ -17,6 +17,18 @@ const workerUrl = pathToFileURL(
   ),
 ).href;
 
+const metricsUrl = pathToFileURL(
+  path.join(
+    __dirname,
+    "..",
+    "..",
+    "apps",
+    "worker",
+    "src",
+    "certops-metrics.js",
+  ),
+).href;
+
 const silentLogger = {
   info() {},
   warn() {},
@@ -63,6 +75,18 @@ function createReaperClient(rows) {
       return { rows: [] };
     },
   };
+}
+
+// runCertOpsMaintenance rejects when any sweep failed, so a failing run exits
+// non-zero. Tests that assert on per-sweep outcomes rather than on that exit
+// signal read the results off the rejection.
+async function runMaintenanceResults(worker, options) {
+  try {
+    return await worker.runCertOpsMaintenance(options);
+  } catch (error) {
+    if (error?.code !== "CERTOPS_MAINTENANCE_SWEEP_FAILED") throw error;
+    return error.results;
+  }
 }
 
 describe("certops maintenance worker", () => {
@@ -372,6 +396,113 @@ describe("certops maintenance worker", () => {
     assert.strictEqual(auditEvents[0].metadata.jobStatus, "failed");
     assert.strictEqual(auditEvents[0].metadata.errorCode, "agent_offline");
     assert.strictEqual(auditEvents[0].metadata.needsOperatorReconciliation, false);
+  });
+
+  it("unwinds a lease-reaped trust job in the reaper's own transaction", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-trust",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "distribute-trust",
+        subject_type: "trust_anchor",
+        subject_id: "anchor-1",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+    const unwinds = [];
+
+    const summary = await worker.reapExpiredLeases({
+      client,
+      log: silentLogger,
+      auditWriter: async () => {},
+      trustTerminalHook: async (args) => {
+        unwinds.push(args);
+        return { action: "deleted" };
+      },
+    });
+
+    assert.strictEqual(summary.failed, 1);
+    assert.strictEqual(unwinds.length, 1, "expected one trust unwind");
+    assert.strictEqual(unwinds[0].client, client);
+    assert.strictEqual(unwinds[0].job.id, "job-trust");
+    assert.strictEqual(unwinds[0].job.status, "failed");
+    assert.strictEqual(unwinds[0].job.operation, "distribute-trust");
+    assert.strictEqual(unwinds[0].job.workspace_id, "ws-1");
+
+    // The unwind must land between the failed UPDATE and the COMMIT, so the
+    // job status and the installation state cannot be observed apart.
+    const updateIndex = client.queries.findIndex((q) =>
+      q.sql.startsWith("UPDATE certificate_jobs SET status = 'failed'"),
+    );
+    const commitIndex = client.queries.findIndex((q) => q.sql === "COMMIT");
+    assert.ok(updateIndex >= 0 && commitIndex > updateIndex);
+  });
+
+  it("does not unwind non-trust jobs the reaper fails", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-renew",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "renew",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+    let unwindCalls = 0;
+
+    await worker.reapExpiredLeases({
+      client,
+      log: silentLogger,
+      auditWriter: async () => {},
+      trustTerminalHook: async () => {
+        unwindCalls += 1;
+      },
+    });
+
+    assert.strictEqual(unwindCalls, 0);
+  });
+
+  it("rolls the whole reaper transaction back when a trust unwind fails", async () => {
+    const worker = await import(workerUrl);
+    const client = createReaperClient([
+      {
+        id: "job-trust-broken",
+        workspace_id: "ws-1",
+        status: "claimed",
+        attempt_count: 3,
+        max_attempts: 3,
+        operation: "revoke-trust",
+        lease_renewed_at: null,
+        agent_alive: false,
+        past_hard_grace: false,
+      },
+    ]);
+
+    await assert.rejects(
+      () =>
+        worker.reapExpiredLeases({
+          client,
+          log: silentLogger,
+          auditWriter: async () => {},
+          trustTerminalHook: async () => {
+            throw new Error("installation row locked");
+          },
+        }),
+      /installation row locked/,
+    );
+
+    assert.strictEqual(client.queries.at(-1).sql, "ROLLBACK");
   });
 
   it("never requeues running jobs; marks them orphaned_unknown_effect instead", async () => {
@@ -1260,7 +1391,7 @@ describe("certops maintenance worker", () => {
     let nonceCalls = 0;
     let renewalCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {},
       log: silentLogger,
       // Lease reaper and stale-agent sweep both explode.
@@ -1301,7 +1432,7 @@ describe("certops maintenance worker", () => {
     let renewalCalls = 0;
     let clientCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
       CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
       CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "0",
@@ -1342,7 +1473,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     let renewalCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_TIMEOUT_MS: "20",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1389,7 +1520,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     const seenClients = [];
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {},
       log: silentLogger,
       withClientFn: async (fn) =>
@@ -1424,7 +1555,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     const seenClients = [];
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1451,7 +1582,7 @@ describe("certops maintenance worker", () => {
     const worker = await import(workerUrl);
     let replayCalls = 0;
 
-    const results = await worker.runCertOpsMaintenance({
+    const results = await runMaintenanceResults(worker, {
       env: {
         CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
         CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
@@ -1470,5 +1601,84 @@ describe("certops maintenance worker", () => {
 
     assert.strictEqual(results.registrationReplaySweep.status, "skipped");
     assert.strictEqual(replayCalls, 0);
+  });
+
+  it("rejects with a sweep-failure code so a failing run exits non-zero", async () => {
+    const worker = await import(workerUrl);
+    let metricsPushed = 0;
+
+    await assert.rejects(
+      () =>
+        worker.runCertOpsMaintenance({
+          env: {
+            CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
+            CERTOPS_SWEEP_AGENT_RECOVERY_ALERTS_ENABLED: "false",
+            CERTOPS_SWEEP_NONCE_ENABLED: "false",
+            CERTOPS_SWEEP_REGISTRATION_REPLAY_ENABLED: "false",
+            CERTOPS_SWEEP_RENEWAL_SCHEDULER_ENABLED: "false",
+            CERTOPS_SWEEP_OUTBOX_DRAIN_ENABLED: "false",
+            CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_ENABLED: "false",
+            CERTOPS_SWEEP_TRUST_ANCHOR_RECONCILIATION_ENABLED: "false",
+          },
+          log: silentLogger,
+          withClientFn: async () => {
+            throw new Error("db down");
+          },
+          pushMetricsFn: async () => {
+            metricsPushed += 1;
+          },
+        }),
+      (err) => {
+        assert.strictEqual(err.code, "CERTOPS_MAINTENANCE_SWEEP_FAILED");
+        assert.match(err.message, /1 sweep\(s\) failed: leaseReaper/);
+        assert.strictEqual(err.results.leaseReaper.status, "failed");
+        return true;
+      },
+    );
+
+    // Metrics must still ship for a failing run, otherwise the failure is
+    // invisible in the series that would explain it.
+    assert.strictEqual(metricsPushed, 1);
+  });
+
+  it("does not fail the run when sweeps are only skipped", async () => {
+    const worker = await import(workerUrl);
+
+    const results = await worker.runCertOpsMaintenance({
+      env: {
+        CERTOPS_SWEEP_LEASE_REAPER_ENABLED: "false",
+        CERTOPS_SWEEP_STALE_AGENTS_ENABLED: "false",
+        CERTOPS_SWEEP_AGENT_RECOVERY_ALERTS_ENABLED: "false",
+        CERTOPS_SWEEP_REGISTRATION_REPLAY_ENABLED: "false",
+        CERTOPS_SWEEP_RENEWAL_SCHEDULER_ENABLED: "false",
+        CERTOPS_SWEEP_OUTBOX_DRAIN_ENABLED: "false",
+        CERTOPS_SWEEP_DIAGNOSTIC_AGENT_INACTIVITY_ENABLED: "false",
+        CERTOPS_SWEEP_TRUST_ANCHOR_RECONCILIATION_ENABLED: "false",
+      },
+      log: silentLogger,
+      dbPool: { marker: "pool" },
+      nonceSweeper: async () => 2,
+      pushMetricsFn: async () => {},
+    });
+
+    assert.strictEqual(results.leaseReaper.status, "skipped");
+    assert.strictEqual(results.trustAnchorReconciliation.status, "skipped");
+    assert.strictEqual(results.nonceSweep.status, "success");
+  });
+
+  it("treats only failed sweeps as a failed run", async () => {
+    const metrics = await import(metricsUrl);
+
+    assert.deepStrictEqual(metrics.identifyFailedSweeps({}), []);
+    assert.deepStrictEqual(metrics.identifyFailedSweeps(undefined), []);
+    assert.deepStrictEqual(
+      metrics.identifyFailedSweeps({
+        a: { status: "success" },
+        b: { status: "skipped" },
+        c: { status: "failed" },
+        d: { status: "failed" },
+      }),
+      ["c", "d"],
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a dedicated `TrustAnchorsPanel` to the dashboard's CertOps Agents page: approve/retire anchors, expandable per-anchor installations table (agent, owner, host, store, state), and distribute/revoke actions.
- Narrows `CreateManualJobModal` with a `trustOp` branch for distribute-trust/revoke-trust, opened from the panel with the anchor and operation pre-set: owner picker (existing-only on revoke, new-or-existing with near-duplicate warning on distribute), auto-generated idempotency key, agentId wiring, and trust-specific error mapping.
- New `certopsTrustAnchorsApi.js` + `useCertOpsTrustAnchors.js` (list/create/retire anchors, list installations), consuming the read-only installations endpoint from this branch's base.
- Adds `distribute-trust`/`revoke-trust`/`trust_anchor` labels to `certopsJobsFormat.js`.

Base branch (`chore/0.14.1-certops-correctness`, PR #191) carries the correctness fixes and the new installations endpoint this UI depends on.

## Test plan
- [x] `pnpm run test:unit` (dashboard + full repo) green
- [x] New unit tests: `CreateManualJobModal.test.jsx` (trust-op branch), `TrustAnchorsPanel.test.jsx`, `useCertOpsTrustAnchors.test.jsx`
- [x] `check:contracts`, `check:contracts:integrity`, leak-scan clean
- [x] prettier/eslint clean on new/changed files
- [ ] Manual browser end-to-end pass (create anchor, distribute, inspect installations, revoke, retire) - tracked separately
