### PR TITLE
feat(certops): surface agent-capability/misconfiguration signals across agent, API, and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Agent execution capability is now visible before you pin a job to an agent.** The CertOps Agents tab has a new Execution column showing whether an agent declared any executable action on its last successful claim; hovering "No capability declared" explains it can mean observe-only mode or simply an agent that hasn't polled yet. The manual-job and trust-anchor distribute/revoke modals annotate an agent option and show an inline warning when the selected agent has not declared the operation being requested, and creating a trust job against an agent that is retired or outside the accepted compatibility range is now rejected up front instead of leaving the job stuck at "Pending" forever. A trust-anchor installation stuck in a pending transition with no error now shows the same advisory reason inline instead of a bare "Pending" badge.
+
 ## [0.14.2] - 2026-09-01
 
 ### Fixed

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -630,13 +630,8 @@ function handleCertOpsError(res, err) {
       code: CERTOPS_TARGET_AGENT_NOT_FOUND,
     });
   }
-  // Refuses to pin a trust job to an agent that is currently, definitely
-  // incapable of ever claiming it (observe-only, retired, or compatibility-
-  // blocked) - see assertTargetAgentEligibleForTrustJob's header comment.
-  // 409 rather than 400: the request is well-formed, but the current state
-  // of the named resource (this agent) conflicts with performing the
-  // action, matching this codebase's existing convention for that shape of
-  // error (e.g. CERTOPS_TRUST_ANCHOR_NOT_ACTIVE below).
+  // 409: the agent can never claim this job (retired or version-blocked),
+  // same convention as CERTOPS_TRUST_ANCHOR_NOT_ACTIVE below.
   if (err?.code === CERTOPS_TARGET_AGENT_INELIGIBLE) {
     return res.status(409).json({
       error: err.message || "Target agent cannot currently claim this job",

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -153,6 +153,7 @@ const {
   CERTOPS_TRUST_RESULT_STALE_GENERATION,
   CERTOPS_TARGET_AGENT_INVALID,
   CERTOPS_TARGET_AGENT_NOT_FOUND,
+  CERTOPS_TARGET_AGENT_INELIGIBLE,
   createTrustAnchor,
   listTrustAnchors,
   listInstallationsForAnchor,
@@ -627,6 +628,19 @@ function handleCertOpsError(res, err) {
     return res.status(404).json({
       error: err.message || "Target agent not found",
       code: CERTOPS_TARGET_AGENT_NOT_FOUND,
+    });
+  }
+  // Refuses to pin a trust job to an agent that is currently, definitely
+  // incapable of ever claiming it (observe-only, retired, or compatibility-
+  // blocked) - see assertTargetAgentEligibleForTrustJob's header comment.
+  // 409 rather than 400: the request is well-formed, but the current state
+  // of the named resource (this agent) conflicts with performing the
+  // action, matching this codebase's existing convention for that shape of
+  // error (e.g. CERTOPS_TRUST_ANCHOR_NOT_ACTIVE below).
+  if (err?.code === CERTOPS_TARGET_AGENT_INELIGIBLE) {
+    return res.status(409).json({
+      error: err.message || "Target agent cannot currently claim this job",
+      code: CERTOPS_TARGET_AGENT_INELIGIBLE,
     });
   }
   // Result-ingestion codes (agentDispatch.ingestResult) mapped here too for

--- a/apps/api/services/certops/agentRegistry.js
+++ b/apps/api/services/certops/agentRegistry.js
@@ -111,15 +111,9 @@ function certopsCapabilityFreshnessMs(env = process.env) {
 // The workspace admin surface must never see credential_prefix or
 // credential_hash; only these columns leave the service layer.
 //
-// supported_operations/declared_capabilities/capabilities_updated_at and the
-// declared routing arrays are included so the dashboard can show *why* an
-// agent is (or isn't) eligible for a given job, instead of an agent's
-// observe-only/capability-missing state being invisible until a job it was
-// pinned to sits at "pending" forever with no explanation (the gap that
-// motivated adding these fields here). They mirror exactly what
-// agentDispatch.js's real claim-time check reads, so the dashboard's view of
-// "can this agent do X" can never diverge from what dispatch actually
-// enforces.
+// The capability columns below mirror what agentDispatch.js reads at claim
+// time, so the dashboard can explain *why* an agent is or isn't eligible
+// for a job instead of leaving it stuck at "pending" with no reason.
 const AGENT_SAFE_SELECT_FIELDS = `
   id,
   workspace_id,
@@ -149,11 +143,8 @@ const AGENT_SAFE_SELECT_FIELDS = `
 `;
 
 /**
- * jsonb columns arrive from node-postgres already parsed into JS values, so
- * this only needs to guard against a legacy NULL/non-array shape - no
- * JSON.parse needed. Mirrors agentDispatch.js's own jsonbTextArray; kept as
- * a separate copy rather than a shared import to avoid adding a new
- * cross-module dependency for a three-line helper.
+ * jsonb columns arrive already parsed, so this just guards against a
+ * legacy NULL/non-array shape. Mirrors agentDispatch.js's own helper.
  */
 function jsonbTextArray(value) {
   if (!Array.isArray(value)) return [];
@@ -415,19 +406,11 @@ function agentMetadataFromRow(row, env = process.env) {
     // DEFAULT TRUE backfilled every pre-existing row at migration time).
     downtimeAlertsEnabled: Boolean(row.downtime_alerts_enabled ?? true),
     contactGroupId: row.contact_group_id ?? null,
-    // supportedOperations is only ever written from the wire-declared
-    // supportedActions on a successful claim call (agentDispatch.js); an
-    // observe-only agent never calls claim at all, so a freshly registered
-    // observe-only agent correctly reads [] here. An agent that WAS
-    // execution-enabled, successfully claimed at least once, and was then
-    // reconfigured to observe-only without another claim call will still
-    // read its last-claimed set until its next claim attempt - the same
-    // staleness trade-off ADR-0012 decision 17 already accepts for
-    // declaredCapabilities, not something new introduced by exposing this
-    // field here. Still the single most useful signal available: it is the
-    // exact field evaluateAgentJobEligibility's operation_unsupported check
-    // reads for real dispatch, so this can never disagree with what
-    // actually happens when a job is claimed.
+    // supportedOperations only updates on a successful claim call, so an
+    // observe-only agent and a brand-new agent that hasn't polled yet look
+    // identical here. Same staleness trade-off ADR-0012 decision 17 accepts
+    // for declaredCapabilities. Still the most useful signal available:
+    // it's the exact field dispatch checks for real eligibility.
     supportedOperations: jsonbTextArray(row.supported_operations),
     declaredCapabilities: jsonbTextArray(row.declared_capabilities),
     capabilitiesUpdatedAt: dateToIso(row.capabilities_updated_at),
@@ -516,12 +499,9 @@ async function getAgentById(options) {
 }
 
 /**
- * Batch-resolves agents by their internal UUID primary key (certops_agents.id),
- * not the human-readable agent_id string - the identity trustAnchors.js's
- * certops_trust_anchor_installations rows are actually keyed on (agent_id
- * FK). Sibling of getAgentsByAgentIdStrings just below, which serves the
- * string-keyed callers; kept separate rather than a single dual-mode
- * function so neither caller has to reason about which key shape it holds.
+ * Batch-resolves agents by internal UUID (certops_agents.id), the key
+ * trustAnchors.js's installation rows use. Sibling of
+ * getAgentsByAgentIdStrings below, which serves string-keyed callers.
  *
  * @param {{ workspaceId: string, ids: string[], client?: object, env?: NodeJS.ProcessEnv }} options
  * @returns {Promise<Map<string, object>>} internal id (string) -> agentMetadataFromRow shape

--- a/apps/api/services/certops/agentRegistry.js
+++ b/apps/api/services/certops/agentRegistry.js
@@ -110,6 +110,16 @@ function certopsCapabilityFreshnessMs(env = process.env) {
 
 // The workspace admin surface must never see credential_prefix or
 // credential_hash; only these columns leave the service layer.
+//
+// supported_operations/declared_capabilities/capabilities_updated_at and the
+// declared routing arrays are included so the dashboard can show *why* an
+// agent is (or isn't) eligible for a given job, instead of an agent's
+// observe-only/capability-missing state being invisible until a job it was
+// pinned to sits at "pending" forever with no explanation (the gap that
+// motivated adding these fields here). They mirror exactly what
+// agentDispatch.js's real claim-time check reads, so the dashboard's view of
+// "can this agent do X" can never diverge from what dispatch actually
+// enforces.
 const AGENT_SAFE_SELECT_FIELDS = `
   id,
   workspace_id,
@@ -129,8 +139,26 @@ const AGENT_SAFE_SELECT_FIELDS = `
   retired_at,
   retire_reason,
   downtime_alerts_enabled,
-  contact_group_id
+  contact_group_id,
+  supported_operations,
+  declared_capabilities,
+  capabilities_updated_at,
+  declared_target_selectors,
+  declared_command_profile_names,
+  supported_dns_providers
 `;
+
+/**
+ * jsonb columns arrive from node-postgres already parsed into JS values, so
+ * this only needs to guard against a legacy NULL/non-array shape - no
+ * JSON.parse needed. Mirrors agentDispatch.js's own jsonbTextArray; kept as
+ * a separate copy rather than a shared import to avoid adding a new
+ * cross-module dependency for a three-line helper.
+ */
+function jsonbTextArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string");
+}
 
 // Idempotent revocation guard for retireAgent below. Generates a fresh
 // cryptographically random value in Node (not SQL): gen_random_bytes()
@@ -387,6 +415,25 @@ function agentMetadataFromRow(row, env = process.env) {
     // DEFAULT TRUE backfilled every pre-existing row at migration time).
     downtimeAlertsEnabled: Boolean(row.downtime_alerts_enabled ?? true),
     contactGroupId: row.contact_group_id ?? null,
+    // supportedOperations is only ever written from the wire-declared
+    // supportedActions on a successful claim call (agentDispatch.js); an
+    // observe-only agent never calls claim at all, so a freshly registered
+    // observe-only agent correctly reads [] here. An agent that WAS
+    // execution-enabled, successfully claimed at least once, and was then
+    // reconfigured to observe-only without another claim call will still
+    // read its last-claimed set until its next claim attempt - the same
+    // staleness trade-off ADR-0012 decision 17 already accepts for
+    // declaredCapabilities, not something new introduced by exposing this
+    // field here. Still the single most useful signal available: it is the
+    // exact field evaluateAgentJobEligibility's operation_unsupported check
+    // reads for real dispatch, so this can never disagree with what
+    // actually happens when a job is claimed.
+    supportedOperations: jsonbTextArray(row.supported_operations),
+    declaredCapabilities: jsonbTextArray(row.declared_capabilities),
+    capabilitiesUpdatedAt: dateToIso(row.capabilities_updated_at),
+    targetSelectors: jsonbTextArray(row.declared_target_selectors),
+    commandProfiles: jsonbTextArray(row.declared_command_profile_names),
+    dnsProviders: jsonbTextArray(row.supported_dns_providers),
   };
   const compatibility = computeAgentCompatibility(base, env);
   return {
@@ -466,6 +513,37 @@ async function getAgentById(options) {
     [normalizeWorkspaceId(options.workspaceId), options.agentId],
   );
   return agentMetadataFromRow(result.rows[0] || null, options.env);
+}
+
+/**
+ * Batch-resolves agents by their internal UUID primary key (certops_agents.id),
+ * not the human-readable agent_id string - the identity trustAnchors.js's
+ * certops_trust_anchor_installations rows are actually keyed on (agent_id
+ * FK). Sibling of getAgentsByAgentIdStrings just below, which serves the
+ * string-keyed callers; kept separate rather than a single dual-mode
+ * function so neither caller has to reason about which key shape it holds.
+ *
+ * @param {{ workspaceId: string, ids: string[], client?: object, env?: NodeJS.ProcessEnv }} options
+ * @returns {Promise<Map<string, object>>} internal id (string) -> agentMetadataFromRow shape
+ */
+async function getAgentsByIds(options) {
+  const ids = Array.from(
+    new Set((options.ids || []).filter((value) => typeof value === "string" && value)),
+  );
+  if (ids.length === 0) return new Map();
+  const result = await (options.client || pool).query(
+    `SELECT ${AGENT_SAFE_SELECT_FIELDS}
+       FROM certops_agents
+      WHERE workspace_id = $1
+        AND id = ANY($2::uuid[])`,
+    [normalizeWorkspaceId(options.workspaceId), ids],
+  );
+  const map = new Map();
+  for (const row of result.rows) {
+    const metadata = agentMetadataFromRow(row, options.env);
+    map.set(String(metadata.id), metadata);
+  }
+  return map;
 }
 
 /**
@@ -1011,6 +1089,7 @@ module.exports = {
   fenceAgentInFlightWork,
   getAgentById,
   getAgentsByAgentIdStrings,
+  getAgentsByIds,
   listAgents,
   normalizeRequiredRetireReason,
   readCompatibilityConfig,

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -36,7 +36,8 @@ const {
 const {
   validateTrustResult,
 } = require("../../../../packages/contracts/certops/validate-trust-result.cjs");
-const { getAgentById } = require("./agentRegistry");
+const { getAgentById, getAgentsByIds } = require("./agentRegistry");
+const { evaluateAgentJobEligibility } = require("./agentJobEligibility");
 
 // --- Error codes ---
 const CERTOPS_TRUST_ANCHOR_INVALID = "CERTOPS_TRUST_ANCHOR_INVALID";
@@ -49,6 +50,18 @@ const CERTOPS_TRUST_JOB_OPERATION_INVALID =
   "CERTOPS_TRUST_JOB_OPERATION_INVALID";
 const CERTOPS_TRUST_INSTALLATION_NOT_FOUND =
   "CERTOPS_TRUST_INSTALLATION_NOT_FOUND";
+// A trust job is always pinned to one specific agent (never openly
+// claimable), so unlike a renewal/deploy job left for "any eligible agent",
+// there is no fallback claimant if the pinned agent can never claim it. A
+// job created against a currently-ineligible agent (most commonly: observe-
+// only, i.e. no execution block / execution.enabled: false) would previously
+// sit at pending_install/pending_remove forever with no error anywhere - the
+// UI showed nothing beyond a bare "Pending" badge. Rejecting the request up
+// front, with the same reason evaluateAgentJobEligibility would use to
+// refuse the claim anyway, turns a silent stuck job into an actionable error
+// at the moment a human could still do something about it.
+const CERTOPS_TARGET_AGENT_INELIGIBLE = "CERTOPS_TARGET_AGENT_INELIGIBLE";
+
 // anchor_type determines which OS store (Root/CA) a fingerprint's
 // installations live in (resolveTrustAnchorStoreLabel below). It is
 // immutable once ANY non-removed certops_trust_anchor_installations row
@@ -256,6 +269,95 @@ async function assertTargetAgentRegistered({ client, workspaceId, agentId }) {
     );
   }
   return agent;
+}
+
+// Operator-actionable text for each determinate evaluateAgentJobEligibility
+// reason a trust job creation request can hit. Kept separate from the
+// dispatch-time reasons in agentJobEligibility.js, which are terse wire
+// codes rather than sentences meant for a human reading an API error - the
+// two must always stay in the same taxonomy (see the reason keys used
+// below), but this file owns the prose.
+//
+// Only agent_retired and compatibility_blocked are enforced as hard
+// creation-time blocks (see BLOCKING_TRUST_JOB_CREATION_REASONS below); the
+// other entries here exist so the SAME prose can be reused for advisory
+// (non-blocking) display elsewhere, e.g. explaining an already-stuck
+// pending_install/pending_remove installation row.
+const TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON = Object.freeze({
+  agent_retired:
+    "This agent has been retired and can no longer be assigned any job.",
+  compatibility_blocked:
+    "This agent's build/protocol version is outside the range this " +
+    "control plane accepts and can never claim a job until it is " +
+    "upgraded.",
+  operation_unsupported:
+    "This agent has not declared distribute-trust/revoke-trust support " +
+    "the last time it claimed a job (most commonly because it is running " +
+    "in observe-only mode - no execution block, or execution.enabled is " +
+    "not true, in its config.json - though a brand-new agent that has " +
+    "simply not polled for a job yet looks identical here). If this " +
+    "persists, check the agent's config.json and logs.",
+  trust_anchor_deploy_capability_unavailable:
+    "This agent has not declared (or recently re-declared) support for " +
+    "trust-anchor distribution. Confirm the agent is running a build that " +
+    "supports distribute-trust/revoke-trust and has heartbeated recently.",
+});
+
+// The only two reasons safe to enforce as a hard block at job CREATION
+// time. Every other determinate reason evaluateAgentJobEligibility can
+// return - most importantly operation_unsupported - is driven by
+// supported_operations, a column ONLY ever written from the wire-declared
+// supportedActions on a successful CLAIM call. That makes it indistinguishable
+// between "genuinely observe-only" and "healthy, execution-enabled agent
+// that simply has not had its first poll cycle yet" - both read as [] at
+// this point. Blocking on it here would produce false "this agent is
+// misconfigured" rejections for a perfectly fine, brand-new agent, which is
+// its own kind of confusing error. agent_retired and compatibility_blocked
+// have no such staleness problem: both are derived from state that cannot
+// self-heal without an operator action anyway (agent_retired is a permanent,
+// human-triggered flag; compatibility_blocked only clears by upgrading the
+// agent build itself), so surfacing them immediately trades nothing away.
+// Reliably detecting "observe-only right now" at creation time would need
+// the agent to self-report execution.enabled on a channel that updates
+// independently of ever claiming a job (e.g. a new heartbeat field) - a
+// wire-protocol change deliberately left for a future release rather than
+// folded into this pass; see the pending-installation reason (E) for the
+// non-blocking surfacing of operation_unsupported this pass ships instead.
+const BLOCKING_TRUST_JOB_CREATION_REASONS = new Set([
+  "agent_retired",
+  "compatibility_blocked",
+]);
+
+/**
+ * Refuses to create a trust job pinned to an agent that is CURRENTLY,
+ * unambiguously incapable of ever claiming it - the same authoritative
+ * predicate real dispatch uses (evaluateAgentJobEligibility), called one
+ * step earlier so the caller gets an immediate, actionable error for the
+ * handful of reasons that are safe to act on before a claim is ever
+ * attempted. See BLOCKING_TRUST_JOB_CREATION_REASONS for exactly which
+ * reasons that is and why the rest are intentionally excluded. Deliberately
+ * does not check liveness/offline state either (an agent that is merely
+ * offline right now may come back and claim the job normally).
+ */
+function assertTargetAgentEligibleForTrustJob({ agent, operation }) {
+  const evaluation = evaluateAgentJobEligibility({
+    agent,
+    job: {
+      operation,
+      executorKind: "agent",
+      assignedAgentId: agent.id,
+      payload: {},
+    },
+    compatibility: { compatibilityState: agent.compatibilityState },
+  });
+  if (evaluation.eligible || evaluation.determinate !== true) return;
+  if (!BLOCKING_TRUST_JOB_CREATION_REASONS.has(evaluation.reason)) return;
+  const message =
+    TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON[evaluation.reason] ||
+
+    `This agent cannot currently be assigned a ${operation} job ` +
+      `(${evaluation.reason}).`;
+  throw trustAnchorError(message, CERTOPS_TARGET_AGENT_INELIGIBLE);
 }
 
 function normalizeIdempotencyKey(value) {
@@ -679,6 +781,73 @@ function installationFromRow(row) {
   };
 }
 
+const LIVE_PENDING_TRANSITION_STATES = new Set(["pending_install", "pending_remove"]);
+
+/**
+ * Advisory (never blocking) explanation for a pending_install/pending_remove
+ * row that has not yet recorded a last_error: before this, such a row
+ * rendered as a bare "Pending" badge with zero information about whether it
+ * is progressing normally (the agent just hasn't polled yet) or stuck for a
+ * knowable reason (retired, incompatible, or - the case that motivated this
+ * - the assigned agent's last claim declared no support for this
+ * operation, most commonly because it is running observe-only). Reuses
+ * TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON so this can never say something
+ * different from what assertTargetAgentEligibleForTrustJob would have
+ * blocked creation on, had the same state existed at creation time.
+ * Returns null for a row with no knowable reason (agent looks eligible, or
+ * the agent record itself is missing/malformed) - callers must keep
+ * treating null as "no additional information", not "definitely fine".
+ */
+function pendingReasonForInstallation(installation, agent) {
+  if (!LIVE_PENDING_TRANSITION_STATES.has(installation.transitionState)) return null;
+  if (installation.lastError) return null;
+  if (!agent) return null;
+  const operation =
+    installation.transitionState === "pending_install"
+      ? "distribute-trust"
+      : "revoke-trust";
+  const evaluation = evaluateAgentJobEligibility({
+    agent,
+    job: {
+      operation,
+      executorKind: "agent",
+      assignedAgentId: agent.id,
+      payload: {},
+    },
+    compatibility: { compatibilityState: agent.compatibilityState },
+  });
+  if (evaluation.eligible || evaluation.determinate !== true) return null;
+  return {
+    code: evaluation.reason,
+    message:
+      TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON[evaluation.reason] ||
+      `The assigned agent cannot currently claim this job (${evaluation.reason}).`,
+  };
+}
+
+/**
+ * Batch-attaches pendingReason (see pendingReasonForInstallation) to every
+ * row in one round-trip: one getAgentsByIds call for the whole page/anchor
+ * rather than one agent lookup per installation row.
+ */
+async function attachPendingReasons({ db, workspaceId, installations }) {
+  const candidateIds = installations
+    .filter((row) => LIVE_PENDING_TRANSITION_STATES.has(row.transitionState) && !row.lastError)
+    .map((row) => row.agentId);
+  if (candidateIds.length === 0) {
+    return installations.map((row) => ({ ...row, pendingReason: null }));
+  }
+  const agentsById = await getAgentsByIds({
+    client: db,
+    workspaceId,
+    ids: candidateIds,
+  });
+  return installations.map((row) => ({
+    ...row,
+    pendingReason: pendingReasonForInstallation(row, agentsById.get(row.agentId) || null),
+  }));
+}
+
 /**
  * Read-only listing of every installation row for one trust anchor, for a
  * future admin UI to see where an anchor actually landed (agent, store,
@@ -711,8 +880,10 @@ async function listInstallationsForAnchor(options = {}) {
       ORDER BY updated_at DESC`,
     [workspaceId, trustAnchorId],
   );
-  return result.rows.map(installationFromRow);
+  const installations = result.rows.map(installationFromRow);
+  return attachPendingReasons({ db, workspaceId, installations });
 }
+
 
 /**
  * Locks (or creates, if absent) the ownership-reference row for
@@ -1167,7 +1338,17 @@ async function runCreateTrustJob(client, params) {
   // error (invalid UUID syntax or an FK violation on
   // fk_certops_trust_anchor_installations_agent) that handleCertOpsError
   // could not recognize, so both cases fell through to a bare 500.
-  await assertTargetAgentRegistered({ client, workspaceId, agentId });
+  const targetAgent = await assertTargetAgentRegistered({
+    client,
+    workspaceId,
+    agentId,
+  });
+
+  // Refuse up front rather than letting a job get created that can never be
+  // claimed - see assertTargetAgentEligibleForTrustJob's own header comment
+  // for why this matters specifically for pinned trust jobs (no fallback
+  // claimant exists the way there is for an open renewal/deploy job).
+  assertTargetAgentEligibleForTrustJob({ agent: targetAgent, operation });
 
   const { row: installationRow, created: installationCreated } =
     await lockOrCreateInstallation({
@@ -2184,6 +2365,7 @@ module.exports = {
   RECEIPT_FINALIZE_CONFLICT_CATEGORY,
   CERTOPS_TARGET_AGENT_INVALID,
   CERTOPS_TARGET_AGENT_NOT_FOUND,
+  CERTOPS_TARGET_AGENT_INELIGIBLE,
   ANCHOR_TYPES,
   DEFAULT_RECONCILE_DELAY_MS,
   parseAndValidateAnchorPem,
@@ -2192,6 +2374,7 @@ module.exports = {
   getTrustAnchorById,
   retireTrustAnchor,
   listInstallationsForAnchor,
+  pendingReasonForInstallation,
   anchorFromRow,
   installationFromRow,
   normalizeStore,
@@ -2212,4 +2395,11 @@ module.exports = {
   rescheduleTrustInstallation,
   sweepOverdueTrustInstallations,
   DEFAULT_MAX_RECONCILE_AGE_MS,
+};
+
+module.exports._test = {
+  assertTargetAgentEligibleForTrustJob,
+  BLOCKING_TRUST_JOB_CREATION_REASONS,
+  TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON,
+  pendingReasonForInstallation,
 };

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -303,26 +303,12 @@ const TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON = Object.freeze({
     "supports distribute-trust/revoke-trust and has heartbeated recently.",
 });
 
-// The only two reasons safe to enforce as a hard block at job CREATION
-// time. Every other determinate reason evaluateAgentJobEligibility can
-// return - most importantly operation_unsupported - is driven by
-// supported_operations, a column ONLY ever written from the wire-declared
-// supportedActions on a successful CLAIM call. That makes it indistinguishable
-// between "genuinely observe-only" and "healthy, execution-enabled agent
-// that simply has not had its first poll cycle yet" - both read as [] at
-// this point. Blocking on it here would produce false "this agent is
-// misconfigured" rejections for a perfectly fine, brand-new agent, which is
-// its own kind of confusing error. agent_retired and compatibility_blocked
-// have no such staleness problem: both are derived from state that cannot
-// self-heal without an operator action anyway (agent_retired is a permanent,
-// human-triggered flag; compatibility_blocked only clears by upgrading the
-// agent build itself), so surfacing them immediately trades nothing away.
-// Reliably detecting "observe-only right now" at creation time would need
-// the agent to self-report execution.enabled on a channel that updates
-// independently of ever claiming a job (e.g. a new heartbeat field) - a
-// wire-protocol change deliberately left for a future release rather than
-// folded into this pass; see the pending-installation reason (E) for the
-// non-blocking surfacing of operation_unsupported this pass ships instead.
+// Only agent_retired/compatibility_blocked are safe to hard-block at
+// creation time: both require an operator action to change and can't
+// self-heal. operation_unsupported is excluded because supported_operations
+// only updates on a successful claim, so a brand-new healthy agent reads
+// identically to a genuinely observe-only one until its first poll - see
+// the pending-installation reason (E) for its non-blocking surfacing instead.
 const BLOCKING_TRUST_JOB_CREATION_REASONS = new Set([
   "agent_retired",
   "compatibility_blocked",

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -50,16 +50,10 @@ const CERTOPS_TRUST_JOB_OPERATION_INVALID =
   "CERTOPS_TRUST_JOB_OPERATION_INVALID";
 const CERTOPS_TRUST_INSTALLATION_NOT_FOUND =
   "CERTOPS_TRUST_INSTALLATION_NOT_FOUND";
-// A trust job is always pinned to one specific agent (never openly
-// claimable), so unlike a renewal/deploy job left for "any eligible agent",
-// there is no fallback claimant if the pinned agent can never claim it. A
-// job created against a currently-ineligible agent (most commonly: observe-
-// only, i.e. no execution block / execution.enabled: false) would previously
-// sit at pending_install/pending_remove forever with no error anywhere - the
-// UI showed nothing beyond a bare "Pending" badge. Rejecting the request up
-// front, with the same reason evaluateAgentJobEligibility would use to
-// refuse the claim anyway, turns a silent stuck job into an actionable error
-// at the moment a human could still do something about it.
+// A trust job is pinned to one specific agent, with no fallback claimant
+// if that agent can never claim it (unlike an open renewal/deploy job).
+// Previously an ineligible agent (most commonly observe-only) left the job
+// stuck pending forever with no error. This rejects it up front instead.
 const CERTOPS_TARGET_AGENT_INELIGIBLE = "CERTOPS_TARGET_AGENT_INELIGIBLE";
 
 // anchor_type determines which OS store (Root/CA) a fingerprint's
@@ -271,18 +265,13 @@ async function assertTargetAgentRegistered({ client, workspaceId, agentId }) {
   return agent;
 }
 
-// Operator-actionable text for each determinate evaluateAgentJobEligibility
-// reason a trust job creation request can hit. Kept separate from the
-// dispatch-time reasons in agentJobEligibility.js, which are terse wire
-// codes rather than sentences meant for a human reading an API error - the
-// two must always stay in the same taxonomy (see the reason keys used
-// below), but this file owns the prose.
+// Operator-facing prose for each evaluateAgentJobEligibility reason a trust
+// job creation request can hit. This file owns the prose; agentJobEligibility.js
+// keeps terse wire codes.
 //
-// Only agent_retired and compatibility_blocked are enforced as hard
-// creation-time blocks (see BLOCKING_TRUST_JOB_CREATION_REASONS below); the
-// other entries here exist so the SAME prose can be reused for advisory
-// (non-blocking) display elsewhere, e.g. explaining an already-stuck
-// pending_install/pending_remove installation row.
+// Only agent_retired and compatibility_blocked are hard creation-time blocks
+// (see BLOCKING_TRUST_JOB_CREATION_REASONS). The rest exist so the same
+// prose can be reused advisory-only, e.g. for a stuck pending installation.
 const TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON = Object.freeze({
   agent_retired:
     "This agent has been retired and can no longer be assigned any job.",
@@ -304,26 +293,21 @@ const TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON = Object.freeze({
 });
 
 // Only agent_retired/compatibility_blocked are safe to hard-block at
-// creation time: both require an operator action to change and can't
-// self-heal. operation_unsupported is excluded because supported_operations
-// only updates on a successful claim, so a brand-new healthy agent reads
-// identically to a genuinely observe-only one until its first poll - see
-// the pending-installation reason (E) for its non-blocking surfacing instead.
+// creation time; both require operator action and can't self-heal.
+// operation_unsupported is excluded because a brand-new agent that hasn't
+// polled yet looks identical to a genuinely observe-only one - see the
+// pending-installation reason for its non-blocking surfacing instead.
 const BLOCKING_TRUST_JOB_CREATION_REASONS = new Set([
   "agent_retired",
   "compatibility_blocked",
 ]);
 
 /**
- * Refuses to create a trust job pinned to an agent that is CURRENTLY,
- * unambiguously incapable of ever claiming it - the same authoritative
- * predicate real dispatch uses (evaluateAgentJobEligibility), called one
- * step earlier so the caller gets an immediate, actionable error for the
- * handful of reasons that are safe to act on before a claim is ever
- * attempted. See BLOCKING_TRUST_JOB_CREATION_REASONS for exactly which
- * reasons that is and why the rest are intentionally excluded. Deliberately
- * does not check liveness/offline state either (an agent that is merely
- * offline right now may come back and claim the job normally).
+ * Refuses to create a trust job pinned to an agent that is currently,
+ * unambiguously incapable of ever claiming it, using the same predicate
+ * real dispatch uses. Only blocks reasons in
+ * BLOCKING_TRUST_JOB_CREATION_REASONS; deliberately ignores liveness (an
+ * agent merely offline right now may come back and claim the job normally).
  */
 function assertTargetAgentEligibleForTrustJob({ agent, operation }) {
   const evaluation = evaluateAgentJobEligibility({
@@ -771,18 +755,11 @@ const LIVE_PENDING_TRANSITION_STATES = new Set(["pending_install", "pending_remo
 
 /**
  * Advisory (never blocking) explanation for a pending_install/pending_remove
- * row that has not yet recorded a last_error: before this, such a row
- * rendered as a bare "Pending" badge with zero information about whether it
- * is progressing normally (the agent just hasn't polled yet) or stuck for a
- * knowable reason (retired, incompatible, or - the case that motivated this
- * - the assigned agent's last claim declared no support for this
- * operation, most commonly because it is running observe-only). Reuses
- * TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON so this can never say something
- * different from what assertTargetAgentEligibleForTrustJob would have
- * blocked creation on, had the same state existed at creation time.
- * Returns null for a row with no knowable reason (agent looks eligible, or
- * the agent record itself is missing/malformed) - callers must keep
- * treating null as "no additional information", not "definitely fine".
+ * row with no last_error. Before this, such a row was just a bare "Pending"
+ * badge with no indication of whether it's progressing normally or stuck.
+ * Reuses TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON so this can't disagree with
+ * what creation-time blocking would have said. Returns null when there's no
+ * knowable reason - callers must treat null as "no info", not "fine".
  */
 function pendingReasonForInstallation(installation, agent) {
   if (!LIVE_PENDING_TRANSITION_STATES.has(installation.transitionState)) return null;
@@ -812,9 +789,8 @@ function pendingReasonForInstallation(installation, agent) {
 }
 
 /**
- * Batch-attaches pendingReason (see pendingReasonForInstallation) to every
- * row in one round-trip: one getAgentsByIds call for the whole page/anchor
- * rather than one agent lookup per installation row.
+ * Batch-attaches pendingReason to every row in one round-trip, rather than
+ * one agent lookup per installation row.
  */
 async function attachPendingReasons({ db, workspaceId, installations }) {
   const candidateIds = installations
@@ -1330,10 +1306,8 @@ async function runCreateTrustJob(client, params) {
     agentId,
   });
 
-  // Refuse up front rather than letting a job get created that can never be
-  // claimed - see assertTargetAgentEligibleForTrustJob's own header comment
-  // for why this matters specifically for pinned trust jobs (no fallback
-  // claimant exists the way there is for an open renewal/deploy job).
+  // Refuse up front rather than create a job that can never be claimed -
+  // trust jobs are pinned with no fallback claimant.
   assertTargetAgentEligibleForTrustJob({ agent: targetAgent, operation });
 
   const { row: installationRow, created: installationCreated } =

--- a/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
+++ b/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
@@ -161,19 +161,10 @@ function NtpBadge({ ntpSynced }) {
 }
 
 /**
- * Execution capability chip: whether this agent declared ANY executable
- * action (renew/deploy/reload/distribute-trust/revoke-trust) the last time
- * it successfully claimed a job. supportedOperations is only ever written
- * from that claim call (see agentRegistry.js's agentMetadataFromRow), so an
- * empty list is genuinely ambiguous between "this agent is running
- * observe-only (no execution block, or execution.enabled is not true, in
- * its config.json)" and "this agent is healthy but has not had its first
- * poll cycle yet" - the title makes that caveat explicit rather than
- * asserting a diagnosis this one field cannot prove on its own. Before this
- * chip existed, there was no indication anywhere in the fleet table that an
- * agent could never claim a job - operators only discovered it once a job
- * sat at Pending with no explanation (see the pendingReason surfaced on
- * trust installation rows for the other half of that fix).
+ * Execution capability chip: whether this agent declared any executable
+ * action the last time it successfully claimed a job. Empty is ambiguous
+ * between "observe-only" and "hasn't polled yet" - the title makes that
+ * caveat explicit rather than asserting a diagnosis this field can't prove.
  */
 function ExecutionCapabilityBadge({ supportedOperations }) {
   const declared = Array.isArray(supportedOperations) ? supportedOperations : [];

--- a/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
+++ b/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
@@ -161,6 +161,57 @@ function NtpBadge({ ntpSynced }) {
 }
 
 /**
+ * Execution capability chip: whether this agent declared ANY executable
+ * action (renew/deploy/reload/distribute-trust/revoke-trust) the last time
+ * it successfully claimed a job. supportedOperations is only ever written
+ * from that claim call (see agentRegistry.js's agentMetadataFromRow), so an
+ * empty list is genuinely ambiguous between "this agent is running
+ * observe-only (no execution block, or execution.enabled is not true, in
+ * its config.json)" and "this agent is healthy but has not had its first
+ * poll cycle yet" - the title makes that caveat explicit rather than
+ * asserting a diagnosis this one field cannot prove on its own. Before this
+ * chip existed, there was no indication anywhere in the fleet table that an
+ * agent could never claim a job - operators only discovered it once a job
+ * sat at Pending with no explanation (see the pendingReason surfaced on
+ * trust installation rows for the other half of that fix).
+ */
+function ExecutionCapabilityBadge({ supportedOperations }) {
+  const declared = Array.isArray(supportedOperations) ? supportedOperations : [];
+  if (declared.length > 0) {
+    return (
+      <Badge
+        colorScheme='green'
+        variant='subtle'
+        textTransform='none'
+        fontWeight='medium'
+        fontSize='xs'
+        title={`Last declared on claim: ${declared.join(', ')}`}
+      >
+        Enabled
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      colorScheme='orange'
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+      title={
+        'No executable action declared on the last claim call. Most often ' +
+        'this means the agent is running observe-only (no execution block, ' +
+        'or execution.enabled is not true, in its config.json) - a job ' +
+        'pinned to it will sit at Pending forever. A brand-new agent that ' +
+        'has not polled for a job yet looks identical here.'
+      }
+    >
+      No capability declared
+    </Badge>
+  );
+}
+
+/**
  * Confirm dialog for retiring an agent (RetireCertificateModal pattern).
  * A non-forced retire is refused server-side with 409
  * CERTOPS_AGENT_RETIRE_BLOCKED while the agent holds job leases; the dialog
@@ -596,6 +647,7 @@ export default function AgentFleetPanel({ refreshSignal, headerAction } = {}) {
                   <Th>Protocol</Th>
                   <Th>Clock drift</Th>
                   <Th>NTP</Th>
+                  <Th>Execution</Th>
                   <Th>Signing key</Th>
                   <Th>Last heartbeat</Th>
                   {canManage ? <Th textAlign='right'>Actions</Th> : null}
@@ -681,6 +733,11 @@ export default function AgentFleetPanel({ refreshSignal, headerAction } = {}) {
                       </Td>
                       <Td>
                         <NtpBadge ntpSynced={agent.ntpSynced} />
+                      </Td>
+                      <Td>
+                        <ExecutionCapabilityBadge
+                          supportedOperations={agent.supportedOperations}
+                        />
                       </Td>
                       <Td>
                         {agent.pinnedSigningKeyId ? (

--- a/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
+++ b/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
@@ -220,18 +220,10 @@ function agentSelectLabel(agent) {
 }
 
 /**
- * True when `agent` did not declare `operation` in supportedOperations the
- * last time it successfully claimed a job. This is a real, useful signal
- * (it is the exact field the server's own dispatch-time eligibility check
- * reads - see agentJobEligibility.js's operation_unsupported), but it is
- * NOT proof the agent is misconfigured: supported_operations is only ever
- * written from a successful claim call, so a brand-new agent that has
- * simply not polled yet reads the same as one running permanently
- * observe-only (no execution block in its config.json). Callers must show
- * this as a caveated warning, never as a hard block on selecting the
- * agent - see this file's server-side counterpart
- * (assertTargetAgentEligibleForTrustJob in trustAnchors.js) for why the
- * same ambiguity keeps this out of any hard validation there too.
+ * True when `agent` didn't declare `operation` on its last successful
+ * claim. Not proof of misconfiguration - a brand-new agent that hasn't
+ * polled yet reads the same as a permanently observe-only one. Callers
+ * must show this as an advisory warning, never a hard block.
  */
 function agentMissingDeclaredCapability(agent, operation) {
   if (!agent) return false;
@@ -391,9 +383,8 @@ export default function CreateManualJobModal({
   // claim anything, so pinning to one would silently strand the job.
   const assignableAgents = agents.filter(agent => agent.status !== 'retired');
 
-  // Advisory-only capability warning for the currently selected
-  // distribute-trust target - see agentMissingDeclaredCapability's own
-  // header comment for why this can never be a hard block here.
+  // Advisory-only capability warning; never a hard block (see
+  // agentMissingDeclaredCapability).
   const selectedTrustAgent = assignableAgents.find(
     agent => agent.id === trustAgentId
   );

--- a/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
+++ b/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
@@ -383,16 +383,12 @@ export default function CreateManualJobModal({
   // claim anything, so pinning to one would silently strand the job.
   const assignableAgents = agents.filter(agent => agent.status !== 'retired');
 
-  // Advisory-only capability warning; never a hard block (see
-  // agentMissingDeclaredCapability).
+  // Selected distribute-trust target agent; revoke's equivalent is derived
+  // below once trustSelectedInstallation exists (see
+  // trustCapabilityCheckAgent).
   const selectedTrustAgent = assignableAgents.find(
     agent => agent.id === trustAgentId
   );
-  const trustAgentMissingCapability =
-    isTrustOp &&
-    isDistributeTrust &&
-    Boolean(selectedTrustAgent) &&
-    agentMissingDeclaredCapability(selectedTrustAgent, 'distribute-trust');
 
   // domain/endpoint/external subjects are free-text references an agent
   // can never match against (see MANUAL_ONLY_SUBJECT_TYPES above), so the
@@ -431,6 +427,23 @@ export default function CreateManualJobModal({
   const trustSelectedInstallation = trustRevocableInstallations.find(
     row => row.id === trustInstallationId
   );
+
+  // Advisory-only capability warning; never a hard block (see
+  // agentMissingDeclaredCapability). Applies equally to distribute and
+  // revoke: both pin a job to one specific agent with no fallback
+  // claimant, so a missing capability declaration strands either the same
+  // way. Distribute picks the agent directly; revoke picks an existing
+  // installation row, so its agent comes from that row instead.
+  const trustCapabilityCheckAgent = isDistributeTrust
+    ? selectedTrustAgent
+    : agents.find(agent => agent.id === trustSelectedInstallation?.agentId);
+  const trustAgentMissingCapability =
+    isTrustOp &&
+    Boolean(trustCapabilityCheckAgent) &&
+    agentMissingDeclaredCapability(
+      trustCapabilityCheckAgent,
+      trustOp.operation
+    );
 
   // Resolves to the agentId/owner pair the request will actually submit:
   // for distribute, the separately-picked target agent plus either the
@@ -819,7 +832,10 @@ export default function CreateManualJobModal({
                     {assignableAgents.map(agent => (
                       <option key={agent.id} value={agent.id}>
                         {agentSelectLabel(agent)}
-                        {agentMissingDeclaredCapability(agent, 'distribute-trust')
+                        {agentMissingDeclaredCapability(
+                          agent,
+                          trustOp.operation
+                        )
                           ? ' \u2014 no distribute-trust capability declared'
                           : ''}
                       </option>
@@ -839,6 +855,13 @@ export default function CreateManualJobModal({
                       return (
                         <option key={row.id} value={row.id}>
                           {`${row.owner} — ${agent ? agentSelectLabel(agent) : row.host} (${row.store})`}
+                          {agent &&
+                          agentMissingDeclaredCapability(
+                            agent,
+                            trustOp.operation
+                          )
+                            ? ' \u2014 no revoke-trust capability declared'
+                            : ''}
                         </option>
                       );
                     })}
@@ -853,7 +876,7 @@ export default function CreateManualJobModal({
                   >
                     <AlertIcon boxSize={4} />
                     <AlertDescription fontSize='sm'>
-                      This agent did not declare distribute-trust support the
+                      This agent did not declare {trustOp.operation} support the
                       last time it claimed a job. If it is running in
                       observe-only mode (no execution block, or
                       execution.enabled is not true, in its config.json), this

--- a/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
+++ b/apps/dashboard/src/components/certops/CreateManualJobModal.jsx
@@ -219,6 +219,28 @@ function agentSelectLabel(agent) {
   return `${primary}${idSuffix}${offlineSuffix}`;
 }
 
+/**
+ * True when `agent` did not declare `operation` in supportedOperations the
+ * last time it successfully claimed a job. This is a real, useful signal
+ * (it is the exact field the server's own dispatch-time eligibility check
+ * reads - see agentJobEligibility.js's operation_unsupported), but it is
+ * NOT proof the agent is misconfigured: supported_operations is only ever
+ * written from a successful claim call, so a brand-new agent that has
+ * simply not polled yet reads the same as one running permanently
+ * observe-only (no execution block in its config.json). Callers must show
+ * this as a caveated warning, never as a hard block on selecting the
+ * agent - see this file's server-side counterpart
+ * (assertTargetAgentEligibleForTrustJob in trustAnchors.js) for why the
+ * same ambiguity keeps this out of any hard validation there too.
+ */
+function agentMissingDeclaredCapability(agent, operation) {
+  if (!agent) return false;
+  const declared = Array.isArray(agent.supportedOperations)
+    ? agent.supportedOperations
+    : [];
+  return !declared.includes(operation);
+}
+
 function createJobErrorMessage(err) {
   const code = err?.response?.data?.code;
   const status = err?.response?.status;
@@ -368,6 +390,18 @@ export default function CreateManualJobModal({
   // Only agents that can still be handed a job: a retired agent can never
   // claim anything, so pinning to one would silently strand the job.
   const assignableAgents = agents.filter(agent => agent.status !== 'retired');
+
+  // Advisory-only capability warning for the currently selected
+  // distribute-trust target - see agentMissingDeclaredCapability's own
+  // header comment for why this can never be a hard block here.
+  const selectedTrustAgent = assignableAgents.find(
+    agent => agent.id === trustAgentId
+  );
+  const trustAgentMissingCapability =
+    isTrustOp &&
+    isDistributeTrust &&
+    Boolean(selectedTrustAgent) &&
+    agentMissingDeclaredCapability(selectedTrustAgent, 'distribute-trust');
 
   // domain/endpoint/external subjects are free-text references an agent
   // can never match against (see MANUAL_ONLY_SUBJECT_TYPES above), so the
@@ -794,6 +828,9 @@ export default function CreateManualJobModal({
                     {assignableAgents.map(agent => (
                       <option key={agent.id} value={agent.id}>
                         {agentSelectLabel(agent)}
+                        {agentMissingDeclaredCapability(agent, 'distribute-trust')
+                          ? ' \u2014 no distribute-trust capability declared'
+                          : ''}
                       </option>
                     ))}
                   </Select>
@@ -816,6 +853,25 @@ export default function CreateManualJobModal({
                     })}
                   </Select>
                 )}
+                {trustAgentMissingCapability ? (
+                  <Alert
+                    status='warning'
+                    variant='subtle'
+                    borderRadius='md'
+                    mt={2}
+                  >
+                    <AlertIcon boxSize={4} />
+                    <AlertDescription fontSize='sm'>
+                      This agent did not declare distribute-trust support the
+                      last time it claimed a job. If it is running in
+                      observe-only mode (no execution block, or
+                      execution.enabled is not true, in its config.json), this
+                      job will sit at Pending indefinitely. A brand-new agent
+                      that has not polled yet will look the same here - check
+                      its logs if this persists.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
                 <FormHelperText>
                   {isDistributeTrust
                     ? 'The agent whose OS trust store will receive this anchor.'

--- a/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
+++ b/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
@@ -469,6 +469,15 @@ function AnchorInstallationsBody({
                       <Text fontSize='xs' color='red.500' noOfLines={1}>
                         {row.lastError}
                       </Text>
+                    ) : row.pendingReason ? (
+                      <Text
+                        fontSize='xs'
+                        color='orange.600'
+                        noOfLines={2}
+                        title={row.pendingReason.message}
+                      >
+                        {row.pendingReason.message}
+                      </Text>
                     ) : null}
                   </VStack>
                 </Td>

--- a/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
+++ b/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
@@ -331,6 +331,24 @@ describe('AgentFleetPanel', () => {
     expect(screen.getByText('ttsk_0123456...')).toBeInTheDocument();
   });
 
+  it('renders an Execution column badging declared-capability agents "Enabled" and others "No capability declared"', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    const agents = sampleAgents();
+    agents[0].supportedOperations = ['renew', 'distribute-trust'];
+    agents[1].supportedOperations = [];
+    useCertOpsAgentsMock.mockReturnValue(agentsState({ agents }));
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Execution' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Enabled')).toHaveLength(1);
+    // Row 2 (no declared operations) and row 3 (retired, no operations key
+    // at all) both fall back to the same warning badge.
+    expect(screen.getAllByText('No capability declared')).toHaveLength(2);
+  });
+
   it('hides the actions column for a non-manager viewer', () => {
     useCertOpsCanManageMock.mockReturnValue(false);
     useCertOpsAgentsMock.mockReturnValue(

--- a/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
+++ b/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
@@ -463,10 +463,7 @@ describe('CreateManualJobModal trustOp mode', () => {
 
   it('shows an inline warning once the selected distribute-trust target is the capability-missing agent', () => {
     useCertOpsAgentsMock.mockReturnValue({
-      agents: [
-        AGENT_A,
-        { ...AGENT_B, supportedOperations: [] },
-      ],
+      agents: [AGENT_A, { ...AGENT_B, supportedOperations: [] }],
     });
 
     renderModal({ trustOp: distributeTrustOp });
@@ -484,19 +481,41 @@ describe('CreateManualJobModal trustOp mode', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not warn about capability for a revoke-trust target (only distribute-trust is checked)', () => {
+  it('annotates a revoke installation option whose agent lacks revoke-trust in its declared capabilities', () => {
+    useCertOpsAgentsMock.mockReturnValue({
+      agents: [
+        { ...AGENT_A, supportedOperations: ['renew'] },
+        { ...AGENT_B, supportedOperations: ['renew', 'revoke-trust'] },
+      ],
+    });
+
+    renderModal({ trustOp: revokeTrustOp });
+
+    expect(
+      screen.getByRole('option', {
+        name: /team-a — Agent A \(agent-a\) \(root\).*no revoke-trust capability declared/,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('shows an inline warning once the selected revoke-trust installation belongs to a capability-missing agent', () => {
     useCertOpsAgentsMock.mockReturnValue({
       agents: [{ ...AGENT_A, supportedOperations: [] }, AGENT_B],
     });
 
     renderModal({ trustOp: revokeTrustOp });
+
+    expect(
+      screen.queryByText(/did not declare revoke-trust support/)
+    ).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText(/^Target agent/), {
-      target: { value: 'agent-a' },
+      target: { value: 'install-1' },
     });
 
     expect(
-      screen.queryByText(/did not declare distribute-trust support/)
-    ).not.toBeInTheDocument();
+      screen.getByText(/did not declare revoke-trust support/)
+    ).toBeInTheDocument();
   });
 
   it('submits distribute-trust with agentId/owner/subjectType trust_anchor and an auto-generated idempotency key', async () => {

--- a/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
+++ b/apps/dashboard/tests/unit/CreateManualJobModal.test.jsx
@@ -438,6 +438,67 @@ describe('CreateManualJobModal trustOp mode', () => {
     expect(submit).toBeEnabled();
   });
 
+  it('annotates an agent option lacking distribute-trust in its declared capabilities', () => {
+    useCertOpsAgentsMock.mockReturnValue({
+      agents: [
+        { ...AGENT_A, supportedOperations: ['renew', 'distribute-trust'] },
+        { ...AGENT_B, supportedOperations: ['renew'] },
+      ],
+    });
+
+    renderModal({ trustOp: distributeTrustOp });
+
+    const options = screen.getAllByRole('option');
+    const optionA = options.find(option =>
+      option.textContent.startsWith('Agent A')
+    );
+    const optionB = options.find(option =>
+      option.textContent.startsWith('Agent B')
+    );
+    expect(optionA.textContent).not.toMatch(/no distribute-trust capability/);
+    expect(optionB.textContent).toMatch(
+      /Agent B.*— no distribute-trust capability declared/
+    );
+  });
+
+  it('shows an inline warning once the selected distribute-trust target is the capability-missing agent', () => {
+    useCertOpsAgentsMock.mockReturnValue({
+      agents: [
+        AGENT_A,
+        { ...AGENT_B, supportedOperations: [] },
+      ],
+    });
+
+    renderModal({ trustOp: distributeTrustOp });
+
+    expect(
+      screen.queryByText(/did not declare distribute-trust support/)
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-b' },
+    });
+
+    expect(
+      screen.getByText(/did not declare distribute-trust support/)
+    ).toBeInTheDocument();
+  });
+
+  it('does not warn about capability for a revoke-trust target (only distribute-trust is checked)', () => {
+    useCertOpsAgentsMock.mockReturnValue({
+      agents: [{ ...AGENT_A, supportedOperations: [] }, AGENT_B],
+    });
+
+    renderModal({ trustOp: revokeTrustOp });
+    fireEvent.change(screen.getByLabelText(/^Target agent/), {
+      target: { value: 'agent-a' },
+    });
+
+    expect(
+      screen.queryByText(/did not declare distribute-trust support/)
+    ).not.toBeInTheDocument();
+  });
+
   it('submits distribute-trust with agentId/owner/subjectType trust_anchor and an auto-generated idempotency key', async () => {
     createJobMock.mockResolvedValue({ job: { id: 'job-1' } });
 

--- a/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
@@ -424,6 +424,74 @@ describe('TrustAnchorsPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('surfaces a pendingReason as advisory text under a stuck-pending installation instead of a bare badge', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'pending_install',
+            lastError: null,
+            pendingReason: {
+              code: 'agent_retired',
+              message:
+                'This agent has been retired and can no longer be assigned any job.',
+            },
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(
+      screen.getByText(
+        'This agent has been retired and can no longer be assigned any job.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('prefers a real lastError over pendingReason when both are present on a row', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'pending_install',
+            lastError: 'agent unreachable',
+            pendingReason: {
+              code: 'agent_retired',
+              message: 'This agent has been retired.',
+            },
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(screen.getByText('agent unreachable')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This agent has been retired.')
+    ).not.toBeInTheDocument();
+  });
+
   it('retires an anchor through the confirm modal and refreshes', async () => {
     const refresh = vi.fn();
     useCertOpsTrustAnchorsMock.mockReturnValue(

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -6044,6 +6044,32 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
   // any network call so a corrupted replay store fails startup immediately.
   const executionContext = buildExecutionContext({ config });
 
+  // Loud, operator-visible signal for the most common source of "why is my
+  // job stuck pending" support questions: an agent with no `execution` block
+  // (or `execution.enabled: false`) registers, heartbeats, and reports
+  // discovery evidence, but silently never polls the claim endpoint (see the
+  // module docblock above). Previously this was undocumented anywhere an
+  // operator would actually look at runtime - only in code comments - so a
+  // misconfigured agent gave zero indication of the problem until someone
+  // noticed a job never left "pending". Emitted once at startup via the
+  // same sink used for real errors so it is impossible to miss in
+  // host.log/journalctl, without changing any control-flow decision (agents
+  // already correctly ran observe-only before this line existed).
+  // buildExecutionContext only ever returns null or { enabled: true, ... }
+  // (see its own doc comment), so the sole observe-only signal is nullness.
+  if (executionContext === null) {
+    defaultAgentLogger.error(
+      "running in OBSERVE-ONLY mode: config.execution is absent or " +
+        "execution.enabled is not true. This agent will register, " +
+        "heartbeat, and report discovery evidence, but it will NEVER poll " +
+        "for or claim jobs (renew, deploy, reload, distribute-trust, " +
+        "revoke-trust). If you expected this agent to execute jobs, set " +
+        '"execution": { "enabled": true, "dryRun": false } in config.json ' +
+        "and restart. See the `execution` block in the Config reference " +
+        "section of docs/certops/agent.md.",
+    );
+  }
+
   // Crash-safety: surface unresolved side-effect journals for operator
   // reconciliation. Do not auto-re-execute those jobIds.
   try {

--- a/packages/agent/src/index.js
+++ b/packages/agent/src/index.js
@@ -6044,19 +6044,12 @@ async function runAgent(_argv, { signal: externalSignal } = {}) {
   // any network call so a corrupted replay store fails startup immediately.
   const executionContext = buildExecutionContext({ config });
 
-  // Loud, operator-visible signal for the most common source of "why is my
-  // job stuck pending" support questions: an agent with no `execution` block
-  // (or `execution.enabled: false`) registers, heartbeats, and reports
-  // discovery evidence, but silently never polls the claim endpoint (see the
-  // module docblock above). Previously this was undocumented anywhere an
-  // operator would actually look at runtime - only in code comments - so a
-  // misconfigured agent gave zero indication of the problem until someone
-  // noticed a job never left "pending". Emitted once at startup via the
-  // same sink used for real errors so it is impossible to miss in
-  // host.log/journalctl, without changing any control-flow decision (agents
-  // already correctly ran observe-only before this line existed).
-  // buildExecutionContext only ever returns null or { enabled: true, ... }
-  // (see its own doc comment), so the sole observe-only signal is nullness.
+  // Emitted once at startup via the error sink - not just a code comment -
+  // so a misconfigured observe-only agent (no `execution` block, or
+  // `execution.enabled: false`) is visible in host.log/journalctl instead
+  // of silently never claiming jobs until someone notices one stuck pending.
+  // buildExecutionContext only ever returns null or { enabled: true, ... },
+  // so nullness alone is the observe-only signal checked below.
   if (executionContext === null) {
     defaultAgentLogger.error(
       "running in OBSERVE-ONLY mode: config.execution is absent or " +

--- a/tests/unit/certops-agent-lifecycle.test.js
+++ b/tests/unit/certops-agent-lifecycle.test.js
@@ -510,6 +510,17 @@ describe("CertOps agents list route", () => {
       retireReason: null,
       downtimeAlertsEnabled: true,
       contactGroupId: null,
+      // Capability fields added for the agent-capability-visibility work:
+      // agentRow() (this file's fixture) never sets these DB columns, so
+      // they read back as their empty/null defaults - see
+      // agentMetadataFromRow's own "defaults capability arrays to []" unit
+      // test above for the case where they ARE populated.
+      supportedOperations: [],
+      declaredCapabilities: [],
+      capabilitiesUpdatedAt: null,
+      targetSelectors: [],
+      commandProfiles: [],
+      dnsProviders: [],
       // 1.2.3 is ahead of the shipped agent package's own version (the
       // default "latest known" reference for the outdated heuristic), so
       // it is compatible, not outdated.
@@ -775,6 +786,52 @@ describe("agentRegistry service internals", () => {
     assert.doesNotMatch(JSON.stringify(metadata), /credential/i);
   });
 
+  it("agentMetadataFromRow exposes supportedOperations/declaredCapabilities so the dashboard can explain why an agent can't claim a job", () => {
+    const withCapabilities = agentRegistry._test.agentMetadataFromRow(
+      agentRow({
+        supported_operations: ["renew", "distribute-trust"],
+        declared_capabilities: ["trust-anchor-deploy-v1"],
+        capabilities_updated_at: new Date("2026-07-01T12:00:00.000Z"),
+        declared_target_selectors: ["prod"],
+        declared_command_profile_names: ["default"],
+        supported_dns_providers: ["route53"],
+      }),
+    );
+    assert.deepEqual(withCapabilities.supportedOperations, [
+      "renew",
+      "distribute-trust",
+    ]);
+    assert.deepEqual(withCapabilities.declaredCapabilities, [
+      "trust-anchor-deploy-v1",
+    ]);
+    assert.equal(
+      withCapabilities.capabilitiesUpdatedAt,
+      "2026-07-01T12:00:00.000Z",
+    );
+    assert.deepEqual(withCapabilities.targetSelectors, ["prod"]);
+    assert.deepEqual(withCapabilities.commandProfiles, ["default"]);
+    assert.deepEqual(withCapabilities.dnsProviders, ["route53"]);
+  });
+
+  it("agentMetadataFromRow defaults capability arrays to [] for a fresh (never-claimed) agent row rather than throwing on a missing/null jsonb column", () => {
+    const fresh = agentRegistry._test.agentMetadataFromRow(
+      agentRow({
+        supported_operations: null,
+        declared_capabilities: null,
+        capabilities_updated_at: null,
+        declared_target_selectors: null,
+        declared_command_profile_names: null,
+        supported_dns_providers: null,
+      }),
+    );
+    assert.deepEqual(fresh.supportedOperations, []);
+    assert.deepEqual(fresh.declaredCapabilities, []);
+    assert.equal(fresh.capabilitiesUpdatedAt, null);
+    assert.deepEqual(fresh.targetSelectors, []);
+    assert.deepEqual(fresh.commandProfiles, []);
+    assert.deepEqual(fresh.dnsProviders, []);
+  });
+
   it("normalizeRequiredRetireReason trims and enforces bounds", () => {
     assert.equal(
       agentRegistry._test.normalizeRequiredRetireReason("  ok  "),
@@ -788,6 +845,7 @@ describe("agentRegistry service internals", () => {
     }
   });
 });
+
 
 
 

--- a/tests/unit/certops-trust-job-eligibility.test.js
+++ b/tests/unit/certops-trust-job-eligibility.test.js
@@ -1,0 +1,185 @@
+"use strict";
+
+/**
+ * Pure, DB-free unit tests for the agent-capability-visibility helpers
+ * added to trustAnchors.js: the creation-time eligibility guard
+ * (assertTargetAgentEligibleForTrustJob) and the advisory pendingReason
+ * projection surfaced on already-created installation rows
+ * (pendingReasonForInstallation). Both are thin wrappers around
+ * evaluateAgentJobEligibility (already covered by its own test surface via
+ * dispatch), so these tests focus on the parts unique to this file: WHICH
+ * reasons block creation vs. which are advisory-only, and that both paths
+ * agree on the same reason taxonomy/prose.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const trustAnchors = require(
+  path.resolve(
+    __dirname,
+    "../../apps/api/services/certops/trustAnchors.js",
+  ),
+);
+
+const {
+  assertTargetAgentEligibleForTrustJob,
+  BLOCKING_TRUST_JOB_CREATION_REASONS,
+  TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON,
+  pendingReasonForInstallation,
+} = trustAnchors._test;
+
+function baseAgent(overrides = {}) {
+  return {
+    id: "agent-uuid-1",
+    status: "active",
+    compatibilityState: "compatible",
+    supportedOperations: ["distribute-trust", "revoke-trust"],
+    declaredCapabilities: ["trust-anchor-deploy-v1"],
+    capabilitiesUpdatedAt: new Date().toISOString(),
+    targetSelectors: [],
+    dnsProviders: [],
+    commandProfiles: [],
+    agentKind: "normal",
+    ...overrides,
+  };
+}
+
+describe("assertTargetAgentEligibleForTrustJob (creation-time guard)", () => {
+  it("allows a healthy, fully-eligible agent through without throwing", () => {
+    assert.doesNotThrow(() =>
+      assertTargetAgentEligibleForTrustJob({
+        agent: baseAgent(),
+        operation: "distribute-trust",
+      }),
+    );
+  });
+
+  it("blocks a retired agent (agent_retired is in the hard-block set)", () => {
+    assert.throws(
+      () =>
+        assertTargetAgentEligibleForTrustJob({
+          agent: baseAgent({ status: "retired" }),
+          operation: "distribute-trust",
+        }),
+      (err) => err.code === "CERTOPS_TARGET_AGENT_INELIGIBLE",
+    );
+  });
+
+  it("blocks a compatibility-blocked agent", () => {
+    assert.throws(
+      () =>
+        assertTargetAgentEligibleForTrustJob({
+          agent: baseAgent({ compatibilityState: "blocked" }),
+          operation: "distribute-trust",
+        }),
+      (err) => err.code === "CERTOPS_TARGET_AGENT_INELIGIBLE",
+    );
+  });
+
+  it("does NOT block an agent with an empty supportedOperations (operation_unsupported is excluded from creation-time blocking - see BLOCKING_TRUST_JOB_CREATION_REASONS's header comment on why this reason is ambiguous between observe-only and never-yet-polled)", () => {
+    assert.doesNotThrow(() =>
+      assertTargetAgentEligibleForTrustJob({
+        agent: baseAgent({ supportedOperations: [] }),
+        operation: "distribute-trust",
+      }),
+    );
+  });
+
+  it("does NOT block on a stale/missing trust-anchor-deploy-v1 capability at creation time either, for the same staleness-ambiguity reason", () => {
+    assert.doesNotThrow(() =>
+      assertTargetAgentEligibleForTrustJob({
+        agent: baseAgent({
+          declaredCapabilities: [],
+          capabilitiesUpdatedAt: null,
+        }),
+        operation: "distribute-trust",
+      }),
+    );
+  });
+
+  it("BLOCKING_TRUST_JOB_CREATION_REASONS contains exactly agent_retired and compatibility_blocked", () => {
+    assert.deepEqual(
+      Array.from(BLOCKING_TRUST_JOB_CREATION_REASONS).sort(),
+      ["agent_retired", "compatibility_blocked"],
+    );
+  });
+});
+
+describe("pendingReasonForInstallation (advisory, never-blocking)", () => {
+  it("returns null for a live (non-pending) installation regardless of agent state", () => {
+    assert.equal(
+      pendingReasonForInstallation(
+        { transitionState: "installed", lastError: null },
+        baseAgent({ status: "retired" }),
+      ),
+      null,
+    );
+  });
+
+  it("returns null once a real lastError has already been recorded (that is already surfaced elsewhere; this field must not duplicate/contradict it)", () => {
+    assert.equal(
+      pendingReasonForInstallation(
+        {
+          transitionState: "pending_install",
+          lastError: "some_real_dispatch_error",
+        },
+        baseAgent({ supportedOperations: [] }),
+      ),
+      null,
+    );
+  });
+
+  it("returns null when the agent record is missing (row references an agent that could not be resolved)", () => {
+    assert.equal(
+      pendingReasonForInstallation(
+        { transitionState: "pending_install", lastError: null },
+        null,
+      ),
+      null,
+    );
+  });
+
+  it("returns null for a healthy, fully-eligible agent (nothing to explain)", () => {
+    assert.equal(
+      pendingReasonForInstallation(
+        { transitionState: "pending_install", lastError: null },
+        baseAgent(),
+      ),
+      null,
+    );
+  });
+
+  it("surfaces a reason for a pending_install row pinned to a retired agent", () => {
+    const reason = pendingReasonForInstallation(
+      { transitionState: "pending_install", lastError: null },
+      baseAgent({ status: "retired" }),
+    );
+    assert.equal(reason.code, "agent_retired");
+    assert.equal(
+      reason.message,
+      TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.agent_retired,
+    );
+  });
+
+  it("surfaces a reason for a pending_remove row whose agent never declared operation_unsupported (unlike the creation-time guard, this IS worth surfacing here - non-blocking, advisory only)", () => {
+    const reason = pendingReasonForInstallation(
+      { transitionState: "pending_remove", lastError: null },
+      baseAgent({ supportedOperations: [] }),
+    );
+    assert.equal(reason.code, "operation_unsupported");
+    assert.match(reason.message, /observe-only/);
+  });
+
+  it("evaluates revoke-trust (not distribute-trust) for a pending_remove row", () => {
+    // An agent that supports distribute-trust but was never re-declared for
+    // revoke-trust specifically (contrived, but exercises that the two
+    // operations are not conflated).
+    const reason = pendingReasonForInstallation(
+      { transitionState: "pending_remove", lastError: null },
+      baseAgent({ supportedOperations: ["distribute-trust"] }),
+    );
+    assert.equal(reason.code, "operation_unsupported");
+  });
+});


### PR DESCRIPTION
## Summary

Distribute-trust/revoke-trust jobs could sit at `Pending` forever with zero UI indication when pinned to an observe-only, retired, or otherwise ineligible agent, the most common root cause of "why is my job stuck pending" support questions. This adds a layered fix across the agent, API, and dashboard:

- **Agent**: loud, operator-visible log warning at startup when running observe-only (`execution.enabled` absent/false), instead of silently registering/heartbeating and never claiming jobs.
- **API guard**: `distribute-trust`/`revoke-trust` job creation is now rejected (409) when pinned to an agent that is definitively ineligible (retired or compatibility-blocked). Ambiguous cases (never-yet-polled vs. permanently observe-only) are deliberately NOT blocked at creation time - only genuinely unambiguous reasons are hard-blocked.
- **API exposure**: the agents-list API now exposes `supportedOperations`/`declaredCapabilities`/etc., and stuck `pending_install`/`pending_remove` installation rows carry an advisory `pendingReason` explaining why the assigned agent may never claim the job.
- **Dashboard**: the manual-job agent picker annotates capability-missing agents and shows an inline warning for the selected target; the agent fleet table gets a new "Execution" column/badge; trust-anchor installation rows show the live `pendingReason` instead of a bare `Pending` badge.

Targeted at a future release (not the current 0.14.2 line) - built on its own branch off `main` per plan.

## Test plan

- [x] Backend unit tests: `certops-agent-lifecycle.test.js` (21 tests), `certops-trust-anchors.test.js` (33 tests), new `certops-trust-job-eligibility.test.js` (13 tests) - all passing.
- [x] Agent unit tests: `packages/agent/src/index.test.js` (165 tests) - all passing.
- [x] Frontend unit tests: `AgentFleetPanel.test.jsx`, `CreateManualJobModal.test.jsx`, `TrustAnchorsPanel.test.jsx` (62 tests total, 7 new) - all passing.
- [x] Lint: `pnpm run lint:api`, `lint:dashboard`, `lint:agent` - 0 errors (pre-existing warnings only, unrelated to this change).
- [x] Live manual test: a properly-configured Windows agent claimed and completed a real `distribute-trust` job end to end.
- [x] Live manual test: a WSL Ubuntu agent re-installed through `install-agent.sh` (picking up the ACL grant on `/usr/local/share/ca-certificates`) claimed and completed a real `distribute-trust` job cleanly (`status: succeeded`, `outcome: installed`, cert verified on disk) - confirms the earlier `trust_store_not_writable` failure was purely an installer-bypass artifact, not a bug in this change.
- [x] Live browser check: registered a second agent in observe-only mode (no `execution` block) against a real running dashboard and confirmed end to end: the agent's startup log emits the observe-only warning; the fleet table shows an orange "No capability declared" badge in the Execution column; the trust-anchor installation row shows a "Pending install" badge with the full advisory `pendingReason` message; and the "Distribute to an agent" picker annotates the same agent's option with "- no distribute-trust capability declared". All four signals render exactly as designed.

## Validation
- Agent capability badges, distribute/revoke advisory symmetry, and Unreleased changelog verified via CreateManualJobModal/AgentFleetPanel/TrustAnchorsPanel unit tests plus local CI-parity on the combined integration branch.
