### PR TITLE
feat(certops): show agent compatibility state and fix clock drift thresholds in the fleet table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **Agent execution capability is now visible before you pin a job to an agent.** The CertOps Agents tab has a new Execution column showing whether an agent declared any executable action on its last successful claim; hovering "No capability declared" explains it can mean observe-only mode or simply an agent that hasn't polled yet. The manual-job and trust-anchor distribute/revoke modals annotate an agent option and show an inline warning when the selected agent has not declared the operation being requested, and creating a trust job against an agent that is retired or outside the accepted compatibility range is now rejected up front instead of leaving the job stuck at "Pending" forever. A trust-anchor installation stuck in a pending transition with no error now shows the same advisory reason inline instead of a bare "Pending" badge.
+- The CertOps agent fleet table has a new Compatibility column showing each agent's Compatible/Outdated/Blocked state, with the accepted agent and protocol version range in the tooltip. A blocked agent cannot claim any job until upgraded; this was previously only visible as a dispatch-time error in the agent's own logs.
 
 ### Fixed
 
 - **A certificate whose renewal is pinned to a real, non-retired agent that can't currently claim the job (a version/protocol compatibility block, or a declared-capability mismatch) reported the generic "no agent is currently associated with this certificate's renewal" instead of naming the pinned agent's actual problem.** The renewal-path health check now reports a distinct `assigned_agent_ineligible` reason with a summary describing why the pinned agent can't claim the job.
+- The fleet table's clock drift badge ignored `CERTOPS_AGENT_CLOCK_DRIFT_WARN_MS`/`CERTOPS_AGENT_CLOCK_DRIFT_ALERT_MS` and always flagged drift past its own hardcoded 5 second threshold regardless of an operator's configured values. It now reads the server-computed drift state and shows a distinct badge once drift passes the alert threshold, not just the warn threshold.
 
 ## [0.14.2] - 2026-09-01
 

--- a/apps/api/services/certops/agentRegistry.js
+++ b/apps/api/services/certops/agentRegistry.js
@@ -425,6 +425,16 @@ function agentMetadataFromRow(row, env = process.env) {
     clockDriftState: compatibility.clockDriftState,
     clockDriftMs: compatibility.clockDriftMs,
     livenessState: compatibility.livenessState,
+    // Narrow projection of compatibilityConfig: only the version/protocol
+    // range an operator needs to see next to compatibilityState. The other
+    // config fields (drift thresholds, latest-known version, offline
+    // threshold) are irrelevant here and already surfaced elsewhere.
+    compatibilityRange: {
+      minAgentVersion: compatibility.compatibilityConfig.minAgentVersion,
+      maxAgentVersion: compatibility.compatibilityConfig.maxAgentVersion,
+      minProtocolVersion: compatibility.compatibilityConfig.minProtocolVersion,
+      maxProtocolVersion: compatibility.compatibilityConfig.maxProtocolVersion,
+    },
   };
 }
 

--- a/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
+++ b/apps/dashboard/src/components/certops/AgentFleetPanel.jsx
@@ -122,9 +122,6 @@ function platformLabel(platform) {
   return PLATFORM_LABELS[platform] || String(platform);
 }
 
-/** Clock offsets beyond this are flagged as drifted in the fleet table. */
-const CLOCK_DRIFT_WARN_MS = 5000;
-
 /** Signed millisecond offset for display, e.g. "+120 ms"; '--' when unknown. */
 function formatClockOffset(value) {
   if (value === null || value === undefined) return '--';
@@ -133,9 +130,76 @@ function formatClockOffset(value) {
   return `${ms < 0 ? '-' : '+'}${Math.abs(ms)} ms`;
 }
 
-function isClockDrifted(value) {
-  const ms = Number(value);
-  return Number.isFinite(ms) && Math.abs(ms) > CLOCK_DRIFT_WARN_MS;
+const CLOCK_DRIFT_SCHEME = {
+  warn: 'orange',
+  alert: 'red',
+};
+
+const CLOCK_DRIFT_LABEL = {
+  warn: 'Drift',
+  alert: 'Drift (alert)',
+};
+
+/** Two-tier clock-drift chip, server-computed (agentRegistry.js#computeAgentCompatibility). */
+function ClockDriftBadge({ clockDriftState }) {
+  const key = String(clockDriftState || '').toLowerCase();
+  if (key !== 'warn' && key !== 'alert') return null;
+  return (
+    <Badge
+      colorScheme={CLOCK_DRIFT_SCHEME[key]}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+      title={
+        key === 'alert'
+          ? 'Clock offset exceeds the alert threshold (CERTOPS_AGENT_CLOCK_DRIFT_ALERT_MS).'
+          : 'Clock offset exceeds the warn threshold (CERTOPS_AGENT_CLOCK_DRIFT_WARN_MS).'
+      }
+    >
+      {CLOCK_DRIFT_LABEL[key]}
+    </Badge>
+  );
+}
+
+const COMPATIBILITY_SCHEME = {
+  compatible: 'green',
+  outdated: 'orange',
+  blocked: 'red',
+};
+
+const COMPATIBILITY_LABEL = {
+  compatible: 'Compatible',
+  outdated: 'Outdated',
+  blocked: 'Blocked',
+};
+
+/** Version/protocol compatibility chip; 'blocked' is a hard stop (agentJobEligibility.js
+ *  rejects every claim from this agent with compatibility_blocked). */
+function AgentCompatibilityBadge({ compatibilityState, compatibilityRange }) {
+  const key = String(compatibilityState || '').toLowerCase();
+  const range = compatibilityRange || {};
+  const rangeText =
+    `agent ${range.minAgentVersion || '?'}-${range.maxAgentVersion || '?'}, ` +
+    `protocol ${range.minProtocolVersion || '?'}-${range.maxProtocolVersion || '?'}`;
+  const title =
+    key === 'blocked'
+      ? `Outside the accepted range (${rangeText}). This agent cannot claim any job until it is upgraded.`
+      : key === 'outdated'
+        ? `Within the accepted range (${rangeText}) but more than one minor version behind the latest known build. Upgrade when convenient; it can still claim jobs.`
+        : `Within the accepted range (${rangeText}).`;
+  return (
+    <Badge
+      colorScheme={COMPATIBILITY_SCHEME[key] || 'gray'}
+      variant='subtle'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+      title={title}
+    >
+      {COMPATIBILITY_LABEL[key] || 'Unknown'}
+    </Badge>
+  );
 }
 
 /** NTP sync state chip: green Synced, orange Not synced, muted when unknown. */
@@ -636,6 +700,7 @@ export default function AgentFleetPanel({ refreshSignal, headerAction } = {}) {
                   <Th>Status</Th>
                   <Th>Version</Th>
                   <Th>Protocol</Th>
+                  <Th>Compatibility</Th>
                   <Th>Clock drift</Th>
                   <Th>NTP</Th>
                   <Th>Execution</Th>
@@ -704,22 +769,19 @@ export default function AgentFleetPanel({ refreshSignal, headerAction } = {}) {
                         </Text>
                       </Td>
                       <Td>
+                        <AgentCompatibilityBadge
+                          compatibilityState={agent.compatibilityState}
+                          compatibilityRange={agent.compatibilityRange}
+                        />
+                      </Td>
+                      <Td>
                         <HStack spacing={2}>
                           <Text fontSize='sm' fontFamily='mono'>
                             {formatClockOffset(agent.clockOffsetMs)}
                           </Text>
-                          {isClockDrifted(agent.clockOffsetMs) ? (
-                            <Badge
-                              colorScheme='orange'
-                              variant='subtle'
-                              textTransform='none'
-                              fontWeight='medium'
-                              fontSize='xs'
-                              title={`Clock offset exceeds ${CLOCK_DRIFT_WARN_MS / 1000}s`}
-                            >
-                              Drift
-                            </Badge>
-                          ) : null}
+                          <ClockDriftBadge
+                            clockDriftState={agent.clockDriftState}
+                          />
                         </HStack>
                       </Td>
                       <Td>

--- a/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
+++ b/apps/dashboard/tests/unit/AgentFleetPanel.test.jsx
@@ -102,11 +102,19 @@ function sampleAgents() {
       agentVersion: '1.2.3',
       protocolVersion: 2,
       clockOffsetMs: 120,
+      clockDriftState: 'ok',
       ntpSynced: true,
       pinnedSigningKeyId: 'ttsk_0123456789abcdef',
       lastSeenAt: new Date(Date.now() - 60000).toISOString(),
       downtimeAlertsEnabled: true,
       contactGroupId: null,
+      compatibilityState: 'compatible',
+      compatibilityRange: {
+        minAgentVersion: '0.1.0',
+        maxAgentVersion: '99.999.999',
+        minProtocolVersion: '1.0.0',
+        maxProtocolVersion: '1.999.999',
+      },
     },
     {
       id: 'row-2',
@@ -118,12 +126,20 @@ function sampleAgents() {
       agentVersion: '1.2.0',
       protocolVersion: 1,
       clockOffsetMs: -8200,
+      clockDriftState: 'warn',
       ntpSynced: false,
       pinnedSigningKeyId: null,
       lastSeenAt: new Date(Date.now() - 3600000).toISOString(),
       downtimeAlertsEnabled: true,
       contactGroupId: 'g1',
       dependentAutoRenewCertificateCount: 3,
+      compatibilityState: 'outdated',
+      compatibilityRange: {
+        minAgentVersion: '0.1.0',
+        maxAgentVersion: '99.999.999',
+        minProtocolVersion: '1.0.0',
+        maxProtocolVersion: '1.999.999',
+      },
     },
     {
       id: 'row-3',
@@ -135,12 +151,20 @@ function sampleAgents() {
       agentVersion: '1.0.0',
       protocolVersion: null,
       clockOffsetMs: null,
+      clockDriftState: null,
       ntpSynced: null,
       pinnedSigningKeyId: null,
       lastSeenAt: null,
       retiredAt: new Date().toISOString(),
       downtimeAlertsEnabled: true,
       contactGroupId: null,
+      compatibilityState: 'blocked',
+      compatibilityRange: {
+        minAgentVersion: '0.1.0',
+        maxAgentVersion: '99.999.999',
+        minProtocolVersion: '1.0.0',
+        maxProtocolVersion: '1.999.999',
+      },
     },
   ];
 }
@@ -299,13 +323,66 @@ describe('AgentFleetPanel', () => {
     expect(within(rows).getByText('2')).toBeInTheDocument();
     expect(within(rows).getByText('1')).toBeInTheDocument();
 
-    // Signed offsets; only the |offset| > 5000ms row is flagged.
+    // Signed offsets, and the badge driven by clockDriftState, not by
+    // recomputing from the raw offset.
     expect(screen.getByText('+120 ms')).toBeInTheDocument();
     expect(screen.getByText('-8200 ms')).toBeInTheDocument();
     expect(screen.getAllByText('Drift')).toHaveLength(1);
 
     // Unknown protocol/offset render as placeholders on the retired row.
     expect(screen.getAllByText('--').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('drives the clock drift badge from clockDriftState, not the raw offset magnitude', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    const agents = sampleAgents();
+    // Under the old hardcoded 5000ms threshold this offset would not have
+    // flagged at all; the alert tier must still render because the
+    // server-computed field, not the offset, drives the badge.
+    agents[0].clockOffsetMs = 4000;
+    agents[0].clockDriftState = 'alert';
+    useCertOpsAgentsMock.mockReturnValue(agentsState({ agents }));
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(screen.getByText('Drift (alert)')).toBeInTheDocument();
+  });
+
+  it('shows no drift badge for a nonzero offset the server has classified as ok', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    const agents = sampleAgents();
+    agents[0].clockOffsetMs = 4500;
+    agents[0].clockDriftState = 'ok';
+    // Row 2's clockDriftState defaults to 'warn'; clear it so this test only
+    // asserts on row 1's ok-with-nonzero-offset case.
+    agents[1].clockDriftState = 'ok';
+    useCertOpsAgentsMock.mockReturnValue(agentsState({ agents }));
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(screen.queryByText('Drift')).not.toBeInTheDocument();
+    expect(screen.queryByText('Drift (alert)')).not.toBeInTheDocument();
+  });
+
+  it('renders a Compatibility column reflecting compatible/outdated/blocked state with the accepted range in the tooltip', () => {
+    useCertOpsCanManageMock.mockReturnValue(true);
+    useCertOpsAgentsMock.mockReturnValue(
+      agentsState({ agents: sampleAgents() })
+    );
+
+    renderWithProviders(<AgentFleetPanel />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Compatibility' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Compatible')).toBeInTheDocument();
+    expect(screen.getByText('Outdated')).toBeInTheDocument();
+    const blockedBadge = screen.getByText('Blocked');
+    expect(blockedBadge).toBeInTheDocument();
+    expect(blockedBadge).toHaveAttribute(
+      'title',
+      expect.stringContaining('agent 0.1.0-99.999.999, protocol 1.0.0-1.999.999')
+    );
   });
 
   it('renders NTP sync state and pinned signing key columns', () => {

--- a/tests/unit/certops-agent-lifecycle.test.js
+++ b/tests/unit/certops-agent-lifecycle.test.js
@@ -525,6 +525,12 @@ describe("CertOps agents list route", () => {
       // default "latest known" reference for the outdated heuristic), so
       // it is compatible, not outdated.
       compatibilityState: "compatible",
+      compatibilityRange: {
+        minAgentVersion: "0.1.0",
+        maxAgentVersion: "99.999.999",
+        minProtocolVersion: "1.0.0",
+        maxProtocolVersion: "1.999.999",
+      },
       clockDriftState: "ok",
       clockDriftMs: 25,
       livenessState: "stale",
@@ -830,6 +836,39 @@ describe("agentRegistry service internals", () => {
     assert.deepEqual(fresh.targetSelectors, []);
     assert.deepEqual(fresh.commandProfiles, []);
     assert.deepEqual(fresh.dnsProviders, []);
+  });
+
+  it("agentMetadataFromRow's compatibilityRange tracks env overrides, not a hardcoded default", () => {
+    const metadata = agentRegistry._test.agentMetadataFromRow(agentRow(), {
+      CERTOPS_AGENT_MIN_AGENT_VERSION: "2.0.0",
+      CERTOPS_AGENT_MAX_AGENT_VERSION: "3.0.0",
+      CERTOPS_AGENT_MIN_PROTOCOL_VERSION: "2.0.0",
+      CERTOPS_AGENT_MAX_PROTOCOL_VERSION: "2.999.999",
+    });
+    assert.deepEqual(metadata.compatibilityRange, {
+      minAgentVersion: "2.0.0",
+      maxAgentVersion: "3.0.0",
+      minProtocolVersion: "2.0.0",
+      maxProtocolVersion: "2.999.999",
+    });
+  });
+
+  it("agentMetadataFromRow's compatibilityState still classifies compatible/outdated/blocked correctly", () => {
+    const compatible = agentRegistry._test.agentMetadataFromRow(
+      agentRow({ agent_version: "1.2.3", protocol_version: "1.0.0" }),
+    );
+    assert.equal(compatible.compatibilityState, "compatible");
+
+    const blocked = agentRegistry._test.agentMetadataFromRow(
+      agentRow({ agent_version: "0.0.1", protocol_version: "1.0.0" }),
+    );
+    assert.equal(blocked.compatibilityState, "blocked");
+
+    const outdated = agentRegistry._test.agentMetadataFromRow(
+      agentRow({ agent_version: "1.2.3", protocol_version: "1.0.0" }),
+      { CERTOPS_AGENT_LATEST_KNOWN_VERSION: "3.0.0" },
+    );
+    assert.equal(outdated.compatibilityState, "outdated");
   });
 
   it("normalizeRequiredRetireReason trims and enforces bounds", () => {


### PR DESCRIPTION
## Summary

- Adds a Compatibility column to the CertOps agent fleet table, showing each agent's Compatible/Outdated/Blocked state (the server already computed this; it just never reached the UI). The badge's tooltip states the accepted agent and protocol version range, matching the wording an agent operator sees if a blocked agent actually gets rejected at dispatch time.
- Fixes the clock drift badge in the same table: it was hardcoded to a 5 second threshold and ignored an operator's own `CERTOPS_AGENT_CLOCK_DRIFT_WARN_MS`/`CERTOPS_AGENT_CLOCK_DRIFT_ALERT_MS` configuration. It now reads the server-computed two-tier drift state and shows a distinct badge once drift crosses the alert threshold, not just the warn threshold.
- `agentMetadataFromRow` now also returns a small `compatibilityRange` object (min/max agent and protocol version) alongside the existing compatibility fields, so the new badge's tooltip can show the accepted range without a second API call.

Both changes touch the same file (`AgentFleetPanel.jsx`) and are bundled into one PR to avoid a trivial merge conflict between two otherwise-independent changes.

## Test plan

- [x] `pnpm --filter @tokentimer/dashboard lint` clean (0 errors; pre-existing unrelated warnings only)
- [x] `pnpm --filter @tokentimer/dashboard exec prettier --check` clean
- [x] `pnpm --filter @tokentimer/dashboard type-check` clean
- [x] `pnpm --filter @tokentimer/dashboard build` succeeds
- [x] `pnpm --filter @tokentimer/dashboard exec vitest run` - 497/497 tests pass, including new/updated cases in `AgentFleetPanel.test.jsx` for the Compatibility column and the two-tier clock drift badge
- [x] `pnpm run test:unit` - 1802/1802 backend unit tests pass, including new cases in `certops-agent-lifecycle.test.js` for `compatibilityRange`
- [x] `pnpm run check:contracts`, `check:contracts:integrity`, `check:lockfile-overrides`, `check:secret-logging`, `test:contracts` (with `CONTRACT_API_REQUIRED=0`) all clean
- [x] `pnpm --filter @tokentimer/api lint`, `pnpm --filter @tokentimer/worker lint`, `pnpm audit --prod --audit-level=moderate` all clean
- [x] Helm chart validation (`helm dependency build` + `scripts/helm-template-verify.sh`) and all four `docker compose ... config -q` checks pass

## Validation
- With #201, fleet Execution and Compatibility columns stay aligned and compatibilityRange/drift thresholds pass AgentFleetPanel and agent-lifecycle unit tests.
