### PR TITLE
fix(certops): report a pinned agent's real ineligibility, not no_execution_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Agent execution capability is now visible before you pin a job to an agent.** The CertOps Agents tab has a new Execution column showing whether an agent declared any executable action on its last successful claim; hovering "No capability declared" explains it can mean observe-only mode or simply an agent that hasn't polled yet. The manual-job and trust-anchor distribute/revoke modals annotate an agent option and show an inline warning when the selected agent has not declared the operation being requested, and creating a trust job against an agent that is retired or outside the accepted compatibility range is now rejected up front instead of leaving the job stuck at "Pending" forever. A trust-anchor installation stuck in a pending transition with no error now shows the same advisory reason inline instead of a bare "Pending" badge.
 
+### Fixed
+
+- **A certificate whose renewal is pinned to a real, non-retired agent that can't currently claim the job (a version/protocol compatibility block, or a declared-capability mismatch) reported the generic "no agent is currently associated with this certificate's renewal" instead of naming the pinned agent's actual problem.** The renewal-path health check now reports a distinct `assigned_agent_ineligible` reason with a summary describing why the pinned agent can't claim the job.
+
 ## [0.14.2] - 2026-09-01
 
 ### Fixed

--- a/apps/api/services/certops/renewalPathHealth.js
+++ b/apps/api/services/certops/renewalPathHealth.js
@@ -29,6 +29,7 @@ const {
 const { computeAgentCompatibility } = require("./agentRegistry");
 const {
   evaluateAgentJobEligibility,
+  persistedTextArray,
   resolveAgentJobRoutingRequirements,
 } = require("./agentJobEligibility");
 const {
@@ -207,13 +208,16 @@ function agentDependencyView(agent, { required, offlineAfterMs, now }) {
  * pre-loaded agent index. Pure function of (certificate row, profile
  * metadata, agent index) so it is trivially unit-testable without a DB.
  *
- * @returns {{ pinned: boolean, pinnedButRetired: boolean, pinnedAgentIneligibleReason: (string|null), agents: object[] }}
+ * @returns {{ pinned: boolean, pinnedButRetired: boolean, pinnedAgentIneligibleReason: (string|null), pinnedAgentDeclaredOperations: (string[]|null), agents: object[] }}
  *   agents is the full candidate list (dependencies view), already
  *   liveness-annotated. pinnedButRetired is true only when a pin target was
  *   configured but resolves to a now-retired agent (see module doc comment).
  *   pinnedAgentIneligibleReason is set only when the pin target is real,
  *   non-retired, and determinately ineligible for a different reason (e.g.
  *   compatibility_blocked, operation_unsupported) -- absent/null otherwise.
+ *   pinnedAgentDeclaredOperations is only populated for operation_unsupported,
+ *   so classifyExecutors can tell "declared nothing" from "declared other
+ *   operations, just not this one" -- both trigger the same reason code.
  */
 function resolveRequiredExecutors({
   certificateRow,
@@ -265,6 +269,7 @@ function resolveRequiredExecutors({
   let eligibilityIndeterminate = false;
   let liveEligibilityIndeterminate = false;
   let pinnedAgentIneligibleReason = null;
+  let pinnedAgentDeclaredOperations = null;
   const matching = jobRequirements
     ? agentIndex.all.filter((agent) => {
         const evaluation = evaluateAgentJobEligibility({
@@ -288,6 +293,11 @@ function resolveRequiredExecutors({
           !evaluation.eligible
         ) {
           pinnedAgentIneligibleReason = evaluation.reason;
+          if (evaluation.reason === "operation_unsupported") {
+            pinnedAgentDeclaredOperations = persistedTextArray(
+              agent.supportedOperations,
+            );
+          }
         }
         return evaluation.eligible;
       })
@@ -301,6 +311,7 @@ function resolveRequiredExecutors({
     pinned: Boolean(assignedAgentId),
     pinnedButRetired: false,
     pinnedAgentIneligibleReason,
+    pinnedAgentDeclaredOperations,
     targetReference,
     eligibilityIndeterminate,
     liveEligibilityIndeterminate,
@@ -319,6 +330,14 @@ function resolveRequiredExecutors({
 // operation-agnostic (no mention of a specific op), unlike
 // TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.operation_unsupported, which
 // hardcodes "distribute-trust/revoke-trust" and would be misleading here.
+//
+// ExecutionCapabilityBadge itself never needs the partial-capability case
+// below: it only asks "did this agent declare anything at all", not "does it
+// support this specific operation", so declaring any operation is enough for
+// its "Enabled" state. operation_unsupported here is a per-job answer, so an
+// agent that declared e.g. issue/deploy but not renew is a real, different
+// case from one that declared nothing -- getting told it's "not declared any
+// executable action" would be wrong; it is executing other jobs just fine.
 const NO_CAPABILITY_DECLARED_SUMMARY =
   "The agent assigned to renew this certificate has not declared any " +
   "executable action the last time it claimed a job. Most often this means " +
@@ -326,12 +345,23 @@ const NO_CAPABILITY_DECLARED_SUMMARY =
   "not true, in its config.json) -- though a brand-new agent that has not " +
   "polled for a job yet looks identical here.";
 
-function ineligiblePinSummary(reason) {
+function partialCapabilitySummary(declaredOperations) {
+  return (
+    `The agent assigned to renew this certificate has declared support ` +
+    `for ${declaredOperations.join(", ")}, but not for renew. It is not ` +
+    `idle -- it simply has not been configured (or does not support) ` +
+    `automatic-renewal jobs.`
+  );
+}
+
+function ineligiblePinSummary(reason, declaredOperations) {
   if (reason === "compatibility_blocked") {
     return TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.compatibility_blocked;
   }
   if (reason === "operation_unsupported") {
-    return NO_CAPABILITY_DECLARED_SUMMARY;
+    return Array.isArray(declaredOperations) && declaredOperations.length > 0
+      ? partialCapabilitySummary(declaredOperations)
+      : NO_CAPABILITY_DECLARED_SUMMARY;
   }
   return (
     `The agent assigned to renew this certificate cannot currently claim ` +
@@ -349,6 +379,7 @@ function classifyExecutors({
   hasResolvableTopology,
   pinnedButRetired = false,
   pinnedAgentIneligibleReason = null,
+  pinnedAgentDeclaredOperations = null,
 }) {
   if (pinnedButRetired) {
     return {
@@ -362,7 +393,10 @@ function classifyExecutors({
     return {
       renewalPathState: RENEWAL_PATH_STATES.UNAVAILABLE,
       renewalPathReason: RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
-      renewalPathSummary: ineligiblePinSummary(pinnedAgentIneligibleReason),
+      renewalPathSummary: ineligiblePinSummary(
+        pinnedAgentIneligibleReason,
+        pinnedAgentDeclaredOperations,
+      ),
     };
   }
   if (!hasResolvableTopology) {
@@ -492,6 +526,7 @@ function resolveRenewalPathForRow({ certificateRow, agentIndex, env = process.en
     pinned,
     pinnedButRetired,
     pinnedAgentIneligibleReason,
+    pinnedAgentDeclaredOperations,
     eligibilityIndeterminate,
     liveEligibilityIndeterminate,
   } = resolveRequiredExecutors({
@@ -525,6 +560,7 @@ function resolveRenewalPathForRow({ certificateRow, agentIndex, env = process.en
     hasResolvableTopology,
     pinnedButRetired,
     pinnedAgentIneligibleReason,
+    pinnedAgentDeclaredOperations,
   });
 
   return {

--- a/apps/api/services/certops/renewalPathHealth.js
+++ b/apps/api/services/certops/renewalPathHealth.js
@@ -35,6 +35,7 @@ const {
   resolveAgentOfflineAfterMs,
   classifyAgentLiveness,
 } = require("./agentLiveness");
+const { TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON } = require("./trustAnchors");
 
 const RENEWAL_PATH_STATES = Object.freeze({
   HEALTHY: "healthy",
@@ -57,6 +58,13 @@ const RENEWAL_PATH_REASONS = Object.freeze({
   // separately so an operator knows re-homing (not just waiting for a
   // liveness recovery) is required.
   ASSIGNED_AGENT_RETIRED: "assigned_agent_retired",
+  // The certificate's pinned executor resolves to a real, non-retired agent
+  // that is currently ineligible for a different determinate reason (version/
+  // protocol compatibility, a declared-capability/selector/DNS/command-profile
+  // mismatch, etc.) -- surfaced separately from NO_EXECUTION_TARGET so an
+  // operator is told an agent IS pinned and why it can't claim the job, rather
+  // than being told none is associated at all.
+  ASSIGNED_AGENT_INELIGIBLE: "assigned_agent_ineligible",
   // Not in the product spec's suggested list, but needed so a certificate
   // that is not currently expected to auto-renew never gets shown next to
   // "Renewal path unavailable" -- rule: "auto-renew disabled should not
@@ -199,10 +207,13 @@ function agentDependencyView(agent, { required, offlineAfterMs, now }) {
  * pre-loaded agent index. Pure function of (certificate row, profile
  * metadata, agent index) so it is trivially unit-testable without a DB.
  *
- * @returns {{ pinned: boolean, pinnedButRetired: boolean, agents: object[] }}
+ * @returns {{ pinned: boolean, pinnedButRetired: boolean, pinnedAgentIneligibleReason: (string|null), agents: object[] }}
  *   agents is the full candidate list (dependencies view), already
  *   liveness-annotated. pinnedButRetired is true only when a pin target was
  *   configured but resolves to a now-retired agent (see module doc comment).
+ *   pinnedAgentIneligibleReason is set only when the pin target is real,
+ *   non-retired, and determinately ineligible for a different reason (e.g.
+ *   compatibility_blocked, operation_unsupported) -- absent/null otherwise.
  */
 function resolveRequiredExecutors({
   certificateRow,
@@ -253,6 +264,7 @@ function resolveRequiredExecutors({
   // the shared dispatch predicate below.
   let eligibilityIndeterminate = false;
   let liveEligibilityIndeterminate = false;
+  let pinnedAgentIneligibleReason = null;
   const matching = jobRequirements
     ? agentIndex.all.filter((agent) => {
         const evaluation = evaluateAgentJobEligibility({
@@ -270,6 +282,12 @@ function resolveRequiredExecutors({
           if (isAgentOnline(agent, { offlineAfterMs, now })) {
             liveEligibilityIndeterminate = true;
           }
+        } else if (
+          assignedAgentId &&
+          agent.id === assignedAgentId &&
+          !evaluation.eligible
+        ) {
+          pinnedAgentIneligibleReason = evaluation.reason;
         }
         return evaluation.eligible;
       })
@@ -282,6 +300,7 @@ function resolveRequiredExecutors({
   return {
     pinned: Boolean(assignedAgentId),
     pinnedButRetired: false,
+    pinnedAgentIneligibleReason,
     targetReference,
     eligibilityIndeterminate,
     liveEligibilityIndeterminate,
@@ -295,6 +314,32 @@ function resolveRequiredExecutors({
   };
 }
 
+// Mirrors AgentFleetPanel.jsx's ExecutionCapabilityBadge tooltip copy for the
+// "never declared any operation" case: that text is deliberately
+// operation-agnostic (no mention of a specific op), unlike
+// TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.operation_unsupported, which
+// hardcodes "distribute-trust/revoke-trust" and would be misleading here.
+const NO_CAPABILITY_DECLARED_SUMMARY =
+  "The agent assigned to renew this certificate has not declared any " +
+  "executable action the last time it claimed a job. Most often this means " +
+  "it is running observe-only (no execution block, or execution.enabled is " +
+  "not true, in its config.json) -- though a brand-new agent that has not " +
+  "polled for a job yet looks identical here.";
+
+function ineligiblePinSummary(reason) {
+  if (reason === "compatibility_blocked") {
+    return TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.compatibility_blocked;
+  }
+  if (reason === "operation_unsupported") {
+    return NO_CAPABILITY_DECLARED_SUMMARY;
+  }
+  return (
+    `The agent assigned to renew this certificate cannot currently claim ` +
+    `the renewal job (${reason}). Check the agent's declared capabilities ` +
+    `and compatibility state.`
+  );
+}
+
 /**
  * Classify a resolved executor set into a renewalPathState projection.
  */
@@ -303,6 +348,7 @@ function classifyExecutors({
   targetReference,
   hasResolvableTopology,
   pinnedButRetired = false,
+  pinnedAgentIneligibleReason = null,
 }) {
   if (pinnedButRetired) {
     return {
@@ -310,6 +356,13 @@ function classifyExecutors({
       renewalPathReason: RENEWAL_PATH_REASONS.ASSIGNED_AGENT_RETIRED,
       renewalPathSummary:
         "The agent assigned to renew this certificate has been retired. Re-assign this certificate to an active agent.",
+    };
+  }
+  if (pinnedAgentIneligibleReason) {
+    return {
+      renewalPathState: RENEWAL_PATH_STATES.UNAVAILABLE,
+      renewalPathReason: RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+      renewalPathSummary: ineligiblePinSummary(pinnedAgentIneligibleReason),
     };
   }
   if (!hasResolvableTopology) {
@@ -438,6 +491,7 @@ function resolveRenewalPathForRow({ certificateRow, agentIndex, env = process.en
     targetReference,
     pinned,
     pinnedButRetired,
+    pinnedAgentIneligibleReason,
     eligibilityIndeterminate,
     liveEligibilityIndeterminate,
   } = resolveRequiredExecutors({
@@ -470,6 +524,7 @@ function resolveRenewalPathForRow({ certificateRow, agentIndex, env = process.en
     targetReference,
     hasResolvableTopology,
     pinnedButRetired,
+    pinnedAgentIneligibleReason,
   });
 
   return {
@@ -646,5 +701,6 @@ module.exports = {
     classifyExecutors,
     targetReferenceFromProfile,
     loadWorkspaceAgentIndex,
+    NO_CAPABILITY_DECLARED_SUMMARY,
   },
 };

--- a/apps/api/services/certops/trustAnchors.js
+++ b/apps/api/services/certops/trustAnchors.js
@@ -2310,6 +2310,7 @@ async function sweepOverdueTrustInstallations({
 }
 
 module.exports = {
+  TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON,
   CERTOPS_TRUST_ANCHOR_INVALID,
   CERTOPS_TRUST_ANCHOR_NOT_FOUND,
   CERTOPS_TRUST_ANCHOR_PEM_INVALID,
@@ -2360,6 +2361,5 @@ module.exports = {
 module.exports._test = {
   assertTargetAgentEligibleForTrustJob,
   BLOCKING_TRUST_JOB_CREATION_REASONS,
-  TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON,
   pendingReasonForInstallation,
 };

--- a/tests/unit/certops-agent-job-eligibility.test.js
+++ b/tests/unit/certops-agent-job-eligibility.test.js
@@ -14,6 +14,7 @@ const { computeAgentCompatibility } = require(service("agentRegistry.js"));
 const dispatch = require(service("agentDispatch.js"));
 const {
   RENEWAL_PATH_STATES,
+  RENEWAL_PATH_REASONS,
   _test: { resolveRenewalPathForRow },
 } = require(service("renewalPathHealth.js"));
 const {
@@ -155,6 +156,67 @@ describe("shared agent-job eligibility", () => {
     }
   });
 
+  it("reports assigned_agent_ineligible (not no_execution_target) when the pinned agent itself is the one that fails eligibility", () => {
+    const validated = validateRenewalProfile(profile());
+    const job = {
+      operation: "renew",
+      ...resolveAgentJobRoutingRequirements({
+        executorKind: "agent",
+        payload: executionFieldsFromRenewalProfile(validated),
+      }),
+      subjectIsProvisioning: false,
+    };
+    const cases = [
+      ["eligible", {}, true],
+      ["operation", { supportedOperations: ["deploy"] }, false],
+      ["selector", { targetSelectors: ["host/other"] }, false],
+      ["dns", { dnsProviders: ["route53"] }, false],
+      ["command", { commandProfiles: ["renew.other"] }, false],
+      ["diagnostic kind", { agentKind: "diagnostic" }, false],
+      ["blocked version", { protocolVersion: "999.0.0" }, false],
+    ];
+
+    for (const [label, overrides, expected] of cases) {
+      const candidate = agent({ id: "agent-1", agentId: "assigned", ...overrides });
+      const predicate = evaluateAgentJobEligibility({
+        agent: candidate,
+        job: { ...job, assignedAgentId: "agent-1" },
+        compatibility: computeAgentCompatibility(candidate, {}),
+        env: {},
+        now: NOW,
+      });
+      assert.equal(predicate.eligible, expected, `${label}: predicate`);
+
+      const row = certificateRow();
+      row.source = "agent_filesystem";
+      row.discovery_agent_id = "assigned";
+      const projection = resolveRenewalPathForRow({
+        certificateRow: row,
+        agentIndex: indexFor(candidate),
+        env: {},
+        now: NOW,
+      });
+      if (expected) {
+        assert.equal(
+          projection.renewalPathState,
+          RENEWAL_PATH_STATES.HEALTHY,
+          `${label}: health projection`,
+        );
+      } else {
+        assert.equal(
+          projection.renewalPathReason,
+          RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+          `${label}: renewal path reason`,
+        );
+        assert.notEqual(
+          projection.renewalPathReason,
+          RENEWAL_PATH_REASONS.NO_EXECUTION_TARGET,
+          `${label}: must not fall back to the generic no-agent message`,
+        );
+      }
+    }
+  });
+
   it("requires fresh claim-binding capability for provisioning renewals", () => {
     const candidate = agent({
       declaredCapabilities: ["evidence-claim-binding-v1"],
@@ -245,6 +307,28 @@ describe("shared agent-job eligibility", () => {
       now: NOW,
     });
     assert.equal(projection.renewalPathState, RENEWAL_PATH_STATES.UNKNOWN);
+  });
+
+  it("reports Unknown, not assigned_agent_ineligible, when the pinned agent itself has malformed persisted facts", () => {
+    const malformedPinned = agent({
+      id: "agent-1",
+      agentId: "assigned",
+      targetSelectors: { unexpected: true },
+    });
+    const row = certificateRow();
+    row.source = "agent_filesystem";
+    row.discovery_agent_id = "assigned";
+    const projection = resolveRenewalPathForRow({
+      certificateRow: row,
+      agentIndex: indexFor(malformedPinned),
+      env: {},
+      now: NOW,
+    });
+    assert.equal(projection.renewalPathState, RENEWAL_PATH_STATES.UNKNOWN);
+    assert.notEqual(
+      projection.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
   });
 
   it("reports Unknown when only a live candidate has malformed required facts", () => {

--- a/tests/unit/certops-renewal-path-health.test.js
+++ b/tests/unit/certops-renewal-path-health.test.js
@@ -344,7 +344,7 @@ describe("renewalPathHealth: resolveRequiredExecutors", () => {
     assert.equal(agents.length, 0);
   });
 
-  it("pinned agent that has never declared any supported operation (fresh/never-polled agent): pinnedAgentIneligibleReason 'operation_unsupported'", () => {
+  it("pinned agent that has never declared any supported operation (fresh/never-polled agent): pinnedAgentIneligibleReason 'operation_unsupported', no declared operations", () => {
     const agentIndex = buildAgentIndex([
       onlineAgentRow({ id: "agent-a", supportedOperations: [] }),
     ]);
@@ -353,23 +353,65 @@ describe("renewalPathHealth: resolveRequiredExecutors", () => {
       executorKind: "agent",
       requiredTargetSelector: "host/web",
     };
-    const { pinned, pinnedAgentIneligibleReason, agents } =
-      resolveRequiredExecutors({
-        certificateRow: certRow({
-          source: "agent_filesystem",
-          deployed_agent_id: null,
-          discovery_agent_id: "agent-a",
-        }),
-        profileMetadata: {
-          renewalProfile: { target: { reference: "host/web" } },
-        },
-        agentIndex,
-        offlineAfterMs: OFFLINE_AFTER_MS,
-        now: NOW,
-        jobRequirements,
-      });
+    const {
+      pinned,
+      pinnedAgentIneligibleReason,
+      pinnedAgentDeclaredOperations,
+      agents,
+    } = resolveRequiredExecutors({
+      certificateRow: certRow({
+        source: "agent_filesystem",
+        deployed_agent_id: null,
+        discovery_agent_id: "agent-a",
+      }),
+      profileMetadata: {
+        renewalProfile: { target: { reference: "host/web" } },
+      },
+      agentIndex,
+      offlineAfterMs: OFFLINE_AFTER_MS,
+      now: NOW,
+      jobRequirements,
+    });
     assert.equal(pinned, true);
     assert.equal(pinnedAgentIneligibleReason, "operation_unsupported");
+    assert.deepEqual(pinnedAgentDeclaredOperations, []);
+    assert.equal(agents.length, 0);
+  });
+
+  it("pinned agent that declared other operations but not renew (partial capability, not never-polled): pinnedAgentDeclaredOperations names what it DID declare", () => {
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({
+        id: "agent-a",
+        supportedOperations: ["issue", "deploy"],
+      }),
+    ]);
+    const jobRequirements = {
+      operation: "renew",
+      executorKind: "agent",
+      requiredTargetSelector: "host/web",
+    };
+    const {
+      pinned,
+      pinnedAgentIneligibleReason,
+      pinnedAgentDeclaredOperations,
+      agents,
+    } = resolveRequiredExecutors({
+      certificateRow: certRow({
+        source: "agent_filesystem",
+        deployed_agent_id: null,
+        discovery_agent_id: "agent-a",
+      }),
+      profileMetadata: {
+        renewalProfile: { target: { reference: "host/web" } },
+      },
+      agentIndex,
+      offlineAfterMs: OFFLINE_AFTER_MS,
+      now: NOW,
+      jobRequirements,
+    });
+    assert.equal(pinned, true);
+    assert.equal(pinnedAgentIneligibleReason, "operation_unsupported");
+    assert.deepEqual(pinnedAgentDeclaredOperations, ["issue", "deploy"]);
     assert.equal(agents.length, 0);
   });
 });
@@ -462,6 +504,24 @@ describe("renewalPathHealth: classifyExecutors", () => {
       result.renewalPathSummary,
       TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.operation_unsupported,
     );
+  });
+
+  it("pinnedAgentIneligibleReason 'operation_unsupported' WITH declared operations -> distinct partial-capability summary, not the 'declared nothing' wording", () => {
+    const result = classifyExecutors({
+      agents: [],
+      targetReference: null,
+      hasResolvableTopology: true,
+      pinnedAgentIneligibleReason: "operation_unsupported",
+      pinnedAgentDeclaredOperations: ["issue", "deploy"],
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.notEqual(result.renewalPathSummary, NO_CAPABILITY_DECLARED_SUMMARY);
+    assert.match(result.renewalPathSummary, /issue, deploy/);
+    assert.match(result.renewalPathSummary, /not for renew/);
   });
 
   it("no execution target resolved -> Renewal path unavailable", () => {
@@ -612,7 +672,7 @@ describe("renewalPathHealth: resolveRenewalPathForRow (end to end classification
     assert.deepEqual(result.dependencies, []);
   });
 
-  it("pinned agent that has never declared any supported operation -> Renewal path unavailable (assigned_agent_ineligible), not no_execution_target", () => {
+  it("pinned agent that has never declared any supported operation -> Renewal path unavailable (assigned_agent_ineligible), not no_execution_target, 'has not declared any executable action' wording", () => {
     const agentIndex = buildAgentIndex([
       onlineAgentRow({ id: "agent-a", supportedOperations: [] }),
     ]);
@@ -630,6 +690,29 @@ describe("renewalPathHealth: resolveRenewalPathForRow (end to end classification
       result.renewalPathReason,
       RENEWAL_PATH_REASONS.NO_EXECUTION_TARGET,
     );
+    assert.match(result.renewalPathSummary, /has not declared any/);
+    assert.deepEqual(result.dependencies, []);
+  });
+
+  it("pinned agent that declared other operations but not renew -> Renewal path unavailable (assigned_agent_ineligible), summary names what it DID declare instead of claiming it declared nothing", () => {
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({
+        id: "agent-a",
+        supportedOperations: ["issue", "deploy"],
+      }),
+    ]);
+    const result = resolveRenewalPathForRow({
+      certificateRow: certRow({ discovery_agent_id: "agent-a" }),
+      agentIndex,
+      now: NOW,
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.doesNotMatch(result.renewalPathSummary, /has not declared any/);
+    assert.match(result.renewalPathSummary, /issue, deploy/);
     assert.deepEqual(result.dependencies, []);
   });
 });

--- a/tests/unit/certops-renewal-path-health.test.js
+++ b/tests/unit/certops-renewal-path-health.test.js
@@ -15,12 +15,16 @@ const {
     resolveRequiredExecutors,
     classifyExecutors,
     targetReferenceFromProfile,
+    NO_CAPABILITY_DECLARED_SUMMARY,
   },
 } = require(
   path.resolve(
     __dirname,
     "../../apps/api/services/certops/renewalPathHealth.js",
   ),
+);
+const { TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON } = require(
+  path.resolve(__dirname, "../../apps/api/services/certops/trustAnchors.js"),
 );
 
 const NOW = new Date("2026-08-07T12:00:00.000Z").getTime();
@@ -36,6 +40,7 @@ function agentRow({
   supportedOperations = ["renew"],
   dnsProviders = ["cloudflare"],
   commandProfiles = ["renew.web"],
+  protocolVersion = "1.0.0",
 }) {
   return {
     id,
@@ -54,7 +59,7 @@ function agentRow({
     capabilities_updated_at: new Date(NOW).toISOString(),
     agent_kind: "normal",
     agent_version: "0.1.0",
-    protocol_version: "1.0.0",
+    protocol_version: protocolVersion,
     clock_offset_ms: 0,
   };
 }
@@ -304,6 +309,69 @@ describe("renewalPathHealth: resolveRequiredExecutors", () => {
     assert.equal(agents.length, 0);
     assert.equal(targetReference, null);
   });
+
+  it("pinned agent_filesystem discovery agent that is compatibility-blocked: pinnedAgentIneligibleReason set, no open-claim fallback even with a live redundant-looking agent", () => {
+    // Real dispatch would never let agent-b claim this job (assigned_agent_id
+    // still hard-pins to agent-a), so a live decoy declaring the same
+    // selector must not resolve this as Degraded/Healthy via agent-b.
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({ id: "agent-a", protocolVersion: "999.0.0" }),
+      onlineAgentRow({ id: "agent-b", targetSelectors: ["host/web"] }),
+    ]);
+    const jobRequirements = {
+      operation: "renew",
+      executorKind: "agent",
+      requiredTargetSelector: "host/web",
+    };
+    const { pinned, pinnedButRetired, pinnedAgentIneligibleReason, agents } =
+      resolveRequiredExecutors({
+        certificateRow: certRow({
+          source: "agent_filesystem",
+          deployed_agent_id: null,
+          discovery_agent_id: "agent-a",
+        }),
+        profileMetadata: {
+          renewalProfile: { target: { reference: "host/web" } },
+        },
+        agentIndex,
+        offlineAfterMs: OFFLINE_AFTER_MS,
+        now: NOW,
+        jobRequirements,
+      });
+    assert.equal(pinned, true);
+    assert.equal(pinnedButRetired, false);
+    assert.equal(pinnedAgentIneligibleReason, "compatibility_blocked");
+    assert.equal(agents.length, 0);
+  });
+
+  it("pinned agent that has never declared any supported operation (fresh/never-polled agent): pinnedAgentIneligibleReason 'operation_unsupported'", () => {
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({ id: "agent-a", supportedOperations: [] }),
+    ]);
+    const jobRequirements = {
+      operation: "renew",
+      executorKind: "agent",
+      requiredTargetSelector: "host/web",
+    };
+    const { pinned, pinnedAgentIneligibleReason, agents } =
+      resolveRequiredExecutors({
+        certificateRow: certRow({
+          source: "agent_filesystem",
+          deployed_agent_id: null,
+          discovery_agent_id: "agent-a",
+        }),
+        profileMetadata: {
+          renewalProfile: { target: { reference: "host/web" } },
+        },
+        agentIndex,
+        offlineAfterMs: OFFLINE_AFTER_MS,
+        now: NOW,
+        jobRequirements,
+      });
+    assert.equal(pinned, true);
+    assert.equal(pinnedAgentIneligibleReason, "operation_unsupported");
+    assert.equal(agents.length, 0);
+  });
 });
 
 describe("renewalPathHealth: classifyExecutors", () => {
@@ -356,6 +424,43 @@ describe("renewalPathHealth: classifyExecutors", () => {
     assert.equal(
       result.renewalPathReason,
       RENEWAL_PATH_REASONS.ALL_EXECUTORS_OFFLINE,
+    );
+  });
+
+  it("pinnedAgentIneligibleReason 'compatibility_blocked' -> Renewal path unavailable, assigned_agent_ineligible, summary reused from TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON", () => {
+    const result = classifyExecutors({
+      agents: [],
+      targetReference: null,
+      hasResolvableTopology: true,
+      pinnedAgentIneligibleReason: "compatibility_blocked",
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.equal(
+      result.renewalPathSummary,
+      TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.compatibility_blocked,
+    );
+  });
+
+  it("pinnedAgentIneligibleReason 'operation_unsupported' -> Renewal path unavailable, assigned_agent_ineligible, operation-agnostic summary (not the trust-specific one)", () => {
+    const result = classifyExecutors({
+      agents: [],
+      targetReference: null,
+      hasResolvableTopology: true,
+      pinnedAgentIneligibleReason: "operation_unsupported",
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.equal(result.renewalPathSummary, NO_CAPABILITY_DECLARED_SUMMARY);
+    assert.notEqual(
+      result.renewalPathSummary,
+      TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON.operation_unsupported,
     );
   });
 
@@ -481,6 +586,49 @@ describe("renewalPathHealth: resolveRenewalPathForRow (end to end classification
     assert.equal(
       result.renewalPathReason,
       RENEWAL_PATH_REASONS.ASSIGNED_AGENT_RETIRED,
+    );
+    assert.deepEqual(result.dependencies, []);
+  });
+
+  it("pinned agent that is compatibility-blocked -> Renewal path unavailable (assigned_agent_ineligible), not no_execution_target, even with a live redundant-looking agent", () => {
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({ id: "agent-a", protocolVersion: "999.0.0" }),
+      onlineAgentRow({ id: "agent-b", targetSelectors: ["host/web"] }),
+    ]);
+    const result = resolveRenewalPathForRow({
+      certificateRow: certRow({ discovery_agent_id: "agent-a" }),
+      agentIndex,
+      now: NOW,
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.notEqual(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.NO_EXECUTION_TARGET,
+    );
+    assert.deepEqual(result.dependencies, []);
+  });
+
+  it("pinned agent that has never declared any supported operation -> Renewal path unavailable (assigned_agent_ineligible), not no_execution_target", () => {
+    const agentIndex = buildAgentIndex([
+      onlineAgentRow({ id: "agent-a", supportedOperations: [] }),
+    ]);
+    const result = resolveRenewalPathForRow({
+      certificateRow: certRow({ discovery_agent_id: "agent-a" }),
+      agentIndex,
+      now: NOW,
+    });
+    assert.equal(result.renewalPathState, RENEWAL_PATH_STATES.UNAVAILABLE);
+    assert.equal(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.ASSIGNED_AGENT_INELIGIBLE,
+    );
+    assert.notEqual(
+      result.renewalPathReason,
+      RENEWAL_PATH_REASONS.NO_EXECUTION_TARGET,
     );
     assert.deepEqual(result.dependencies, []);
   });

--- a/tests/unit/certops-trust-job-eligibility.test.js
+++ b/tests/unit/certops-trust-job-eligibility.test.js
@@ -23,10 +23,10 @@ const trustAnchors = require(
   ),
 );
 
+const { TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON } = trustAnchors;
 const {
   assertTargetAgentEligibleForTrustJob,
   BLOCKING_TRUST_JOB_CREATION_REASONS,
-  TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON,
   pendingReasonForInstallation,
 } = trustAnchors._test;
 


### PR DESCRIPTION
## Summary
- Recovers the work from closed PR #207, which was auto-closed (not merged) when its stacked base branch eature/agent-capability-visibility was deleted after #201 merged.
- Same three commits cherry-picked onto current main: export TRUST_JOB_INELIGIBLE_MESSAGE_BY_REASON, report ssigned_agent_ineligible for pinned-but-ineligible agents, and distinguish empty vs partial capability in renewal-path messaging.

## Validation
- Partial-capability pinned agents get copy naming declared ops (not "declared nothing"); certops-renewal-path-health unit tests pass. Content verified present after cherry-pick onto main.

## Note
Supersedes https://github.com/tokentimerch/tokentimer-core/pull/207 (closed without merge).
