### PR TITLE
feat(certops): show approval attribution in the jobs panel and evidence timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The CertOps agent fleet table has a new Compatibility column showing each agent's Compatible/Outdated/Blocked state, with the accepted agent and protocol version range in the tooltip. A blocked agent cannot claim any job until upgraded; this was previously only visible as a dispatch-time error in the agent's own logs.
 - The Trust anchors panel now marks a `pending_install`/`pending_remove` row that automatic reconciliation gave up on with a "Needs attention" badge and a plain-language explanation, instead of showing it identically to one still actively retrying or leaving the raw internal reason code on screen.
 - The CertOps jobs list now shows when a job needs manual reconciliation instead of only on the Audit page: a job stuck as `orphaned_unknown_effect` gets a red "Needs reconciliation" badge (previously an unlabeled gray badge), and its row shows either the recorded error or, if none was recorded, an advisory line explaining the side effects could not be confirmed.
+- The jobs panel and evidence timeline now show who approved or rejected a certificate job and when, instead of only the Audit page.
 
 ### Fixed
 

--- a/apps/api/routes/certops.js
+++ b/apps/api/routes/certops.js
@@ -1329,6 +1329,8 @@ function jobSummary(job) {
     cancelledAt: job.cancelledAt,
     requestedByUserId: job.requestedByUserId,
     requestedByApiTokenId: job.requestedByApiTokenId,
+    approvedByUserId: job.approvedByUserId,
+    approvedAt: job.approvedAt,
   };
 }
 
@@ -3723,6 +3725,7 @@ module.exports._test = {
   loadRenewalSetupIntents,
   projectRenewalSetupState,
   apiTokenMetadata,
+  jobSummary,
   jobDetail,
   redactClaimIdForNonAdmins,
 };

--- a/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
+++ b/apps/dashboard/src/components/certops/EvidenceTimeline.jsx
@@ -174,6 +174,10 @@ function TimelineItem({ item, attemptLabel }) {
   const detail = isEvidence
     ? metadataSummary || subjectLabel || 'No subject recorded'
     : entry.message || entry.status || '';
+  const decidedByUserId =
+    !isEvidence && (type === 'approval.granted' || type === 'approval.rejected')
+      ? entry.createdByUserId
+      : null;
 
   return (
     <Box position='relative' pl={6} pb={4} _last={{ pb: 0 }}>
@@ -230,6 +234,9 @@ function TimelineItem({ item, attemptLabel }) {
           <Text fontSize='sm' color={muted} noOfLines={3}>
             {detail}
           </Text>
+        ) : null}
+        {decidedByUserId ? (
+          <CopyableId id={decidedByUserId} label='Decided by user' size='xs' />
         ) : null}
         <Text fontSize='xs' color={muted}>
           {timestamp}
@@ -376,8 +383,14 @@ export default function EvidenceTimeline({ jobId, onClose, refreshToken }) {
                 label="Agent's pinned signing key"
               />
             ) : null}
+            {job.approvedByUserId ? (
+              <CopyableId id={job.approvedByUserId} label='Approved by user' />
+            ) : null}
           </HStack>
-          {job.claimId || job.leaseExpiresAt || job.attemptCount ? (
+          {job.claimId ||
+          job.leaseExpiresAt ||
+          job.attemptCount ||
+          job.approvedAt ? (
             <HStack spacing={3} flexWrap='wrap'>
               {job.leaseExpiresAt ? (
                 <Text fontSize='xs' color={muted}>
@@ -390,6 +403,11 @@ export default function EvidenceTimeline({ jobId, onClose, refreshToken }) {
                   {typeof job.maxAttempts === 'number'
                     ? ` of ${job.maxAttempts}`
                     : ''}
+                </Text>
+              ) : null}
+              {job.approvedAt ? (
+                <Text fontSize='xs' color={muted}>
+                  Approved {formatDateTime(job.approvedAt)}
                 </Text>
               ) : null}
             </HStack>

--- a/apps/dashboard/src/components/certops/ExecutorJobsPanel.jsx
+++ b/apps/dashboard/src/components/certops/ExecutorJobsPanel.jsx
@@ -344,6 +344,19 @@ export default function ExecutorJobsPanel({ certOpsPaused = false }) {
                       )
                     ) : null}
                   </VStack>
+                  {job.approvedByUserId ? (
+                    <Tooltip
+                      label={`Approved by user ${job.approvedByUserId}${
+                        job.approvedAt
+                          ? ` at ${formatDateTime(job.approvedAt)}`
+                          : ''
+                      }`}
+                    >
+                      <Text fontSize='xs' color={muted} flexShrink={0}>
+                        Approved
+                      </Text>
+                    </Tooltip>
+                  ) : null}
                   <Text
                     fontSize='xs'
                     color={muted}

--- a/apps/dashboard/src/components/certops/certopsJobsFormat.js
+++ b/apps/dashboard/src/components/certops/certopsJobsFormat.js
@@ -50,6 +50,9 @@ const EVENT_TYPE_LABELS = {
   'job.cancelled': 'Job cancelled',
   'job.status_updated': 'Status updated',
   'evidence.attached': 'Evidence attached',
+  'approval.granted': 'Approval granted',
+  'approval.rejected': 'Approval rejected',
+  'approval.invalidated': 'Approval invalidated',
 };
 
 const EVIDENCE_TYPE_LABELS = {

--- a/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
+++ b/apps/dashboard/tests/unit/EvidenceTimeline.test.jsx
@@ -419,6 +419,138 @@ describe('EvidenceTimeline', () => {
     expect(screen.queryByText('Claim ID')).not.toBeInTheDocument();
   });
 
+  it('shows the "Approved by user" chip and an "Approved" date line when the job carries approval attribution', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob({
+        approvedByUserId: 'user-42',
+        approvedAt: '2026-01-05T00:00:00.000Z',
+      }),
+      logEntries: [],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.getByText('Approved by user')).toBeInTheDocument();
+    expect(screen.getByText('user-42')).toBeInTheDocument();
+    expect(screen.getByText(/^Approved \d/)).toBeInTheDocument();
+  });
+
+  it('hides the "Approved by user" chip and date line when the job has no approval attribution', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.queryByText('Approved by user')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Approved \d/)).not.toBeInTheDocument();
+  });
+
+  it('renders friendly labels for approval.granted, approval.rejected, and approval.invalidated log entries', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [
+        {
+          id: 'log-1',
+          eventType: 'approval.granted',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          createdByUserId: 'user-42',
+        },
+        {
+          id: 'log-2',
+          eventType: 'approval.rejected',
+          createdAt: '2026-01-02T00:00:00.000Z',
+          createdByUserId: 'user-99',
+        },
+        {
+          id: 'log-3',
+          eventType: 'approval.invalidated',
+          createdAt: '2026-01-03T00:00:00.000Z',
+        },
+      ],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.getByText('Approval granted')).toBeInTheDocument();
+    expect(screen.getByText('Approval rejected')).toBeInTheDocument();
+    expect(screen.getByText('Approval invalidated')).toBeInTheDocument();
+  });
+
+  it('shows a "Decided by user" line with the approver\'s id for an approval.granted entry', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [
+        {
+          id: 'log-1',
+          eventType: 'approval.granted',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          createdByUserId: 'user-42',
+        },
+      ],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.getByText('Decided by user')).toBeInTheDocument();
+    expect(screen.getByText('user-42')).toBeInTheDocument();
+  });
+
+  it('shows a "Decided by user" line with the rejecter\'s id for an approval.rejected entry', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [
+        {
+          id: 'log-1',
+          eventType: 'approval.rejected',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          createdByUserId: 'user-99',
+        },
+      ],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.getByText('Decided by user')).toBeInTheDocument();
+    expect(screen.getByText('user-99')).toBeInTheDocument();
+  });
+
+  it('does not show a "Decided by user" line for an approval.invalidated entry (system-detected, no human actor)', () => {
+    useCertOpsJobTimelineMock.mockReturnValue({
+      job: baseJob(),
+      logEntries: [
+        {
+          id: 'log-1',
+          eventType: 'approval.invalidated',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      evidence: [],
+      loading: false,
+      error: '',
+    });
+
+    renderWithProviders(<EvidenceTimeline jobId='job-1' />);
+
+    expect(screen.queryByText('Decided by user')).not.toBeInTheDocument();
+  });
+
   it('renders the failure reason for a failed job', () => {
     useCertOpsJobTimelineMock.mockReturnValue({
       job: baseJob({

--- a/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx
@@ -540,6 +540,32 @@ describe('ExecutorJobsPanel approvals', () => {
     ).toBeInTheDocument();
     expect(refresh).not.toHaveBeenCalled();
   });
+
+  it('shows the "Approved" indicator on a row for a job with approval attribution', () => {
+    useCertOpsJobsMock.mockReturnValue(
+      jobsState({
+        jobs: [
+          job({
+            status: 'succeeded',
+            approvedByUserId: 'user-42',
+            approvedAt: '2026-01-05T00:00:00.000Z',
+          }),
+        ],
+      })
+    );
+
+    renderPanel();
+
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+  });
+
+  it('does not show the "Approved" indicator on a row with no approval attribution', () => {
+    useCertOpsJobsMock.mockReturnValue(jobsState({ jobs: [job()] }));
+
+    renderPanel();
+
+    expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+  });
 });
 
 describe('ExecutorJobsPanel list states', () => {

--- a/apps/dashboard/tests/unit/certopsJobsFormat.test.js
+++ b/apps/dashboard/tests/unit/certopsJobsFormat.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  eventTypeLabel,
   hasRedactionMarkers,
   jobStatusLabel,
   jobStatusScheme,
@@ -42,6 +43,22 @@ describe('reconciliationAdvisoryText', () => {
       )
     ).toBe(
       "This job's side effects could not be confirmed and need manual review (reason: lease_expired_after_side_effect_window_agent_unresponsive)."
+    );
+  });
+});
+
+describe('eventTypeLabel', () => {
+  it('labels the approval decision event types', () => {
+    expect(eventTypeLabel('approval.granted')).toBe('Approval granted');
+    expect(eventTypeLabel('approval.rejected')).toBe('Approval rejected');
+    expect(eventTypeLabel('approval.invalidated')).toBe(
+      'Approval invalidated'
+    );
+  });
+
+  it('falls back to the raw type string for an unmapped event type', () => {
+    expect(eventTypeLabel('job.some_future_event_type_v9')).toBe(
+      'job.some_future_event_type_v9'
     );
   });
 });

--- a/tests/unit/certops-job-claim-id-visibility.test.js
+++ b/tests/unit/certops-job-claim-id-visibility.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 
 const {
-  _test: { jobDetail, redactClaimIdForNonAdmins },
+  _test: { jobSummary, jobDetail, redactClaimIdForNonAdmins },
 } = require(path.resolve(__dirname, "../../apps/api/routes/certops.js"));
 
 const CLAIM_ID = "22222222-2222-4222-8222-222222222222";
@@ -85,5 +85,59 @@ describe("CertOps job-detail claimId visibility", () => {
       if (key === "claimId") continue;
       assert.equal(projection[key], value, `${key} must be unchanged`);
     }
+  });
+});
+
+describe("CertOps job projection approval attribution", () => {
+  it("jobSummary carries approvedByUserId/approvedAt when present on the job", () => {
+    const approved = jobSummary(
+      claimedJob({
+        status: "approved",
+        approvedByUserId: "user-42",
+        approvedAt: "2026-01-01T00:05:00.000Z",
+      }),
+    );
+
+    assert.equal(approved.approvedByUserId, "user-42");
+    assert.equal(approved.approvedAt, "2026-01-01T00:05:00.000Z");
+  });
+
+  it("jobSummary surfaces null approvedByUserId/approvedAt rather than dropping the keys", () => {
+    const pending = jobSummary(
+      claimedJob({
+        status: "pending_approval",
+        approvedByUserId: null,
+        approvedAt: null,
+      }),
+    );
+
+    assert.equal(pending.approvedByUserId, null);
+    assert.equal(pending.approvedAt, null);
+  });
+
+  it("jobDetail (which spreads jobSummary) also carries approvedByUserId/approvedAt", () => {
+    const detail = jobDetail(
+      claimedJob({
+        status: "approved",
+        approvedByUserId: "user-42",
+        approvedAt: "2026-01-01T00:05:00.000Z",
+      }),
+    );
+
+    assert.equal(detail.approvedByUserId, "user-42");
+    assert.equal(detail.approvedAt, "2026-01-01T00:05:00.000Z");
+  });
+
+  it("jobDetail on a job with null approval fields surfaces them as null, not undefined", () => {
+    const detail = jobDetail(
+      claimedJob({
+        status: "rejected",
+        approvedByUserId: null,
+        approvedAt: null,
+      }),
+    );
+
+    assert.equal(detail.approvedByUserId, null);
+    assert.equal(detail.approvedAt, null);
   });
 });


### PR DESCRIPTION
## Summary

The job model already computed who approved a certificate job and when, and job-log entries already carried the deciding user for approval and rejection events. None of that reached the dashboard: the API route projection dropped the approval fields before the response left the server, and neither the jobs panel nor the evidence timeline rendered any of it. The only place this was visible was the separate Audit page.

- `jobSummary()` (and `jobDetail()`, which spreads it) now includes `approvedByUserId` and `approvedAt`, so both the jobs list and job detail API responses carry them.
- The evidence timeline header shows an "Approved by user" id chip and an "Approved &lt;date&gt;" line whenever a job's approval is currently live (a later invalidation clears both, correctly, since it nulls those fields again).
- Each `approval.granted` / `approval.rejected` log entry in the timeline now shows a "Decided by user" line with the deciding user's id. `approval.invalidated` entries correctly show no such line, since that event is system-detected rather than a human decision.
- `approval.granted`, `approval.rejected`, and `approval.invalidated` log entries now render friendly labels instead of the raw event-type string.
- The jobs panel row shows a small "Approved" indicator next to the status badge, with a tooltip naming the approver's id and the approval time.

Rejection has no per-job-row column to source attribution from (no `rejected_by_user_id` exists on the job row), so it intentionally stays visible only in the expanded timeline via the log entry's deciding user, consistent with how the rest of the panel is scoped.

Bare user ids are shown as-is via the existing `CopyableId` convention, matching how `requestedByUserId` and `claimId` are already shown elsewhere on this surface. No new user-lookup fetch was added.

## Test plan

- Extended `tests/unit/certops-job-claim-id-visibility.test.js` with coverage that `jobSummary()`/`jobDetail()` now carry `approvedByUserId`/`approvedAt`, including the null case.
- Extended `apps/dashboard/tests/unit/certopsJobsFormat.test.js` with `eventTypeLabel()` coverage for the three approval event types and the unmapped-type fallback.
- Extended `apps/dashboard/tests/unit/EvidenceTimeline.test.jsx` with cases for the header chip/date (present and absent), the friendly event-type labels, and the "Decided by user" line (present for granted/rejected, absent for invalidated).
- Extended `apps/dashboard/tests/unit/ExecutorJobsPanel.test.jsx` with a case for the row-level "Approved" indicator (present/absent).
- Full backend unit suite: 1804 passed, 0 failed.
- Full dashboard unit suite: 504 passed, 0 failed.
- Ran the CI-parity checks locally: dashboard lint, prettier check, type-check, build; worker lint; API lint; `pnpm run test:unit`; `check:contracts`, `check:contracts:integrity`, `check:lockfile-overrides`, `check:secret-logging`; `test:contracts` (`CONTRACT_API_REQUIRED=0`); `pnpm audit --prod --audit-level=moderate`. All passed with no new errors (pre-existing lint warnings only).

## Validation
- With #204, reconciliation advisory and approval attribution coexist on the same job row; ExecutorJobsPanel unit tests pass.
