### PR TITLE
fix(dashboard): complete workspaceAPI mock in DashboardPages smoke tests

### DIFF
--- a/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
+++ b/apps/dashboard/tests/unit/DashboardPages.smoke.test.jsx
@@ -12,6 +12,7 @@ const {
   apiGetMock,
   apiPostMock,
   apiDeleteMock,
+  workspaceGetMock,
   workspaceListMock,
   workspaceListMembersMock,
   workspaceCreateMock,
@@ -21,6 +22,7 @@ const {
   apiGetMock: vi.fn(),
   apiPostMock: vi.fn(),
   apiDeleteMock: vi.fn(),
+  workspaceGetMock: vi.fn(),
   workspaceListMock: vi.fn(),
   workspaceListMembersMock: vi.fn(),
   workspaceCreateMock: vi.fn(),
@@ -112,6 +114,7 @@ vi.mock('../../src/utils/apiClient', () => ({
     ALERT_STATS: '/api/alert-stats',
   },
   workspaceAPI: {
+    get: workspaceGetMock,
     list: workspaceListMock,
     listMembers: workspaceListMembersMock,
     create: workspaceCreateMock,
@@ -187,6 +190,10 @@ const baseProps = {
 describe('Dashboard page smoke tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Audit.jsx pulls in useCertOpsAgents -> useCertOpsCanManage, which
+    // resolves the caller's role via workspaceAPI.get; these smoke tests
+    // don't assert on manager gating, so any resolvable role is fine.
+    workspaceGetMock.mockResolvedValue({ role: 'admin' });
     workspaceListMock.mockResolvedValue({ items: [] });
     workspaceListMembersMock.mockResolvedValue({ items: [] });
     workspaceCreateMock.mockResolvedValue({ id: 'ws-2' });


### PR DESCRIPTION
## Summary

`ci.yml`'s `coverage_frontend` job (`continue-on-error: true`, never blocks CI) has been failing since the v0.14.1 merge with:

```
TypeError: workspaceAPI.get is not a function
o' resolveWorkspaceRole apps/dashboard/src/components/certops/useCertOps.js:46:6
```

**Root cause:** test-mock gap, not a real bug. `workspaceAPI.get` is genuinely defined in `apps/dashboard/src/utils/apiClient.js`. `DashboardPages.smoke.test.jsx` mocks `../../src/utils/apiClient` with a `workspaceAPI` object that has `list`, `listMembers`, `create`, etc., but no `get`. The 0.14.1 trust-anchor-UI work wired `Audit.jsx` to `useCertOpsAgents()` -> `useCertOpsCanManage()` -> `resolveWorkspaceRole()`, which calls `workspaceAPI.get(workspaceId)`. Every smoke test that renders the `Audit` route now hits the missing mock and throws, which is exactly the 5 failing tests reproduced locally (`renders Audit route with mocked data state`, `renders SSO audit metadata in Audit route`, `renders the newly wired CertOps audit actions without crashing`, `shows organization scope for system admins on Audit route`, `re-reads the ?q= filter from the URL...`).

**Fix:** add a `workspaceAPI.get` mock (`workspaceGetMock`, resolving `{ role: 'admin' }`) to `DashboardPages.smoke.test.jsx`'s `apiClient` mock, so `resolveWorkspaceRole` resolves normally instead of throwing. No production code changed.

## Test plan

- [x] Reproduced locally: `pnpm run test:coverage:frontend` failed with 5 failures, all in `DashboardPages.smoke.test.jsx`, before the fix.
- [x] After the fix: `pnpm run test:coverage:frontend` passes with 0 failures (49 test files / 494 tests).
- [x] `pnpm --filter @tokentimer/dashboard lint`: 0 errors (pre-existing warnings only, unrelated to this change).
- [x] Dashboard Prettier `--write` then `--check` on `src/**`: no diff, all files already formatted.
- [x] `pnpm run test:unit`: 1800 passed, 0 failed.
