### PR TITLE
feat(certops): distinguish a stalled trust-anchor reconciliation from active retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Agent execution capability is now visible before you pin a job to an agent.** The CertOps Agents tab has a new Execution column showing whether an agent declared any executable action on its last successful claim; hovering "No capability declared" explains it can mean observe-only mode or simply an agent that hasn't polled yet. The manual-job and trust-anchor distribute/revoke modals annotate an agent option and show an inline warning when the selected agent has not declared the operation being requested, and creating a trust job against an agent that is retired or outside the accepted compatibility range is now rejected up front instead of leaving the job stuck at "Pending" forever. A trust-anchor installation stuck in a pending transition with no error now shows the same advisory reason inline instead of a bare "Pending" badge.
 - The CertOps agent fleet table has a new Compatibility column showing each agent's Compatible/Outdated/Blocked state, with the accepted agent and protocol version range in the tooltip. A blocked agent cannot claim any job until upgraded; this was previously only visible as a dispatch-time error in the agent's own logs.
+- The Trust anchors panel now marks a `pending_install`/`pending_remove` row that automatic reconciliation gave up on with a "Needs attention" badge and a plain-language explanation, instead of showing it identically to one still actively retrying or leaving the raw internal reason code on screen.
 
 ### Fixed
 

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -843,7 +843,15 @@ async function listInstallationsForAnchor(options = {}) {
     [workspaceId, trustAnchorId],
   );
   const installations = result.rows.map(installationFromRow);
-  return attachPendingReasons({ db, workspaceId, installations });
+  const withPending = await attachPendingReasons({
+    db,
+    workspaceId,
+    installations,
+  });
+  return withPending.map((row) => ({
+    ...row,
+    staleReason: reconciliationStaleReasonForInstallation(row),
+  }));
 }
 
 
@@ -2210,6 +2218,51 @@ async function rescheduleTrustInstallation({
 // counter (this row shape has no per-row attempt count).
 const DEFAULT_MAX_RECONCILE_AGE_MS = 6 * DEFAULT_RECONCILE_DELAY_MS;
 
+// Operator-facing prose for each markTrustInstallationStale() code. Backend
+// owns the prose so the UI never has to render a raw internal code.
+// reconciliation_stale_job_<status> codes not listed here fall back to a
+// generic template in reconciliationStaleReasonForInstallation below.
+const RECONCILIATION_STALE_MESSAGE_BY_CODE = Object.freeze({
+  reconciliation_stale_no_job:
+    "Automatic reconciliation gave up: this installation has no dispatched job to track. This should not normally happen; contact support before retrying.",
+  reconciliation_stale_job_pending_approval:
+    "The job for this change is still waiting on manual approval and automatic reconciliation has given up retrying. Approve or reject the job to unblock it.",
+  reconciliation_stale_job_approved:
+    "The job for this change was approved but never claimed by the target agent in time, and automatic reconciliation has given up retrying. Check the agent's connectivity/heartbeat, then retry manually.",
+  reconciliation_stale_job_pending:
+    "The job for this change has been waiting to be claimed by the target agent for too long, and automatic reconciliation has given up retrying. Check the agent's connectivity/heartbeat, then retry manually.",
+  reconciliation_stale_job_claimed:
+    "The target agent claimed this job but never started executing it in time, and automatic reconciliation has given up retrying. Check the agent's logs, then retry manually.",
+  reconciliation_stale_job_running:
+    "The target agent has been running this job far longer than expected, and automatic reconciliation has given up retrying. Check the agent's logs before retrying manually.",
+});
+
+const RECONCILIATION_STALE_CODE_PREFIX = "reconciliation_stale_";
+
+const RECONCILE_LIVE_PENDING_STATES = new Set(["pending_install", "pending_remove"]);
+
+/**
+ * Distinguishes "the sweep gave up on this row" from "still actively being
+ * retried" or "a genuine unrelated error". Only ever non-null when
+ * markTrustInstallationStale is the reason last_error is set: requires the
+ * row still pending, next_reconcile_at cleared (the sweep's own signal that
+ * it stopped touching this row), AND last_error matching the sweep's own
+ * code prefix - any other last_error value must fall through unchanged to
+ * the existing plain-text rendering.
+ */
+function reconciliationStaleReasonForInstallation(installation) {
+  if (!RECONCILE_LIVE_PENDING_STATES.has(installation.transitionState)) return null;
+  if (installation.nextReconcileAt) return null;
+  const code = installation.lastError;
+  if (!code || !code.startsWith(RECONCILIATION_STALE_CODE_PREFIX)) return null;
+  return {
+    code,
+    message:
+      RECONCILIATION_STALE_MESSAGE_BY_CODE[code] ||
+      `Automatic reconciliation gave up retrying this change (${code}). Manual retry is required.`,
+  };
+}
+
 /**
  * The reconciliation sweep, called by certops-worker.js on the same
  * tick-based schedule as this codebase's other certops sweeps. Owns one
@@ -2362,4 +2415,6 @@ module.exports._test = {
   assertTargetAgentEligibleForTrustJob,
   BLOCKING_TRUST_JOB_CREATION_REASONS,
   pendingReasonForInstallation,
+  reconciliationStaleReasonForInstallation,
+  RECONCILIATION_STALE_MESSAGE_BY_CODE,
 };

--- a/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
+++ b/apps/dashboard/src/components/certops/TrustAnchorsPanel.jsx
@@ -115,6 +115,20 @@ function InstallationStateBadge({ state }) {
   );
 }
 
+function StaleReconciliationBadge() {
+  return (
+    <Badge
+      colorScheme='red'
+      variant='solid'
+      textTransform='none'
+      fontWeight='medium'
+      fontSize='xs'
+    >
+      Needs attention
+    </Badge>
+  );
+}
+
 const ANCHOR_TRUST_ANCHOR_PEM_ERROR_MESSAGE =
   'That does not look like a single CA certificate (Basic Constraints CA=true). Bundles and leaf/server certificates are rejected.';
 
@@ -465,7 +479,19 @@ function AnchorInstallationsBody({
                 <Td>
                   <VStack align='flex-start' spacing={0.5}>
                     <InstallationStateBadge state={row.transitionState} />
-                    {row.lastError ? (
+                    {row.staleReason ? (
+                      <>
+                        <StaleReconciliationBadge />
+                        <Text
+                          fontSize='xs'
+                          color='red.600'
+                          noOfLines={2}
+                          title={row.staleReason.message}
+                        >
+                          {row.staleReason.message}
+                        </Text>
+                      </>
+                    ) : row.lastError ? (
                       <Text fontSize='xs' color='red.500' noOfLines={1}>
                         {row.lastError}
                       </Text>

--- a/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
+++ b/apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx
@@ -217,6 +217,105 @@ describe('TrustAnchorsPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the Needs attention badge and mapped message for a stalled reconciliation, not the raw code', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'pending_install',
+            nextReconcileAt: null,
+            lastError: 'reconciliation_stale_job_pending',
+            staleReason: {
+              code: 'reconciliation_stale_job_pending',
+              message:
+                "Check the agent's connectivity/heartbeat, then retry manually.",
+            },
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(screen.getByText('Pending install')).toBeInTheDocument();
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Check the agent's connectivity/heartbeat, then retry manually."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('reconciliation_stale_job_pending')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show Needs attention for a row still actively retrying', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'pending_install',
+            nextReconcileAt: new Date(Date.now() + 60_000).toISOString(),
+            lastError: null,
+            staleReason: null,
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(screen.getByText('Pending install')).toBeInTheDocument();
+    expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+  });
+
+  it('still shows the raw last_error text for a genuine unrelated error, without the stalled badge', () => {
+    useCertOpsTrustAnchorsMock.mockReturnValue(
+      anchorsState({ anchors: [sampleAnchor()] })
+    );
+    useCertOpsTrustAnchorInstallationsMock.mockReturnValue(
+      installationsState({
+        installations: [
+          {
+            id: 'install-1',
+            agentId: 'agent-a',
+            owner: 'team-a',
+            host: 'host-a',
+            store: 'root',
+            transitionState: 'pending_install',
+            nextReconcileAt: null,
+            lastError: 'agent unreachable',
+            staleReason: null,
+          },
+        ],
+      })
+    );
+
+    renderPanel();
+    fireEvent.click(screen.getByText('Internal Root CA'));
+
+    expect(screen.getByText('agent unreachable')).toBeInTheDocument();
+    expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+  });
+
   it('opens the trust-op modal in distribute mode with the anchor pre-set', () => {
     useCertOpsTrustAnchorsMock.mockReturnValue(
       anchorsState({ anchors: [sampleAnchor()] })

--- a/tests/integration/certops-trust-anchors.test.js
+++ b/tests/integration/certops-trust-anchors.test.js
@@ -45,7 +45,9 @@ const {
   CERTOPS_TRUST_JOB_IDEMPOTENCY_KEY_REQUIRED,
   CERTOPS_TRUST_INSTALLATION_NOT_FOUND,
   deriveTrustJobIdempotencyKey,
+  _test: trustAnchorsTest,
 } = require("../../apps/api/services/certops/trustAnchors");
+const { RECONCILIATION_STALE_MESSAGE_BY_CODE } = trustAnchorsTest;
 const agentTrustStore = require("../../packages/agent/src/trust-store");
 
 // Ten distinct self-signed CA certificates (Basic Constraints CA:TRUE),
@@ -2684,6 +2686,57 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
     expect(installation.last_error).to.equal(
       "reconciliation_stale_job_pending",
     );
+
+    const items = await listInstallationsForAnchor({
+      workspaceId,
+      trustAnchorId: anchor.id,
+    });
+    const listed = items.find(
+      (item) => item.id === String(outcome.installation.id),
+    );
+    expect(listed.staleReason).to.deep.equal({
+      code: "reconciliation_stale_job_pending",
+      message:
+        RECONCILIATION_STALE_MESSAGE_BY_CODE.reconciliation_stale_job_pending,
+    });
+  });
+
+  it("marks an overdue pending row stale with the no-job reason when it has no last_job_id", async () => {
+    const anchor = await createFreshAnchor();
+    const agent = await createAgent();
+    const outcome = await createTrustJob(
+      distributeOptions({
+        anchor,
+        agent,
+        idempotencyKey: `sweep-stale-no-job-${crypto.randomUUID()}`,
+      }),
+    );
+
+    // Simulate the (normally unreachable) no-job case directly on the row,
+    // since createTrustJob always attaches a last_job_id.
+    await TestUtils.execQuery(
+      `UPDATE certops_trust_anchor_installations
+          SET next_reconcile_at = NOW() - INTERVAL '1 hour',
+              last_attempt_at = NOW() - INTERVAL '10 hours',
+              last_job_id = NULL
+        WHERE id = $1`,
+      [outcome.installation.id],
+    );
+
+    const summary = await sweepOverdueTrustInstallations({
+      dbPool: pool,
+      maxAgeMs: 60 * 60 * 1000,
+    });
+    expect(summary.markedStale).to.be.greaterThanOrEqual(1);
+
+    const items = await listInstallationsForAnchor({
+      workspaceId,
+      trustAnchorId: anchor.id,
+    });
+    const listed = items.find(
+      (item) => item.id === String(outcome.installation.id),
+    );
+    expect(listed.staleReason.code).to.equal("reconciliation_stale_no_job");
   });
 
   it("reschedules an overdue row that is still within its max age budget", async () => {
@@ -2717,6 +2770,51 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
     expect(new Date(after.next_reconcile_at).getTime()).to.be.greaterThan(
       new Date(before.next_reconcile_at).getTime(),
     );
+
+    const items = await listInstallationsForAnchor({
+      workspaceId,
+      trustAnchorId: anchor.id,
+    });
+    const listed = items.find(
+      (item) => item.id === String(outcome.installation.id),
+    );
+    expect(listed.staleReason).to.equal(
+      null,
+      "a still-retrying row must never show the stalled-reconciliation badge",
+    );
+  });
+
+  it("does not reclassify a genuine unrelated last_error as a stalled reconciliation", async () => {
+    const anchor = await createFreshAnchor();
+    const agent = await createAgent();
+    const outcome = await createTrustJob(
+      distributeOptions({
+        anchor,
+        agent,
+        idempotencyKey: `sweep-unrelated-error-${crypto.randomUUID()}`,
+      }),
+    );
+
+    await TestUtils.execQuery(
+      `UPDATE certops_trust_anchor_installations
+          SET next_reconcile_at = NULL,
+              last_error = 'some_genuinely_unrelated_error'
+        WHERE id = $1`,
+      [outcome.installation.id],
+    );
+
+    const items = await listInstallationsForAnchor({
+      workspaceId,
+      trustAnchorId: anchor.id,
+    });
+    const listed = items.find(
+      (item) => item.id === String(outcome.installation.id),
+    );
+    expect(listed.staleReason).to.equal(
+      null,
+      "an unrelated error must not be reclassified as a stalled reconciliation",
+    );
+    expect(listed.lastError).to.equal("some_genuinely_unrelated_error");
   });
 
   it("unwinds (rather than redispatches) an overdue row whose job already reached a terminal-negative status", async () => {
@@ -3336,6 +3434,7 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
             "publicMetadata",
             "createdAt",
             "updatedAt",
+            "staleReason",
           ].sort(),
         );
         expect(returnedB).to.include({
@@ -3347,6 +3446,7 @@ describe("CertOps trust-anchor orchestration (real database, ADR-0012 decision 2
           transitionState: "pending_install",
           provenance: "preexisting",
           lastError: null,
+          staleReason: null,
         });
       });
     });

--- a/tests/unit/certops-trust-reconciliation-stale.test.js
+++ b/tests/unit/certops-trust-reconciliation-stale.test.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  _test: { reconciliationStaleReasonForInstallation, RECONCILIATION_STALE_MESSAGE_BY_CODE },
+} = require("../../apps/api/services/certops/trustAnchors");
+
+function installation(overrides = {}) {
+  return {
+    transitionState: "pending_install",
+    nextReconcileAt: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe("reconciliationStaleReasonForInstallation", () => {
+  const knownCodes = [
+    "reconciliation_stale_no_job",
+    "reconciliation_stale_job_pending_approval",
+    "reconciliation_stale_job_approved",
+    "reconciliation_stale_job_pending",
+    "reconciliation_stale_job_claimed",
+    "reconciliation_stale_job_running",
+  ];
+
+  for (const code of knownCodes) {
+    it(`maps ${code} to its operator-facing message`, () => {
+      const reason = reconciliationStaleReasonForInstallation(
+        installation({ lastError: code }),
+      );
+      assert.deepEqual(reason, {
+        code,
+        message: RECONCILIATION_STALE_MESSAGE_BY_CODE[code],
+      });
+    });
+  }
+
+  it("falls back to a generic message for an unmapped-but-prefixed code", () => {
+    const reason = reconciliationStaleReasonForInstallation(
+      installation({ lastError: "reconciliation_stale_job_dry_run_complete" }),
+    );
+    assert.equal(reason.code, "reconciliation_stale_job_dry_run_complete");
+    assert.match(reason.message, /Manual retry is required/);
+  });
+
+  it("returns null when next_reconcile_at is still set, even with a known stale code", () => {
+    // Defends against the "still scheduled" case being misclassified, even
+    // though the sweep itself guarantees this can't currently co-occur.
+    const reason = reconciliationStaleReasonForInstallation(
+      installation({
+        lastError: "reconciliation_stale_job_pending",
+        nextReconcileAt: new Date().toISOString(),
+      }),
+    );
+    assert.equal(reason, null);
+  });
+
+  it("returns null for a row that is not a live pending transition", () => {
+    for (const transitionState of ["installed", "removed"]) {
+      const reason = reconciliationStaleReasonForInstallation(
+        installation({
+          transitionState,
+          lastError: "reconciliation_stale_job_pending",
+        }),
+      );
+      assert.equal(reason, null);
+    }
+  });
+
+  it("returns null for a genuine unrelated error", () => {
+    const reason = reconciliationStaleReasonForInstallation(
+      installation({ lastError: "agent unreachable" }),
+    );
+    assert.equal(reason, null);
+  });
+
+  it("returns null when last_error is null or empty", () => {
+    assert.equal(
+      reconciliationStaleReasonForInstallation(installation({ lastError: null })),
+      null,
+    );
+    assert.equal(
+      reconciliationStaleReasonForInstallation(installation({ lastError: "" })),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The reconciliation sweep for trust-anchor installations gives up retrying a stuck row after about 90 minutes: it clears `next_reconcile_at` and writes an internal code (for example `reconciliation_stale_job_pending`) into `last_error`. Before this change the Trust anchors panel rendered that row identically to one still being actively retried, and showed the raw internal code verbatim instead of an explanation.
- `listInstallationsForAnchor` now derives a `staleReason` field (`{ code, message }`) for any row the sweep has given up on, using a backend-owned message map so the UI never has to interpret an internal code. A genuinely unrelated `last_error` is left untouched; the derivation only fires when `next_reconcile_at` is cleared and `last_error` carries one of the sweep's own `reconciliation_stale_*` codes.
- The Trust anchors panel now shows a red "Needs attention" badge plus the mapped message for a stalled row, while a row still actively retrying (future `next_reconcile_at`, no error) keeps showing only the plain state badge, and a row with a genuine unrelated error keeps the existing raw-text rendering.

## Test plan

- [x] Backend pure unit tests for the new derivation helper (`tests/unit/certops-trust-reconciliation-stale.test.js`): all six mapped codes, the generic fallback for an unmapped code, and the negative guards (still scheduled, not a live pending row, unrelated error, empty error).
- [x] Backend integration tests (`tests/integration/certops-trust-anchors.test.js`): extended the existing stale-marking and reschedule tests with `staleReason` assertions, added a no-job-reason case and a genuine-unrelated-error case, and updated the exact-keys shape test to include the new field.
- [x] Frontend tests (`apps/dashboard/tests/unit/TrustAnchorsPanel.test.jsx`): stalled row shows the badge and mapped message (not the raw code), an actively-retrying row does not show the badge, and a row with an unrelated error still shows the raw text without the badge.
- [x] `pnpm run test:unit`, contract checks, lockfile-overrides, secret-logging, API/dashboard/worker lint, `pnpm audit`, dashboard prettier/type-check/build all pass locally.
- [x] Full trust-anchor integration suite run against the local Docker test stack: 75 passing.

## Validation
- With #201, installation pendingReason and staleReason both survive with staleReason → lastError → pendingReason precedence in TrustAnchorsPanel.
